### PR TITLE
poseidon2: some cleanup and improvements

### DIFF
--- a/src/lean_spec/subspecs/poseidon2/__init__.py
+++ b/src/lean_spec/subspecs/poseidon2/__init__.py
@@ -3,11 +3,13 @@
 from .permutation import (
     PARAMS_16,
     PARAMS_24,
-    permute,
+    Poseidon2,
+    Poseidon2Params,
 )
 
 __all__ = [
-    "permute",
+    "Poseidon2",
+    "Poseidon2Params",
     "PARAMS_16",
     "PARAMS_24",
 ]

--- a/tests/lean_spec/subspecs/poseidon2/test_permutation.py
+++ b/tests/lean_spec/subspecs/poseidon2/test_permutation.py
@@ -1,8 +1,4 @@
-"""
-Tests for the Poseidon2 permutation for widths 16 and 24.
-"""
-
-from typing import List
+"""Tests for the Poseidon2 permutation for widths 16 and 24."""
 
 import pytest
 
@@ -10,8 +6,8 @@ from lean_spec.subspecs.koalabear.field import Fp
 from lean_spec.subspecs.poseidon2.permutation import (
     PARAMS_16,
     PARAMS_24,
+    Poseidon2,
     Poseidon2Params,
-    permute,
 )
 
 # --- Test Vectors ---
@@ -120,17 +116,16 @@ EXPECTED_24 = [
     ids=["width_16", "width_24"],
 )
 def test_permutation_vector(
-    params: Poseidon2Params, input_state: List[Fp], expected_output: List[Fp]
+    params: Poseidon2Params, input_state: list[Fp], expected_output: list[Fp]
 ) -> None:
     """
-    Tests the Poseidon2 permutation against known answer vectors.
+    Test the Poseidon2 permutation against known answer vectors.
 
-    This serves as a regression test to ensure the logic is consistent.
+    Serves as a regression test to ensure logic consistency.
     """
-    # Run the permutation
-    output_state = permute(input_state, params)
+    engine = Poseidon2(params)
+    output_state = engine.permute(input_state)
 
-    # Verify the output
     assert len(output_state) == params.width
     assert output_state == expected_output, (
         f"Permutation output for width {params.width} did not match."


### PR DESCRIPTION
## Refactor Poseidon2 permutation to use engine class

Followup PR on https://github.com/leanEthereum/leanSpec/pull/281

@unnawut Let me know what you think about it.

This PR replaces the global cache and standalone functions with a unified `Poseidon2` engine class.

### Changes

**Architecture:**
- Introduce `Poseidon2` class that encapsulates all permutation logic
- Remove global `_CACHE` dictionary and `_precompute_params` function
- Move `external_linear_layer` and `internal_linear_layer` to private methods

**Performance:**
- Pre-transpose M4 matrix (`_M4_T`) for efficient row-vector multiplication
- Pre-convert Fp lists to numpy arrays during initialization
- Use `__slots__` for memory efficiency. When you use the Poseidon2 class with `__slots__`, the "cache" is built directly into the object instance.
         - Initialization (__init__): The heavy lifting (converting lists to Numpy arrays) happens once.
         - Execution (permute): When you access `self._round_constants`, Python doesn't do a dictionary lookup. Because we used `__slots__`, Python knows exactly which byte offset in memory that variable lives at.



- Eliminate dictionary lookups in the hot path

**Type annotations:**
- Add `State` type alias for `NDArray[np.int64]`
- Add `Final` annotations for module-level constants

**API change:**
```python
# Before
output = permute(input_state, params)

# After
engine = Poseidon2(params)
output = engine.permute(input_state)
```

I've revamped a bit the documentation using our documentation agent and the Poseidon2 paper to have sharper and more concise explanations.

I've also removed the `_apply_m4` method because I think that with the new logic this function is so small that it makes no sense to keep it, we can just apply this on the fly with the proper doc to explain what we are doing.
