### PR TITLE
core: rm unused `Bytes3116`

### DIFF
--- a/src/lean_spec/types/__init__.py
+++ b/src/lean_spec/types/__init__.py
@@ -4,7 +4,7 @@ from .base import CamelModel, StrictBaseModel
 from .basispt import BasisPoint
 from .bitfields import BaseBitlist
 from .boolean import Boolean
-from .byte_arrays import ZERO_HASH, Bytes12, Bytes16, Bytes20, Bytes32, Bytes52, Bytes3116
+from .byte_arrays import ZERO_HASH, Bytes12, Bytes16, Bytes20, Bytes32, Bytes52
 from .collections import SSZList, SSZVector
 from .container import Container
 from .exceptions import (
@@ -30,7 +30,6 @@ __all__ = [
     "Bytes20",
     "Bytes32",
     "Bytes52",
-    "Bytes3116",
     "ZERO_HASH",
     "CamelModel",
     "StrictBaseModel",

--- a/src/lean_spec/types/byte_arrays.py
+++ b/src/lean_spec/types/byte_arrays.py
@@ -255,12 +255,6 @@ class Bytes96(BaseBytes):
     LENGTH = 96
 
 
-class Bytes3116(BaseBytes):
-    """Fixed-size byte array of exactly 3116 bytes."""
-
-    LENGTH = 3116
-
-
 class BaseByteList(SSZModel):
     """
     Base class for specialized `ByteList[L]`.


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

I think this one is unused so that for now we don't need it anymore.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
