### PR TITLE
fix(python,uv): Fix issues with local tox use; clarify min python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,22 @@ The Lean Ethereum protocol specifications and cryptographic subspecifications.
 
 ### Prerequisites
 
-- Python 3.12 or later
-- [uv](https://github.com/astral-sh/uv) package manager
+#### Installing uv
+
+[uv](https://github.com/astral-sh/uv) is a fast Python package manager that handles dependencies and Python versions.
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+````
+
+#### Installing Python 3.12+
+
+This project requires Python 3.12 or later and should be installed via `uv`:
+
+```bash
+# Install Python 3.12, or latest stable version
+uv python install 3.12
+```
 
 ### Setup
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,10 @@ env_list =
     docs
 skip_missing_interpreters = true
 
+[testenv]
+basepython = python3
+uv_python = >=3.12
+
 [testenv:all-checks]
 description = Run all quality checks (lint, typecheck, spellcheck)
 extras =


### PR DESCRIPTION
Minor updates to help debug running things locally. Reported issue:

- Running `uvx --with=tox-uv tox -e all-checks` when the user did not have python >= 3.12 (current requirement for the project) does not yield a very good error message and we don't currently walk through this step in the README.

Updates README and the `uv_python` that `tox-uv` should look for. I believe all a user needs to do is `uv python install 3.12` (or any later version) and this should be resolved.