### PR TITLE
types: rm redundant `ELEMENT_TYPE` assignments

### DIFF
--- a/src/lean_spec/subspecs/containers/block/types.py
+++ b/src/lean_spec/subspecs/containers/block/types.py
@@ -20,7 +20,6 @@ BlockLookup = dict[Bytes32, "Block"]
 class AggregatedAttestations(SSZList[AggregatedAttestation]):
     """List of aggregated attestations included in a block."""
 
-    ELEMENT_TYPE = AggregatedAttestation
     LIMIT = int(VALIDATOR_REGISTRY_LIMIT)
 
 
@@ -35,5 +34,4 @@ class AttestationSignatures(SSZList[AggregatedSignatureProof]):
         - proof bytes from leanVM signature aggregation.
     """
 
-    ELEMENT_TYPE = AggregatedSignatureProof
     LIMIT = int(VALIDATOR_REGISTRY_LIMIT)

--- a/src/lean_spec/subspecs/containers/state/types.py
+++ b/src/lean_spec/subspecs/containers/state/types.py
@@ -12,14 +12,12 @@ from ..validator import Validator
 class HistoricalBlockHashes(SSZList[Bytes32]):
     """List of historical block root hashes up to historical_roots_limit."""
 
-    ELEMENT_TYPE = Bytes32
     LIMIT = int(DEVNET_CONFIG.historical_roots_limit)
 
 
 class JustificationRoots(SSZList[Bytes32]):
     """List of justified block roots up to historical_roots_limit."""
 
-    ELEMENT_TYPE = Bytes32
     LIMIT = int(DEVNET_CONFIG.historical_roots_limit)
 
 
@@ -38,5 +36,4 @@ class JustificationValidators(BaseBitlist):
 class Validators(SSZList[Validator]):
     """Validator registry tracked in the state."""
 
-    ELEMENT_TYPE = Validator
     LIMIT = int(DEVNET_CONFIG.validator_registry_limit)

--- a/src/lean_spec/subspecs/xmss/types.py
+++ b/src/lean_spec/subspecs/xmss/types.py
@@ -54,7 +54,6 @@ class HashDigestVector(SSZVector[Fp]):
     as SSZ can pack these back-to-back without per-element offsets.
     """
 
-    ELEMENT_TYPE = Fp
     LENGTH = HASH_DIGEST_LENGTH
 
 
@@ -67,7 +66,6 @@ class HashDigestList(SSZList[HashDigestVector]):
     This type is used to represent collections of hash digests in the XMSS scheme.
     """
 
-    ELEMENT_TYPE = HashDigestVector
     LIMIT = NODE_LIST_LIMIT
 
 
@@ -80,7 +78,6 @@ class Parameter(SSZVector[Fp]):
     certain cross-key attacks. It is public knowledge.
     """
 
-    ELEMENT_TYPE = Fp
     LENGTH = TARGET_CONFIG.PARAMETER_LEN
 
 
@@ -95,7 +92,6 @@ class Randomness(SSZVector[Fp]):
     SSZ notation: `Vector[Fp, RAND_LEN_FE]`
     """
 
-    ELEMENT_TYPE = Fp
     LENGTH = TARGET_CONFIG.RAND_LEN_FE
 
 
@@ -152,5 +148,4 @@ class HashTreeLayers(SSZList[HashTreeLayer]):
     - Maximum: `LOG_LIFETIME + 1` layers
     """
 
-    ELEMENT_TYPE = HashTreeLayer
     LIMIT = LAYERS_LIMIT

--- a/tests/lean_spec/subspecs/ssz/test_hash.py
+++ b/tests/lean_spec/subspecs/ssz/test_hash.py
@@ -28,28 +28,23 @@ from lean_spec.types.union import SSZUnion
 
 
 # Concrete SSZList classes for tests
-class Uint16List32(SSZList):
-    ELEMENT_TYPE = Uint16
+class Uint16List32(SSZList[Uint16]):
     LIMIT = 32
 
 
-class Uint16List128(SSZList):
-    ELEMENT_TYPE = Uint16
+class Uint16List128(SSZList[Uint16]):
     LIMIT = 128
 
 
-class Uint16List1024(SSZList):
-    ELEMENT_TYPE = Uint16
+class Uint16List1024(SSZList[Uint16]):
     LIMIT = 1024
 
 
-class Uint32List128(SSZList):
-    ELEMENT_TYPE = Uint32
+class Uint32List128(SSZList[Uint32]):
     LIMIT = 128
 
 
-class Uint256List32(SSZList):
-    ELEMENT_TYPE = Uint256
+class Uint256List32(SSZList[Uint256]):
     LIMIT = 32
 
 
@@ -460,10 +455,9 @@ def test_hash_tree_root_bitlist_512_all_ones() -> None:
 
 
 # Define explicit SSZVector types for testing our new approach
-class Uint16Vector2(SSZVector):
+class Uint16Vector2(SSZVector[Uint16]):
     """A vector of exactly 2 Uint16 values."""
 
-    ELEMENT_TYPE = Uint16
     LENGTH = 2
 
 

--- a/tests/lean_spec/types/test_collections.py
+++ b/tests/lean_spec/types/test_collections.py
@@ -18,10 +18,9 @@ ValueOrValidationError = (SSZValueError, ValidationError)
 
 
 # Define some List types that are needed for Container definitions
-class Uint16List4(SSZList):
+class Uint16List4(SSZList[Uint16]):
     """A list with up to 4 Uint16 values."""
 
-    ELEMENT_TYPE = Uint16
     LIMIT = 4
 
 
@@ -40,160 +39,138 @@ class VariableContainer(Container):
 
 
 # Define explicit SSZVector types for testing
-class Uint16Vector2(SSZVector):
+class Uint16Vector2(SSZVector[Uint16]):
     """A vector of exactly 2 Uint16 values."""
 
-    ELEMENT_TYPE = Uint16
     LENGTH = 2
 
 
-class Uint8Vector4(SSZVector):
+class Uint8Vector4(SSZVector[Uint8]):
     """A vector of exactly 4 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LENGTH = 4
 
 
-class Uint8Vector48(SSZVector):
+class Uint8Vector48(SSZVector[Uint8]):
     """A vector of exactly 48 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LENGTH = 48
 
 
-class Uint8Vector96(SSZVector):
+class Uint8Vector96(SSZVector[Uint8]):
     """A vector of exactly 96 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LENGTH = 96
 
 
-class FixedContainerVector2(SSZVector):
+class FixedContainerVector2(SSZVector[FixedContainer]):
     """A vector of exactly 2 FixedContainer values."""
 
-    ELEMENT_TYPE = FixedContainer
     LENGTH = 2
 
 
-class VariableContainerVector2(SSZVector):
+class VariableContainerVector2(SSZVector[VariableContainer]):
     """A vector of exactly 2 VariableContainer values."""
 
-    ELEMENT_TYPE = VariableContainer
     LENGTH = 2
 
 
 # Define explicit List types for testing
-class Uint16List32(SSZList):
+class Uint16List32(SSZList[Uint16]):
     """A list with up to 32 Uint16 values."""
 
-    ELEMENT_TYPE = Uint16
     LIMIT = 32
 
 
-class Uint8List10(SSZList):
+class Uint8List10(SSZList[Uint8]):
     """A list with up to 10 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LIMIT = 10
 
 
-class Uint32List128(SSZList):
+class Uint32List128(SSZList[Uint32]):
     """A list with up to 128 Uint32 values."""
 
-    ELEMENT_TYPE = Uint32
     LIMIT = 128
 
 
-class Uint256List32(SSZList):
+class Uint256List32(SSZList[Uint256]):
     """A list with up to 32 Uint256 values."""
 
-    ELEMENT_TYPE = Uint256
     LIMIT = 32
 
 
-class Uint256List128(SSZList):
+class Uint256List128(SSZList[Uint256]):
     """A list with up to 128 Uint256 values."""
 
-    ELEMENT_TYPE = Uint256
     LIMIT = 128
 
 
-class VariableContainerList2(SSZList):
+class VariableContainerList2(SSZList[VariableContainer]):
     """A list with up to 2 VariableContainer values."""
 
-    ELEMENT_TYPE = VariableContainer
     LIMIT = 2
 
 
 # Additional SSZVector classes for tests
-class Uint8Vector32(SSZVector):
+class Uint8Vector32(SSZVector[Uint8]):
     """A vector of exactly 32 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LENGTH = 32
 
 
-class Uint16Vector32(SSZVector):
+class Uint16Vector32(SSZVector[Uint16]):
     """A vector of exactly 32 Uint16 values."""
 
-    ELEMENT_TYPE = Uint16
     LENGTH = 32
 
 
-class Uint8Vector64(SSZVector):
+class Uint8Vector64(SSZVector[Uint8]):
     """A vector of exactly 64 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LENGTH = 64
 
 
-class Uint8Vector2(SSZVector):
+class Uint8Vector2(SSZVector[Uint8]):
     """A vector of exactly 2 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LENGTH = 2
 
 
-class FpVector8(SSZVector):
+class FpVector8(SSZVector[Fp]):
     """A vector of exactly 8 Fp values."""
 
-    ELEMENT_TYPE = Fp
     LENGTH = 8
 
 
 # Additional List classes for tests
-class Uint8List32(SSZList):
+class Uint8List32(SSZList[Uint8]):
     """A list with up to 32 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LIMIT = 32
 
 
-class Uint8List64(SSZList):
+class Uint8List64(SSZList[Uint8]):
     """A list with up to 64 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LIMIT = 64
 
 
-class Uint8List4(SSZList):
+class Uint8List4(SSZList[Uint8]):
     """A list with up to 4 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LIMIT = 4
 
 
-class BooleanList4(SSZList):
+class BooleanList4(SSZList[Boolean]):
     """A list with up to 4 Boolean values."""
 
-    ELEMENT_TYPE = Boolean
     LIMIT = 4
 
 
-class FpList8(SSZList):
+class FpList8(SSZList[Fp]):
     """A list with up to 8 Fp values."""
 
-    ELEMENT_TYPE = Fp
     LIMIT = 8
 
 

--- a/tests/lean_spec/types/test_union.py
+++ b/tests/lean_spec/types/test_union.py
@@ -15,17 +15,15 @@ from lean_spec.types.uint import Uint8, Uint16, Uint32
 from lean_spec.types.union import SSZUnion
 
 
-class Uint8Vector3(SSZVector):
+class Uint8Vector3(SSZVector[Uint8]):
     """A vector of exactly 3 Uint8 values."""
 
-    ELEMENT_TYPE = Uint8
     LENGTH = 3
 
 
-class Uint16List8(SSZList):
+class Uint16List8(SSZList[Uint16]):
     """A list with up to 8 Uint16 values."""
 
-    ELEMENT_TYPE = Uint16
     LIMIT = 8
 
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
