### PR TITLE
refactor(tests): Use pytest params with ids

### DIFF
--- a/tests/lean_spec/subspecs/xmss/test_interface.py
+++ b/tests/lean_spec/subspecs/xmss/test_interface.py
@@ -57,17 +57,15 @@ def _test_correctness_roundtrip(
 
 
 @pytest.mark.parametrize(
-    "activation_epoch, num_active_epochs, description",
+    "activation_epoch, num_active_epochs",
     [
-        (10, 4, "Standard case with a short, active lifetime"),
-        (0, 8, "Lifetime starting at epoch 0"),
-        (20, 1, "Lifetime with only a single active epoch"),
-        (7, 5, "Lifetime starting at an odd-numbered epoch"),
+        pytest.param(10, 4, id="Standard case with a short, active lifetime"),
+        pytest.param(0, 8, id="Lifetime starting at epoch 0"),
+        pytest.param(20, 1, id="Lifetime with only a single active epoch"),
+        pytest.param(7, 5, id="Lifetime starting at an odd-numbered epoch"),
     ],
 )
-def test_signature_scheme_correctness(
-    activation_epoch: int, num_active_epochs: int, description: str
-) -> None:
+def test_signature_scheme_correctness(activation_epoch: int, num_active_epochs: int) -> None:
     """Runs an end-to-end test of the signature scheme."""
     _test_correctness_roundtrip(
         scheme=TEST_SIGNATURE_SCHEME,

--- a/tests/lean_spec/subspecs/xmss/test_merkle_tree.py
+++ b/tests/lean_spec/subspecs/xmss/test_merkle_tree.py
@@ -63,16 +63,16 @@ def _run_commit_open_verify_roundtrip(
 
 
 @pytest.mark.parametrize(
-    "num_leaves, depth, start_index, leaf_parts_len, description",
+    "num_leaves, depth, start_index, leaf_parts_len",
     [
-        (16, 4, 0, 3, "Full tree (depth 4)"),
-        (12, 5, 0, 5, "Half tree, left-aligned (depth 5)"),
-        (16, 5, 16, 2, "Half tree, right-aligned (depth 5)"),
-        (22, 6, 13, 3, "Sparse, non-aligned tree (depth 6)"),
-        (2, 2, 2, 6, "Half tree, right-aligned (small)"),
-        (1, 1, 0, 1, "Tree with a single leaf at the start"),
-        (1, 1, 1, 1, "Tree with a single leaf at an odd index"),
-        (16, 5, 7, 2, "Small sparse tree starting at an odd index"),
+        pytest.param(16, 4, 0, 3, id="Full tree (depth 4)"),
+        pytest.param(12, 5, 0, 5, id="Half tree, left-aligned (depth 5)"),
+        pytest.param(16, 5, 16, 2, id="Half tree, right-aligned (depth 5)"),
+        pytest.param(22, 6, 13, 3, id="Sparse, non-aligned tree (depth 6)"),
+        pytest.param(2, 2, 2, 6, id="Half tree, right-aligned (small)"),
+        pytest.param(1, 1, 0, 1, id="Tree with a single leaf at the start"),
+        pytest.param(1, 1, 1, 1, id="Tree with a single leaf at an odd index"),
+        pytest.param(16, 5, 7, 2, id="Small sparse tree starting at an odd index"),
     ],
 )
 def test_commit_open_verify_roundtrip(
@@ -80,7 +80,6 @@ def test_commit_open_verify_roundtrip(
     depth: int,
     start_index: int,
     leaf_parts_len: int,
-    description: str,
 ) -> None:
     """Tests the Merkle tree logic for various configurations."""
     # Ensure the test case parameters are valid for the specified tree depth.


### PR DESCRIPTION
## 🗒️ Description

Don't parametrize descriptions, instead use ``pytest.param`` with ``id`` to describe the test case.


This makes it nice for displaying as well. For example, if you run with `-v` (verbose):

```
 pytest tests -k test_signature_scheme_correctness -v
 ```
 
 You get something nice like this:
 
 ```
 tests/lean_spec/subspecs/xmss/test_interface.py::test_signature_scheme_correctness[Standard case with a short, active lifetime] PASSED                                                                    [ 25%]
tests/lean_spec/subspecs/xmss/test_interface.py::test_signature_scheme_correctness[Lifetime starting at epoch 0] PASSED                                                                                   [ 50%]
tests/lean_spec/subspecs/xmss/test_interface.py::test_signature_scheme_correctness[Lifetime with only a single active epoch] PASSED                                                                       [ 75%]
tests/lean_spec/subspecs/xmss/test_interface.py::test_signature_scheme_correctness[Lifetime starting at an odd-numbered epoch] PASSED                                                                     [100%]
```