### PR TITLE
forkchoice store: avoid mutable self

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -269,7 +269,7 @@ class ForkChoiceTest(BaseConsensusFixture):
         )
 
         # Process to get correct state root
-        post_state = temp_state.on_block(temp_block)
+        post_state = temp_state.process_block(temp_block)
         correct_state_root = hash_tree_root(post_state)
 
         # Create final block

--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -230,7 +230,7 @@ class StateTransitionTest(BaseConsensusFixture):
                 state_root=Bytes32.zero(),
                 body=body,
             )
-            post_state = temp_state.on_block(temp_block)
+            post_state = temp_state.process_block(temp_block)
             state_root = hash_tree_root(post_state)
 
         # Create final block with all fields

--- a/src/lean_spec/subspecs/containers/state/state.py
+++ b/src/lean_spec/subspecs/containers/state/state.py
@@ -389,7 +389,7 @@ class State(Container):
         # Return the state with all header updates applied.
         return self.model_copy(update=updates)
 
-    def on_block(self, block: Block) -> "State":
+    def process_block(self, block: Block) -> "State":
         """
         Apply full block processing including header and body.
 
@@ -528,7 +528,7 @@ class State(Container):
         state = self.process_slots(block.slot)
 
         # Process the block itself.
-        new_state = state.on_block(block)
+        new_state = state.process_block(block)
 
         # Validate that the block's state root matches the computed state
         computed_state_root = hash_tree_root(new_state)

--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -839,7 +839,7 @@ class Store(Container):
             # Apply state transition to get the post-block state
             # First advance state to target slot, then process the block
             advanced_state = head_state.process_slots(slot)
-            post_state = advanced_state.on_block(candidate_block)
+            post_state = advanced_state.process_block(candidate_block)
 
             # Find new valid attestations matching post-state justification
             new_attestations: list[Attestation] = []
@@ -880,7 +880,7 @@ class Store(Container):
         )
 
         # Apply state transition to get final post-state and compute state root
-        final_post_state = final_state.on_block(final_block)
+        final_post_state = final_state.process_block(final_block)
         finalized_block = final_block.model_copy(
             update={"state_root": hash_tree_root(final_post_state)}
         )

--- a/tests/lean_spec/subspecs/containers/test_state.py
+++ b/tests/lean_spec/subspecs/containers/test_state.py
@@ -669,12 +669,12 @@ def test_process_attestations_justification_and_finalization(genesis_state: Stat
     state_at_slot_1 = state.process_slots(Slot(1))
     # Create and process the block at slot 1.
     block1 = _create_block(1, state_at_slot_1.latest_block_header)
-    state = state_at_slot_1.on_block(block1)
+    state = state_at_slot_1.process_block(block1)
 
     # Move to slot 4 and produce/process a block.
     state_at_slot_4 = state.process_slots(Slot(4))
     block4 = _create_block(4, state_at_slot_4.latest_block_header)
-    state = state_at_slot_4.on_block(block4)
+    state = state_at_slot_4.process_block(block4)
 
     # Advance to slot 5 so the header at slot 4 caches its state root.
     state = state.process_slots(Slot(5))
@@ -737,7 +737,7 @@ def test_state_transition_full(genesis_state: State) -> None:
     block = _create_block(1, state_at_slot_1.latest_block_header)
 
     # Manually compute the post-state result of processing this block.
-    expected_state = state_at_slot_1.on_block(block)
+    expected_state = state_at_slot_1.process_block(block)
     # Embed the correct state root into the header to simulate a valid block.
     block_with_correct_root = block.model_copy(
         update={"state_root": hash_tree_root(expected_state)}


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

@syjn99 I guess this should solve the problem you had in #94 with the mess due to mutable objects. I've tried to rearrange things and documentation a bit so that:
- everything is clearer
- we don't mutate self anymore in the store.py file, everything is immutable and we return new copy each time

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
