### PR TITLE
forkchoice: don't modify attestation during block production

### DIFF
--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -506,20 +506,8 @@ class Store(Container):
                 if data.source != post_state.latest_justified:
                     continue
 
-                # Create attestation with post-state's latest justified as source
-                attestation_data = AttestationData(
-                    slot=data.slot,
-                    head=data.head,
-                    target=data.target,
-                    source=post_state.latest_justified,
-                )
-                candidate_attestation = Attestation(
-                    validator_id=signed_attestation.message.validator_id,
-                    data=attestation_data,
-                )
-
-                if candidate_attestation not in attestations:
-                    new_attestations.append(candidate_attestation)
+                if signed_attestation.message not in attestations:
+                    new_attestations.append(signed_attestation.message)
                     new_signatures.append(signed_attestation.signature)
 
             # Fixed point reached: no new attestations found


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

Should close https://github.com/leanEthereum/leanSpec/issues/82

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox -e all-checks,pytest
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
