### PR TITLE
validator index: transform to class and impl `is_proposer`

### DIFF
--- a/src/lean_spec/subspecs/containers/block/block.py
+++ b/src/lean_spec/subspecs/containers/block/block.py
@@ -10,7 +10,7 @@ can propose.
 """
 
 from lean_spec.subspecs.containers.slot import Slot
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, ValidatorIndex
 from lean_spec.types.container import Container
 
 from ..attestation import Attestation
@@ -48,7 +48,7 @@ class BlockHeader(Container):
     slot: Slot
     """The slot in which the block was proposed."""
 
-    proposer_index: Uint64
+    proposer_index: ValidatorIndex
     """The index of the validator that proposed the block."""
 
     parent_root: Bytes32
@@ -67,7 +67,7 @@ class Block(Container):
     slot: Slot
     """The slot in which the block was proposed."""
 
-    proposer_index: Uint64
+    proposer_index: ValidatorIndex
     """The index of the validator that proposed the block."""
 
     parent_root: Bytes32

--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -39,7 +39,6 @@ from lean_spec.types import (
     Bytes32,
     Uint64,
     ValidatorIndex,
-    is_proposer,
 )
 from lean_spec.types.container import Container
 
@@ -816,7 +815,7 @@ class Store(Container):
 
         # Validate proposer authorization for this slot
         num_validators = Uint64(head_state.validators.count)
-        assert is_proposer(validator_index, slot, num_validators), (
+        assert validator_index.is_proposer(slot, num_validators), (
             f"Validator {validator_index} is not the proposer for slot {slot}"
         )
 

--- a/src/lean_spec/types/__init__.py
+++ b/src/lean_spec/types/__init__.py
@@ -7,7 +7,7 @@ from .byte_arrays import Bytes32, Bytes52, Bytes3100
 from .collections import SSZList, SSZVector
 from .container import Container
 from .uint import Uint64
-from .validator import ValidatorIndex, is_proposer
+from .validator import ValidatorIndex
 
 __all__ = [
     "Uint64",
@@ -18,7 +18,6 @@ __all__ = [
     "CamelModel",
     "StrictBaseModel",
     "ValidatorIndex",
-    "is_proposer",
     "SSZList",
     "SSZVector",
     "Boolean",

--- a/src/lean_spec/types/validator.py
+++ b/src/lean_spec/types/validator.py
@@ -2,23 +2,32 @@
 
 from .uint import Uint64
 
-ValidatorIndex = Uint64
-"""A type alias for a validator's index in the registry."""
 
-
-def is_proposer(validator_index: ValidatorIndex, slot: Uint64, num_validators: Uint64) -> bool:
+class ValidatorIndex(Uint64):
     """
-    Determine if a validator is the proposer for a given slot.
+    A validator's index in the registry.
 
-    Uses round-robin proposer selection based on slot number and total
-    validator count, following the lean protocol specification.
-
-    Args:
-        validator_index: The validator's unique index.
-        slot: The slot number to check proposer assignment for.
-        num_validators: Total number of validators in the registry.
-
-    Returns:
-        True if the validator is the proposer for the slot, False otherwise.
+    Extends Uint64 with proposer selection logic for determining
+    if this validator is the proposer for a given slot.
     """
-    return slot % num_validators == validator_index
+
+    def is_proposer(self, slot: Uint64, num_validators: Uint64) -> bool:
+        """
+        Determine if this validator is the proposer for a given slot.
+
+        Uses round-robin proposer selection based on slot number and total
+        validator count, following the lean protocol specification.
+
+        Parameters:
+        ----------
+        slot : Uint64
+            The slot number to check proposer assignment for.
+        num_validators : Uint64
+            Total number of validators in the registry.
+
+        Returns:
+        -------
+        bool
+            True if this validator is the proposer for the slot, False otherwise.
+        """
+        return slot % num_validators == self

--- a/tests/lean_spec/subspecs/forkchoice/test_validator.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_validator.py
@@ -27,7 +27,6 @@ from lean_spec.subspecs.containers.state import (
 from lean_spec.subspecs.forkchoice import Store
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.types import Bytes32, Bytes52, Uint64, ValidatorIndex
-from lean_spec.types.validator import is_proposer
 
 
 @pytest.fixture
@@ -617,7 +616,7 @@ class TestValidatorErrorHandling:
         num_validators = Uint64(state.validators.count)
 
         # is_proposer should work (though likely return False)
-        result = is_proposer(large_validator, large_slot, num_validators)
+        result = large_validator.is_proposer(large_slot, num_validators)
         assert isinstance(result, bool)
 
         # produce_attestation should work for any validator

--- a/tests/lean_spec/types/test_validator_utils.py
+++ b/tests/lean_spec/types/test_validator_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from lean_spec.types import Uint64, ValidatorIndex, is_proposer
+from lean_spec.types import Uint64, ValidatorIndex
 
 
 class TestIsProposer:
@@ -18,16 +18,16 @@ class TestIsProposer:
         num_validators = Uint64(10)
 
         # At slot 0, validator 0 should be the proposer (0 % 10 == 0)
-        assert is_proposer(ValidatorIndex(0), Uint64(0), num_validators) is True
-        assert is_proposer(ValidatorIndex(1), Uint64(0), num_validators) is False
+        assert ValidatorIndex(0).is_proposer(Uint64(0), num_validators) is True
+        assert ValidatorIndex(1).is_proposer(Uint64(0), num_validators) is False
 
         # At slot 7, validator 7 should be the proposer (7 % 10 == 7)
-        assert is_proposer(ValidatorIndex(7), Uint64(7), num_validators) is True
-        assert is_proposer(ValidatorIndex(8), Uint64(7), num_validators) is False
+        assert ValidatorIndex(7).is_proposer(Uint64(7), num_validators) is True
+        assert ValidatorIndex(8).is_proposer(Uint64(7), num_validators) is False
 
         # At slot 9, validator 9 should be the proposer (9 % 10 == 9)
-        assert is_proposer(ValidatorIndex(9), Uint64(9), num_validators) is True
-        assert is_proposer(ValidatorIndex(0), Uint64(9), num_validators) is False
+        assert ValidatorIndex(9).is_proposer(Uint64(9), num_validators) is True
+        assert ValidatorIndex(0).is_proposer(Uint64(9), num_validators) is False
 
     def test_is_proposer_wraparound(self) -> None:
         """
@@ -39,16 +39,16 @@ class TestIsProposer:
         num_validators = Uint64(10)
 
         # At slot 10, wrap-around selects validator 0 (10 % 10 == 0)
-        assert is_proposer(ValidatorIndex(0), Uint64(10), num_validators) is True
-        assert is_proposer(ValidatorIndex(1), Uint64(10), num_validators) is False
+        assert ValidatorIndex(0).is_proposer(Uint64(10), num_validators) is True
+        assert ValidatorIndex(1).is_proposer(Uint64(10), num_validators) is False
 
         # At slot 23, wrap-around selects validator 3 (23 % 10 == 3)
-        assert is_proposer(ValidatorIndex(3), Uint64(23), num_validators) is True
-        assert is_proposer(ValidatorIndex(2), Uint64(23), num_validators) is False
+        assert ValidatorIndex(3).is_proposer(Uint64(23), num_validators) is True
+        assert ValidatorIndex(2).is_proposer(Uint64(23), num_validators) is False
 
         # At slot 100, wrap-around selects validator 0 (100 % 10 == 0)
-        assert is_proposer(ValidatorIndex(0), Uint64(100), num_validators) is True
-        assert is_proposer(ValidatorIndex(5), Uint64(100), num_validators) is False
+        assert ValidatorIndex(0).is_proposer(Uint64(100), num_validators) is True
+        assert ValidatorIndex(5).is_proposer(Uint64(100), num_validators) is False
 
     def test_is_proposer_large_numbers(self) -> None:
         """
@@ -59,14 +59,14 @@ class TestIsProposer:
         num_validators = Uint64(1000)
 
         # Test with large slot numbers
-        assert is_proposer(ValidatorIndex(555), Uint64(555), num_validators) is True
-        assert is_proposer(ValidatorIndex(556), Uint64(555), num_validators) is False
+        assert ValidatorIndex(555).is_proposer(Uint64(555), num_validators) is True
+        assert ValidatorIndex(556).is_proposer(Uint64(555), num_validators) is False
 
         # Test wrap-around with large numbers
         slot = Uint64(12345)
         expected_proposer = ValidatorIndex(slot % num_validators)  # 345
-        assert is_proposer(expected_proposer, slot, num_validators) is True
-        assert is_proposer(ValidatorIndex(0), slot, num_validators) is False
+        assert expected_proposer.is_proposer(slot, num_validators) is True
+        assert ValidatorIndex(0).is_proposer(slot, num_validators) is False
 
     def test_is_proposer_single_validator(self) -> None:
         """
@@ -77,9 +77,9 @@ class TestIsProposer:
         num_validators = Uint64(1)
 
         # With only one validator, they should always be the proposer
-        assert is_proposer(ValidatorIndex(0), Uint64(0), num_validators) is True
-        assert is_proposer(ValidatorIndex(0), Uint64(1), num_validators) is True
-        assert is_proposer(ValidatorIndex(0), Uint64(100), num_validators) is True
+        assert ValidatorIndex(0).is_proposer(Uint64(0), num_validators) is True
+        assert ValidatorIndex(0).is_proposer(Uint64(1), num_validators) is True
+        assert ValidatorIndex(0).is_proposer(Uint64(100), num_validators) is True
 
     def test_is_proposer_edge_cases(self) -> None:
         """
@@ -91,14 +91,14 @@ class TestIsProposer:
         num_validators = Uint64(3)
 
         # Test all validators in a 3-validator system
-        assert is_proposer(ValidatorIndex(0), Uint64(0), num_validators) is True
-        assert is_proposer(ValidatorIndex(1), Uint64(1), num_validators) is True
-        assert is_proposer(ValidatorIndex(2), Uint64(2), num_validators) is True
+        assert ValidatorIndex(0).is_proposer(Uint64(0), num_validators) is True
+        assert ValidatorIndex(1).is_proposer(Uint64(1), num_validators) is True
+        assert ValidatorIndex(2).is_proposer(Uint64(2), num_validators) is True
 
         # Test wrap-around in small system
-        assert is_proposer(ValidatorIndex(0), Uint64(3), num_validators) is True
-        assert is_proposer(ValidatorIndex(1), Uint64(4), num_validators) is True
-        assert is_proposer(ValidatorIndex(2), Uint64(5), num_validators) is True
+        assert ValidatorIndex(0).is_proposer(Uint64(3), num_validators) is True
+        assert ValidatorIndex(1).is_proposer(Uint64(4), num_validators) is True
+        assert ValidatorIndex(2).is_proposer(Uint64(5), num_validators) is True
 
     def test_is_proposer_validation(self) -> None:
         """
@@ -116,7 +116,7 @@ class TestIsProposer:
             for validator_idx in range(5):
                 validator = ValidatorIndex(validator_idx)
                 expected_result = validator == expected_proposer
-                actual_result = is_proposer(validator, slot, num_validators)
+                actual_result = validator.is_proposer(slot, num_validators)
 
                 assert actual_result == expected_result, (
                     f"Slot {slot_num}: validator {validator_idx} should "
@@ -135,11 +135,11 @@ class TestIsProposer:
         validator = ValidatorIndex(3)
         slot = Uint64(10)  # 10 % 7 = 3
 
-        assert is_proposer(validator, slot, num_validators) is True
+        assert validator.is_proposer(slot, num_validators) is True
 
         # Test with different validator
         other_validator = ValidatorIndex(4)
-        assert is_proposer(other_validator, slot, num_validators) is False
+        assert other_validator.is_proposer(slot, num_validators) is False
 
     @pytest.mark.parametrize("num_validators", [1, 2, 5, 10, 100, 1000])
     def test_is_proposer_parametrized(self, num_validators: int) -> None:
@@ -156,9 +156,9 @@ class TestIsProposer:
             expected_proposer = ValidatorIndex(slot_num % num_validators)
 
             # The expected proposer should return True
-            assert is_proposer(expected_proposer, slot, validators) is True
+            assert expected_proposer.is_proposer(slot, validators) is True
 
             # A different validator should return False
             if num_validators > 1:
                 other_validator = ValidatorIndex((slot_num + 1) % num_validators)
-                assert is_proposer(other_validator, slot, validators) is False
+                assert other_validator.is_proposer(slot, validators) is False


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

I think this is clearer to have `is_proposer` implemented directly into `ValidatorIndex` and not to have this into the `State` implementation which seemed weird to me.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
