### PR TITLE
test: add tests for genesis

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/state_expectation.py
+++ b/packages/testing/src/consensus_testing/test_types/state_expectation.py
@@ -3,6 +3,12 @@
 from typing import TYPE_CHECKING
 
 from lean_spec.subspecs.containers.slot import Slot
+from lean_spec.subspecs.containers.state.types import (
+    HistoricalBlockHashes,
+    JustificationRoots,
+    JustificationValidators,
+    JustifiedSlots,
+)
 from lean_spec.types import Bytes32, CamelModel
 
 if TYPE_CHECKING:
@@ -45,14 +51,38 @@ class StateExpectation(CamelModel):
     validator_count: int | None = None
     """Expected number of validators."""
 
+    config_genesis_time: int | None = None
+    """Expected genesis time in the config."""
+
     latest_block_header_slot: Slot | None = None
     """Expected slot of the latest block header."""
+
+    latest_block_header_proposer_index: int | None = None
+    """Expected proposer index in the latest block header."""
+
+    latest_block_header_parent_root: Bytes32 | None = None
+    """Expected parent root in the latest block header."""
 
     latest_block_header_state_root: Bytes32 | None = None
     """Expected state root in the latest block header."""
 
+    latest_block_header_body_root: Bytes32 | None = None
+    """Expected body root in the latest block header."""
+
     historical_block_hashes_count: int | None = None
     """Expected number of historical block hashes."""
+
+    historical_block_hashes: HistoricalBlockHashes | None = None
+    """Expected historical block hashes collection."""
+
+    justified_slots: JustifiedSlots | None = None
+    """Expected justified slots bitlist."""
+
+    justifications_roots: JustificationRoots | None = None
+    """Expected justifications roots collection."""
+
+    justifications_validators: JustificationValidators | None = None
+    """Expected justifications validators bitlist."""
 
     def validate_against_state(self, state: "State") -> None:
         """
@@ -124,12 +154,36 @@ class StateExpectation(CamelModel):
                         f"expected {expected_value}"
                     )
 
+            elif field_name == "config_genesis_time":
+                actual_time = int(state.config.genesis_time)
+                if actual_time != expected_value:
+                    raise AssertionError(
+                        f"State validation failed: config.genesis_time = {actual_time}, "
+                        f"expected {expected_value}"
+                    )
+
             elif field_name == "latest_block_header_slot":
                 actual_slot = state.latest_block_header.slot
                 if actual_slot != expected_value:
                     raise AssertionError(
                         f"State validation failed: latest_block_header.slot = {actual_slot}, "
                         f"expected {expected_value}"
+                    )
+
+            elif field_name == "latest_block_header_proposer_index":
+                actual_proposer = int(state.latest_block_header.proposer_index)
+                if actual_proposer != expected_value:
+                    raise AssertionError(
+                        f"State validation failed: latest_block_header.proposer_index = "
+                        f"{actual_proposer}, expected {expected_value}"
+                    )
+
+            elif field_name == "latest_block_header_parent_root":
+                actual_parent_root = state.latest_block_header.parent_root
+                if actual_parent_root != expected_value:
+                    raise AssertionError(
+                        f"State validation failed: latest_block_header.parent_root = "
+                        f"0x{actual_parent_root.hex()}, expected 0x{expected_value.hex()}"
                     )
 
             elif field_name == "latest_block_header_state_root":
@@ -140,10 +194,46 @@ class StateExpectation(CamelModel):
                         f"0x{actual_state_root.hex()}, expected 0x{expected_value.hex()}"
                     )
 
+            elif field_name == "latest_block_header_body_root":
+                actual_body_root = state.latest_block_header.body_root
+                if actual_body_root != expected_value:
+                    raise AssertionError(
+                        f"State validation failed: latest_block_header.body_root = "
+                        f"0x{actual_body_root.hex()}, expected 0x{expected_value.hex()}"
+                    )
+
             elif field_name == "historical_block_hashes_count":
                 actual_count = len(state.historical_block_hashes)
                 if actual_count != expected_value:
                     raise AssertionError(
                         f"State validation failed: historical_block_hashes count = {actual_count}, "
                         f"expected {expected_value}"
+                    )
+
+            elif field_name == "historical_block_hashes":
+                if state.historical_block_hashes != expected_value:
+                    raise AssertionError(
+                        f"State validation failed: historical_block_hashes = "
+                        f"{state.historical_block_hashes}, expected {expected_value}"
+                    )
+
+            elif field_name == "justified_slots":
+                if state.justified_slots != expected_value:
+                    raise AssertionError(
+                        f"State validation failed: justified_slots = "
+                        f"{state.justified_slots}, expected {expected_value}"
+                    )
+
+            elif field_name == "justifications_roots":
+                if state.justifications_roots != expected_value:
+                    raise AssertionError(
+                        f"State validation failed: justifications_roots = "
+                        f"{state.justifications_roots}, expected {expected_value}"
+                    )
+
+            elif field_name == "justifications_validators":
+                if state.justifications_validators != expected_value:
+                    raise AssertionError(
+                        f"State validation failed: justifications_validators = "
+                        f"{state.justifications_validators}, expected {expected_value}"
                     )

--- a/tests/consensus/devnet/state_transition/test_genesis.py
+++ b/tests/consensus/devnet/state_transition/test_genesis.py
@@ -1,0 +1,156 @@
+"""
+State Transition: Genesis State
+=================================
+
+Overview
+--------
+Tests for genesis state generation and initialization.
+"""
+
+import pytest
+from consensus_testing import StateExpectation, StateTransitionTestFiller, generate_pre_state
+
+from lean_spec.subspecs.containers.block import BlockBody
+from lean_spec.subspecs.containers.block.types import Attestations
+from lean_spec.subspecs.containers.slot import Slot
+from lean_spec.subspecs.containers.state import Validators
+from lean_spec.subspecs.containers.state.types import (
+    HistoricalBlockHashes,
+    JustificationRoots,
+    JustificationValidators,
+    JustifiedSlots,
+)
+from lean_spec.subspecs.containers.validator import Validator
+from lean_spec.subspecs.ssz.hash import hash_tree_root
+from lean_spec.types import Bytes32, Bytes52, Uint64
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_genesis_default_configuration(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test genesis state with default configuration.
+
+    Scenario
+    --------
+    Generate a genesis state with default parameters:
+    - genesis_time = 0
+    - 4 validators with zero pubkeys
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[],
+        post=StateExpectation(
+            slot=Slot(0),
+            config_genesis_time=0,
+            validator_count=4,
+            latest_justified_slot=Slot(0),
+            latest_justified_root=Bytes32.zero(),
+            latest_finalized_slot=Slot(0),
+            latest_finalized_root=Bytes32.zero(),
+            latest_block_header_slot=Slot(0),
+            latest_block_header_proposer_index=0,
+            latest_block_header_parent_root=Bytes32.zero(),
+            latest_block_header_state_root=Bytes32.zero(),
+            latest_block_header_body_root=hash_tree_root(
+                BlockBody(attestations=Attestations(data=[]))
+            ),
+            historical_block_hashes=HistoricalBlockHashes(data=[]),
+            justified_slots=JustifiedSlots(data=[]),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
+        ),
+    )
+
+
+def test_genesis_custom_time(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test genesis state with custom genesis time.
+
+    Scenario
+    --------
+    Generate a genesis state with:
+    - genesis_time = 1234567890
+    - Default 4 validators
+
+    Expected Behavior
+    -----------------
+    Genesis state should respect the custom genesis time while
+    maintaining all other genesis properties.
+    """
+    genesis_time = Uint64(1234567890)
+
+    state_transition_test(
+        pre=generate_pre_state(genesis_time=genesis_time),
+        blocks=[],
+        post=StateExpectation(
+            slot=Slot(0),
+            config_genesis_time=int(genesis_time),
+            validator_count=4,
+            latest_justified_slot=Slot(0),
+            latest_justified_root=Bytes32.zero(),
+            latest_finalized_slot=Slot(0),
+            latest_finalized_root=Bytes32.zero(),
+            latest_block_header_slot=Slot(0),
+            latest_block_header_proposer_index=0,
+            latest_block_header_parent_root=Bytes32.zero(),
+            latest_block_header_state_root=Bytes32.zero(),
+            latest_block_header_body_root=hash_tree_root(
+                BlockBody(attestations=Attestations(data=[]))
+            ),
+            historical_block_hashes=HistoricalBlockHashes(data=[]),
+            justified_slots=JustifiedSlots(data=[]),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
+        ),
+    )
+
+
+def test_genesis_custom_validator_set(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test genesis state with custom validator set.
+
+    Scenario
+    --------
+    Generate a genesis state with:
+    - 8 validators instead of default 4
+    - Custom validator pubkeys
+
+    Expected Behavior
+    -----------------
+    Genesis state should contain exactly 8 validators while
+    maintaining all other genesis properties.
+    """
+    # Create 8 validators with unique pubkeys
+    validators = Validators(data=[Validator(pubkey=Bytes52(bytes([i] * 52))) for i in range(8)])
+
+    state_transition_test(
+        pre=generate_pre_state(validators=validators),
+        blocks=[],
+        post=StateExpectation(
+            slot=Slot(0),
+            config_genesis_time=0,
+            validator_count=8,
+            latest_justified_slot=Slot(0),
+            latest_justified_root=Bytes32.zero(),
+            latest_finalized_slot=Slot(0),
+            latest_finalized_root=Bytes32.zero(),
+            latest_block_header_slot=Slot(0),
+            latest_block_header_proposer_index=0,
+            latest_block_header_parent_root=Bytes32.zero(),
+            latest_block_header_state_root=Bytes32.zero(),
+            latest_block_header_body_root=hash_tree_root(
+                BlockBody(attestations=Attestations(data=[]))
+            ),
+            historical_block_hashes=HistoricalBlockHashes(data=[]),
+            justified_slots=JustifiedSlots(data=[]),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
+        ),
+    )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

I realized that the state transition function tests lacked a simple test to test all the fields of the genesis setup.

So I added the necessary tools and a couple of tests to properly test this basic element.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
