### PR TITLE
fix(networking): update `message-id` calculation

### DIFF
--- a/src/lean_spec/subspecs/networking/gossipsub.py
+++ b/src/lean_spec/subspecs/networking/gossipsub.py
@@ -1,6 +1,18 @@
-"""Gossipsub protocol parameters."""
+"""
+Gossipsub protocol
+
+- Parameters for gossipsub operation.
+- Message ID computation based on topic and message data, with snappy decompression handling.
+"""
+
+import hashlib
+from typing import Callable, Optional
 
 from lean_spec.subspecs.chain.config import DEVNET_CONFIG
+from lean_spec.subspecs.networking.config import (
+    MESSAGE_DOMAIN_INVALID_SNAPPY,
+    MESSAGE_DOMAIN_VALID_SNAPPY,
+)
 from lean_spec.types import StrictBaseModel
 
 
@@ -46,3 +58,68 @@ class GossipsubParameters(StrictBaseModel):
 
     This is calculated as SECONDS_PER_SLOT * JUSTIFICATION_LOOKBACK_SLOTS * 2.
     """
+
+
+MessageId = bytes
+"""A 20-byte ID for gossipsub messages."""
+
+
+def compute_message_id(
+    topic: bytes,
+    data: bytes,
+    snappy_decompress: Optional[Callable[[bytes], bytes]] = None,
+) -> MessageId:
+    """
+    Compute the message ID for a gossipsub message.
+
+    The message ID is computed based on whether the data can be
+    successfully decompressed with snappy.
+
+    Args:
+        topic: The topic byte string.
+        data: The raw message data.
+        snappy_decompress: Optional snappy decompression function.
+            If not provided, treats data as invalid snappy.
+
+    Returns:
+        A 20-byte message ID.
+    """
+    if snappy_decompress is not None:
+        try:
+            # Try to decompress the data with snappy
+            decompressed_data = snappy_decompress(data)
+            # Valid snappy decompression - use valid domain
+            return _compute_message_id_with_domain(
+                MESSAGE_DOMAIN_VALID_SNAPPY, topic, decompressed_data
+            )
+        except Exception:
+            # Invalid snappy decompression - use invalid domain
+            pass
+
+    # No decompressor provided or decompression failed - use invalid domain
+    return _compute_message_id_with_domain(MESSAGE_DOMAIN_INVALID_SNAPPY, topic, data)
+
+
+def _compute_message_id_with_domain(domain: bytes, topic: bytes, message_data: bytes) -> MessageId:
+    """
+    Compute message ID with the given domain.
+
+    Computes SHA256(domain + uint64_le(len(topic)) + topic + message_data)[:20].
+
+    Args:
+        domain: The 4-byte domain for message-id isolation.
+        topic: The topic byte string.
+        message_data: The message data (either decompressed or raw).
+
+    Returns:
+        A 20-byte message ID.
+    """
+    # Encode the topic length as little-endian uint64
+    topic_len_bytes = len(topic).to_bytes(8, "little")
+
+    # Concatenate all components
+    data_to_hash = domain + topic_len_bytes + topic + message_data
+
+    # Compute SHA256 and take first 20 bytes
+    digest = hashlib.sha256(data_to_hash).digest()
+    return digest[:20]

--- a/src/lean_spec/subspecs/networking/gossipsub.py
+++ b/src/lean_spec/subspecs/networking/gossipsub.py
@@ -60,7 +60,10 @@ class GossipsubParameters(StrictBaseModel):
     """
 
 
-MessageId = bytes
+_MessageId = NewType("MessageId", bytes)
+"""Static analysis to prevent accidental misuse of generic bytes."""
+
+MessageId = Annotated[_MessageId, Field(min_length=20, max_length=20)]
 """A 20-byte ID for gossipsub messages."""
 
 

--- a/src/lean_spec/subspecs/networking/gossipsub.py
+++ b/src/lean_spec/subspecs/networking/gossipsub.py
@@ -6,7 +6,9 @@ Gossipsub protocol
 """
 
 import hashlib
-from typing import Callable, Optional
+from typing import Annotated, Callable, Optional
+
+from pydantic import Field
 
 from lean_spec.subspecs.chain.config import DEVNET_CONFIG
 from lean_spec.subspecs.networking.config import (
@@ -60,10 +62,7 @@ class GossipsubParameters(StrictBaseModel):
     """
 
 
-_MessageId = NewType("MessageId", bytes)
-"""Static analysis to prevent accidental misuse of generic bytes."""
-
-MessageId = Annotated[_MessageId, Field(min_length=20, max_length=20)]
+MessageId = Annotated[bytes, Field(min_length=20, max_length=20)]
 """A 20-byte ID for gossipsub messages."""
 
 
@@ -75,6 +74,7 @@ class GossipsubMessage:
     message ID, correctly handling snappy decompression. The generated ID is
     cached for efficiency.
     """
+
     def __init__(
         self,
         topic: bytes,
@@ -93,7 +93,7 @@ class GossipsubMessage:
         self.raw_data: bytes = data
         self._snappy_decompress = snappy_decompress
         # Cache for the computed ID
-        self._id: Optional[MessageId] = None  
+        self._id: Optional[MessageId] = None
 
     @property
     def id(self) -> MessageId:
@@ -129,9 +129,9 @@ class GossipsubMessage:
 
         # The internal computation returns the raw bytes...
         computed_id_bytes = self._compute_raw_id(domain, data_for_hash)
-        
+
         # We then cast to our strict NewType before caching and returning.
-        self._id = _MessageId(computed_id_bytes)
+        self._id = MessageId(computed_id_bytes)
         return self._id
 
     def _compute_raw_id(self, domain: bytes, message_data: bytes) -> bytes:


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

- Update `message-id` to include `topic`: for consistency with Altair as well.
- Add corresponding Python code.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

N/A

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx --with=tox-uv tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
