### PR TITLE
Add Status Exchange requirements

### DIFF
--- a/src/lean_spec/subspecs/networking/reqresp/message.py
+++ b/src/lean_spec/subspecs/networking/reqresp/message.py
@@ -28,6 +28,8 @@ class Status(StrictBaseModel):
     the peer-to-peer handshake. It allows nodes to verify compatibility and
     determine if they are on the same chain.
 
+    For devnet 2, we include the following changes
+
     The dialing client MUST send a `Status` request upon connection.
 
     The request/response MUST be encoded as an SSZ-container.


### PR DESCRIPTION
## 🗒️ Description

I copy pasted this from our original networking doc https://github.com/leanEthereum/leanSpec/pull/8/files#diff-80d51cf6fd9015f791df4db30f7101a089f95f4bfe1ece79ddce8ee7665c76cfR170-R192

I am opening this PR as @unnawut said in our team call that @g11tech wanted to test the reqresp domain in devnet1.

I am not too concerned with the final result we end up with, I am mostly opening this PR to start a conversion on what we want to do.

Since we have specified the `Status` message, I think we should specify the behavior. Maybe that is desired in a devnet beyond devnet1. 

But I think we should start specifying the desired req/resp behavior we want for devnet1, assuming there is consensus to test the req/resp domain in devnet1. 

I am interested in what others think

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
