### PR TITLE
networking: rename `BlocksByRootRequestRoots` to `RequestedBlockRoots`

### DIFF
--- a/src/lean_spec/subspecs/networking/__init__.py
+++ b/src/lean_spec/subspecs/networking/__init__.py
@@ -15,8 +15,8 @@ from .reqresp import (
     BLOCKS_BY_ROOT_PROTOCOL_V1,
     STATUS_PROTOCOL_V1,
     BlocksByRootRequest,
-    BlocksByRootRequestRoots,
     CodecError,
+    RequestedBlockRoots,
     ResponseCode,
     Status,
     decode_request,
@@ -52,7 +52,7 @@ __all__ = [
     "STATUS_PROTOCOL_V1",
     # ReqResp - Message types
     "BlocksByRootRequest",
-    "BlocksByRootRequestRoots",
+    "RequestedBlockRoots",
     "Status",
     # ReqResp - Codec
     "CodecError",

--- a/src/lean_spec/subspecs/networking/client/reqresp_client.py
+++ b/src/lean_spec/subspecs/networking/client/reqresp_client.py
@@ -42,7 +42,7 @@ from lean_spec.subspecs.networking.reqresp.message import (
     BLOCKS_BY_ROOT_PROTOCOL_V1,
     STATUS_PROTOCOL_V1,
     BlocksByRootRequest,
-    BlocksByRootRequestRoots,
+    RequestedBlockRoots,
     Status,
 )
 from lean_spec.subspecs.networking.transport import PeerId
@@ -162,7 +162,7 @@ class ReqRespClient:
 
         try:
             # Build and send the request.
-            request = BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=roots))
+            request = BlocksByRootRequest(roots=RequestedBlockRoots(data=roots))
             request_bytes = encode_request(request.encode_bytes())
             await stream.write(request_bytes)
 

--- a/src/lean_spec/subspecs/networking/reqresp/__init__.py
+++ b/src/lean_spec/subspecs/networking/reqresp/__init__.py
@@ -19,7 +19,7 @@ from .message import (
     BLOCKS_BY_ROOT_PROTOCOL_V1,
     STATUS_PROTOCOL_V1,
     BlocksByRootRequest,
-    BlocksByRootRequestRoots,
+    RequestedBlockRoots,
     Status,
 )
 
@@ -30,7 +30,7 @@ __all__ = [
     "REQRESP_PROTOCOL_IDS",
     # Message types
     "BlocksByRootRequest",
-    "BlocksByRootRequestRoots",
+    "RequestedBlockRoots",
     "Status",
     # Codec
     "CodecError",

--- a/src/lean_spec/subspecs/networking/reqresp/message.py
+++ b/src/lean_spec/subspecs/networking/reqresp/message.py
@@ -48,8 +48,8 @@ BLOCKS_BY_ROOT_PROTOCOL_V1: ProtocolId = "/leanconsensus/req/blocks_by_root/1/ss
 """The protocol ID for the BlocksByRoot v1 request/response message."""
 
 
-class BlocksByRootRequestRoots(SSZList[Bytes32]):
-    """List of requested root hashes."""
+class RequestedBlockRoots(SSZList[Bytes32]):
+    """List of block roots requested from a peer."""
 
     LIMIT: ClassVar[int] = MAX_REQUEST_BLOCKS
 
@@ -61,5 +61,5 @@ class BlocksByRootRequest(Container):
     This is primarily used to recover recent or missing blocks from a peer.
     """
 
-    roots: BlocksByRootRequestRoots
-    """List of requested root hashes."""
+    roots: RequestedBlockRoots
+    """List of block roots requested from a peer."""

--- a/tests/lean_spec/subspecs/networking/reqresp/test_handler.py
+++ b/tests/lean_spec/subspecs/networking/reqresp/test_handler.py
@@ -25,7 +25,7 @@ from lean_spec.subspecs.networking.reqresp.message import (
     BLOCKS_BY_ROOT_PROTOCOL_V1,
     STATUS_PROTOCOL_V1,
     BlocksByRootRequest,
-    BlocksByRootRequestRoots,
+    RequestedBlockRoots,
     Status,
 )
 from lean_spec.types import Bytes32
@@ -354,7 +354,7 @@ class TestDefaultRequestHandlerBlocksByRoot:
             response = MockResponseStream()
 
             request = BlocksByRootRequest(
-                roots=BlocksByRootRequestRoots(data=[Bytes32(b"\x11" * 32), Bytes32(b"\x22" * 32)])
+                roots=RequestedBlockRoots(data=[Bytes32(b"\x11" * 32), Bytes32(b"\x22" * 32)])
             )
 
             await handler.handle_blocks_by_root(request, response)
@@ -390,7 +390,7 @@ class TestDefaultRequestHandlerBlocksByRoot:
 
             # Request two blocks, only one exists
             request = BlocksByRootRequest(
-                roots=BlocksByRootRequestRoots(
+                roots=RequestedBlockRoots(
                     data=[
                         Bytes32(b"\x11" * 32),  # exists
                         Bytes32(b"\x99" * 32),  # missing
@@ -415,9 +415,7 @@ class TestDefaultRequestHandlerBlocksByRoot:
             handler = DefaultRequestHandler()  # No block_lookup set
             response = MockResponseStream()
 
-            request = BlocksByRootRequest(
-                roots=BlocksByRootRequestRoots(data=[Bytes32(b"\x11" * 32)])
-            )
+            request = BlocksByRootRequest(roots=RequestedBlockRoots(data=[Bytes32(b"\x11" * 32)]))
 
             await handler.handle_blocks_by_root(request, response)
 
@@ -440,7 +438,7 @@ class TestDefaultRequestHandlerBlocksByRoot:
             handler = DefaultRequestHandler(block_lookup=lookup)
             response = MockResponseStream()
 
-            request = BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=[]))
+            request = BlocksByRootRequest(roots=RequestedBlockRoots(data=[]))
 
             await handler.handle_blocks_by_root(request, response)
 
@@ -469,7 +467,7 @@ class TestDefaultRequestHandlerBlocksByRoot:
 
             # First block causes error, second succeeds
             request = BlocksByRootRequest(
-                roots=BlocksByRootRequestRoots(data=[Bytes32(b"\x11" * 32), Bytes32(b"\x22" * 32)])
+                roots=RequestedBlockRoots(data=[Bytes32(b"\x11" * 32), Bytes32(b"\x22" * 32)])
             )
 
             await handler.handle_blocks_by_root(request, response)
@@ -546,7 +544,7 @@ class TestReqRespServer:
             server = ReqRespServer(handler=handler)
 
             # Build wire-format request
-            request = BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=[root1]))
+            request = BlocksByRootRequest(roots=RequestedBlockRoots(data=[root1]))
             request_bytes = encode_request(request.encode_bytes())
 
             stream = MockStream(request_data=request_bytes)
@@ -794,7 +792,7 @@ class TestIntegration:
             server = ReqRespServer(handler=handler)
 
             # Client side: encode request
-            request = BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=[root1, root2]))
+            request = BlocksByRootRequest(roots=RequestedBlockRoots(data=[root1, root2]))
             request_wire = encode_request(request.encode_bytes())
 
             # Server side: handle request
@@ -835,9 +833,7 @@ class TestIntegration:
             server = ReqRespServer(handler=handler)
 
             # Request two blocks, only one exists
-            request = BlocksByRootRequest(
-                roots=BlocksByRootRequestRoots(data=[root1, root_missing])
-            )
+            request = BlocksByRootRequest(roots=RequestedBlockRoots(data=[root1, root_missing]))
             request_wire = encode_request(request.encode_bytes())
 
             stream = MockStream(request_data=request_wire)
@@ -1190,7 +1186,7 @@ class TestDefaultRequestHandlerEdgeCases:
             handler = DefaultRequestHandler(block_lookup=lookup)
             response = MockResponseStream()
 
-            request = BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=[root]))
+            request = BlocksByRootRequest(roots=RequestedBlockRoots(data=[root]))
 
             await handler.handle_blocks_by_root(request, response)
 
@@ -1215,7 +1211,7 @@ class TestDefaultRequestHandlerEdgeCases:
             response = MockResponseStream()
 
             request = BlocksByRootRequest(
-                roots=BlocksByRootRequestRoots(
+                roots=RequestedBlockRoots(
                     data=[
                         Bytes32(b"\x11" * 32),
                         Bytes32(b"\x22" * 32),
@@ -1253,7 +1249,7 @@ class TestDefaultRequestHandlerEdgeCases:
             response = MockResponseStream()
 
             request = BlocksByRootRequest(
-                roots=BlocksByRootRequestRoots(
+                roots=RequestedBlockRoots(
                     data=[
                         Bytes32(b"\x11" * 32),
                         Bytes32(b"\x22" * 32),
@@ -1374,7 +1370,7 @@ class TestConcurrentRequestHandling:
 
             # BlocksByRoot request
             blocks_request = encode_request(
-                BlocksByRootRequest(roots=BlocksByRootRequestRoots(data=[root])).encode_bytes()
+                BlocksByRootRequest(roots=RequestedBlockRoots(data=[root])).encode_bytes()
             )
             blocks_stream = MockStream(request_data=blocks_request)
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
