### PR TITLE
chore: rename advance_time to on_tick

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -143,7 +143,7 @@ class ForkChoiceTest(BaseConsensusFixture):
             try:
                 if isinstance(step, TickStep):
                     # Advance time (immutable)
-                    store = store.advance_time(Uint64(step.time), has_proposal=False)
+                    store = store.on_tick(Uint64(step.time), has_proposal=False)
 
                 elif isinstance(step, BlockStep):
                     # Build SignedBlockWithAttestation from BlockSpec
@@ -166,7 +166,7 @@ class ForkChoiceTest(BaseConsensusFixture):
 
                     # Automatically advance time to block's slot before processing (immutable)
                     block_time = store.config.genesis_time + block.slot * Uint64(SECONDS_PER_SLOT)
-                    store = store.advance_time(block_time, has_proposal=True)
+                    store = store.on_tick(block_time, has_proposal=True)
 
                     # Process the block (immutable)
                     store = store.on_block(signed_block)

--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -645,7 +645,7 @@ class Store(Container):
 
         return store
 
-    def advance_time(self, time: Uint64, has_proposal: bool) -> "Store":
+    def on_tick(self, time: Uint64, has_proposal: bool) -> "Store":
         """
         Advance forkchoice store time to given timestamp.
 
@@ -663,7 +663,7 @@ class Store(Container):
         Example:
             >>> # Advance from slot 0 to slot 5
             >>> slot_5_time = config.genesis_time + 5 * SECONDS_PER_SLOT
-            >>> store = store.advance_time(slot_5_time, has_proposal=True)
+            >>> store = store.on_tick(slot_5_time, has_proposal=True)
         """
         # Calculate target time in intervals
         tick_interval_time = (time - self.config.genesis_time) // SECONDS_PER_INTERVAL
@@ -704,7 +704,7 @@ class Store(Container):
         slot_time = self.config.genesis_time + slot * SECONDS_PER_SLOT
 
         # Advance time to current slot (ticking intervals)
-        store = self.advance_time(slot_time, True)
+        store = self.on_tick(slot_time, True)
 
         # Process any pending attestations before proposal
         store = store.accept_new_attestations()

--- a/tests/lean_spec/subspecs/forkchoice/test_time_management.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_time_management.py
@@ -60,46 +60,46 @@ def sample_store(sample_config: Config) -> Store:
     )
 
 
-class TestTimeAdvancement:
-    """Test Store time advancement functionality."""
+class TestOnTick:
+    """Test Store on_tick functionality."""
 
-    def test_advance_time_basic(self, sample_store: Store) -> None:
-        """Test basic time advancement."""
+    def test_on_tick_basic(self, sample_store: Store) -> None:
+        """Test basic on_tick."""
         initial_time = sample_store.time
         target_time = sample_store.config.genesis_time + Uint64(200)  # Much later time
 
-        sample_store = sample_store.advance_time(target_time, has_proposal=True)
+        sample_store = sample_store.on_tick(target_time, has_proposal=True)
 
         # Time should advance
         assert sample_store.time > initial_time
 
-    def test_advance_time_no_proposal(self, sample_store: Store) -> None:
-        """Test time advancement without proposal."""
+    def test_on_tick_no_proposal(self, sample_store: Store) -> None:
+        """Test on_tick without proposal."""
         initial_time = sample_store.time
         target_time = sample_store.config.genesis_time + Uint64(100)
 
-        sample_store = sample_store.advance_time(target_time, has_proposal=False)
+        sample_store = sample_store.on_tick(target_time, has_proposal=False)
 
         # Time should still advance
         assert sample_store.time >= initial_time
 
-    def test_advance_time_already_current(self, sample_store: Store) -> None:
-        """Test advance_time when already at target time."""
+    def test_on_tick_already_current(self, sample_store: Store) -> None:
+        """Test on_tick when already at target time."""
         initial_time = sample_store.time
         current_target = sample_store.config.genesis_time + initial_time
 
         # Try to advance to current time (should be no-op)
-        sample_store = sample_store.advance_time(current_target, has_proposal=True)
+        sample_store = sample_store.on_tick(current_target, has_proposal=True)
 
         # Should not change significantly
         assert abs(sample_store.time.as_int() - initial_time.as_int()) <= 10  # small tolerance
 
-    def test_advance_time_small_increment(self, sample_store: Store) -> None:
-        """Test advance_time with small time increment."""
+    def test_on_tick_small_increment(self, sample_store: Store) -> None:
+        """Test on_tick with small time increment."""
         initial_time = sample_store.time
         target_time = sample_store.config.genesis_time + initial_time + Uint64(1)
 
-        sample_store = sample_store.advance_time(target_time, has_proposal=False)
+        sample_store = sample_store.on_tick(target_time, has_proposal=False)
 
         # Should advance by small amount
         assert sample_store.time >= initial_time


### PR DESCRIPTION
## 🗒️ Description

I noticed that `advance_time` is the same logic as `on_tick` back in the [markdown leanspecs](https://github.com/leanEthereum/leanSpec/blob/4b750f2748a3718fe3e1e9cdb3c65e3a7ddabff5/docs/client/forkchoice.md#on_tick) and also in the [beacon specs](https://ethereum.github.io/consensus-specs/specs/phase0/fork-choice/#on_tick).

Because we're using `on_block` and `on_attestation` terminology, so I think we should use `on_tick` as well.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
