### PR TITLE
docs: clarify key in docs for `Store.states` map

### DIFF
--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -117,7 +117,7 @@ class Store(Container):
 
     states: dict[Bytes32, State] = {}
     """
-    Mapping from state root to State objects.
+    Mapping from block root to State objects.
 
     For each known block, we keep its post-state.
 


### PR DESCRIPTION
## 🗒️ Description

Noticed the `Store.states` field docstring says the map has the "state root" as a key, when it actually uses the block root. This is confusing, so this PR changes it to "block root".

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
