### PR TITLE
core: better block production and usage in fixture

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -324,7 +324,7 @@ class ForkChoiceTest(BaseConsensusFixture):
 
         # Use State.build_block for core block building (pure spec logic)
         parent_state = store.states[parent_root]
-        final_block, _ = parent_state.build_block(
+        final_block, _, _, _ = parent_state.build_block(
             slot=spec.slot,
             proposer_index=proposer_index,
             parent_root=parent_root,

--- a/src/lean_spec/subspecs/containers/state/state.py
+++ b/src/lean_spec/subspecs/containers/state/state.py
@@ -6,6 +6,8 @@ recent blocks, and validator attestations. State also records which blocks are
 justified and finalized.
 """
 
+from typing import TYPE_CHECKING, AbstractSet, Iterable
+
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.types import (
     ZERO_HASH,
@@ -16,7 +18,10 @@ from lean_spec.types import (
     is_proposer,
 )
 
-from ..attestation import Attestation
+from ..attestation import Attestation, SignedAttestation
+
+if TYPE_CHECKING:
+    from lean_spec.subspecs.xmss.containers import Signature
 from ..block import Block, BlockBody, BlockHeader
 from ..block.types import Attestations
 from ..checkpoint import Checkpoint
@@ -523,46 +528,85 @@ class State(Container):
         proposer_index: Uint64,
         parent_root: Bytes32,
         attestations: list[Attestation] | None = None,
-    ) -> tuple[Block, "State"]:
+        available_signed_attestations: Iterable[SignedAttestation] | None = None,
+        known_block_roots: AbstractSet[Bytes32] | None = None,
+    ) -> tuple[Block, "State", list[Attestation], list["Signature"]]:
         """
         Build a valid block on top of this state.
 
-        This is a pure function that:
-        1. Advances the state to the target slot
-        2. Processes the block to compute the correct state root
-        3. Returns the finalized block and post-state
+        Computes the post-state and creates a block with the correct state root.
+
+        If `available_signed_attestations` and `known_block_roots` are provided,
+        performs fixed-point attestation collection: iteratively adds valid
+        attestations until no more can be included. This is necessary because
+        processing attestations may update the justified checkpoint, which may
+        make additional attestations valid.
 
         Args:
             slot: Target slot for the block.
             proposer_index: Validator index of the proposer.
-            parent_root: Root of this state's block (the parent).
-            attestations: Attestations to include. Defaults to empty.
+            parent_root: Root of the parent block.
+            attestations: Initial attestations to include.
+            available_signed_attestations: Pool of attestations to collect from.
+            known_block_roots: Set of known block roots for attestation validation.
 
         Returns:
-            Tuple of (finalized Block, post-state State).
+            Tuple of (Block, post-State, collected attestations, signatures).
         """
-        # Default to empty attestations
-        attestations = attestations or []
+        # Initialize empty attestation set for iterative collection
+        attestations = list(attestations or [])
+        signatures: list[Signature] = []
 
-        # Build block with temporary state root
-        temp_block = Block(
-            slot=slot,
-            proposer_index=proposer_index,
-            parent_root=parent_root,
-            state_root=Bytes32.zero(),
-            body=BlockBody(attestations=Attestations(data=attestations)),
-        )
+        # Iteratively collect valid attestations using fixed-point algorithm
+        #
+        # Continue until no new attestations can be added to the block.
+        # This ensures we include the maximal valid attestation set.
+        while True:
+            # Create candidate block with current attestation set
+            candidate_block = Block(
+                slot=slot,
+                proposer_index=proposer_index,
+                parent_root=parent_root,
+                state_root=Bytes32.zero(),
+                body=BlockBody(attestations=Attestations(data=attestations)),
+            )
 
-        # Compute post-state via state transition
-        post_state = self.process_slots(slot).process_block(temp_block)
+            # Apply state transition to get the post-block state
+            post_state = self.process_slots(slot).process_block(candidate_block)
 
-        # Finalize block with correct state root
-        final_block = Block(
-            slot=slot,
-            proposer_index=proposer_index,
-            parent_root=parent_root,
-            state_root=hash_tree_root(post_state),
-            body=BlockBody(attestations=Attestations(data=attestations)),
-        )
+            # No attestation source provided: done after computing post_state
+            if available_signed_attestations is None or known_block_roots is None:
+                break
 
-        return final_block, post_state
+            # Find new valid attestations matching post-state justification
+            new_attestations: list[Attestation] = []
+            new_signatures: list[Signature] = []
+
+            for signed_attestation in available_signed_attestations:
+                data = signed_attestation.message.data
+
+                # Skip if target block is unknown
+                if data.head.root not in known_block_roots:
+                    continue
+
+                # Skip if attestation source does not match post-state's latest justified
+                if data.source != post_state.latest_justified:
+                    continue
+
+                # Add attestation if not already included
+                if signed_attestation.message not in attestations:
+                    new_attestations.append(signed_attestation.message)
+                    new_signatures.append(signed_attestation.signature)
+
+            # Fixed point reached: no new attestations found
+            if not new_attestations:
+                break
+
+            # Add new attestations and continue iteration
+            attestations.extend(new_attestations)
+            signatures.extend(new_signatures)
+
+        # Store the post state root in the block
+        final_block = candidate_block.model_copy(update={"state_root": hash_tree_root(post_state)})
+
+        return final_block, post_state, attestations, signatures


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

Now we can use the same block building function in the test fixture that we are using in the spec, making the logic more consistent and more concise.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

Should close https://github.com/leanEthereum/leanSpec/issues/167

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
