### PR TITLE
tests: add genesis tests with hardcoded hash values

### DIFF
--- a/tests/consensus/devnet/state_transition/test_genesis.py
+++ b/tests/consensus/devnet/state_transition/test_genesis.py
@@ -10,10 +10,10 @@ Tests for genesis state generation and initialization.
 import pytest
 from consensus_testing import StateExpectation, StateTransitionTestFiller, generate_pre_state
 
-from lean_spec.subspecs.containers.block import BlockBody
+from lean_spec.subspecs.containers.block import Block, BlockBody
 from lean_spec.subspecs.containers.block.types import Attestations
 from lean_spec.subspecs.containers.slot import Slot
-from lean_spec.subspecs.containers.state import Validators
+from lean_spec.subspecs.containers.state import State, Validators
 from lean_spec.subspecs.containers.state.types import (
     HistoricalBlockHashes,
     JustificationRoots,
@@ -22,7 +22,7 @@ from lean_spec.subspecs.containers.state.types import (
 )
 from lean_spec.subspecs.containers.validator import Validator
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Bytes52, Uint64
+from lean_spec.types import Bytes32, Bytes52, Uint64, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Devnet")
 
@@ -154,3 +154,103 @@ def test_genesis_custom_validator_set(
             justifications_validators=JustificationValidators(data=[]),
         ),
     )
+
+
+def test_genesis_block_hash_comparison() -> None:
+    """Test that genesis block hashes are deterministic and differ with different inputs."""
+    # Create first genesis state with 3 validators
+    # Fill pubkeys with different values (1, 2, 3)
+    pubkeys1 = [Bytes52(bytes([i + 1] * 52)) for i in range(3)]
+    validators1 = Validators(data=[Validator(pubkey=pubkey) for pubkey in pubkeys1])
+
+    genesis_state1 = State.generate_genesis(
+        genesis_time=Uint64(1000),
+        validators=validators1,
+    )
+
+    # Generate genesis block from first state
+    genesis_block1 = Block(
+        slot=Slot(0),
+        proposer_index=ValidatorIndex(0),
+        parent_root=Bytes32.zero(),
+        state_root=hash_tree_root(genesis_state1),
+        body=BlockBody(attestations=Attestations(data=[])),
+    )
+
+    # Compute hash of first genesis block
+    genesis_block_hash1 = hash_tree_root(genesis_block1)
+
+    # Create a second genesis state with same config but regenerated (should produce same hash)
+    genesis_state1_copy = State.generate_genesis(
+        genesis_time=Uint64(1000),
+        validators=validators1,
+    )
+
+    genesis_block1_copy = Block(
+        slot=Slot(0),
+        proposer_index=ValidatorIndex(0),
+        parent_root=Bytes32.zero(),
+        state_root=hash_tree_root(genesis_state1_copy),
+        body=BlockBody(attestations=Attestations(data=[])),
+    )
+
+    genesis_block_hash1_copy = hash_tree_root(genesis_block1_copy)
+
+    # Same genesis spec should produce same hash
+    assert genesis_block_hash1 == genesis_block_hash1_copy
+
+    # Create second genesis state with different validators
+    # Fill pubkeys with different values (10, 11, 12)
+    pubkeys2 = [Bytes52(bytes([i + 10] * 52)) for i in range(3)]
+    validators2 = Validators(data=[Validator(pubkey=pubkey) for pubkey in pubkeys2])
+
+    genesis_state2 = State.generate_genesis(
+        genesis_time=Uint64(1000),  # Same genesis_time but different validators
+        validators=validators2,
+    )
+
+    genesis_block2 = Block(
+        slot=Slot(0),
+        proposer_index=ValidatorIndex(0),
+        parent_root=Bytes32.zero(),
+        state_root=hash_tree_root(genesis_state2),
+        body=BlockBody(attestations=Attestations(data=[])),
+    )
+
+    genesis_block_hash2 = hash_tree_root(genesis_block2)
+
+    # Different validators should produce different genesis block hash
+    assert genesis_block_hash1 != genesis_block_hash2
+
+    # Create third genesis state with same validators but different genesis_time
+    # Same as pubkeys1
+    pubkeys3 = [Bytes52(bytes([i + 1] * 52)) for i in range(3)]
+    validators3 = Validators(data=[Validator(pubkey=pubkey) for pubkey in pubkeys3])
+
+    genesis_state3 = State.generate_genesis(
+        genesis_time=Uint64(2000),  # Different genesis_time but same validators
+        validators=validators3,
+    )
+
+    genesis_block3 = Block(
+        slot=Slot(0),
+        proposer_index=ValidatorIndex(0),
+        parent_root=Bytes32.zero(),
+        state_root=hash_tree_root(genesis_state3),
+        body=BlockBody(attestations=Attestations(data=[])),
+    )
+
+    genesis_block_hash3 = hash_tree_root(genesis_block3)
+
+    # Different genesis_time should produce different genesis block hash
+    assert genesis_block_hash1 != genesis_block_hash3
+
+    # Compare genesis block hashes with expected hex values
+    hash1_hex = f"0x{genesis_block_hash1.hex()}"
+    assert hash1_hex == "0x4c0bcc4750b71818224a826cd59f8bcb75ae2920eb3e75b4097b818be6d1049a"
+
+    hash2_hex = f"0x{genesis_block_hash2.hex()}"
+    assert hash2_hex == "0x639b6162e6b432653a77a64b678717e7634428eda88ad6ccb1862e6397c0c47b"
+
+    hash3_hex = f"0x{genesis_block_hash3.hex()}"
+    assert hash3_hex == "0x6593976e31c915b5d534e2ee6172652aed7690be24777947de39c726aa2af59e"


### PR DESCRIPTION
## 🗒️ Description
Adds hardcoded genesis block hashes for clients to verify implementation

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [X] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
