### PR TITLE
fix deprecated `tool.uv.dev-dependencies` field to `dependency-groups.dev` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,8 @@ branch = true
 number = true
 wrap = 80
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ipython>=8.31.0,<9",
     "ipdb>=0.13",
     "tomli-w>=1.0.0",


### PR DESCRIPTION
## 🗒️ Description

There's a warning when run `uv sync --all-extras` step in README:
```
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx --with=tox-uv tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
