### PR TITLE
refactor: change Signature size to 3116

### DIFF
--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -180,7 +180,7 @@ class XmssKeyManager:
         # Convert the signature to the wire format (byte array).
         signature_bytes = xmss_sig.to_bytes(self.scheme.config)
 
-        # Ensure the signature meets the consensus spec length (3100 bytes).
+        # Ensure the signature meets the consensus spec length (3116 bytes).
         #
         # This is necessary when using TEST_CONFIG (796 bytes) vs PROD_CONFIG.
         # Padding with zeros on the right maintains compatibility.

--- a/src/lean_spec/subspecs/containers/signature.py
+++ b/src/lean_spec/subspecs/containers/signature.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from lean_spec.types import Bytes3100, Uint64
+from lean_spec.types import Bytes3116, Uint64
 
 from ..xmss.containers import PublicKey
 from ..xmss.containers import Signature as XmssSignature
 from ..xmss.interface import TEST_SIGNATURE_SCHEME, GeneralizedXmssScheme
 
 
-class Signature(Bytes3100):
+class Signature(Bytes3116):
     """Represents aggregated signature produced by the leanVM (SNARKs in the future)."""
 
     def verify(
@@ -21,7 +21,7 @@ class Signature(Bytes3100):
     ) -> bool:
         """Verify the signature using XMSS verification algorithm."""
         try:
-            # Signature container is always 3100 bytes, but scheme config may expect less.
+            # Signature container is always 3116 bytes, but scheme config may expect less.
             # Slice to the expected size if needed, assumes padding to the right.
             signature_data = bytes(self)[: scheme.config.SIGNATURE_LEN_BYTES]
             signature = XmssSignature.from_bytes(signature_data, scheme.config)

--- a/src/lean_spec/types/__init__.py
+++ b/src/lean_spec/types/__init__.py
@@ -3,7 +3,7 @@
 from .base import CamelModel, StrictBaseModel
 from .basispt import BasisPoint
 from .boolean import Boolean
-from .byte_arrays import Bytes32, Bytes52, Bytes3100
+from .byte_arrays import Bytes32, Bytes52, Bytes3116
 from .collections import SSZList, SSZVector
 from .container import Container
 from .uint import Uint64
@@ -14,7 +14,7 @@ __all__ = [
     "BasisPoint",
     "Bytes32",
     "Bytes52",
-    "Bytes3100",
+    "Bytes3116",
     "CamelModel",
     "StrictBaseModel",
     "ValidatorIndex",

--- a/src/lean_spec/types/byte_arrays.py
+++ b/src/lean_spec/types/byte_arrays.py
@@ -231,10 +231,10 @@ class Bytes96(BaseBytes):
     LENGTH = 96
 
 
-class Bytes3100(BaseBytes):
-    """Fixed-size byte array of exactly 3100 bytes."""
+class Bytes3116(BaseBytes):
+    """Fixed-size byte array of exactly 3116 bytes."""
 
-    LENGTH = 3100
+    LENGTH = 3116
 
 
 class BaseByteList(SSZModel):


### PR DESCRIPTION
## 🗒️ Description
https://github.com/ReamLabs/ream/issues/922

because where using bincode the serialize size of the signature is actually a maximum of 3116
