### PR TITLE
xmss: mv `KeyPair` as a container

### DIFF
--- a/src/lean_spec/subspecs/xmss/containers.py
+++ b/src/lean_spec/subspecs/xmss/containers.py
@@ -7,7 +7,7 @@ Base types (HashDigestVector, Parameter, etc.) are defined in types.py.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping, NamedTuple
 
 from ...types import Uint64
 from ...types.container import Container
@@ -181,3 +181,31 @@ class SecretKey(Container):
     Together with `left_bottom_tree`, this provides a prepared interval of
     exactly `2 * sqrt(LIFETIME)` consecutive epochs.
     """
+
+
+class KeyPair(NamedTuple):
+    """
+    Immutable XMSS key pair for a validator.
+
+    Attributes:
+        public: Public key for signature verification.
+        secret: Secret key containing Merkle tree structures.
+    """
+
+    public: PublicKey
+    secret: SecretKey
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, str]) -> "KeyPair":
+        """Deserialize from JSON-compatible dict with hex-encoded SSZ."""
+        return cls(
+            public=PublicKey.decode_bytes(bytes.fromhex(data["public"])),
+            secret=SecretKey.decode_bytes(bytes.fromhex(data["secret"])),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize to JSON-compatible dict with hex-encoded SSZ."""
+        return {
+            "public": self.public.encode_bytes().hex(),
+            "secret": self.secret.encode_bytes().hex(),
+        }

--- a/src/lean_spec/subspecs/xmss/interface.py
+++ b/src/lean_spec/subspecs/xmss/interface.py
@@ -24,7 +24,7 @@ from .constants import (
     TEST_CONFIG,
     XmssConfig,
 )
-from .containers import PublicKey, SecretKey, Signature
+from .containers import KeyPair, PublicKey, SecretKey, Signature
 from .prf import PROD_PRF, TEST_PRF, Prf
 from .rand import PROD_RAND, TEST_RAND, Rand
 from .subtree import HashSubTree, combined_path, verify_path
@@ -73,9 +73,7 @@ class GeneralizedXmssScheme(StrictBaseModel):
         )
         return self
 
-    def key_gen(
-        self, activation_epoch: Uint64, num_active_epochs: Uint64
-    ) -> tuple[PublicKey, SecretKey]:
+    def key_gen(self, activation_epoch: Uint64, num_active_epochs: Uint64) -> KeyPair:
         """
         Generates a new cryptographic key pair for a specified range of epochs.
 
@@ -120,7 +118,7 @@ class GeneralizedXmssScheme(StrictBaseModel):
             - Will be rounded up to at least `2 * sqrt(LIFETIME)`.
 
         Returns:
-            A tuple containing the `PublicKey` and `SecretKey`.
+            A `KeyPair` containing the public and secret keys.
 
         Note:
             The actual activation epoch and num_active_epochs in the returned SecretKey
@@ -220,7 +218,7 @@ class GeneralizedXmssScheme(StrictBaseModel):
             left_bottom_tree=left_bottom_tree,
             right_bottom_tree=right_bottom_tree,
         )
-        return pk, sk
+        return KeyPair(public=pk, secret=sk)
 
     def sign(self, sk: SecretKey, epoch: Uint64, message: bytes) -> Signature:
         """


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

As we already have `KeyPair` as a class in the testing framework, I think that is cleaner to migrate it as a proper XMSS container so that we can reuse it as a return type of the key generation process for example.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
