### PR TITLE
xmss: make `PRFKey` ssz compatible

### DIFF
--- a/src/lean_spec/subspecs/xmss/containers.py
+++ b/src/lean_spec/subspecs/xmss/containers.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, List, cast
-
-from pydantic import Field
+from typing import TYPE_CHECKING, List, cast
 
 from ...types import StrictBaseModel, Uint64
+from ...types.byte_arrays import BaseBytes
 from ...types.collections import SSZList, SSZVector
 from ..koalabear import P_BYTES, Fp
 from .constants import PRF_KEY_LENGTH, PROD_CONFIG
@@ -15,13 +14,16 @@ if TYPE_CHECKING:
     from .constants import XmssConfig
     from .subtree import HashSubTree
 
-PRFKey = Annotated[bytes, Field(min_length=PRF_KEY_LENGTH, max_length=PRF_KEY_LENGTH)]
-"""
-A type alias for the PRF **master secret key**.
 
-This is a high-entropy byte string that acts as the single root secret from
-which all one-time signing keys are deterministically derived.
-"""
+class PRFKey(BaseBytes):
+    """
+    The PRF master secret key.
+
+    This is a high-entropy byte string that acts as the single root secret from
+    which all one-time signing keys are deterministically derived.
+    """
+
+    LENGTH = PRF_KEY_LENGTH
 
 
 HASH_DIGEST_LENGTH = PROD_CONFIG.HASH_LEN_FE

--- a/src/lean_spec/subspecs/xmss/prf.py
+++ b/src/lean_spec/subspecs/xmss/prf.py
@@ -104,7 +104,7 @@ class Prf(StrictBaseModel):
         Returns:
             A new, randomly generated PRF key of `PRF_KEY_LENGTH` bytes.
         """
-        return os.urandom(PRF_KEY_LENGTH)
+        return PRFKey(os.urandom(PRF_KEY_LENGTH))
 
     def apply(self, key: PRFKey, epoch: Uint64, chain_index: Uint64) -> List[Fp]:
         """

--- a/src/lean_spec/subspecs/xmss/utils.py
+++ b/src/lean_spec/subspecs/xmss/utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, List
 from ...types.uint import Uint64
 from ..koalabear import Fp, P
 from .constants import XmssConfig
-from .containers import HashDigestList, HashDigestVector, HashTreeLayer
+from .containers import HashDigestList, HashDigestVector, HashTreeLayer, PRFKey
 from .rand import Rand
 
 if TYPE_CHECKING:
@@ -166,7 +166,7 @@ def bottom_tree_from_prf_key(
     hasher: "TweakHasher",
     merkle_tree: "MerkleTree",
     config: XmssConfig,
-    prf_key: bytes,
+    prf_key: PRFKey,
     bottom_tree_index: Uint64,
     parameter: List[Fp],
 ) -> "HashSubTree":

--- a/tests/lean_spec/subspecs/xmss/test_prf.py
+++ b/tests/lean_spec/subspecs/xmss/test_prf.py
@@ -4,6 +4,7 @@ from lean_spec.subspecs.xmss.constants import (
     PRF_KEY_LENGTH,
     TEST_CONFIG,
 )
+from lean_spec.subspecs.xmss.containers import PRFKey
 from lean_spec.subspecs.xmss.prf import TEST_PRF
 from lean_spec.types.uint import Uint64
 
@@ -52,14 +53,14 @@ def test_apply_is_sensitive_to_inputs() -> None:
     config = TEST_CONFIG
 
     # Generate a baseline output with a set of initial inputs.
-    key1 = b"\x11" * PRF_KEY_LENGTH
+    key1 = PRFKey(b"\x11" * PRF_KEY_LENGTH)
     epoch1 = Uint64(10)
     chain_index1 = Uint64(20)
     baseline_output = prf.apply(key1, epoch1, chain_index1)
     assert len(baseline_output) == config.HASH_LEN_FE
 
     # Test sensitivity to the key.
-    key2 = b"\x22" * PRF_KEY_LENGTH
+    key2 = PRFKey(b"\x22" * PRF_KEY_LENGTH)
     output_key_changed = prf.apply(key2, epoch1, chain_index1)
     assert baseline_output != output_key_changed
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
