### PR TITLE
fix: resolve circular import in chain.clock module

### DIFF
--- a/src/lean_spec/subspecs/chain/clock.py
+++ b/src/lean_spec/subspecs/chain/clock.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from time import time as wall_time
 from typing import Callable
 
-from lean_spec.subspecs.containers import Slot
+from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.types import Uint64
 
 from .config import SECONDS_PER_INTERVAL, SECONDS_PER_SLOT


### PR DESCRIPTION
Fix circular import error when importing from `lean_spec.subspecs.containers.state`.


