### PR TITLE
fix: replace SLOTS_PER_EPOCH with JUSTIFICATION_LOOKBACK_SLOTS

### DIFF
--- a/src/lean_spec/subspecs/chain/config.py
+++ b/src/lean_spec/subspecs/chain/config.py
@@ -18,8 +18,8 @@ SLOT_DURATION_MS: Final = 4000
 SECONDS_PER_SLOT: Final = SLOT_DURATION_MS // 1000
 """The fixed duration of a single slot in seconds."""
 
-SLOTS_PER_EPOCH: Final = 96
-"""The number of slots in an epoch."""
+SLOTS_JUSTIFICATION_LOOKBACK: Final = 3
+"""The number of slots to lookback for justification."""
 
 PROPOSER_REORG_CUTOFF_BPS: Final = 2500
 """
@@ -81,7 +81,7 @@ class _ChainConfig(BaseModel):
     # Time Parameters
     slot_duration_ms: Uint64
     second_per_slot: Uint64
-    slots_per_epoch: Uint64
+    slots_justification_lookback: Uint64
     proposer_reorg_cutoff_bps: BasisPoint
     vote_due_bps: BasisPoint
     fast_confirm_due_bps: BasisPoint
@@ -96,7 +96,7 @@ class _ChainConfig(BaseModel):
 DEVNET_CONFIG: Final = _ChainConfig(
     slot_duration_ms=SLOT_DURATION_MS,
     second_per_slot=SECONDS_PER_SLOT,
-    slots_per_epoch=SLOTS_PER_EPOCH,
+    slots_justification_lookback=SLOTS_JUSTIFICATION_LOOKBACK,
     proposer_reorg_cutoff_bps=PROPOSER_REORG_CUTOFF_BPS,
     vote_due_bps=VOTE_DUE_BPS,
     fast_confirm_due_bps=FAST_CONFIRM_DUE_BPS,

--- a/src/lean_spec/subspecs/chain/config.py
+++ b/src/lean_spec/subspecs/chain/config.py
@@ -18,7 +18,7 @@ SLOT_DURATION_MS: Final = 4000
 SECONDS_PER_SLOT: Final = SLOT_DURATION_MS // 1000
 """The fixed duration of a single slot in seconds."""
 
-SLOTS_JUSTIFICATION_LOOKBACK: Final = 3
+JUSTIFICATION_LOOKBACK_SLOTS: Final = 3
 """The number of slots to lookback for justification."""
 
 PROPOSER_REORG_CUTOFF_BPS: Final = 2500
@@ -81,7 +81,7 @@ class _ChainConfig(BaseModel):
     # Time Parameters
     slot_duration_ms: Uint64
     second_per_slot: Uint64
-    slots_justification_lookback: Uint64
+    justification_lookback_slots: Uint64
     proposer_reorg_cutoff_bps: BasisPoint
     vote_due_bps: BasisPoint
     fast_confirm_due_bps: BasisPoint
@@ -96,7 +96,7 @@ class _ChainConfig(BaseModel):
 DEVNET_CONFIG: Final = _ChainConfig(
     slot_duration_ms=SLOT_DURATION_MS,
     second_per_slot=SECONDS_PER_SLOT,
-    slots_justification_lookback=SLOTS_JUSTIFICATION_LOOKBACK,
+    justification_lookback_slots=JUSTIFICATION_LOOKBACK_SLOTS,
     proposer_reorg_cutoff_bps=PROPOSER_REORG_CUTOFF_BPS,
     vote_due_bps=VOTE_DUE_BPS,
     fast_confirm_due_bps=FAST_CONFIRM_DUE_BPS,

--- a/src/lean_spec/subspecs/networking/gossipsub.py
+++ b/src/lean_spec/subspecs/networking/gossipsub.py
@@ -39,10 +39,10 @@ class GossipsubParameters(StrictBaseModel):
     """The number of history windows to gossip about."""
 
     seen_ttl_secs: int = (
-        DEVNET_CONFIG.second_per_slot * DEVNET_CONFIG.slots_per_epoch * 2
+        DEVNET_CONFIG.second_per_slot * DEVNET_CONFIG.slots_justification_lookback * 2
     )
     """
     The expiry time in seconds for the cache of seen message IDs.
 
-    This is calculated as SECONDS_PER_SLOT * SLOTS_PER_EPOCH * 2.
+    This is calculated as SECONDS_PER_SLOT * SLOTS_JUSTIFICATION_LOOKBACK * 2.
     """

--- a/src/lean_spec/subspecs/networking/gossipsub.py
+++ b/src/lean_spec/subspecs/networking/gossipsub.py
@@ -39,10 +39,10 @@ class GossipsubParameters(StrictBaseModel):
     """The number of history windows to gossip about."""
 
     seen_ttl_secs: int = (
-        DEVNET_CONFIG.second_per_slot * DEVNET_CONFIG.slots_justification_lookback * 2
+        DEVNET_CONFIG.second_per_slot * DEVNET_CONFIG.justification_lookback_slots * 2
     )
     """
     The expiry time in seconds for the cache of seen message IDs.
 
-    This is calculated as SECONDS_PER_SLOT * SLOTS_JUSTIFICATION_LOOKBACK * 2.
+    This is calculated as SECONDS_PER_SLOT * JUSTIFICATION_LOOKBACK_SLOTS * 2.
     """


### PR DESCRIPTION
## 🗒️ Description

Replaces `SLOTS_PER_EPOCH` with `JUSTIFICATION_LOOKBACK_SLOTS`

## 🔗 Related Issues or PRs

- Problem spotted here: https://github.com/leanEthereum/leanSpec/pull/20#discussion_r2307914381
- Discussion was previously here: https://github.com/leanEthereum/leanSpec/pull/8#pullrequestreview-3119234482
