### PR TITLE
fix: make `Store` mutable

### DIFF
--- a/tests/lean_spec/subspecs/forkchoice/test_store_lifecycle.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_store_lifecycle.py
@@ -185,17 +185,6 @@ class TestStoreDefaultValues:
         assert len(store.latest_known_attestations) == 0
         assert len(store.latest_new_attestations) == 0
 
-    def test_store_immutability(self, sample_store: Store) -> None:
-        """Test that Store fields are immutable (frozen)."""
-        original_time = sample_store.time
-
-        # Should not be able to modify Store fields directly
-        with pytest.raises((AttributeError, ValueError)):  # Pydantic frozen model
-            sample_store.time = Uint64(999)  # type: ignore[misc]
-
-        # Store should remain unchanged
-        assert sample_store.time == original_time
-
 
 class TestStoreValidation:
     """Test Store field validation."""

--- a/tests/lean_spec/subspecs/forkchoice/test_time_management.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_time_management.py
@@ -144,7 +144,7 @@ class TestIntervalTicking:
 
         # Reset store to known state
         initial_time = Uint64(0)
-        object.__setattr__(sample_store, "time", initial_time)
+        sample_store.time = initial_time
 
         # Add some test attestations for processing
         test_checkpoint = Checkpoint(root=Bytes32(b"test" + b"\x00" * 28), slot=Slot(1))
@@ -310,7 +310,7 @@ class TestProposalHeadTiming:
         sample_store.blocks[genesis_hash] = genesis_block
 
         # Set store head to genesis
-        object.__setattr__(sample_store, "head", genesis_hash)
+        sample_store.head = genesis_hash
 
         # Get proposal head for slot 0
         head = sample_store.get_proposal_head(Slot(0))


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

Currently, `Store` inherits SSZ `Container` class which enforce the fork choice store immutable. This led some anti patterns like `object.__setattr__` to modify its field, and I think `Store` should be modifiable to track the necessary values. Also `Store` isn't a target for SSZ encoding/decoding.

This PR nukes immutability of `Store` by giving `BaseModel` from Pydantic as inheritance.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox -e all-checks,pytest
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
