### PR TITLE
xmss: rm useless `HashTree` class

### DIFF
--- a/src/lean_spec/subspecs/xmss/__init__.py
+++ b/src/lean_spec/subspecs/xmss/__init__.py
@@ -7,7 +7,6 @@ It exposes the core data structures and the main interface functions.
 
 from .constants import PROD_CONFIG, TEST_CONFIG
 from .containers import (
-    HashTree,
     HashTreeOpening,
     PublicKey,
     SecretKey,
@@ -21,7 +20,6 @@ __all__ = [
     "Signature",
     "SecretKey",
     "HashTreeOpening",
-    "HashTree",
     "PROD_CONFIG",
     "TEST_CONFIG",
 ]

--- a/src/lean_spec/subspecs/xmss/containers.py
+++ b/src/lean_spec/subspecs/xmss/containers.py
@@ -111,24 +111,6 @@ class HashTreeLayer(StrictBaseModel):
     """A list of the actual hash digests stored for this layer."""
 
 
-class HashTree(StrictBaseModel):
-    """
-    A simple representation of a sparse Merkle tree.
-
-    This structure contains the necessary nodes to generate an authentication path
-    for any signature within a key's active lifetime. For production use with
-    long lifetimes, prefer `HashSubTree` with the top-bottom tree approach.
-    """
-
-    depth: Uint64
-    """The total depth of the tree (e.g., 32 for a 2^32 leaf space)."""
-    layers: List[HashTreeLayer]
-    """
-    A list of `HashTreeLayer` objects, from the leaf hashes
-    (layer 0) up to the layer just below the root.
-    """
-
-
 class PublicKey(StrictBaseModel):
     """
     The public-facing component of a key pair.


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
