### PR TITLE
fix: correct interval calculation in tick_interval method

### DIFF
--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -732,15 +732,7 @@ class Store(Container):
         """
         # Advance time by one interval
         store = self.model_copy(update={"time": self.time + Uint64(1)})
-        # Calculate current interval within slot
-        # time is in seconds, so we need to:
-        # 1. Get seconds within current slot: time % SECONDS_PER_SLOT
-        # 2. Convert to intervals: // SECONDS_PER_INTERVAL
-        # This formula correctly handles the case when SECONDS_PER_SLOT != INTERVALS_PER_SLOT,
-        # unlike the incorrect formula: time % INTERVALS_PER_SLOT
-        # Note: This requires that SECONDS_PER_SLOT is a multiple of INTERVALS_PER_SLOT
-        # (i.e., SECONDS_PER_INTERVAL must be an integer >= 1)
-        current_interval = (store.time % SECONDS_PER_SLOT) // SECONDS_PER_INTERVAL
+        current_interval = store.time % INTERVALS_PER_SLOT
 
         if current_interval == Uint64(0):
             # Start of slot - process attestations if proposal exists


### PR DESCRIPTION
Fix interval calculation to use INTERVALS_PER_SLOT instead of the incorrect
double modulo operation. The store.time field stores intervals since genesis,
so calculating the interval within a slot should use modulo INTERVALS_PER_SLOT
directly. This matches the formula used in tests and ensures correctness
even if SECONDS_PER_SLOT and INTERVALS_PER_SLOT values diverge in the future.