### PR TITLE
feat: update Gossip Topic name Vote -> Attestation

### DIFF
--- a/docs/client/networking.md
+++ b/docs/client/networking.md
@@ -69,7 +69,7 @@ Two main message types exist:
 Blocks are proposed by validators. They propagate on the block topic. Every
 node needs to see blocks quickly.
 
-Votes come from all validators. They propagate on the vote topic. High volume
+Attestations come from all validators. They propagate on the attestation topic. High volume
 but small messages.
 
 ### Encoding
@@ -127,7 +127,7 @@ messages or violating protocol rules.
 All connections are encrypted. Eavesdroppers cannot read network traffic.
 
 Messages are authenticated at the application layer. Validators sign their
-votes and blocks. This prevents impersonation.
+attestations and blocks. This prevents impersonation.
 
 The network must resist denial of service. Rate limiting and resource
 management protect against overload.


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

We should do away with the `Vote` gossip message since we are pivoting to a more `Attestation` centric nomenclature as per https://github.com/leanEthereum/leanSpec/pull/67
This changes the Gossip topic from `vote` to `attestation`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx --with=tox-uv tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
