### PR TITLE
fix: typo in proposer_index type declaration

### DIFF
--- a/docs/client/containers.md
+++ b/docs/client/containers.md
@@ -74,7 +74,7 @@ class Block(Container):
 ```python
 class BlockHeader(Container):
     slot: uint64
-    proposer_index: uin64
+    proposer_index: uint64
     parent_root: Bytes32
     state_root: Bytes32
     body_root: Bytes32


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx --with=tox-uv tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
