### PR TITLE
Fix mutable dictionary reference in on_attestation

### DIFF
--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -390,11 +390,11 @@ class Store(Container):
         # Copy the known attestation map:
         # - we build a new Store immutably,
         # - changes are applied on this local copy.
-        new_known = self.latest_known_attestations
+        new_known = dict(self.latest_known_attestations)
 
         # Copy the new attestation map:
         # - holds pending attestations that are not yet active.
-        new_new = self.latest_new_attestations
+        new_new = dict(self.latest_new_attestations)
 
         if is_from_block:
             # On-chain attestation processing


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
Dictionary references were mutating the original frozen Store's data. Creating copies preserves immutability and prevents shared state corruption.
## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
