### PR TITLE
test: Add encode decode ssz tests for SignedBlockWithAttestation and State and SignedAttestation

### DIFF
--- a/tests/lean_spec/subspecs/ssz/test_block.py
+++ b/tests/lean_spec/subspecs/ssz/test_block.py
@@ -1,0 +1,49 @@
+from lean_spec.subspecs.containers.attestation import (
+    Attestation,
+    AttestationData,
+)
+from lean_spec.subspecs.containers.block.block import (
+    Block,
+    BlockBody,
+    BlockWithAttestation,
+    SignedBlockWithAttestation,
+)
+from lean_spec.subspecs.containers.block.types import Attestations, BlockSignatures
+from lean_spec.subspecs.containers.checkpoint import Checkpoint
+from lean_spec.types import Bytes32, ValidatorIndex
+
+
+def test_encode_decode_signed_block_with_attestation_roundtrip() -> None:
+    signed_block_with_attestation = SignedBlockWithAttestation(
+        message=BlockWithAttestation(
+            block=Block(
+                slot=0,
+                proposer_index=ValidatorIndex(0),
+                parent_root=Bytes32.zero(),
+                state_root=Bytes32.zero(),
+                body=BlockBody(attestations=Attestations(data=[])),
+            ),
+            proposer_attestation=Attestation(
+                validator_id=ValidatorIndex(0),
+                data=AttestationData(
+                    slot=0,
+                    head=Checkpoint(root=Bytes32.zero(), slot=0),
+                    target=Checkpoint(root=Bytes32.zero(), slot=0),
+                    source=Checkpoint(root=Bytes32.zero(), slot=0),
+                ),
+            ),
+        ),
+        signature=BlockSignatures(data=[]),
+    )
+
+    encode = signed_block_with_attestation.encode_bytes()
+    expected_value = (
+        "08000000ec0000008c000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000005400000004000000"
+    )
+    assert encode.hex() == expected_value
+    assert SignedBlockWithAttestation.decode_bytes(encode) == signed_block_with_attestation

--- a/tests/lean_spec/subspecs/ssz/test_signed_attestation.py
+++ b/tests/lean_spec/subspecs/ssz/test_signed_attestation.py
@@ -1,0 +1,30 @@
+from lean_spec.subspecs.containers import (
+    Attestation,
+    AttestationData,
+    Checkpoint,
+    Signature,
+    SignedAttestation,
+)
+from lean_spec.subspecs.containers.block.types import BlockSignatures
+from lean_spec.types.byte_arrays import Bytes32
+from lean_spec.types.validator import ValidatorIndex
+
+
+def test_encode_decode_signed_attestation_roundtrip() -> None:
+    signed_attestation = SignedAttestation(
+        message=Attestation(
+            validator_id=ValidatorIndex(0),
+            data=AttestationData(
+                slot=0,
+                head=Checkpoint(root=Bytes32.zero(), slot=0),
+                target=Checkpoint(root=Bytes32.zero(), slot=0),
+                source=Checkpoint(root=Bytes32.zero(), slot=0),
+            ),
+        ),
+        signature=Signature.zero(),
+    )
+
+    encode = signed_attestation.encode_bytes()
+    expected_value = "0" * 6504
+    assert encode.hex() == expected_value
+    assert SignedAttestation.decode_bytes(encode) == signed_attestation

--- a/tests/lean_spec/subspecs/ssz/test_state.py
+++ b/tests/lean_spec/subspecs/ssz/test_state.py
@@ -1,0 +1,52 @@
+from lean_spec.subspecs.containers import (
+    State,
+)
+from lean_spec.subspecs.containers.block.block import (
+    BlockHeader,
+)
+from lean_spec.subspecs.containers.checkpoint import Checkpoint
+from lean_spec.subspecs.containers.config import Config
+from lean_spec.subspecs.containers.state.types import (
+    HistoricalBlockHashes,
+    JustificationRoots,
+    JustificationValidators,
+    JustifiedSlots,
+    Validators,
+)
+from lean_spec.types import Bytes32, ValidatorIndex
+from lean_spec.types.uint import Uint64
+
+
+def test_encode_decode_state_roundtrip() -> None:
+    block_header = BlockHeader(
+        slot=0,
+        proposer_index=ValidatorIndex(0),
+        parent_root=Bytes32.zero(),
+        state_root=Bytes32.zero(),
+        body_root=Bytes32.zero(),
+    )
+    temp_finalized = Checkpoint(root=Bytes32.zero(), slot=0)
+    state = State(
+        config=Config(genesis_time=Uint64(1000)),
+        slot=0,
+        latest_block_header=block_header,
+        latest_justified=temp_finalized,
+        latest_finalized=temp_finalized,
+        historical_block_hashes=HistoricalBlockHashes(data=[]),
+        justified_slots=JustifiedSlots(data=[]),
+        justifications_roots=JustificationRoots(data=[]),
+        justifications_validators=JustificationValidators(data=[]),
+        validators=Validators(data=[]),
+    )
+
+    encode = state.encode_bytes()
+    expected_value = (
+        "e80300000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000000000000000000000000000000e4000000e4000000e5000000e5000000e5"
+        "0000000101"
+    )
+    assert encode.hex() == expected_value
+    assert State.decode_bytes(encode) == state


### PR DESCRIPTION
## 🗒️ Description
https://github.com/leanEthereum/leanSpec/issues/185

## 🔗 Related Issues or PRs
https://github.com/leanEthereum/leanSpec/issues/185

## ✅ Checklist

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
