### PR TITLE
fix: fix index bug and add blockRootLabel

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/genesis.py
+++ b/packages/testing/src/consensus_testing/test_types/genesis.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from lean_spec.subspecs.containers.state import State, Validators
 from lean_spec.subspecs.containers.validator import Validator
-from lean_spec.types import Bytes52, Uint64
+from lean_spec.types import Bytes52, Uint64, ValidatorIndex
 
 
 def generate_pre_state(**kwargs: Any) -> State:
@@ -24,7 +24,9 @@ def generate_pre_state(**kwargs: Any) -> State:
     # If validators not provided, create a default set of 4 validators with dummy pubkeys
     # TODO: Set an appropriate default here for test fixtures
     if "validators" not in kwargs:
-        validators = Validators(data=[Validator(pubkey=Bytes52.zero()) for _ in range(4)])
+        validators = Validators(
+            data=[Validator(pubkey=Bytes52.zero(), index=ValidatorIndex(i)) for i in range(4)]
+        )
     else:
         validators = kwargs["validators"]
 

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -102,13 +102,15 @@ class BlockStep(BaseForkChoiceStep):
         ValueError
             If _filled_block is None (make_fixture not called yet).
         """
-        del value
         if self._filled_block is None:
             raise ValueError(
                 "Block not filled yet - make_fixture() must be called before serialization. "
                 "This BlockStep should only be serialized after the fixture has been processed."
             )
-        return self._filled_block.to_json()
+        result = self._filled_block.to_json()
+        if value.label:
+            result["blockRootLabel"] = value.label
+        return result
 
 
 class AttestationStep(BaseForkChoiceStep):

--- a/tests/consensus/devnet/fc/test_fork_choice_reorgs.py
+++ b/tests/consensus/devnet/fc/test_fork_choice_reorgs.py
@@ -362,7 +362,9 @@ def test_reorg_with_slot_gaps(
     """
     fork_choice_test(
         anchor_state=generate_pre_state(
-            validators=Validators(data=[Validator(pubkey=Bytes52.zero()) for _ in range(10)]),
+            validators=Validators(
+                data=[Validator(pubkey=Bytes52.zero(), index=ValidatorIndex(i)) for i in range(10)]
+            ),
         ),
         steps=[
             # Base at slot 1
@@ -576,7 +578,9 @@ def test_reorg_prevention_heavy_fork_resists_light_competition(
     """
     fork_choice_test(
         anchor_state=generate_pre_state(
-            validators=Validators(data=[Validator(pubkey=Bytes52.zero()) for _ in range(12)])
+            validators=Validators(
+                data=[Validator(pubkey=Bytes52.zero(), index=ValidatorIndex(i)) for i in range(12)]
+            )
         ),
         steps=[
             # Common base
@@ -811,7 +815,9 @@ def test_reorg_on_newly_justified_slot(
     fork_choice_test(
         # Using 9 validators: 3 for Fork A and 6 for Fork B to achieve 2/3rd for Fork B
         anchor_state=generate_pre_state(
-            validators=Validators(data=[Validator(pubkey=Bytes52.zero()) for _ in range(9)])
+            validators=Validators(
+                data=[Validator(pubkey=Bytes52.zero(), index=ValidatorIndex(i)) for i in range(9)]
+            )
         ),
         steps=[
             # Common base at slot 1

--- a/tests/consensus/devnet/state_transition/test_genesis.py
+++ b/tests/consensus/devnet/state_transition/test_genesis.py
@@ -128,7 +128,9 @@ def test_genesis_custom_validator_set(
     maintaining all other genesis properties.
     """
     # Create 8 validators with unique pubkeys
-    validators = Validators(data=[Validator(pubkey=Bytes52(bytes([i] * 52))) for i in range(8)])
+    validators = Validators(
+        data=[Validator(pubkey=Bytes52(bytes([i] * 52)), index=ValidatorIndex(i)) for i in range(8)]
+    )
 
     state_transition_test(
         pre=generate_pre_state(validators=validators),

--- a/tests/lean_spec/subspecs/forkchoice/test_time_management.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_time_management.py
@@ -42,7 +42,9 @@ def sample_store(sample_config: Config) -> Store:
     checkpoint = Checkpoint(root=genesis_hash, slot=Slot(0))
 
     # Create genesis state with 10 validators for testing
-    validators = Validators(data=[Validator(pubkey=Bytes52.zero()) for _ in range(10)])
+    validators = Validators(
+        data=[Validator(pubkey=Bytes52.zero(), index=ValidatorIndex(i)) for i in range(10)]
+    )
     state = State.generate_genesis(
         genesis_time=sample_config.genesis_time,
         validators=validators,

--- a/tests/lean_spec/subspecs/forkchoice/test_validator.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_validator.py
@@ -59,7 +59,9 @@ def sample_state(config: Config) -> State:
     temp_finalized = Checkpoint(root=Bytes32(b"genesis" + b"\x00" * 25), slot=Slot(0))
 
     # Create validators list with 10 validators for testing
-    validators = Validators(data=[Validator(pubkey=Bytes52.zero()) for _ in range(10)])
+    validators = Validators(
+        data=[Validator(pubkey=Bytes52.zero(), index=ValidatorIndex(i)) for i in range(10)]
+    )
 
     return State(
         config=config,
@@ -523,7 +525,9 @@ class TestValidatorIntegration:
         genesis_body = BlockBody(attestations=Attestations(data=[]))
 
         # Create validators list with 3 validators
-        validators = Validators(data=[Validator(pubkey=Bytes52.zero()) for _ in range(3)])
+        validators = Validators(
+            data=[Validator(pubkey=Bytes52.zero(), index=ValidatorIndex(i)) for i in range(3)]
+        )
 
         # Create minimal state with temporary header
         checkpoint = Checkpoint.default()


### PR DESCRIPTION
## 🗒️ Description
This PR fix the bug the assignment of validator index always 0 which make the test vector validator index also 0. And also add `blockRootLabel` in the test vector for client to implement `test_lexicographic_tiebreaker` test.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
