### PR TITLE
xmss secret key: make field `Uint64` instead of `int`

### DIFF
--- a/src/lean_spec/subspecs/xmss/containers.py
+++ b/src/lean_spec/subspecs/xmss/containers.py
@@ -400,7 +400,7 @@ class SecretKey(StrictBaseModel):
     in its lowest layer. Its root is the public key's Merkle root.
     """
 
-    left_bottom_tree_index: int | None = None
+    left_bottom_tree_index: Uint64
     """
     The index of the left bottom tree in the sliding window.
 

--- a/src/lean_spec/subspecs/xmss/utils.py
+++ b/src/lean_spec/subspecs/xmss/utils.py
@@ -124,7 +124,7 @@ def bottom_tree_from_prf_key(
     merkle_tree: "MerkleTree",
     config: XmssConfig,
     prf_key: bytes,
-    bottom_tree_index: int,
+    bottom_tree_index: Uint64,
     parameter: List[Fp],
 ) -> "HashSubTree":
     """
@@ -165,13 +165,13 @@ def bottom_tree_from_prf_key(
     leafs_per_bottom_tree = 1 << (config.LOG_LIFETIME // 2)
 
     # Determine the epoch range for this bottom tree.
-    start_epoch = bottom_tree_index * leafs_per_bottom_tree
-    end_epoch = start_epoch + leafs_per_bottom_tree
+    start_epoch = bottom_tree_index * Uint64(leafs_per_bottom_tree)
+    end_epoch = start_epoch + Uint64(leafs_per_bottom_tree)
 
     # Generate leaf hashes for all epochs in this bottom tree.
     leaf_hashes: List[HashDigest] = []
 
-    for epoch in range(start_epoch, end_epoch):
+    for epoch in range(int(start_epoch), int(end_epoch)):
         # For each epoch, compute the one-time public key (chain endpoints).
         chain_ends: List[HashDigest] = []
 

--- a/tests/lean_spec/subspecs/xmss/test_interface.py
+++ b/tests/lean_spec/subspecs/xmss/test_interface.py
@@ -120,7 +120,6 @@ def test_advance_preparation() -> None:
     # Get initial prepared interval
     initial_interval = scheme.get_prepared_interval(sk)
     initial_left_index = sk.left_bottom_tree_index
-    assert initial_left_index is not None
 
     # Advance preparation (returns new SecretKey since models are immutable)
     sk = scheme.advance_preparation(sk)
@@ -128,10 +127,9 @@ def test_advance_preparation() -> None:
     # Get new prepared interval
     new_interval = scheme.get_prepared_interval(sk)
     new_left_index = sk.left_bottom_tree_index
-    assert new_left_index is not None
 
     # Verify the left index incremented
-    assert new_left_index == initial_left_index + 1
+    assert new_left_index == initial_left_index + Uint64(1)
 
     # Verify the prepared interval shifted forward
     leafs_per_bottom_tree = 1 << (scheme.config.LOG_LIFETIME // 2)

--- a/tests/lean_spec/subspecs/xmss/test_utils.py
+++ b/tests/lean_spec/subspecs/xmss/test_utils.py
@@ -125,7 +125,7 @@ def test_bottom_tree_from_prf_key() -> None:
         merkle_tree=TEST_MERKLE_TREE,
         config=config,
         prf_key=prf_key,
-        bottom_tree_index=0,
+        bottom_tree_index=Uint64(0),
         parameter=parameter,
     )
 
@@ -157,7 +157,7 @@ def test_bottom_tree_from_prf_key_deterministic() -> None:
         merkle_tree=TEST_MERKLE_TREE,
         config=config,
         prf_key=prf_key,
-        bottom_tree_index=0,
+        bottom_tree_index=Uint64(0),
         parameter=parameter,
     )
 
@@ -167,7 +167,7 @@ def test_bottom_tree_from_prf_key_deterministic() -> None:
         merkle_tree=TEST_MERKLE_TREE,
         config=config,
         prf_key=prf_key,
-        bottom_tree_index=0,
+        bottom_tree_index=Uint64(0),
         parameter=parameter,
     )
 
@@ -188,7 +188,7 @@ def test_bottom_tree_from_prf_key_different_indices() -> None:
         merkle_tree=TEST_MERKLE_TREE,
         config=config,
         prf_key=prf_key,
-        bottom_tree_index=0,
+        bottom_tree_index=Uint64(0),
         parameter=parameter,
     )
 
@@ -198,7 +198,7 @@ def test_bottom_tree_from_prf_key_different_indices() -> None:
         merkle_tree=TEST_MERKLE_TREE,
         config=config,
         prf_key=prf_key,
-        bottom_tree_index=1,
+        bottom_tree_index=Uint64(1),
         parameter=parameter,
     )
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
