### PR TITLE
framework: fix CI workflow for prod vectors

### DIFF
--- a/.github/workflows/prod-vectors.yml
+++ b/.github/workflows/prod-vectors.yml
@@ -44,16 +44,11 @@ jobs:
         run: uv run python -m consensus_testing.keys --download --scheme prod
 
       - name: Fill production test fixtures
-        env:
-          LEAN_ENV: prod
-        run: uv run fill --fork=Devnet --clean -n auto
-
-      - name: Create fixtures archive
-        run: tar -czf fixtures-prod-scheme.tar.gz fixtures/
+        run: uv run fill --fork=Devnet --scheme prod --clean -n auto
 
       - name: Upload production test fixtures
         uses: actions/upload-artifact@v4
         with:
           name: fixtures-prod-scheme
-          path: fixtures-prod-scheme.tar.gz
+          path: fixtures/
           if-no-files-found: error


### PR DESCRIPTION
## 🗒️ Description

Fixes from reviewing #230's [build job](https://github.com/leanEthereum/leanSpec/actions/runs/20307539329) after merged:

- Test filling with `--scheme prod` argument
- Remove redundant archiving (GitHub automatically zips the artifacts during artifact upload)

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
