### PR TITLE
chore: add tox command for client tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,8 @@ commands = pytest {posargs} tests -n auto --maxprocesses=10 --durations=10 --dis
 description = Run tests with coverage (pytest)
 commands = pytest --cov --cov-report=html --cov-report=term {posargs}
 
-[testenv:pytest-client]
-description = Run client tests (pytest)
+[testenv:pytest-consensus]
+description = Run consensus tests (pytest)
 commands = pytest {posargs} -n auto --maxprocesses=10 --durations=10 --dist=worksteal \
     tests/lean_spec/subspecs/containers \
     tests/lean_spec/subspecs/forkchoice \


### PR DESCRIPTION
## 🗒️ Description

Adds `uvx tox -e pytest-client` for running client-related tests. 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
