### PR TITLE
chore: remove unused slot timing constants

### DIFF
--- a/src/lean_spec/subspecs/chain/config.py
+++ b/src/lean_spec/subspecs/chain/config.py
@@ -7,17 +7,14 @@ Lean Consensus Experimental Chain.
 
 from typing_extensions import Final
 
-from lean_spec.types import BasisPoint, StrictBaseModel, Uint64
+from lean_spec.types import StrictBaseModel, Uint64
 
 # --- Time Parameters ---
 
 INTERVALS_PER_SLOT = Uint64(4)
 """Number of intervals per slot for forkchoice processing."""
 
-SLOT_DURATION_MS: Final = Uint64(4000)
-"""The fixed duration of a single slot in milliseconds."""
-
-SECONDS_PER_SLOT: Final = SLOT_DURATION_MS // Uint64(1000)
+SECONDS_PER_SLOT: Final = Uint64(4)
 """The fixed duration of a single slot in seconds."""
 
 SECONDS_PER_INTERVAL = SECONDS_PER_SLOT // INTERVALS_PER_SLOT
@@ -25,40 +22,6 @@ SECONDS_PER_INTERVAL = SECONDS_PER_SLOT // INTERVALS_PER_SLOT
 
 JUSTIFICATION_LOOKBACK_SLOTS: Final = Uint64(3)
 """The number of slots to lookback for justification."""
-
-PROPOSER_REORG_CUTOFF_BPS: Final = Uint64(2500)
-"""
-The deadline within a slot (in basis points) for a proposer to publish a
-block.
-
-Honest validators may re-org blocks published after this cutoff.
-
-(2500 bps = 25% of slot duration).
-"""
-
-VOTE_DUE_BPS: Final = Uint64(5000)
-"""
-The deadline within a slot (in basis points) by which validators must
-submit their votes.
-
-(5000 bps = 50% of slot duration).
-"""
-
-FAST_CONFIRM_DUE_BPS: Final = Uint64(7500)
-"""
-The deadline within a slot (in basis points) for achieving a fast
-confirmation.
-
-(7500 bps = 75% of slot duration).
-"""
-
-VIEW_FREEZE_CUTOFF_BPS: Final = Uint64(7500)
-"""
-The cutoff within a slot (in basis points) after which the current view is
-considered 'frozen', preventing further changes.
-
-(7500 bps = 75% of slot duration).
-"""
 
 # --- State List Length Presets ---
 
@@ -81,13 +44,8 @@ class _ChainConfig(StrictBaseModel):
     """
 
     # Time Parameters
-    slot_duration_ms: Uint64
-    second_per_slot: Uint64
+    seconds_per_slot: Uint64
     justification_lookback_slots: Uint64
-    proposer_reorg_cutoff_bps: BasisPoint
-    vote_due_bps: BasisPoint
-    fast_confirm_due_bps: BasisPoint
-    view_freeze_cutoff_bps: BasisPoint
 
     # State List Length Presets
     historical_roots_limit: Uint64
@@ -96,13 +54,8 @@ class _ChainConfig(StrictBaseModel):
 
 # The Devnet Chain Configuration.
 DEVNET_CONFIG: Final = _ChainConfig(
-    slot_duration_ms=SLOT_DURATION_MS,
-    second_per_slot=SECONDS_PER_SLOT,
+    seconds_per_slot=SECONDS_PER_SLOT,
     justification_lookback_slots=JUSTIFICATION_LOOKBACK_SLOTS,
-    proposer_reorg_cutoff_bps=PROPOSER_REORG_CUTOFF_BPS,
-    vote_due_bps=VOTE_DUE_BPS,
-    fast_confirm_due_bps=FAST_CONFIRM_DUE_BPS,
-    view_freeze_cutoff_bps=VIEW_FREEZE_CUTOFF_BPS,
     historical_roots_limit=HISTORICAL_ROOTS_LIMIT,
     validator_registry_limit=VALIDATOR_REGISTRY_LIMIT,
 )

--- a/src/lean_spec/subspecs/networking/gossipsub/parameters.py
+++ b/src/lean_spec/subspecs/networking/gossipsub/parameters.py
@@ -39,7 +39,7 @@ class GossipsubParameters(StrictBaseModel):
     """The number of history windows to gossip about."""
 
     seen_ttl_secs: int = (
-        DEVNET_CONFIG.second_per_slot.as_int()
+        DEVNET_CONFIG.seconds_per_slot.as_int()
         * DEVNET_CONFIG.justification_lookback_slots.as_int()
         * 2
     )


### PR DESCRIPTION
## 🗒️ Description

These constants were introduced in devnet0 to align with https://github.com/ethereum/consensus-specs/pull/4476 but since we have not used them we should remove then until it's ready to be introduced with their related logic.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
