### PR TITLE
chore: use more direct source-target comparison

### DIFF
--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -163,7 +163,7 @@ class Store(Container):
 
         # Topology Check
         #
-        # History is linear and monotonic. Source must be an older than Target.
+        # History is linear and monotonic. Source must be older than Target.
         assert data.source.slot <= data.target.slot, "Source checkpoint slot must not exceed target"
 
         # Consistency Check


### PR DESCRIPTION
## 🗒️ Description

RE: https://github.com/leanEthereum/leanSpec/pull/177#pullrequestreview-3477992151, updating `validate_attestation()` to use attestation data directly instead of referring to the store's block for source-target check.

## 🔗 Related Issues or PRs

#177

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
