### PR TITLE
docs: use mdformat to format markdown files under `docs/`

### DIFF
--- a/docs/client/chain.md
+++ b/docs/client/chain.md
@@ -117,7 +117,9 @@ def set_justifications(state: State, justifications: Dict[str, List[bool]]) -> N
         flattened_justifications.extend(justifications[root])
 
     # Create a new Bitlist with all the flattened votes
-    justifications_validators = Bitlist[HISTORICAL_ROOTS_LIMIT * VALIDATOR_REGISTRY_LIMIT](*flattened_justifications)
+    justifications_validators = Bitlist[HISTORICAL_ROOTS_LIMIT * VALIDATOR_REGISTRY_LIMIT](
+        *flattened_justifications
+    )
 
     state.justifications_roots = justifications_roots
     state.justifications_validators = justifications_validators
@@ -133,8 +135,8 @@ def is_justifiable_slot(finalized_slot: int, candidate: int):
     delta = candidate - finalized_slot
     return (
         delta <= 5
-        or (delta ** 0.5) % 1 == 0            # any x^2
-        or ((delta + 0.25) ** 0.5) % 1 == 0.5 # any x^2+x
+        or (delta**0.5) % 1 == 0  # any x^2
+        or ((delta + 0.25) ** 0.5) % 1 == 0.5  # any x^2+x
     )
 ```
 
@@ -153,16 +155,15 @@ Even though `Devnet0` has no individual validators tracking, there would also be
 
 ```python
 def generate_genesis_state(genesis_time: uint64, num_validators: uint64) -> State:
-  state = State(
-    config=Config(
-      genesis_time=genesis_time,
-      num_validators=num_validators,
-    ),
-    latest_block_header=BlockHeader(body_root=hash_tree_root(BlockBody())),
-  )
+    state = State(
+        config=Config(
+            genesis_time=genesis_time,
+            num_validators=num_validators,
+        ),
+        latest_block_header=BlockHeader(body_root=hash_tree_root(BlockBody())),
+    )
 
-  return state;
-}
+    return state
 ```
 
 ### Genesis block

--- a/docs/client/containers.md
+++ b/docs/client/containers.md
@@ -1,3 +1,5 @@
+# Containers
+
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Encoding](#encoding)
@@ -15,8 +17,6 @@
 
 <!-- mdformat-toc end -->
 
-# Containers
-
 ## Encoding
 
 The containers for various blockchain consensus objects are primarily SSZ objects. To be more prover friendly, the Poseidon2 hasher will be used for hash tree rooting of these objects. However `devnet0` & `devnet1` continue to use the sha256 hasher.
@@ -25,7 +25,7 @@ The containers for various blockchain consensus objects are primarily SSZ object
 
 ```python
 class Config(Container):
-    // temporary property to support simplified round robin block production in absence of randao & deposit mechanisms
+    # temporary property to support simplified round robin block production in absence of randao & deposit mechanisms
     num_validators: uint64
     genesis_time: uint64
 ```
@@ -55,9 +55,7 @@ class State(Container):
     # Diverged from 3SF-mini.py:
     # Flattened `justifications: Dict[str, List[bool]]` for SSZ compatibility
     justifications_roots: List[Bytes32, HISTORICAL_ROOTS_LIMIT]
-    justifications_validators: Bitlist[
-        HISTORICAL_ROOTS_LIMIT * VALIDATOR_REGISTRY_LIMIT
-    ]
+    justifications_validators: Bitlist[HISTORICAL_ROOTS_LIMIT * VALIDATOR_REGISTRY_LIMIT]
 ```
 
 ## `Block`
@@ -65,7 +63,7 @@ class State(Container):
 ```python
 class Block(Container):
     slot: uint64
-    proposer_index: uin64
+    proposer_index: uint64
     parent_root: Bytes32
     state_root: Bytes32
     body: BlockBody
@@ -95,8 +93,8 @@ Remark: `SignedVote` will be replaced by aggregated attestations.
 
 ```python
 class SignedBlock(Container):
-    message: Block,
-    signature: Vector[byte, 4000],
+    message: Block
+    signature: Vector[byte, 4000]
 ```
 
 ## `Vote`
@@ -115,10 +113,10 @@ class Vote(Container):
 
 ```python
 class SignedVote(Container):
-    validator_id: uint64,
-    message: Vote,
+    validator_id: uint64
+    message: Vote
     # signature over vote message only as it would be aggregated later in attestation
-    signature: Vector[byte, 4000],
+    signature: Vector[byte, 4000]
 ```
 
 #### `Attestation`
@@ -129,7 +127,7 @@ The votes are aggregated in `Attestation` similar to beacon protocol but without
 class Attestation(Container):
     aggregation_bits: Bitlist[VALIDATOR_REGISTRY_LIMIT]
     message: Vote
-    # this is an aggregated zk proof and is not a fix size signature 
+    # this is an aggregated zk proof and is not a fix size signature
     signature: List[byte, 4000]
 ```
 

--- a/docs/client/networking.md
+++ b/docs/client/networking.md
@@ -1,3 +1,5 @@
+# Networking
+
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Setup](#setup)
@@ -59,8 +61,8 @@ This section outlines configurations that are used in this spec.
 | Name                            | Value                      | Description                                                                |
 | ------------------------------- | -------------------------- | -------------------------------------------------------------------------- |
 | `MAX_REQUEST_BLOCKS`            | `2**10` (= 1024)           | Maximum number of blocks in a single request                               |
-| `MESSAGE_DOMAIN_INVALID_SNAPPY` | `DomainType('0x00000000')` | 4-byte domain for gossip message-id isolation of *invalid* snappy messages |
-| `MESSAGE_DOMAIN_VALID_SNAPPY`   | `DomainType('0x01000000')` | 4-byte domain for gossip message-id isolation of *valid* snappy messages   |
+| `MESSAGE_DOMAIN_INVALID_SNAPPY` | `DomainType('0x00000000')` | 4-byte domain for gossip message-id isolation of _invalid_ snappy messages |
+| `MESSAGE_DOMAIN_VALID_SNAPPY`   | `DomainType('0x01000000')` | 4-byte domain for gossip message-id isolation of _valid_ snappy messages   |
 
 ## Gossip domain
 
@@ -83,7 +85,7 @@ will be used:
   responses): 6
 - `mcache_gossip` (number of windows to gossip about): 3
 - `seen_ttl` (expiry time for cache of seen message ids, seconds):
-  SECONDS_PER_SLOT * SLOTS_PER_EPOCH * 2
+  `SECONDS_PER_SLOT * SLOTS_PER_EPOCH * 2`
 
 #### Topics and messages
 
@@ -199,7 +201,7 @@ Once the handshake completes, the client with the lower `finalized_epoch` or
 `head_slot` (if the clients have equal `finalized_epoch`s) SHOULD request blocks
 from its counterparty via the `BlocksByRoot` request.
 
-*Note*: Under abnormal network condition or after some rounds of
+_Note_: Under abnormal network condition or after some rounds of
 `BlocksByRoot` requests, the client might need to send `Status` request
 again to learn if the peer has a higher head. Implementers are free to implement
 such behavior in their own way.

--- a/docs/client/validator.md
+++ b/docs/client/validator.md
@@ -1,3 +1,5 @@
+# Honest Validator
+
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Validator identification](#validator-identification)
@@ -10,8 +12,6 @@
 - [Remarks](#remarks)
 
 <!-- mdformat-toc end -->
-
-# Validator
 
 ## Validator identification
 
@@ -46,37 +46,33 @@ The validator constructs, signs a `Block` message and further broadcasts the `Si
 
 ```python
 def produce_block(store: Store, slot: Slot) -> Block:
-  head_root = get_proposal_head(store)
-  head_state = store.states[head_root]
+    head_root = get_proposal_head(store)
+    head_state = store.states[head_root]
 
-  new_block, state = None, None
-  votes_to_add = []
+    new_block, state = None, None
+    votes_to_add = []
 
-  # Keep attempt to add valid votes from the list of available votes
-  while 1:
-      new_block = Block(
-          slot=new_slot,
-          parent=store.head,
-          votes=votes_to_add
-      )
-      state = process_block(head_state, new_block)
-      new_votes_to_add = [
-          vote for vote in store.latest_known_votes if
-          vote.source == state.latest_justified and
-          vote not in votes_to_add
-      ]
+    # Keep attempt to add valid votes from the list of available votes
+    while 1:
+        new_block = Block(slot=new_slot, parent=store.head, votes=votes_to_add)
+        state = process_block(head_state, new_block)
+        new_votes_to_add = [
+            vote
+            for vote in store.latest_known_votes
+            if vote.source == state.latest_justified and vote not in votes_to_add
+        ]
 
-      if len(new_votes_to_add) == 0:
-          break
-      votes_to_add.extend(new_votes_to_add)
+        if len(new_votes_to_add) == 0:
+            break
+        votes_to_add.extend(new_votes_to_add)
 
-  new_block.state_root = compute_hash(state)
-  new_hash = compute_hash(new_block)
+    new_block.state_root = compute_hash(state)
+    new_hash = compute_hash(new_block)
 
-  store.blocks[new_hash] = new_block
-  store.states[new_hash] = state
+    store.blocks[new_hash] = new_block
+    store.states[new_hash] = state
 
-  return new_block
+    return new_block
 ```
 
 ## Attesting
@@ -102,7 +98,6 @@ def produce_attestation_vote(store: Store, slot: Slot) -> Vote:
     """
     head = get_proposal_head(store, slot)
     target = get_vote_target(store)
-
 
     return Vote(
         slot=slot,

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,8 @@ format for the time being and are subject to change.
 ## Design Principles
 
 1. **Clarity over Performance**: Readable reference implementations
-2. **Strong Typing**: Pydantic models with full validation
-3. **Test Coverage**: Extensive tests for all modules
+1. **Strong Typing**: Pydantic models with full validation
+1. **Test Coverage**: Extensive tests for all modules
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,13 @@ docs = [
     "pyspelling>=2.8.2,<3",
 ]
 dev = ["lean-spec[test,lint,typecheck,docs]", "tox>=4.23.0,<5"]
+mdformat = [
+    "mdformat-gfm-alerts==2.0.0",
+    "mdformat-gfm==0.4.1",
+    "mdformat-ruff==0.1.3",
+    "mdformat-toc==0.3.0",
+    "mdformat==0.7.22",
+]
 
 [project.urls]
 Homepage = "https://github.com/leanEthereum/lean-spec"
@@ -106,6 +113,10 @@ markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 [tool.coverage.run]
 source = ["src"]
 branch = true
+
+[tool.mdformat]
+number = true
+wrap = 80
 
 [tool.uv]
 dev-dependencies = [

--- a/tox.ini
+++ b/tox.ini
@@ -10,16 +10,18 @@ basepython = python3
 uv_python = >=3.12
 
 [testenv:all-checks]
-description = Run all quality checks (lint, typecheck, spellcheck)
+description = Run all quality checks (lint, typecheck, spellcheck, mdformat)
 extras =
     lint
     typecheck
     test
     docs
+    mdformat
 commands =
     {[testenv:lint]commands}
     {[testenv:typecheck]commands}
     {[testenv:spellcheck]commands}
+    {[testenv:mdformat]commands}
 
 [testenv:lint]
 description = Lint and code formatting checks (ruff)
@@ -46,6 +48,11 @@ commands = mypy src tests
 description = Run spell checking (codespell)
 extras = docs
 commands = codespell src tests docs README.md CLAUDE.md --skip="*.lock,*.svg,.git,__pycache__,.mypy_cache,.pytest_cache" --ignore-words=.codespell-ignore-words.txt
+
+[testenv:mdformat]
+description = Check markdown formatting for docs (mdformat)
+extras = mdformat
+commands = mdformat docs/
 
 [testenv:pytest]
 description = Run tests (pytest)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

Use `mdformat` and its extensions for better documentation. This PR includes:

- Add `mdformat` as deps.
- New task for `tox` so that CI will automatically catch bad formatted files.
- Format existing files under `docs/`: mostly Python issues.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

N/A

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx --with=tox-uv tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
