### PR TITLE
xmss: returning false instead of raising for verification

### DIFF
--- a/src/lean_spec/subspecs/xmss/interface.py
+++ b/src/lean_spec/subspecs/xmss/interface.py
@@ -405,9 +405,12 @@ class GeneralizedXmssScheme(StrictBaseModel):
         # Retrieve the scheme's configuration parameters.
         config = self.config
 
-        # A signature for an epoch beyond the scheme's lifetime is invalid.
+        # Validate epoch bounds.
+        #
+        # Return False instead of raising to avoid panic on invalid signatures.
+        # The epoch is attacker-controlled input.
         if epoch > self.config.LIFETIME:
-            raise ValueError("The signature is for a future epoch.")
+            return False
 
         # Re-encode the message using the randomness `rho` from the signature.
         #

--- a/src/lean_spec/subspecs/xmss/subtree.py
+++ b/src/lean_spec/subspecs/xmss/subtree.py
@@ -587,16 +587,17 @@ def verify_path(
 
     Returns:
         `True` if the path is valid and reconstructs the root, `False` otherwise.
-
-    Raises:
-        ValueError: If the tree depth exceeds 32 or position doesn't match path length.
+        Returns `False` for invalid inputs (depth > 32 or position out of bounds).
     """
-    # Compute the depth
+    # Validate depth and position bounds.
+    #
+    # These checks guard against malformed attacker-controlled input.
+    # Return False instead of raising to avoid panic on invalid signatures.
     depth = len(opening.siblings)
     if depth > 32:
-        raise ValueError("Depth exceeds maximum of 32.")
+        return False
     if int(position) >= (1 << depth):
-        raise ValueError("Position exceeds tree capacity.")
+        return False
 
     # Start: hash leaf parts to get leaf node.
     current = hasher.apply(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

Related https://github.com/leanEthereum/leanSig/pull/36

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
