### PR TITLE
refactor: rename justified endpoint to checkpoints to match return type

### DIFF
--- a/src/lean_spec/subspecs/api/server.py
+++ b/src/lean_spec/subspecs/api/server.py
@@ -3,7 +3,7 @@ API server for checkpoint sync, node status, and metrics endpoints.
 
 Provides HTTP endpoints for:
 - /lean/v0/states/finalized - Serve finalized checkpoint state as SSZ
-- /lean/v0/states/justified - Return latest justified checkpoint information
+- /lean/v0/checkpoints/justified - Return latest justified checkpoint information
 - /lean/v0/health - Health check endpoint
 - /metrics - Prometheus metrics endpoint
 
@@ -101,7 +101,7 @@ class ApiServer:
                 web.get("/lean/v0/health", _handle_health),
                 web.get("/metrics", _handle_metrics),
                 web.get("/lean/v0/states/finalized", self._handle_finalized_state),
-                web.get("/lean/v0/states/justified", self._handle_justified_state),
+                web.get("/lean/v0/checkpoints/justified", self._handle_justified_checkpoint),
             ]
         )
 
@@ -166,13 +166,12 @@ class ApiServer:
 
         return web.Response(body=ssz_bytes, content_type="application/octet-stream")
 
-    async def _handle_justified_state(self, _request: web.Request) -> web.Response:
+    async def _handle_justified_checkpoint(self, _request: web.Request) -> web.Response:
         """
         Handle latest justified checkpoint endpoint.
 
-        Returns the latest justified checkpoint information as JSON at /lean/v0/states/justified.
-        This provides the slot number and root hash of the most recent justified checkpoint,
-        which is useful for monitoring consensus progress and fork choice state.
+        Returns checkpoint info as JSON at /lean/v0/checkpoints/justified.
+        Useful for monitoring consensus progress and fork choice state.
 
         Response format:
         {

--- a/tests/lean_spec/subspecs/api/test_server.py
+++ b/tests/lean_spec/subspecs/api/test_server.py
@@ -142,8 +142,8 @@ class TestFinalizedStateEndpoint:
         asyncio.run(run_test())
 
 
-class TestJustifiedEndpoint:
-    """Tests for the /lean/v0/states/justified endpoint behavior."""
+class TestJustifiedCheckpointEndpoint:
+    """Tests for the /lean/v0/checkpoints/justified endpoint behavior."""
 
     def test_returns_503_when_store_not_initialized(self) -> None:
         """Endpoint returns 503 Service Unavailable when store is not set."""
@@ -156,7 +156,9 @@ class TestJustifiedEndpoint:
 
             try:
                 async with httpx.AsyncClient() as client:
-                    response = await client.get("http://127.0.0.1:15057/lean/v0/states/justified")
+                    response = await client.get(
+                        "http://127.0.0.1:15057/lean/v0/checkpoints/justified"
+                    )
 
                     assert response.status_code == 503
 
@@ -177,7 +179,9 @@ class TestJustifiedEndpoint:
 
             try:
                 async with httpx.AsyncClient() as client:
-                    response = await client.get("http://127.0.0.1:15058/lean/v0/states/justified")
+                    response = await client.get(
+                        "http://127.0.0.1:15058/lean/v0/checkpoints/justified"
+                    )
 
                     assert response.status_code == 200
                     assert "application/json" in response.headers["content-type"]


### PR DESCRIPTION
## 🗒️ Description

It is misleading for the API for get states / justified to return a Checkpoint in JSON while get states / finalized returns a State in SSZ.

I am willing to take time here and make the right decision on the path and naming of this API. I am open to suggestions.

The get checkpoints/justified endpoint now returns a Checkpoint as JSON while the get states/finalized returns a State in ssz.

## 🔗 Related Issues or PRs
Initially brought up renaming to root by Jun in the initial PR.
https://github.com/leanEthereum/leanSpec/pull/309#discussion_r2712897264

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
