### PR TITLE
feat: remove redundant state root calculation

### DIFF
--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -949,7 +949,6 @@ class Store(Container):
         # Get parent block and state to build upon
         store, head_root = self.get_proposal_head(slot)
         head_state = store.states[head_root]
-        post_state = head_state
 
         # Validate proposer authorization for this slot
         num_validators = Uint64(head_state.validators.count)
@@ -1008,14 +1007,8 @@ class Store(Container):
             attestations.extend(new_attestations)
             signatures.extend(new_signatures)
 
-        # Create final block with all collected attestations
-        final_block = Block(
-            slot=slot,
-            proposer_index=validator_index,
-            parent_root=head_root,
-            state_root=hash_tree_root(post_state),
-            body=BlockBody(attestations=Attestations(data=attestations)),
-        )
+        # Store the post state root in the block
+        final_block = candidate_block.model_copy(update={"state_root": hash_tree_root(post_state)})
 
         # Store block and state immutably
         block_hash = hash_tree_root(final_block)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
There was an extra `process_slot` and `process_block` breing called from `produce_block_with_signatures`. This removes that redundant call and uses the final state from inside the loop.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->
Fixes #211

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
