### PR TITLE
chore: remove default xmss signature scheme

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -27,7 +27,7 @@ from lean_spec.subspecs.containers.state import Validators
 from lean_spec.subspecs.containers.state.state import State
 from lean_spec.subspecs.forkchoice import Store
 from lean_spec.subspecs.ssz import hash_tree_root
-from lean_spec.subspecs.xmss.interface import DEFAULT_SIGNATURE_SCHEME
+from lean_spec.subspecs.xmss.interface import TEST_SIGNATURE_SCHEME
 from lean_spec.types import Bytes32, Uint64, ValidatorIndex
 
 from ..keys import XmssKeyManager
@@ -186,7 +186,7 @@ class ForkChoiceTest(BaseConsensusFixture):
         key_manager = (
             shared_key_manager
             if self.max_slot <= shared_key_manager.max_slot
-            else XmssKeyManager(max_slot=self.max_slot)
+            else XmssKeyManager(max_slot=self.max_slot, scheme=TEST_SIGNATURE_SCHEME)
         )
 
         # Update validator pubkeys to match key_manager's generated keys
@@ -194,7 +194,7 @@ class ForkChoiceTest(BaseConsensusFixture):
             validator.model_copy(
                 update={
                     "pubkey": key_manager[ValidatorIndex(i)].public.to_bytes(
-                        DEFAULT_SIGNATURE_SCHEME.config
+                        key_manager.scheme.config
                     )
                 }
             )

--- a/src/lean_spec/subspecs/containers/signature.py
+++ b/src/lean_spec/subspecs/containers/signature.py
@@ -6,16 +6,21 @@ from lean_spec.types import Bytes3100, Uint64
 
 from ..xmss.containers import PublicKey
 from ..xmss.containers import Signature as XmssSignature
-from ..xmss.interface import DEFAULT_SIGNATURE_SCHEME
+from ..xmss.interface import TEST_SIGNATURE_SCHEME, GeneralizedXmssScheme
 
 
 class Signature(Bytes3100):
     """Represents aggregated signature produced by the leanVM (SNARKs in the future)."""
 
-    def verify(self, public_key: PublicKey, epoch: Uint64, message: bytes) -> bool:
+    def verify(
+        self,
+        public_key: PublicKey,
+        epoch: Uint64,
+        message: bytes,
+        scheme: GeneralizedXmssScheme = TEST_SIGNATURE_SCHEME,
+    ) -> bool:
         """Verify the signature using XMSS verification algorithm."""
         try:
-            scheme = DEFAULT_SIGNATURE_SCHEME
             # Signature container is always 3100 bytes, but scheme config may expect less.
             # Slice to the expected size if needed, assumes padding to the right.
             signature_data = bytes(self)[: scheme.config.SIGNATURE_LEN_BYTES]

--- a/src/lean_spec/subspecs/containers/validator.py
+++ b/src/lean_spec/subspecs/containers/validator.py
@@ -3,7 +3,7 @@
 from lean_spec.types import Bytes52, Container
 
 from ..xmss.containers import PublicKey
-from ..xmss.interface import DEFAULT_SIGNATURE_SCHEME
+from ..xmss.interface import TEST_SIGNATURE_SCHEME, GeneralizedXmssScheme
 
 
 class Validator(Container):
@@ -12,6 +12,6 @@ class Validator(Container):
     pubkey: Bytes52
     """XMSS one-time signature public key."""
 
-    def get_pubkey(self) -> PublicKey:
+    def get_pubkey(self, scheme: GeneralizedXmssScheme = TEST_SIGNATURE_SCHEME) -> PublicKey:
         """Get the XMSS public key from this validator."""
-        return PublicKey.from_bytes(bytes(self.pubkey), DEFAULT_SIGNATURE_SCHEME.config)
+        return PublicKey.from_bytes(bytes(self.pubkey), scheme.config)

--- a/src/lean_spec/subspecs/xmss/interface.py
+++ b/src/lean_spec/subspecs/xmss/interface.py
@@ -589,6 +589,3 @@ TEST_SIGNATURE_SCHEME = GeneralizedXmssScheme(
     TEST_RAND,
 )
 """A lightweight instance for test environments."""
-
-DEFAULT_SIGNATURE_SCHEME = PROD_SIGNATURE_SCHEME
-"""The default signature scheme to use."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,3 @@ import lean_spec.subspecs.xmss as xmss
 # Create a profile named "no_deadline" with deadline disabled.
 settings.register_profile("no_deadline", deadline=None)
 settings.load_profile("no_deadline")
-
-# Enable test mode for XMSS signature scheme
-# This uses smaller parameters (TEST_CONFIG) for faster test execution
-xmss.interface.DEFAULT_SIGNATURE_SCHEME = xmss.interface.TEST_SIGNATURE_SCHEME


### PR DESCRIPTION
## 🗒️ Description
Removes DEFAULT_SIGNATURE_SCHEME, replaces it with specific scheme calls in function.

## ✅ Checklist
- [X] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
