### PR TITLE
fix: use SECONDS_PER_SLOT when deriving slots from time

### DIFF
--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -126,7 +126,7 @@ class Store(Container):
         anchor_checkpoint = Checkpoint(root=anchor_root, slot=anchor_slot)
 
         return cls(
-            time=Uint64(anchor_slot * INTERVALS_PER_SLOT),
+            time=Uint64(anchor_slot * SECONDS_PER_SLOT),
             config=state.config,
             head=anchor_root,
             safe_target=anchor_root,
@@ -168,7 +168,7 @@ class Store(Container):
         assert target_block.slot == data.target.slot, "Target checkpoint slot mismatch"
 
         # Validate attestation is not too far in the future
-        current_slot = Slot(self.time // INTERVALS_PER_SLOT)
+        current_slot = Slot(self.time // SECONDS_PER_SLOT)
         assert data.slot <= Slot(current_slot + Slot(1)), "Attestation too far in future"
 
     def on_attestation(
@@ -246,7 +246,7 @@ class Store(Container):
             #   contributing to fork choice weights.
 
             # Ensure forkchoice is current before processing gossip
-            time_slots = self.time // INTERVALS_PER_SLOT
+            time_slots = self.time // SECONDS_PER_SLOT
             assert attestation_slot <= time_slots, "Attestation from future slot"
 
             # Update new attestations if this is latest from validator
@@ -630,7 +630,7 @@ class Store(Container):
         """
         # Advance time by one interval
         store = self.model_copy(update={"time": self.time + Uint64(1)})
-        current_interval = store.time % INTERVALS_PER_SLOT
+        current_interval = store.time % SECONDS_PER_SLOT % INTERVALS_PER_SLOT
 
         if current_interval == Uint64(0):
             # Start of slot - process attestations if proposal exists


### PR DESCRIPTION
## 🗒️ Description

Most slot calculation were using `INTERVALS_PER_SLOT` to derive slot number from time. This is only a coincidence that it's correct because both `SECONDS_PER_SLOT = 4` and `INTERVALS_PER_SLOT = 4`.

A quick mental check on this is imagine we have more sub-slots cutoffs but slot time is still the same at 4 seconds, so `INTERVALS_PER_SLOT = 6` but `SECONDS_PER_SLOT = 4`.

Then `current_slot = Slot(self.time // INTERVALS_PER_SLOT)` becomes `current_slot = Slot(self.time // 6)` which gives the wrong slot number at 4 seconds per slot. It should be `current_slot = Slot(self.time // SECONDS_PER_SLOT)`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
