### PR TITLE
chain: add a simplified `ChainService` and tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ uvx tox                  # Everything (checks + tests + docs)
 - Google docstring style
 - Test files/functions must start with `test_`
 - **No example code in docstrings**: Do not include `Example:` sections with code blocks in docstrings. Keep documentation concise and focused on explaining *what* and *why*, not *how to use*. Unit tests serve as usage examples.
+- **Avoid explicit function names in documentation**: In docstrings and comments, describe behavior using plain language rather than explicit function or method names. Names change over time, making documentation stale. Prefer descriptive sentences like "tick the store forward" instead of referencing the exact API signature.
 
 ## Test Framework Structure
 

--- a/src/lean_spec/subspecs/chain/__init__.py
+++ b/src/lean_spec/subspecs/chain/__init__.py
@@ -2,8 +2,10 @@
 
 from .clock import Interval, SlotClock
 from .config import DEVNET_CONFIG
+from .service import ChainService
 
 __all__ = [
+    "ChainService",
     "DEVNET_CONFIG",
     "Interval",
     "SlotClock",

--- a/src/lean_spec/subspecs/chain/service.py
+++ b/src/lean_spec/subspecs/chain/service.py
@@ -1,0 +1,147 @@
+"""
+Chain service that drives consensus timing.
+
+The Chain Problem
+-----------------
+Ethereum consensus runs on a clock. Every 4 seconds (1 slot), validators:
+- Interval 0: Propose blocks
+- Interval 1: Create attestations
+- Interval 2: Update safe target
+- Interval 3: Accept attestations into fork choice
+
+The Store has all this logic built in. But nothing drives the clock.
+ChainService is that driver - a simple timer loop.
+
+How It Works
+------------
+1. Sleep until next interval boundary
+2. Get current wall-clock time
+3. Tick the store forward to current time
+4. Update the sync service with the new store state
+5. Repeat forever
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from lean_spec.types import Uint64
+
+from .clock import SlotClock
+from .config import SECONDS_PER_INTERVAL
+
+if TYPE_CHECKING:
+    from lean_spec.subspecs.sync import SyncService
+
+
+@dataclass(slots=True)
+class ChainService:
+    """
+    Drives the consensus clock by periodically ticking the forkchoice store.
+
+    ChainService is the heartbeat of a consensus client. It ensures time
+    advances in the Store, triggering interval-specific actions like
+    attestation acceptance and safe target updates.
+
+    The service is intentionally minimal:
+    - Timer loop that wakes every interval
+    - Ticks the store forward to current time
+    - Updates the sync service's store reference
+    """
+
+    sync_service: SyncService
+    """Sync service whose store we tick."""
+
+    clock: SlotClock
+    """Clock for time calculation."""
+
+    _running: bool = field(default=False, repr=False)
+    """Whether the service is running."""
+
+    async def run(self) -> None:
+        """
+        Main loop - tick the store every interval.
+
+        This is the core of the chain service. It runs forever, sleeping
+        until each interval boundary and then advancing the store's time.
+
+        The loop continues until the service is stopped.
+        """
+        self._running = True
+
+        while self._running:
+            # Sleep until next interval boundary for precise timing.
+            #
+            # Interval boundaries occur every SECONDS_PER_INTERVAL (1 second).
+            # Sleeping to boundaries ensures consistent tick timing.
+            await self._sleep_until_next_interval()
+
+            # Get current wall-clock time as Unix timestamp.
+            #
+            # The store expects an absolute timestamp, not intervals.
+            # It internally converts to intervals.
+            current_time = Uint64(int(self.clock._time_fn()))
+
+            # Tick the store forward to current time.
+            #
+            # The store advances time interval by interval, performing
+            # appropriate actions at each interval.
+            #
+            # This minimal service does not produce blocks.
+            # Block production requires validator keys.
+            new_store = self.sync_service.store.on_tick(
+                time=current_time,
+                has_proposal=False,
+            )
+
+            # Update sync service's store reference.
+            #
+            # SyncService owns the authoritative store. After ticking,
+            # we update its reference so gossip block processing sees
+            # the updated time.
+            self.sync_service.store = new_store
+
+    async def _sleep_until_next_interval(self) -> None:
+        """
+        Sleep until the next interval boundary.
+
+        Calculates the precise sleep duration to wake up at the start
+        of the next interval. This ensures tick timing is aligned with
+        network consensus expectations.
+        """
+        now = self.clock._time_fn()
+        genesis = int(self.clock.genesis_time)
+
+        # Time since genesis in seconds (float for precision).
+        elapsed = now - genesis
+
+        if elapsed < 0:
+            # Before genesis - sleep until genesis.
+            await asyncio.sleep(-elapsed)
+            return
+
+        # Current interval number (floored to integer).
+        current_interval = int(elapsed // int(SECONDS_PER_INTERVAL))
+
+        # Next interval boundary in absolute time.
+        next_boundary = genesis + (current_interval + 1) * int(SECONDS_PER_INTERVAL)
+
+        # Sleep duration (may be zero if we're exactly at boundary).
+        sleep_time = max(0.0, next_boundary - now)
+        await asyncio.sleep(sleep_time)
+
+    def stop(self) -> None:
+        """
+        Stop the service.
+
+        Sets the running flag to False, causing the run() loop to exit
+        after completing its current sleep cycle.
+        """
+        self._running = False
+
+    @property
+    def is_running(self) -> bool:
+        """Check if the service is currently running."""
+        return self._running

--- a/tests/lean_spec/subspecs/chain/test_service.py
+++ b/tests/lean_spec/subspecs/chain/test_service.py
@@ -1,0 +1,327 @@
+"""Tests for the ChainService consensus clock driver."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+from lean_spec.subspecs.chain import ChainService, SlotClock
+from lean_spec.subspecs.chain.config import SECONDS_PER_INTERVAL
+from lean_spec.types import Uint64
+
+
+@dataclass
+class MockStore:
+    """Mock store that tracks on_tick calls."""
+
+    time: Uint64 = field(default_factory=lambda: Uint64(0))
+    tick_calls: list[tuple[Uint64, bool]] = field(default_factory=list)
+
+    def on_tick(self, time: Uint64, has_proposal: bool) -> "MockStore":
+        """Record the tick call and return a new store."""
+        new_store = MockStore(time=time, tick_calls=list(self.tick_calls))
+        new_store.tick_calls.append((time, has_proposal))
+        return new_store
+
+
+@dataclass
+class MockSyncService:
+    """Mock sync service for testing ChainService."""
+
+    store: Any = field(default_factory=MockStore)
+
+
+class TestChainServiceLifecycle:
+    """Tests for ChainService start/stop lifecycle."""
+
+    def test_starts_not_running(self) -> None:
+        """Service is not running by default."""
+        sync_service = MockSyncService()
+        clock = SlotClock(genesis_time=Uint64(0), _time_fn=lambda: 0.0)
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        assert chain_service.is_running is False
+
+    def test_stop_sets_flag(self) -> None:
+        """stop() sets the running flag to False."""
+        sync_service = MockSyncService()
+        clock = SlotClock(genesis_time=Uint64(0), _time_fn=lambda: 0.0)
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        chain_service._running = True
+        assert chain_service.is_running is True
+
+        chain_service.stop()
+        assert chain_service.is_running is False
+
+    def test_run_sets_running_flag(self) -> None:
+        """run() sets the running flag before loop starts."""
+        sync_service = MockSyncService()
+        clock = SlotClock(genesis_time=Uint64(0), _time_fn=lambda: 0.0)
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        call_count = 0
+
+        async def stop_on_second_call(_duration: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                chain_service.stop()
+
+        async def run_briefly() -> None:
+            with patch("asyncio.sleep", new=stop_on_second_call):
+                await chain_service.run()
+
+        asyncio.run(run_briefly())
+
+        # After stopping, flag should be False
+        assert chain_service.is_running is False
+
+
+class TestIntervalTiming:
+    """Tests for interval boundary timing."""
+
+    def test_sleep_calculation_mid_interval(self) -> None:
+        """Sleep duration is calculated correctly mid-interval."""
+        genesis = Uint64(1000)
+        current_time = 1000.5  # 0.5 seconds into first interval
+        clock = SlotClock(genesis_time=genesis, _time_fn=lambda: current_time)
+        sync_service = MockSyncService()
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        captured_duration: float | None = None
+
+        async def capture_sleep(duration: float) -> None:
+            nonlocal captured_duration
+            captured_duration = duration
+
+        async def check_sleep() -> None:
+            with patch("asyncio.sleep", new=capture_sleep):
+                await chain_service._sleep_until_next_interval()
+
+        asyncio.run(check_sleep())
+
+        # Should sleep until next interval boundary (1.0 second mark)
+        # With SECONDS_PER_INTERVAL = 1, next boundary is at 1001.0
+        expected = 1001.0 - current_time  # 0.5 seconds
+        assert captured_duration is not None
+        assert abs(captured_duration - expected) < 0.001
+
+    def test_sleep_at_interval_boundary(self) -> None:
+        """Sleep duration is one full interval at exact boundary."""
+        genesis = Uint64(1000)
+        # Exactly at interval boundary
+        current_time = float(genesis + SECONDS_PER_INTERVAL)
+        clock = SlotClock(genesis_time=genesis, _time_fn=lambda: current_time)
+        sync_service = MockSyncService()
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        captured_duration: float | None = None
+
+        async def capture_sleep(duration: float) -> None:
+            nonlocal captured_duration
+            captured_duration = duration
+
+        async def check_sleep() -> None:
+            with patch("asyncio.sleep", new=capture_sleep):
+                await chain_service._sleep_until_next_interval()
+
+        asyncio.run(check_sleep())
+
+        # At boundary, should sleep until next boundary
+        expected = float(SECONDS_PER_INTERVAL)
+        assert captured_duration is not None
+        assert abs(captured_duration - expected) < 0.001
+
+    def test_sleep_before_genesis(self) -> None:
+        """Sleeps until genesis when current time is before genesis."""
+        genesis = Uint64(1000)
+        current_time = 900.0  # 100 seconds before genesis
+        clock = SlotClock(genesis_time=genesis, _time_fn=lambda: current_time)
+        sync_service = MockSyncService()
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        captured_duration: float | None = None
+
+        async def capture_sleep(duration: float) -> None:
+            nonlocal captured_duration
+            captured_duration = duration
+
+        async def check_sleep() -> None:
+            with patch("asyncio.sleep", new=capture_sleep):
+                await chain_service._sleep_until_next_interval()
+
+        asyncio.run(check_sleep())
+
+        # Should sleep until genesis
+        expected = float(genesis) - current_time  # 100 seconds
+        assert captured_duration is not None
+        assert abs(captured_duration - expected) < 0.001
+
+
+class TestStoreTicking:
+    """Tests for store tick integration."""
+
+    def test_ticks_store_with_current_time(self) -> None:
+        """Store is ticked with current wall-clock time."""
+        genesis = Uint64(1000)
+        current_time = 1005.0  # 5 seconds after genesis
+
+        clock = SlotClock(genesis_time=genesis, _time_fn=lambda: current_time)
+        sync_service = MockSyncService()
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        call_count = 0
+
+        async def stop_on_second_call(_duration: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                chain_service.stop()
+
+        async def run_limited() -> None:
+            with patch("asyncio.sleep", new=stop_on_second_call):
+                await chain_service.run()
+
+        asyncio.run(run_limited())
+
+        # Store should have been ticked
+        assert len(sync_service.store.tick_calls) >= 1
+        # First tick should be with current time
+        first_call = sync_service.store.tick_calls[0]
+        assert first_call[0] == Uint64(int(current_time))
+        assert first_call[1] is False  # has_proposal always False
+
+    def test_has_proposal_always_false(self) -> None:
+        """has_proposal is always False (minimal version)."""
+        genesis = Uint64(1000)
+        current_time = 1005.0
+
+        clock = SlotClock(genesis_time=genesis, _time_fn=lambda: current_time)
+        sync_service = MockSyncService()
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        tick_count = 0
+
+        async def stop_after_three(_duration: float) -> None:
+            nonlocal tick_count
+            tick_count += 1
+            if tick_count >= 3:
+                chain_service.stop()
+
+        async def run_and_check() -> None:
+            with patch("asyncio.sleep", new=stop_after_three):
+                await chain_service.run()
+
+        asyncio.run(run_and_check())
+
+        # All ticks should have has_proposal=False
+        for _time_val, has_proposal in sync_service.store.tick_calls:
+            assert has_proposal is False
+
+    def test_sync_service_store_updated(self) -> None:
+        """SyncService.store is updated with new store after tick."""
+        genesis = Uint64(1000)
+        current_time = 1005.0
+
+        clock = SlotClock(genesis_time=genesis, _time_fn=lambda: current_time)
+        initial_store = MockStore()
+        sync_service = MockSyncService(store=initial_store)
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        async def stop_immediately(_duration: float) -> None:
+            chain_service.stop()
+
+        async def run_once() -> None:
+            with patch("asyncio.sleep", new=stop_immediately):
+                await chain_service.run()
+
+        asyncio.run(run_once())
+
+        # Store should have been replaced
+        assert sync_service.store is not initial_store
+        # New store should have tick record
+        assert len(sync_service.store.tick_calls) == 1
+
+
+class TestMultipleIntervals:
+    """Tests for running through multiple intervals."""
+
+    def test_advances_through_intervals(self) -> None:
+        """Service advances through multiple intervals correctly."""
+        genesis = Uint64(1000)
+        times = [1001.0, 1002.0, 1003.0, 1004.0]  # 4 intervals
+        time_index = 0
+
+        def advancing_time() -> float:
+            nonlocal time_index
+            if time_index < len(times):
+                return times[time_index]
+            return times[-1]
+
+        clock = SlotClock(genesis_time=genesis, _time_fn=advancing_time)
+        sync_service = MockSyncService()
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        async def advance_and_stop(_duration: float) -> None:
+            nonlocal time_index
+            time_index += 1
+            if time_index >= len(times):
+                chain_service.stop()
+
+        async def run_four_intervals() -> None:
+            with patch("asyncio.sleep", new=advance_and_stop):
+                await chain_service.run()
+
+        asyncio.run(run_four_intervals())
+
+        # Should have ticked for each interval
+        assert len(sync_service.store.tick_calls) >= 3
+
+
+class TestEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_genesis_time_zero(self) -> None:
+        """Works with genesis_time of 0."""
+        genesis = Uint64(0)
+        current_time = 5.0
+
+        clock = SlotClock(genesis_time=genesis, _time_fn=lambda: current_time)
+        sync_service = MockSyncService()
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        async def stop_immediately(_duration: float) -> None:
+            chain_service.stop()
+
+        async def run_once() -> None:
+            with patch("asyncio.sleep", new=stop_immediately):
+                await chain_service.run()
+
+        asyncio.run(run_once())
+
+        assert len(sync_service.store.tick_calls) == 1
+        assert sync_service.store.tick_calls[0][0] == Uint64(5)
+
+    def test_large_genesis_time(self) -> None:
+        """Works with realistic Unix timestamp genesis times."""
+        genesis = Uint64(1700000000)  # Nov 2023
+        current_time = float(genesis) + 100.5
+
+        clock = SlotClock(genesis_time=genesis, _time_fn=lambda: current_time)
+        sync_service = MockSyncService()
+        chain_service = ChainService(sync_service=sync_service, clock=clock)  # type: ignore[arg-type]
+
+        async def stop_immediately(_duration: float) -> None:
+            chain_service.stop()
+
+        async def run_once() -> None:
+            with patch("asyncio.sleep", new=stop_immediately):
+                await chain_service.run()
+
+        asyncio.run(run_once())
+
+        assert len(sync_service.store.tick_calls) == 1
+        assert sync_service.store.tick_calls[0][0] == Uint64(int(current_time))


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

  What it intentionally does NOT do (keeping it minimal for now):
  - No block production (requires validator keys)
  - No attestation production (requires validator keys)
  - No proposal detection (`has_proposal` is always False)
  - No metrics/logging
  - No database persistence

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
