### PR TITLE
[DRAFT] feat: pqsig specs for devnet1

### DIFF
--- a/src/lean_spec/subspecs/containers/block/block.py
+++ b/src/lean_spec/subspecs/containers/block/block.py
@@ -3,6 +3,7 @@
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.types import Bytes32, Uint64
 from lean_spec.types.container import Container
+from lean_spec.subspecs.xmss.containers import Signature
 
 from .types import Attestations
 
@@ -62,8 +63,7 @@ class SignedBlock(Container):
     message: Block
     """The block being signed."""
 
-    signature: Bytes32
+    signature: Signature
     """
     The proposer's signature of the block message.
-    Note: Bytes32 is a placeholder; the actual signature is much larger.
     """

--- a/src/lean_spec/subspecs/containers/signed_message_bundle.py
+++ b/src/lean_spec/subspecs/containers/signed_message_bundle.py
@@ -1,0 +1,20 @@
+"""Message Bundle Containers."""
+
+from lean_spec.types.container import Container
+from lean_spec.subspecs.xmss.containers import Signature
+
+from .block import Block
+from .vote import Vote
+
+
+class SignedMessageBundle(Container):
+    """Represents a validator's signed message bundle."""
+
+    block_message: Block
+    """The block message."""
+
+    vote_data: Vote
+    """The vote data."""
+
+    signature: Signature
+    """The signature of the message bundle."""

--- a/src/lean_spec/subspecs/containers/state/state.py
+++ b/src/lean_spec/subspecs/containers/state/state.py
@@ -24,6 +24,7 @@ from .types import (
     JustificationRoots,
     JustificationValidators,
     JustifiedSlots,
+    Validators,
 )
 
 
@@ -37,6 +38,9 @@ class State(Container):
     # Slot and block tracking
     slot: Slot
     """The current slot number."""
+
+    validators: Validators
+    """The list of validators."""
 
     latest_block_header: BlockHeader
     """The header of the most recent block."""

--- a/src/lean_spec/subspecs/containers/state/types.py
+++ b/src/lean_spec/subspecs/containers/state/types.py
@@ -1,7 +1,7 @@
 """State-specific SSZ types for the Lean Ethereum consensus specification."""
 
 from lean_spec.subspecs.chain.config import DEVNET_CONFIG
-from lean_spec.types import Bytes32, SSZList
+from lean_spec.types import Bytes32, SSZList, Validator
 from lean_spec.types.bitfields import BaseBitlist
 
 
@@ -32,3 +32,9 @@ class JustificationValidators(BaseBitlist):
         DEVNET_CONFIG.historical_roots_limit.as_int()
         * DEVNET_CONFIG.validator_registry_limit.as_int()
     )
+
+class Validators(SSZList):
+    """List of validators up to validator registry limit."""
+
+    ELEMENT_TYPE = Validator
+    LIMIT = DEVNET_CONFIG.validator_registry_limit.as_int()

--- a/src/lean_spec/subspecs/containers/vote.py
+++ b/src/lean_spec/subspecs/containers/vote.py
@@ -3,6 +3,7 @@
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.types import Bytes32, Uint64
 from lean_spec.types.container import Container
+from lean_spec.subspecs.xmss.containers import Signature
 
 from .checkpoint import Checkpoint
 
@@ -32,9 +33,5 @@ class SignedVote(Container):
     data: Vote
     """The vote data."""
 
-    signature: Bytes32
-    """
-    The signature of the vote data.
-
-    Note: Bytes32 is a placeholder; the actual signature is much larger.
-    """
+    signature: Signature
+    """The signature of the vote data."""

--- a/src/lean_spec/types/__init__.py
+++ b/src/lean_spec/types/__init__.py
@@ -7,13 +7,14 @@ from .byte_arrays import Bytes32
 from .collections import SSZList, SSZVector
 from .container import Container
 from .uint import Uint64
-from .validator import ValidatorIndex, is_proposer
+from .validator import Validator, ValidatorIndex, is_proposer
 
 __all__ = [
     "Uint64",
     "BasisPoint",
     "Bytes32",
     "StrictBaseModel",
+    "Validator",
     "ValidatorIndex",
     "is_proposer",
     "SSZList",

--- a/src/lean_spec/types/validator.py
+++ b/src/lean_spec/types/validator.py
@@ -1,9 +1,17 @@
 """Validator-related type definitions and utilities for the specification."""
 
+from lean_spec.subspecs.xmss.containers import PublicKey
+from lean_spec.types.container import Container
 from .uint import Uint64
 
 ValidatorIndex = Uint64
 """A type alias for a validator's index in the registry."""
+
+class Validator(Container):
+    """A validator."""
+
+    pubkey: PublicKey
+    """The validator's public key."""
 
 
 def is_proposer(validator_index: ValidatorIndex, slot: Uint64, num_validators: Uint64) -> bool:
@@ -22,3 +30,4 @@ def is_proposer(validator_index: ValidatorIndex, slot: Uint64, num_validators: U
         True if the validator is the proposer for the slot, False otherwise.
     """
     return slot % num_validators == validator_index
+


### PR DESCRIPTION
Opening this PR prematurely for discussion

## 🗒️ Description

Listing down expected changes if we introduce `SignedMessageBundle` to allow a single PQ key to authenticate multiple actions in a slot. The general direction from PQinterop keygen session.

We can take another path and just keep the signed messages separate i.e. `SignedBlock`, `SignedVote` but need more discussion on requiring multiple PQkeys or whether 1 action per slot is really acceptable.

### Container changes
  - [x] Modify: `State::validators: { pubkeys: xmss::containers::PublicKey }`
  - [ ] Modify: `BlockBody::attestations: List[SignedMessageBundle]`
  - [x] Add `SignedMessageBundle : { block_message: Block, vote_data: Vote, signature: Signature }`
  - [ ] Add: `Signature: { path: HashTreeOpening, rho: Randomness, hashes: List[HashDigest] }` -> Added but not 
  - [ ] Remove: `SignedBlock` -> use `SignedMessageBundle` instead
  - [ ] Remove: `SignedVote` -> use `SignedMessageBundle` instead

### STF changes
  - [ ] Modify: `state_transition` from receiving `signed_block` to `block` and block signature pre-validated
  - [ ] Add: `process_bundle(signed_message_bundle)`
  - [ ] ❓ Modify: `process_attestations()`from receiving `attestations: List[SignedVote]` to `List[SignedMessageBundle]` (TBD)

### Gossipsub
  - [ ] ❓ Add: `SignedMessageBundle`
  - [ ] ❓ Remove: `SignedBlock`
  - [ ] ❓ Remove: `SignedVote`
  
Note: this looks worse for network optimization

### ResResp
- [ ] ❓ Modify: `BlocksByRootResponse` ReqResp returns `List[SignedBlock]` -> returns `List[SignedMessageBundle]`. Ideal?

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx --with=tox-uv tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
