### PR TITLE
clock: fix `_milliseconds_since_genesis`

### DIFF
--- a/src/lean_spec/subspecs/chain/clock.py
+++ b/src/lean_spec/subspecs/chain/clock.py
@@ -45,8 +45,11 @@ class SlotClock:
 
     def _milliseconds_since_genesis(self) -> Uint64:
         """Milliseconds elapsed since genesis (0 if before genesis)."""
-        # TODO(kamilsa): #360, return the actual milliseconds instead of converting from seconds
-        return self._seconds_since_genesis() * Uint64(1000)
+        now_ms = int(self.time_fn() * 1000)
+        genesis_ms = int(self.genesis_time) * 1000
+        if now_ms < genesis_ms:
+            return Uint64(0)
+        return Uint64(now_ms - genesis_ms)
 
     def current_slot(self) -> Slot:
         """Get the current slot number (0 if before genesis)."""


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

Should close #360.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
