### PR TITLE
Add github workflows and clarify + clean up project info

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,15 @@
-### What was wrong?
-
-Related to Issue #
-
-### How was it fixed?
-
 ## 🗒️ Description
 <!-- Brief description of the changes introduced by this PR -->
-<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
 
 ## 🔗 Related Issues or PRs
-<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
-N/A.
+<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->
 
 ## ✅ Checklist
 <!-- Please check off all required items. For those that don't apply remove them accordingly. -->
 
-- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails:
+- [ ] Ran `tox` checks to avoid unnecessary CI fails:
     ```console
-    uvx --with=tox-uv tox -e check,pytest
+    uvx --with=tox-uv tox
     ```
 - [ ] Considered adding appropriate tests for the changes.
-- [ ] Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
-- [ ] Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
-- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
+- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint and format checks - Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - name: Checkout leanSpec
+        uses: actions/checkout@v4
+      
+      - name: Install uv and Python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+          python-version: ${{ matrix.python-version }}
+      
+      - name: Run all quality checks via tox
+        run: uvx --with=tox-uv tox -e all-checks
+
+  test:
+    name: Tests - Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.12", "3.13"]
+    steps:
+      - name: Checkout leanSpec
+        uses: actions/checkout@v4
+      
+      - name: Install uv and Python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+          python-version: ${{ matrix.python-version }}
+      
+      - name: Run tests via tox
+        run: uvx --with=tox-uv tox -e pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,11 @@ uv run ruff check --fix src tests
 # Type checking
 uv run mypy src tests
 
-# Run all checks via tox
-uvx --with=tox-uv tox
+# Run all quality checks (lint, typecheck, spellcheck)
+uv run tox -e all-checks
+
+# Run everything (all checks + tests + docs)
+uv run tox
 ```
 
 ### Common Tasks
@@ -78,17 +81,18 @@ uvx --with=tox-uv tox
 
 ## Common Commands Reference
 
-| Task                 | Command |
-|----------------------|---------|
-| Install dependencies | `uv sync --all-extras` |
-| Run tests            | `uv run pytest` |
-| Format code          | `uv run ruff format src tests` |
-| Lint code            | `uv run ruff check src tests` |
-| Fix lint errors      | `uv run ruff check --fix src tests` |
-| Type check           | `uv run mypy src tests` |
-| Run all tox checks   | `uvx --with=tox-uv tox` |
-| Build docs           | `uv run mkdocs build` |
-| Serve docs           | `uv run mkdocs serve` |
+| Task                                   | Command                             |
+|----------------------------------------|-------------------------------------|
+| Install dependencies                   | `uv sync --all-extras`              |
+| Run tests                              | `uv run pytest`                     |
+| Format code                            | `uv run ruff format src tests`      |
+| Lint code                              | `uv run ruff check src tests`       |
+| Fix lint errors                        | `uv run ruff check --fix src tests` |
+| Type check                             | `uv run mypy src tests`             |
+| Build docs                             | `uv run mkdocs build`               |
+| Serve docs                             | `uv run mkdocs serve`               |
+| Run all quality checks (no tests/docs) | `uv run tox -e all-checks`          |
+| Run everything (checks + tests + docs) | `uv run tox`                        |
 
 ## Important Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 1. Fork and clone the repository
 2. Install dependencies: `uv sync --all-extras`
 3. Make your changes
-4. Run checks: `uvx --with=tox-uv tox -e check`
+4. Run checks: `uv run tox -e all-checks`
 5. Run tests: `uv run pytest`
 6. Submit a pull request
 
@@ -22,7 +22,7 @@
 - **Type hints**: Required for all functions and methods
 - **Docstrings**: Use Google style for public APIs
 - **Line length**: 79 characters (enforced by ruff)
-- **Formatting**: Run `uvx --with=tox-uv tox -e fix` to auto-format
+- **Formatting**: Run `uv run tox -e fix` to auto-format
 
 ## Adding New Subspecifications
 
@@ -40,25 +40,8 @@ mkdir -p tests/subspecs/my_new_subspec
 - Use `pytest.mark.parametrize` for multiple test cases
 - Mark slow tests with `@pytest.mark.slow`
 
-## Development Commands
-
-### Running Quality Checks
-```bash
-# Run all checks
-uvx --with=tox-uv tox -e check,pytest
-
-# Run individual checks
-uvx --with=tox-uv tox -e lint       # Linting with ruff
-uvx --with=tox-uv tox -e typecheck  # Type checking with mypy
-uvx --with=tox-uv tox -e spellcheck # Spell checking
-uvx --with=tox-uv tox -e pytest     # Run tests
-
-# Auto-fix formatting issues
-uvx --with=tox-uv tox -e fix
-```
-
 ## Questions?
 
 - Check existing [issues](https://github.com/leanEthereum/leanSpec/issues)
 - Open a new issue for discussion
-- See [README.md](README.md) for project overview
+- See [README.md](README.md) for more details on the project structure and commands

--- a/README.md
+++ b/README.md
@@ -82,14 +82,32 @@ uv run ruff format src tests
 uv run mypy src tests
 ```
 
-### Using Tox
+### Using Tox for Comprehensive Checks
+
+After running `uv sync --all-extras`, you can use tox with `uv run`:
 
 ```bash
-# Run all tox environments
-uvx --with=tox-uv tox
+# Run all quality checks (lint, typecheck, spellcheck)
+uv run tox -e all-checks
+
+# Run all tox environments (all checks + tests + docs)
+uv run tox
 
 # Run specific environment
-uvx --with=tox-uv tox -e lint
+uv run tox -e lint
+```
+
+**Alternative: Using uvx (no setup required)**
+
+If you haven't run `uv sync --all-extras` or want to use tox in isolation, 
+you can use `uvx`, which: 
+
+* Creates a temporary environment just for tox
+* Doesn't require `uv sync` first
+* Uses tox-uv for faster dependency installation
+
+```bash
+uvx --with=tox-uv tox -e all-checks
 ```
 
 ### Documentation
@@ -153,22 +171,32 @@ def test_withdrawal_amount_above_uint64_max():
 
 ## Common Commands Reference
 
-| Task                 | Command |
-|----------------------|---------|
-| Install dependencies | `uv sync --all-extras` |
-| Run tests            | `uv run pytest` |
-| Format code          | `uv run ruff format src tests` |
-| Lint code            | `uv run ruff check src tests` |
-| Fix lint errors      | `uv run ruff check --fix src tests` |
-| Type check           | `uv run mypy src tests` |
-| Run all tox checks   | `uvx --with=tox-uv tox` |
-| Build docs           | `uv run mkdocs build` |
-| Serve docs           | `uv run mkdocs serve` |
+| Task                                   | Command                             |
+|----------------------------------------|-------------------------------------|
+| Install dependencies                   | `uv sync --all-extras`              |
+| Run tests                              | `uv run pytest`                     |
+| Format code                            | `uv run ruff format src tests`      |
+| Lint code                              | `uv run ruff check src tests`       |
+| Fix lint errors                        | `uv run ruff check --fix src tests` |
+| Type check                             | `uv run mypy src tests`             |
+| Build docs                             | `uv run mkdocs build`               |
+| Serve docs                             | `uv run mkdocs serve`               |
+| Run all quality checks (no tests/docs) | `uv run tox -e all-checks`          |
+| Run everything (checks + tests + docs) | `uv run tox`                        |
+| Run specific tox environment           | `uv run tox -e lint`                |
 
+If you have not run `uv sync --all-extras` or want to use `tox` in isolation, 
+you can use `uvx`:
+
+| Task                                    | Command                               |
+|-----------------------------------------|---------------------------------------|
+| Run all quality checks (no tests/docs)  | `uvx --with=tox-uv tox -e all-checks` |
+| Run everything (checks + tests + docs)  | `uvx --with=tox-uv tox`               |
+| Run specific tox environment            | `uvx --with=tox-uv tox -e lint`       |
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more guidelines.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,11 +7,11 @@ cryptographic subspecifications.
 
 ### Lean Ethereum Specifications
 
-The core protocol specifications are located in `lean_spec/`.
+The core protocol specifications are located in `src/lean_spec/`.
 
 ### Cryptographic Subspecifications
 
-Supporting cryptographic primitives are located in `lean_spec/subspecs/`.
+Supporting cryptographic primitives are located in `src/lean_spec/subspecs/`.
 
 ## Design Principles
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,20 @@
 [tox]
 env_list =
-    check
-    lint
-    typecheck
-    spellcheck
+    all-checks
     pytest
     docs
 skip_missing_interpreters = true
 
-[testenv:check]
+[testenv:all-checks]
 description = Run all quality checks (lint, typecheck, spellcheck)
 extras =
     lint
     typecheck
     docs
 commands =
-    ruff check --no-fix --show-fixes src tests
-    ruff format --check src tests
-    mypy src tests
-    codespell src tests docs README.md CLAUDE.md --skip="*.lock,*.svg,.git,__pycache__,.mypy_cache,.pytest_cache" --ignore-words=.codespell-ignore-words.txt
+    {[testenv:lint]commands}
+    {[testenv:typecheck]commands}
+    {[testenv:spellcheck]commands}
 
 [testenv:lint]
 description = Lint and code formatting checks (ruff)


### PR DESCRIPTION
## 🗒️ Description

- Added a github workflow for CI to run tests and linting.
- Clarified the linting commands and reduced the surface area of the instructions to just the `README.md`. I felt like there were too many places to read the same things when I was updating this. Clarified differences between `uv run tox` and `uvx`.
- Cleaned up tox environment setup for better UX: `-e all-checks` runs all lint + code style checks and we can use this directly in CI, separate from pytest run.

## 🔗 Related Issues or PRs

## ✅ Checklist

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx --with=tox-uv tox
    ```