### PR TITLE
`SignedBlockWithAttestation`: add `process_block_body_attestations`

### DIFF
--- a/src/lean_spec/subspecs/containers/block/block.py
+++ b/src/lean_spec/subspecs/containers/block/block.py
@@ -16,11 +16,10 @@ from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.types import Bytes32, Uint64
 from lean_spec.types.container import Container
 
-from ..attestation import Attestation, SignedAttestation
+from ..attestation import Attestation
 from .types import Attestations, BlockSignatures
 
 if TYPE_CHECKING:
-    from ...forkchoice.store import Store
     from ..state import State
 
 
@@ -183,36 +182,3 @@ class SignedBlockWithAttestation(Container):
             ), "Attestation signature verification failed"
 
         return True
-
-    def process_block_body_attestations(self, store: "Store") -> "Store":
-        """
-        Process on-chain attestations from block body.
-
-        These are historical attestations from other validators that the proposer
-        chose to include. They are processed as on-chain (`is_from_block=True`)
-        and immediately added to known attestations.
-
-        Args:
-            store: Fork choice store to update with attestations.
-
-        Returns:
-            New Store with attestations processed.
-
-        Note:
-            Future implementation may use aggregated signatures where a single
-            signature covers multiple attestations.
-        """
-        # Iterate over attestations and their corresponding signatures.
-        for attestation, signature in zip(
-            self.message.block.body.attestations, self.signature, strict=False
-        ):
-            # Process as on-chain attestation (immediately becomes "known")
-            store = store.on_attestation(
-                signed_attestation=SignedAttestation(
-                    message=attestation,
-                    signature=signature,
-                ),
-                is_from_block=True,
-            )
-
-        return store

--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -384,9 +384,12 @@ class Store(Container):
         )
 
         # Process block body attestations
+        #
         # Iterate over attestations and their corresponding signatures.
         for attestation, signature in zip(
-            block.message.block.body.attestations, block.signature, strict=False
+            signed_block_with_attestation.message.block.body.attestations,
+            signed_block_with_attestation.signature,
+            strict=False,
         ):
             # Process as on-chain attestation (immediately becomes "known")
             store = store.on_attestation(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

Related https://github.com/leanEthereum/leanSpec/issues/128

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
