### PR TITLE
test framework: cache post state when building block for stf

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -182,6 +182,10 @@ class StateTransitionTest(BaseConsensusFixture):
         Returns both the block and the cached post-state (if computed) to avoid
         redundant state transitions.
 
+        TODO: If the spec implements a State.produce_block() method in the future,
+        we should use that instead of manually computing fields here. Until then,
+        this manual approach is necessary.
+
         Parameters
         ----------
         spec : BlockSpec


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

Previously during each test which used this we computed the post state twice which was identified as a bottleneck.

Inspired by the consensus spec here https://github.com/ethereum/consensus-specs/blob/11e15092dccdffed0db15a0314682ee0c5737eec/tests/generators/compliance_runners/fork_choice/instantiators/helpers.py#L138, we can return the post state directly when building the block (if computed) and cache it for the next usage.

On my machine, it seems to reduce the timing of certain tests almost by a factor of 2.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

Related https://github.com/leanEthereum/leanSpec/issues/166 but it doesn't fully close this I guess.


## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
