### PR TITLE
BlocksByRootRequest container

### DIFF
--- a/src/lean_spec/subspecs/networking/__init__.py
+++ b/src/lean_spec/subspecs/networking/__init__.py
@@ -15,6 +15,7 @@ from .reqresp import (
     BLOCKS_BY_ROOT_PROTOCOL_V1,
     STATUS_PROTOCOL_V1,
     BlocksByRootRequest,
+    BlocksByRootRequestRoots,
     CodecError,
     ResponseCode,
     Status,
@@ -51,6 +52,7 @@ __all__ = [
     "STATUS_PROTOCOL_V1",
     # ReqResp - Message types
     "BlocksByRootRequest",
+    "BlocksByRootRequestRoots",
     "Status",
     # ReqResp - Codec
     "CodecError",

--- a/src/lean_spec/subspecs/networking/client/reqresp_client.py
+++ b/src/lean_spec/subspecs/networking/client/reqresp_client.py
@@ -42,6 +42,7 @@ from lean_spec.subspecs.networking.reqresp.message import (
     BLOCKS_BY_ROOT_PROTOCOL_V1,
     STATUS_PROTOCOL_V1,
     BlocksByRootRequest,
+    BlocksByRootRequestRoots,
     Status,
 )
 from lean_spec.subspecs.networking.transport import PeerId
@@ -161,7 +162,7 @@ class ReqRespClient:
 
         try:
             # Build and send the request.
-            request = BlocksByRootRequest(data=list(roots))
+            request = BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=roots))
             request_bytes = encode_request(request.encode_bytes())
             await stream.write(request_bytes)
 

--- a/src/lean_spec/subspecs/networking/reqresp/__init__.py
+++ b/src/lean_spec/subspecs/networking/reqresp/__init__.py
@@ -19,6 +19,7 @@ from .message import (
     BLOCKS_BY_ROOT_PROTOCOL_V1,
     STATUS_PROTOCOL_V1,
     BlocksByRootRequest,
+    BlocksByRootRequestRoots,
     Status,
 )
 
@@ -29,6 +30,7 @@ __all__ = [
     "REQRESP_PROTOCOL_IDS",
     # Message types
     "BlocksByRootRequest",
+    "BlocksByRootRequestRoots",
     "Status",
     # Codec
     "CodecError",

--- a/src/lean_spec/subspecs/networking/reqresp/handler.py
+++ b/src/lean_spec/subspecs/networking/reqresp/handler.py
@@ -364,7 +364,7 @@ class DefaultRequestHandler(RequestHandler):
         #
         # 3. Order is preserved.
         #    Blocks are sent in the same order as requested.
-        for root in request.data:
+        for root in request.roots.data:
             try:
                 block = await self.block_lookup(root)
                 if block is not None:

--- a/src/lean_spec/subspecs/networking/reqresp/message.py
+++ b/src/lean_spec/subspecs/networking/reqresp/message.py
@@ -8,7 +8,7 @@ domain. All messages are SSZ-encoded and then compressed with Snappy frames.
 from typing import ClassVar
 
 from lean_spec.subspecs.containers import Checkpoint
-from lean_spec.types import Bytes32, SSZList, SSZType
+from lean_spec.types import Bytes32, SSZList
 from lean_spec.types.container import Container
 
 from ..config import MAX_REQUEST_BLOCKS
@@ -48,12 +48,18 @@ BLOCKS_BY_ROOT_PROTOCOL_V1: ProtocolId = "/leanconsensus/req/blocks_by_root/1/ss
 """The protocol ID for the BlocksByRoot v1 request/response message."""
 
 
-class BlocksByRootRequest(SSZList[Bytes32]):
+class BlocksByRootRequestRoots(SSZList[Bytes32]):
+    """List of requested root hashes."""
+
+    LIMIT: ClassVar[int] = MAX_REQUEST_BLOCKS
+
+
+class BlocksByRootRequest(Container):
     """
     A request for one or more blocks by their root hashes.
 
     This is primarily used to recover recent or missing blocks from a peer.
     """
 
-    ELEMENT_TYPE: ClassVar[type[SSZType]] = Bytes32
-    LIMIT: ClassVar[int] = MAX_REQUEST_BLOCKS
+    roots: BlocksByRootRequestRoots
+    """List of requested root hashes."""

--- a/tests/lean_spec/subspecs/networking/reqresp/test_handler.py
+++ b/tests/lean_spec/subspecs/networking/reqresp/test_handler.py
@@ -25,6 +25,7 @@ from lean_spec.subspecs.networking.reqresp.message import (
     BLOCKS_BY_ROOT_PROTOCOL_V1,
     STATUS_PROTOCOL_V1,
     BlocksByRootRequest,
+    BlocksByRootRequestRoots,
     Status,
 )
 from lean_spec.types import Bytes32
@@ -352,7 +353,9 @@ class TestDefaultRequestHandlerBlocksByRoot:
             handler = DefaultRequestHandler(block_lookup=lookup)
             response = MockResponseStream()
 
-            request = BlocksByRootRequest(data=[Bytes32(b"\x11" * 32), Bytes32(b"\x22" * 32)])
+            request = BlocksByRootRequest(
+                roots=BlocksByRootRequestRoots(data=[Bytes32(b"\x11" * 32), Bytes32(b"\x22" * 32)])
+            )
 
             await handler.handle_blocks_by_root(request, response)
 
@@ -387,10 +390,12 @@ class TestDefaultRequestHandlerBlocksByRoot:
 
             # Request two blocks, only one exists
             request = BlocksByRootRequest(
-                data=[
-                    Bytes32(b"\x11" * 32),  # exists
-                    Bytes32(b"\x99" * 32),  # missing
-                ]
+                roots=BlocksByRootRequestRoots(
+                    data=[
+                        Bytes32(b"\x11" * 32),  # exists
+                        Bytes32(b"\x99" * 32),  # missing
+                    ]
+                )
             )
 
             await handler.handle_blocks_by_root(request, response)
@@ -410,7 +415,9 @@ class TestDefaultRequestHandlerBlocksByRoot:
             handler = DefaultRequestHandler()  # No block_lookup set
             response = MockResponseStream()
 
-            request = BlocksByRootRequest(data=[Bytes32(b"\x11" * 32)])
+            request = BlocksByRootRequest(
+                roots=BlocksByRootRequestRoots(data=[Bytes32(b"\x11" * 32)])
+            )
 
             await handler.handle_blocks_by_root(request, response)
 
@@ -433,7 +440,7 @@ class TestDefaultRequestHandlerBlocksByRoot:
             handler = DefaultRequestHandler(block_lookup=lookup)
             response = MockResponseStream()
 
-            request = BlocksByRootRequest(data=[])
+            request = BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=[]))
 
             await handler.handle_blocks_by_root(request, response)
 
@@ -461,7 +468,9 @@ class TestDefaultRequestHandlerBlocksByRoot:
             response = MockResponseStream()
 
             # First block causes error, second succeeds
-            request = BlocksByRootRequest(data=[Bytes32(b"\x11" * 32), Bytes32(b"\x22" * 32)])
+            request = BlocksByRootRequest(
+                roots=BlocksByRootRequestRoots(data=[Bytes32(b"\x11" * 32), Bytes32(b"\x22" * 32)])
+            )
 
             await handler.handle_blocks_by_root(request, response)
 
@@ -537,7 +546,7 @@ class TestReqRespServer:
             server = ReqRespServer(handler=handler)
 
             # Build wire-format request
-            request = BlocksByRootRequest(data=[root1])
+            request = BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=[root1]))
             request_bytes = encode_request(request.encode_bytes())
 
             stream = MockStream(request_data=request_bytes)
@@ -785,7 +794,7 @@ class TestIntegration:
             server = ReqRespServer(handler=handler)
 
             # Client side: encode request
-            request = BlocksByRootRequest(data=[root1, root2])
+            request = BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=[root1, root2]))
             request_wire = encode_request(request.encode_bytes())
 
             # Server side: handle request
@@ -826,7 +835,9 @@ class TestIntegration:
             server = ReqRespServer(handler=handler)
 
             # Request two blocks, only one exists
-            request = BlocksByRootRequest(data=[root1, root_missing])
+            request = BlocksByRootRequest(
+                roots=BlocksByRootRequestRoots(data=[root1, root_missing])
+            )
             request_wire = encode_request(request.encode_bytes())
 
             stream = MockStream(request_data=request_wire)
@@ -1179,7 +1190,7 @@ class TestDefaultRequestHandlerEdgeCases:
             handler = DefaultRequestHandler(block_lookup=lookup)
             response = MockResponseStream()
 
-            request = BlocksByRootRequest(data=[root])
+            request = BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=[root]))
 
             await handler.handle_blocks_by_root(request, response)
 
@@ -1204,11 +1215,13 @@ class TestDefaultRequestHandlerEdgeCases:
             response = MockResponseStream()
 
             request = BlocksByRootRequest(
-                data=[
-                    Bytes32(b"\x11" * 32),
-                    Bytes32(b"\x22" * 32),
-                    Bytes32(b"\x33" * 32),
-                ]
+                roots=BlocksByRootRequestRoots(
+                    data=[
+                        Bytes32(b"\x11" * 32),
+                        Bytes32(b"\x22" * 32),
+                        Bytes32(b"\x33" * 32),
+                    ]
+                )
             )
 
             await handler.handle_blocks_by_root(request, response)
@@ -1240,11 +1253,13 @@ class TestDefaultRequestHandlerEdgeCases:
             response = MockResponseStream()
 
             request = BlocksByRootRequest(
-                data=[
-                    Bytes32(b"\x11" * 32),
-                    Bytes32(b"\x22" * 32),
-                    Bytes32(b"\x33" * 32),
-                ]
+                roots=BlocksByRootRequestRoots(
+                    data=[
+                        Bytes32(b"\x11" * 32),
+                        Bytes32(b"\x22" * 32),
+                        Bytes32(b"\x33" * 32),
+                    ]
+                )
             )
 
             await handler.handle_blocks_by_root(request, response)
@@ -1358,7 +1373,9 @@ class TestConcurrentRequestHandling:
             status_stream = MockStream(request_data=status_request)
 
             # BlocksByRoot request
-            blocks_request = encode_request(BlocksByRootRequest(data=[root]).encode_bytes())
+            blocks_request = encode_request(
+                BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=[root])).encode_bytes()
+            )
             blocks_stream = MockStream(request_data=blocks_request)
 
             # Handle concurrently


### PR DESCRIPTION
## 🗒️ Description
- make `BlocksByRootRequest` [compatible with zeam](https://github.com/blockblaz/zeam/blob/9e95065d935a68f97c6a96cbc1b04dd2a8ecc4a0/pkgs/types/src/block.zig#L638-L639)

## 🔗 Related Issues or PRs
N/A

## ✅ Checklist
- [x] Ran `tox` checks to avoid unnecessary CI fails
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
