### PR TITLE
docs: switch to docstring for consistency

### DIFF
--- a/src/lean_spec/subspecs/chain/config.py
+++ b/src/lean_spec/subspecs/chain/config.py
@@ -12,45 +12,55 @@ from ..types import BasisPoint, uint64
 
 # --- Time Parameters ---
 
-# The fixed duration of a single slot in milliseconds.
 SLOT_DURATION_MS: Final = 4000
+"""The fixed duration of a single slot in milliseconds."""
 
-# The deadline within a slot (in basis points) for a proposer to publish a
-# block.
-#
-# Honest validators may re-org blocks published after this cutoff.
-#
-# (2500 bps = 25% of slot duration).
 PROPOSER_REORG_CUTOFF_BPS: Final = 2500
+"""
+The deadline within a slot (in basis points) for a proposer to publish a
+block.
 
-# The deadline within a slot (in basis points) by which validators must
-# submit their votes.
-#
-# (5000 bps = 50% of slot duration).
+Honest validators may re-org blocks published after this cutoff.
+
+(2500 bps = 25% of slot duration).
+"""
+
 VOTE_DUE_BPS: Final = 5000
+"""
+The deadline within a slot (in basis points) by which validators must
+submit their votes.
 
-# The deadline within a slot (in basis points) for achieving a fast
-# confirmation.
-#
-# (7500 bps = 75% of slot duration).
+(5000 bps = 50% of slot duration).
+"""
+
 FAST_CONFIRM_DUE_BPS: Final = 7500
+"""
+The deadline within a slot (in basis points) for achieving a fast
+confirmation.
 
-# The cutoff within a slot (in basis points) after which the current view is
-# considered 'frozen', preventing further changes.
-#
-# (7500 bps = 75% of slot duration).
+(7500 bps = 75% of slot duration).
+"""
+
 VIEW_FREEZE_CUTOFF_BPS: Final = 7500
+"""
+The cutoff within a slot (in basis points) after which the current view is
+considered 'frozen', preventing further changes.
+
+(7500 bps = 75% of slot duration).
+"""
 
 # --- State List Length Presets ---
 
-# The maximum number of historical block roots to store in the state.
-#
-# With a 4-second slot, this corresponds to a history
-# of approximately 12.1 days.
 HISTORICAL_ROOTS_LIMIT: Final = 2**18
+"""
+The maximum number of historical block roots to store in the state.
 
-# The maximum number of validators that can be in the registry.
+With a 4-second slot, this corresponds to a history
+of approximately 12.1 days.
+"""
+
 VALIDATOR_REGISTRY_LIMIT: Final = 2**12
+"""The maximum number of validators that can be in the registry."""
 
 
 class _ChainConfig(BaseModel):

--- a/src/lean_spec/subspecs/koalabear/field.py
+++ b/src/lean_spec/subspecs/koalabear/field.py
@@ -11,21 +11,19 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 # automorphism of the multiplicative group.
 # =================================================================
 
-# The KoalaBear Prime: P = 2^31 - 2^24 + 1
 P: int = 2**31 - 2**24 + 1
+"""The KoalaBear Prime: P = 2^31 - 2^24 + 1"""
 
-# The number of bits in the prime P.
 P_BITS: int = 31
+"""The number of bits in the prime P."""
 
-# The largest integer n such that 2^n divides (P - 1).
-#
-# P - 1 = 2^24 * 127
 TWO_ADICITY: int = 24
+"""
+The largest integer n such that 2^n divides (P - 1).
 
-# A pre-computed list of 2^n-th roots of unity.
-#
-# The element at index `n` is a generator for
-# the multiplicative subgroup of order 2^n.
+P - 1 = 2^24 * 127
+"""
+
 TWO_ADIC_GENERATORS: list[int] = [
     0x1,
     0x7F000000,
@@ -53,6 +51,12 @@ TWO_ADIC_GENERATORS: list[int] = [
     0x68E7DD49,
     0x6AC49F88,
 ]
+"""
+A pre-computed list of 2^n-th roots of unity.
+
+The element at index `n` is a generator for
+the multiplicative subgroup of order 2^n.
+"""
 
 
 # =================================================================

--- a/src/lean_spec/subspecs/types/basispt.py
+++ b/src/lean_spec/subspecs/types/basispt.py
@@ -5,10 +5,12 @@ from typing_extensions import Annotated
 
 from ..types.uint64 import uint64
 
-# A type alias for basis points
-#
-# A basis point (bps) is 1/100th of a percent. 100% = 10,000 bps.
 BasisPoint = Annotated[
     uint64,
     Field(le=10000, description="A value in basis points (1/10000)."),
 ]
+"""
+A type alias for basis points.
+
+A basis point (bps) is 1/100th of a percent. 100% = 10,000 bps.
+"""

--- a/src/lean_spec/subspecs/types/uint64.py
+++ b/src/lean_spec/subspecs/types/uint64.py
@@ -3,8 +3,8 @@
 from pydantic import Field
 from typing_extensions import Annotated
 
-# The maximum value for an unsigned 64-bit integer (2**64).
 UINT64_MAX = 2**64
+"""The maximum value for an unsigned 64-bit integer (2**64)."""
 
-# A type alias to represent a uint64.
 uint64 = Annotated[int, Field(ge=0, lt=UINT64_MAX)]
+"""A type alias to represent a uint64."""


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

Thanks for all those hard works! I've been reading the full specification, and found some comments could be docstring.
Note that this PR doesn't change any specification.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

N/A

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx --with=tox-uv tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
