### PR TITLE
forkchoice: simplify store's latest_justified and latest_finalized updates

### DIFF
--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -437,21 +437,21 @@ class Store(Container):
         # Execute state transition function to compute post-block state
         post_state = copy.deepcopy(parent_state).state_transition(block, valid_signatures)
 
-        # If the new post-state has a higher justified checkpoint, update the store's latest justified checkpoint.
+        # If post-state has a higher justified checkpoint, update it to the store.
         latest_justified = (
             post_state.latest_justified
             if post_state.latest_justified.slot > self.latest_justified.slot
             else self.latest_justified
         )
 
-        # If the new post-state has a higher finalized checkpoint, update the store's latest finalized checkpoint.
+        # If post-state has a higher finalized checkpoint, update it to the store.
         latest_finalized = (
             post_state.latest_finalized
             if post_state.latest_finalized.slot > self.latest_finalized.slot
             else self.latest_finalized
         )
 
-        # Create new store with block and state
+        # Create new store with the computed data.
         store = self.model_copy(
             update={
                 "blocks": self.blocks | {block_root: block},


### PR DESCRIPTION
## 🗒️ Description

The fork choice store was relying on looping through the entire historical states to update itself to the latest_justified and latest_finalized checkpoints. This is an overkill and also problematic as the genesis state's latest_justified and latest_finalized block roots are set to 0x00... (the latter might also be an issue, I'll bring up as a separate PR)

[Zeam is doing it more elegantly](https://github.com/blockblaz/zeam/blob/8180cbae7076abc9c408c376a1448fddaa7429bc/pkgs/node/src/forkchoice.zig#L186-L194) by simply just comparing the latest state's latest_justified and latest_finalized with the fork choice store, and update the store if the state contains higher checkpoints. So I propose bringing this optimization over.

This should not change the behavior of the fork choice so tests are unchanged.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
