### PR TITLE
feat: add approximate Signature container

### DIFF
--- a/docs/client/containers.md
+++ b/docs/client/containers.md
@@ -17,18 +17,6 @@ class Checkpoint(Container):
     slot: uint64
 ```
 
-## `Signature`
-
-```python
-class Signature(Container):
-    # path: hash_len_fe (8) * bytes_per_fe (4) * log_lifetime (32)
-    path: Vector[Bytes32, 32]
-    # rho: rand_len_fe (7) * bytes_per_fe (4)
-    rho: Bytes28
-    # hashes: hash_len_fe (8) * bytes_per_fe (4) * num_chains (64)
-    hashes: Vector[Bytes32, 64]
-```
-
 ## `State`
 
 ```python
@@ -64,7 +52,6 @@ class Block(Container):
 
 ## `BlockBody`
 
-
 ```python
 class BlockBody(Container):
     votes: List[Vote, VALIDATOR_REGISTRY_LIMIT]
@@ -77,7 +64,7 @@ Remark: `votes` will be replaced by aggregated attestations.
 ```python
 class SignedBlock(Container):
     message: Block,
-    signature: Signature,
+    signature: List[byte, 4000],
 ```
 
 ## `Vote`
@@ -96,7 +83,7 @@ class Vote(Container):
 ```python
 class SignedVote(Container):
     data: Vote,
-    signature: Signature,
+    signature: List[byte, 4000],
 ```
 
 ## Remarks

--- a/docs/client/containers.md
+++ b/docs/client/containers.md
@@ -17,6 +17,18 @@ class Checkpoint(Container):
     slot: uint64
 ```
 
+## `Signature`
+
+```python
+class Signature(Container):
+    # path: hash_len_fe (8) * bytes_per_fe (4) * log_lifetime (32)
+    path: Vector[Bytes32, 32]
+    # rho: rand_len_fe (7) * bytes_per_fe (4)
+    rho: Bytes28
+    # hashes: hash_len_fe (8) * bytes_per_fe (4) * num_chains (64)
+    hashes: Vector[Bytes32, 64]
+```
+
 ## `State`
 
 ```python
@@ -65,7 +77,7 @@ Remark: `votes` will be replaced by aggregated attestations.
 ```python
 class SignedBlock(Container):
     message: Block,
-    signature: Bytes32,
+    signature: Signature,
 ```
 
 ## `Vote`
@@ -84,7 +96,7 @@ class Vote(Container):
 ```python
 class SignedVote(Container):
     data: Vote,
-    signature: Bytes32,
+    signature: Signature,
 ```
 
 ## Remarks


### PR DESCRIPTION
## 🗒️ Description

Introduces an _approximate_ Signature container to the client specs.

This is "_approximate_" because while the [size is accurate](https://github.com/leanEthereum/leanSpec/issues/14#issuecomment-3223355674) (`32 * 32 + 28 + 32 * 64 = 3100`), the structure is a simplified version of the [XMSS subspec](https://github.com/leanEthereum/leanSpec/blob/main/src/lean_spec/subspecs/xmss/structures.py#L56-L64) which required `HashTreeOpening`, `HashDigest`, `Randomness`, which is a lot of structure unneeded in devnet0. So I think they're more suitable to be handled in devnet1 where PQ signature will be actually implemented.

Multiple signature types are also not incorporated here because I think it's only relevant for devnet1.

## 🔗 Related Issues or PRs

- Closes https://github.com/leanEthereum/leanSpec/issues/14
