### PR TITLE
fix: fix process attestation source/target check bug

### DIFF
--- a/src/lean_spec/subspecs/containers/state/state.py
+++ b/src/lean_spec/subspecs/containers/state/state.py
@@ -460,7 +460,7 @@ class State(Container):
             # This prevents votes about unknown or conflicting forks.
             if (
                 source.root != self.historical_block_hashes[source.slot]
-                and target.root != self.historical_block_hashes[target.slot]
+                or target.root != self.historical_block_hashes[target.slot]
             ):
                 continue
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
This pull request makes a small fix to the logic in the `process_attestations` function in `src/lean_spec/subspecs/containers/state/state.py`. The change corrects the conditional statement to ensure that votes about unknown or conflicting forks are properly filtered.

* Updated the conditional logic in `process_attestations` to use `or` instead of `and`, preventing votes about unknown or conflicting forks more accurately

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
