### PR TITLE
fix: justifications_validators size and use DEVNET_CONFIG

### DIFF
--- a/src/lean_spec/subspecs/containers/state/types.py
+++ b/src/lean_spec/subspecs/containers/state/types.py
@@ -1,33 +1,34 @@
 """State-specific SSZ types for the Lean Ethereum consensus specification."""
 
+from lean_spec.subspecs.chain.config import DEVNET_CONFIG
 from lean_spec.types import Bytes32, SSZList
 from lean_spec.types.bitfields import BaseBitlist
-
-# Maximum number of historical roots to keep
-HISTORICAL_ROOTS_LIMIT = 262144
 
 
 class HistoricalBlockHashes(SSZList):
     """List of historical block root hashes up to historical_roots_limit."""
 
     ELEMENT_TYPE = Bytes32
-    LIMIT = HISTORICAL_ROOTS_LIMIT
+    LIMIT = DEVNET_CONFIG.historical_roots_limit.as_int()
 
 
 class JustificationRoots(SSZList):
     """List of justified block roots up to historical_roots_limit."""
 
     ELEMENT_TYPE = Bytes32
-    LIMIT = HISTORICAL_ROOTS_LIMIT
+    LIMIT = DEVNET_CONFIG.historical_roots_limit.as_int()
 
 
 class JustifiedSlots(BaseBitlist):
     """Bitlist tracking justified slots up to historical roots limit."""
 
-    LIMIT = HISTORICAL_ROOTS_LIMIT
+    LIMIT = DEVNET_CONFIG.historical_roots_limit.as_int()
 
 
 class JustificationValidators(BaseBitlist):
-    """Bitlist for tracking validator justifications (262144^2 limit)."""
+    """Bitlist for tracking validator justifications per historical root."""
 
-    LIMIT = HISTORICAL_ROOTS_LIMIT * HISTORICAL_ROOTS_LIMIT
+    LIMIT = (
+        DEVNET_CONFIG.historical_roots_limit.as_int()
+        * DEVNET_CONFIG.validator_registry_limit.as_int()
+    )


### PR DESCRIPTION
## 🗒️ Description

- Use `DEVNET_CONFIG.historical_roots_limit` instead of declaring `HISTORICAL_ROOTS_LIMIT` separately
- Fix `JustificationValidators` size from `historical_roots_limit * historical_roots_limit` to `historical_roots_limit * validator_registry_limit`