### PR TITLE
feat: add devnet versioning

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,0 +1,3 @@
+| Version  |             Last Commit Hash             |                                          Link                                          |
+| :------: | :--------------------------------------: | :------------------------------------------------------------------------------------: |
+| Devnet 0 | 4b750f2748a3718fe3e1e9cdb3c65e3a7ddabff5 | https://github.com/leanEthereum/leanSpec/tree/4b750f2748a3718fe3e1e9cdb3c65e3a7ddabff5 |


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

As more devnets release the changes will have a compounding effect and it might be nice if one could compare entire changes between devnet X and devnet Y.

But since we are currently at a very fast paced, heavy changes phase it does not seem feasible to maintain branch/tags or file format separation similar to Beacon specs.

This approach uses a simple markdown file to hold mapping for `Devnet -> Last Hash -> Link` . This has minimum maintainence overhead while still solving the issue.

Looking through the past commits, I believe this was the last commit for `Devnet 0` and it was also made during the Cambridge retreat


## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
