### PR TITLE
feat(tooling): Add support for python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Checkout leanSpec
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Checkout leanSpec
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">=3.12"
-dependencies = ["pydantic>=2.9.2,<3", "typing-extensions>=4.4"]
+dependencies = ["pydantic>=2.12.0,<3", "typing-extensions>=4.4"]
 
 [project.license]
 file = "LICENSE"


### PR DESCRIPTION
## 🗒️ Description

Adds official support for newly released Python 3. Only major hiccup I saw was we needed to bump `pydantic` to `>=2.12` which introduced official Python 3.14 support [here](https://pydantic.dev/articles/pydantic-v2-12-release).

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx --with=tox-uv tox
    ```
