### PR TITLE
testing tools: redesign `XmssKeyManager`

### DIFF
--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -1,6 +1,6 @@
 """XMSS key management utilities for testing."""
 
-from typing import Optional
+from typing import NamedTuple, Optional
 
 from lean_spec.subspecs.containers import Attestation, Signature
 from lean_spec.subspecs.containers.slot import Slot
@@ -10,94 +10,166 @@ from lean_spec.subspecs.xmss.interface import DEFAULT_SIGNATURE_SCHEME
 from lean_spec.types import ValidatorIndex
 
 
-class XmssKeyManager:
-    """
-    Manages XMSS keys for test validators.
+class KeyPair(NamedTuple):
+    """A validator’s XMSS key pair."""
 
-    Generates and manages XMSS key pairs for validators on demand.
-    Keys are generated to be valid up to the specified max_slot.
-    """
+    public: PublicKey
+    """The validator’s public key (used for verification)."""
+
+    secret: SecretKey
+    """The validator’s secret key (used for signing)."""
+
+
+class XmssKeyManager:
+    """Lazy key manager for test validators using XMSS signatures."""
 
     DEFAULT_MAX_SLOT = Slot(100)
-    """Default maximum slot for key generation."""
+    """Default maximum slot horizon if not specified."""
 
-    max_slot: Slot
-    public_keys: dict[ValidatorIndex, PublicKey]
-    secret_keys: dict[ValidatorIndex, SecretKey]
-
-    def __init__(
-        self,
-        max_slot: Optional[Slot] = None,
-    ) -> None:
+    def __init__(self, max_slot: Optional[Slot] = None) -> None:
         """
-        Initialize the XMSS key manager.
+        Initialize the key manager.
 
-        Args:
-            max_slot: Maximum slot for which keys should be valid. Keys will be
-                generated with enough capacity to sign messages up to this slot.
-                Defaults to 100 slots.
+        Parameters
+        ----------
+        max_slot : Slot, optional
+            Highest slot number for which keys must remain valid.
+            Defaults to `Slot(100)`.
+
+        Notes:
+        -----
+        Internally, keys are stored in a single dictionary:
+        `{ValidatorIndex → KeyPair}`.
         """
         self.max_slot = max_slot if max_slot is not None else self.DEFAULT_MAX_SLOT
-        self.public_keys: dict[ValidatorIndex, PublicKey] = {}
-        self.secret_keys: dict[ValidatorIndex, SecretKey] = {}
+        self._key_pairs: dict[ValidatorIndex, KeyPair] = {}
 
-    def create_and_store_key_pair(
-        self, validator_index: ValidatorIndex
-    ) -> tuple[PublicKey, SecretKey]:
+    def __getitem__(self, validator_index: ValidatorIndex) -> KeyPair:
         """
-        Create an XMSS key pair for the given validator index.
+        Retrieve or lazily generate a validator’s key pair.
 
-        Args:
-            validator_index: The index of the validator to create a key for.
+        Parameters
+        ----------
+        validator_index : ValidatorIndex
+            The validator whose key pair to fetch.
 
         Returns:
-            A tuple containing the public and secret keys for the given validator index.
+        -------
+        KeyPair
+            The validator’s XMSS key pair.
+
+        Notes:
+        -----
+        - Generates a new key if none exists.
+        - Keys are deterministic for testing (`seed=0`).
+        - Lifetime = `max_slot + 1` to include the genesis slot.
         """
-        if validator_index not in self.public_keys:
-            # Use max_slot + 1 as num_active_epochs since slots are used as epochs in the spec.
-            # +1 to include genesis slot
-            num_active_epochs = self.max_slot.as_int() + 1
-            self.public_keys[validator_index], self.secret_keys[validator_index] = (
-                DEFAULT_SIGNATURE_SCHEME.key_gen(0, num_active_epochs)
-            )
-        return self.public_keys[validator_index], self.secret_keys[validator_index]
+        # Return cached keys if they exist.
+        if validator_index in self._key_pairs:
+            return self._key_pairs[validator_index]
+
+        # Generate New Key Pair
+        #
+        # XMSS requires knowing the total number of signatures in advance.
+        # We use max_slot + 1 as the lifetime since:
+        # - Validators may sign once per slot (attestations)
+        # - We include slot 0 (genesis) in the count
+        num_active_epochs = self.max_slot.as_int() + 1
+
+        # Generate the key pair using the default XMSS scheme.
+        #
+        # The seed is set to 0 for deterministic test keys.
+        pk, sk = DEFAULT_SIGNATURE_SCHEME.key_gen(0, num_active_epochs)
+
+        # Store as a cohesive unit and return.
+        key_pair = KeyPair(public=pk, secret=sk)
+        self._key_pairs[validator_index] = key_pair
+        return key_pair
 
     def sign_attestation(self, attestation: Attestation) -> Signature:
         """
-        Sign an attestation with the given validator index.
+        Sign an attestation with the validator’s XMSS key.
 
-        Args:
-            attestation: The attestation to sign.
+        Parameters
+        ----------
+        attestation : Attestation
+            The attestation to sign. Must include `validator_id` and `data.slot`.
 
         Returns:
-            A signature for the given attestation.
+        -------
+        Signature
+            A consensus-compatible XMSS signature.
+
+        Notes:
+        -----
+        - Automatically generates missing keys.
+        - One XMSS epoch is consumed per slot.
+        - Produces deterministic test signatures.
         """
+        # Identify the validator who is attesting.
         validator_id = attestation.validator_id
 
-        sk = self.secret_keys[validator_id]
+        # Lazy key retrieval: creates keys if first time seeing this validator.
+        key_pair = self[validator_id]
+
+        # Compute the message digest from the attestation's SSZ tree root.
+        #
+        # This produces a cryptographic hash of the entire attestation structure.
         message = bytes(hash_tree_root(attestation))
+
+        # Map the attestation slot to an XMSS epoch.
+        #
+        # Each slot gets its own epoch to avoid key reuse.
         epoch = int(attestation.data.slot)
-        xmss_sig = DEFAULT_SIGNATURE_SCHEME.sign(sk, epoch, message)
 
+        # Generate the XMSS signature using the validator's secret key.
+        xmss_sig = DEFAULT_SIGNATURE_SCHEME.sign(key_pair.secret, epoch, message)
+
+        # Convert the signature to the wire format (byte array).
         signature_bytes = xmss_sig.to_bytes(DEFAULT_SIGNATURE_SCHEME.config)
-        # Pad to 3100 bytes (Signature.LENGTH) with zeros on the right
-        # Padding only occurs with TEST_CONFIG(796 bytes) and not PROD_CONFIG(3100 bytes).
+
+        # Ensure the signature meets the consensus spec length (3100 bytes).
+        #
+        # This is necessary when using TEST_CONFIG (796 bytes) vs PROD_CONFIG.
+        # Padding with zeros on the right maintains compatibility.
         padded_bytes = signature_bytes.ljust(Signature.LENGTH, b"\x00")
-        signature = Signature(padded_bytes)
-        return signature
 
-    def __contains__(self, validator_index: ValidatorIndex) -> bool:
+        return Signature(padded_bytes)
+
+    def get_public_key(self, validator_index: ValidatorIndex) -> PublicKey:
         """
-        Check if a validator has a registered key.
+        Return the public key for a validator.
 
-        Args:
-            validator_index: The index of the validator to check.
+        Parameters
+        ----------
+        validator_index : ValidatorIndex
 
         Returns:
-            True if the validator has a registered key, False otherwise.
+        -------
+        PublicKey
+            The validator’s public key.
         """
-        return validator_index in self.secret_keys
+        return self[validator_index].public
+
+    def get_all_public_keys(self) -> dict[ValidatorIndex, PublicKey]:
+        """
+        Return all generated public keys.
+
+        Returns:
+        -------
+        dict[ValidatorIndex, PublicKey]
+            Snapshot of all currently known public keys.
+
+        Notes:
+        -----
+        Only includes validators whose keys have been generated.
+        """
+        return {i: p.public for i, p in self._key_pairs.items()}
+
+    def __contains__(self, validator_index: ValidatorIndex) -> bool:
+        """Check if a validator has generated keys."""
+        return validator_index in self._key_pairs
 
     def __len__(self) -> int:
-        """Return the number of registered keys."""
-        return len(self.secret_keys)
+        """Return the number of validators with generated keys."""
+        return len(self._key_pairs)

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -192,8 +192,8 @@ class ForkChoiceTest(BaseConsensusFixture):
         # Update validator pubkeys to match key_manager's generated keys
         updated_validators = []
         for i, validator in enumerate(self.anchor_state.validators):
-            pubkey, _ = key_manager.create_and_store_key_pair(ValidatorIndex(i))
-            pubkey_bytes = pubkey.to_bytes(DEFAULT_SIGNATURE_SCHEME.config)
+            key_pair = key_manager[ValidatorIndex(i)]
+            pubkey_bytes = key_pair.public.to_bytes(DEFAULT_SIGNATURE_SCHEME.config)
             updated_validator = validator.model_copy(update={"pubkey": pubkey_bytes})
             updated_validators.append(updated_validator)
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

I've refactored a bit our xmss key manager for testing, mainly incorporating:
- a proper `KeyPair` class
- a `__getitem__` that retrieves or lazily generate a validator’s key pair instead of the old `create_and_store_key_pair` in order to be easier to use.



## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
