### PR TITLE
add(networking): tests for message_id generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = ["pydantic>=2.9.2,<3", "typing-extensions>=4.4"]
 file = "LICENSE"
 
 [project.optional-dependencies]
-test = ["pytest>=8.3.3,<9", "pytest-cov>=6.0.0,<7", "pytest-xdist>=3.6.1,<4", "hypothesis>=6.138.14"]
+test = ["pytest>=8.3.3,<9", "pytest-cov>=6.0.0,<7", "pytest-xdist>=3.6.1,<4", "hypothesis>=6.138.14", "python-snappy>=0.7.3"]
 lint = ["ruff>=0.11.8,<1"]
 typecheck = ["mypy>=1.15.0,<1.16"]
 docs = [

--- a/src/lean_spec/subspecs/networking/gossipsub.py
+++ b/src/lean_spec/subspecs/networking/gossipsub.py
@@ -15,7 +15,7 @@ from lean_spec.subspecs.networking.config import (
     MESSAGE_DOMAIN_INVALID_SNAPPY,
     MESSAGE_DOMAIN_VALID_SNAPPY,
 )
-from lean_spec.types import StrictBaseModel
+from lean_spec.types import StrictBaseModel, Uint64
 
 
 class GossipsubParameters(StrictBaseModel):
@@ -53,7 +53,7 @@ class GossipsubParameters(StrictBaseModel):
     """The number of history windows to gossip about."""
 
     seen_ttl_secs: int = (
-        DEVNET_CONFIG.second_per_slot * DEVNET_CONFIG.justification_lookback_slots * 2
+        DEVNET_CONFIG.second_per_slot * DEVNET_CONFIG.justification_lookback_slots * Uint64(2)
     )
     """
     The expiry time in seconds for the cache of seen message IDs.

--- a/tests/lean_spec/subspecs/networking/test_message_id.py
+++ b/tests/lean_spec/subspecs/networking/test_message_id.py
@@ -1,0 +1,66 @@
+"""Tests for the message ID computation in GossipsubMessage."""
+
+import snappy  # type: ignore[import-untyped]
+
+from lean_spec.subspecs.networking.gossipsub import GossipsubMessage
+
+
+def test_message_id_computation_basic() -> None:
+    """Test basic message ID computation without snappy decompression."""
+    message = GossipsubMessage(topic=b"test", data=b"hello")
+    message_id = message.id
+
+    # Verify the ID is exactly 20 bytes long
+    assert len(message_id) == 20
+
+    # Verify the ID is correct
+    assert message_id == bytes.fromhex("a7f41aaccd241477955c981714eb92244c2efc98")
+
+
+def test_message_id_computation_with_snappy() -> None:
+    """Test the message ID computation with snappy."""
+    message = GossipsubMessage(
+        topic=b"test", data=snappy.compress(b"hello"), snappy_decompress=snappy.decompress
+    )
+    message_id = message.id
+
+    assert len(message_id) == 20
+    assert message_id == bytes.fromhex("2e40c861545cc5b46d2220062e7440b9190bc383")
+
+
+def test_message_id_computation_with_invalid_snappy() -> None:
+    """Test the message ID computation when snappy decompression fails."""
+
+    def _raise_invalid_snappy(data: bytes) -> bytes:
+        raise Exception("Invalid snappy")
+
+    message = GossipsubMessage(
+        topic=b"test", data=b"hello", snappy_decompress=_raise_invalid_snappy
+    )
+    message_id = message.id
+
+    assert len(message_id) == 20
+    # When snappy decompression fails, it should fall back to MESSAGE_DOMAIN_INVALID_SNAPPY
+    # This should produce the same ID as the no-snappy case
+    assert message_id == bytes.fromhex("a7f41aaccd241477955c981714eb92244c2efc98")
+
+
+def test_message_id_caching() -> None:
+    """Test that message ID is computed once and then cached."""
+    call_count = 0
+
+    def counting_decompress(data: bytes) -> bytes:
+        nonlocal call_count
+        call_count += 1
+        return data
+
+    message = GossipsubMessage(topic=b"test", data=b"hello", snappy_decompress=counting_decompress)
+
+    # First access should trigger computation
+    first_id = message.id
+    assert call_count == 1
+
+    # Second access should use cached value
+    second_id = message.id
+    assert call_count == 1  # Should not increment
+    assert first_id == second_id


### PR DESCRIPTION
## 🗒️ Description
Adds tests for message_id generation, helpful for client teams to verify their implementation

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx --with=tox-uv tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
