### PR TITLE
optimize gossip signature management

### DIFF
--- a/tests/consensus/devnet/fc/test_fork_choice_reorgs.py
+++ b/tests/consensus/devnet/fc/test_fork_choice_reorgs.py
@@ -391,7 +391,7 @@ def test_reorg_with_slot_gaps(
             ),
             # Accept fork_a_7's proposer attestation to ensure it counts in fork choice
             TickStep(
-                time=(7 * 4 + 3),  # Slot 7, interval 3
+                time=(7 * 5 + 4),  # Slot 7, interval 4 (acceptance)
                 checks=StoreChecks(
                     head_slot=Slot(7),
                     head_root_label="fork_a_7",
@@ -412,7 +412,7 @@ def test_reorg_with_slot_gaps(
             # Advance to end of slot 9 to accept fork_b_9's proposer attestation
             # This ensures the attestation contributes to fork choice weight
             TickStep(
-                time=(9 * 4 + 4),  # Slot 9, interval 4 (end of slot)
+                time=(9 * 5 + 4),  # Slot 9, interval 4 (end of slot)
                 checks=StoreChecks(
                     head_slot=Slot(9),
                     head_root_label="fork_b_9",  # REORG with sparse blocks


### PR DESCRIPTION
## 🗒️ Description
This PR optimizes the performance of the fork choice store by pruning successfully aggregated gossip signatures and fixes failing test vectors caused by the transition to a 5-interval-per-slot configuration.
 
Previously, signatures were kept in the map indefinitely, causing the aggregator to re-aggregate historical signatures from all previous slots every time a new slot was processed. This led to $O(N^2)$ computational complexity relative to chain length. By pruning signatures once they are successfully aggregated into a proof, we ensure each signature is processed exactly once, reducing the fill command execution time.

Updates the test_reorg_with_slot_gaps test in test_fork_choice_reorgs.py. The test had hardcoded TickStep times based on the old 4-interval-per-slot configuration. These have been updated to the current 5-interval-per-slot timing (using interval 4 for end-of-slot acceptance) to restore test correctness.

## 🔗 Related Issues or PRs
N/A

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
