### PR TITLE
test: use new download url for prod keys testing after plonky3 reorder

### DIFF
--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -62,8 +62,8 @@ if TYPE_CHECKING:
 
 # Pre-generated key download URLs
 KEY_DOWNLOAD_URLS = {
-    "test": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-d6cec9b/test_scheme.tar.gz",
-    "prod": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-d6cec9b/prod_scheme.tar.gz",
+    "test": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-77bde6b/test_scheme.tar.gz",
+    "prod": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-77bde6b/prod_scheme.tar.gz",
 }
 """URLs for downloading pre-generated keys."""
 


### PR DESCRIPTION
## 🗒️ Description
After #251, the testing keys for prod signature scheme needs to be updated for the test vectors with prod scheme to work. This PR updates the download URL so it refers to the [latest leansig-test-keys release](https://github.com/leanEthereum/leansig-test-keys/releases/tag/leanSpec-77bde6b) that's regenerated after #251 applied.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
