### PR TITLE
validator: rm useless `produce_attestation`

### DIFF
--- a/src/lean_spec/subspecs/containers/validator.py
+++ b/src/lean_spec/subspecs/containers/validator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from lean_spec.types import Bytes52, Container, Uint64
 
 from ..xmss.containers import PublicKey
-from .attestation import Attestation, AttestationData
 
 
 class Validator(Container):
@@ -20,21 +19,3 @@ class Validator(Container):
     def get_pubkey(self) -> PublicKey:
         """Get the XMSS public key from this validator."""
         return PublicKey.decode_bytes(bytes(self.pubkey))
-
-    def produce_attestation(self, data: AttestationData) -> Attestation:
-        """
-        Produce an attestation from attestation data.
-
-        This method wraps AttestationData with the validator's identity to create
-        a complete Attestation object ready for signing and broadcast.
-
-        Args:
-            data: The attestation data containing slot, head, target, and source.
-
-        Returns:
-            A fully constructed Attestation object with this validator's index.
-        """
-        return Attestation(
-            validator_id=self.index,
-            data=data,
-        )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

This function is not used in the code (except in tests) so that we should remove it.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
