### PR TITLE
documentation: replace wrong p2p interface link

### DIFF
--- a/src/lean_spec/subspecs/networking/client/event_source.py
+++ b/src/lean_spec/subspecs/networking/client/event_source.py
@@ -92,7 +92,7 @@ Key v1.1 features used:
 
 
 References:
-    - Ethereum P2P spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+    - Ethereum P2P spec: https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md
     - Gossipsub v1.1: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md
     - SSZ spec: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md
     - Snappy format: https://github.com/google/snappy/blob/main/format_description.txt

--- a/src/lean_spec/subspecs/networking/enr/eth2.py
+++ b/src/lean_spec/subspecs/networking/enr/eth2.py
@@ -13,7 +13,7 @@ Subnet subscription keys (SSZ Bitvectors):
 - attnets: Bitvector[64] - attestation subnets (bit i = subscribed to subnet i)
 - syncnets: Bitvector[4] - sync committee subnets
 
-See: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+See: https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md
 """
 
 from typing import ClassVar

--- a/src/lean_spec/subspecs/networking/gossipsub/__init__.py
+++ b/src/lean_spec/subspecs/networking/gossipsub/__init__.py
@@ -19,7 +19,7 @@ References:
 ----------
 - Gossipsub v1.0: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md
 - Gossipsub v1.2: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.2.md
-- Ethereum P2P: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+- Ethereum P2P: https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md
 """
 
 from .behavior import (

--- a/src/lean_spec/subspecs/networking/gossipsub/message.py
+++ b/src/lean_spec/subspecs/networking/gossipsub/message.py
@@ -48,7 +48,7 @@ which domain byte to use.
 
 References:
 ----------
-- `Ethereum P2P spec <https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md>`_
+- `Ethereum P2P spec <https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md>`_
 - `Gossipsub v1.0 <https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md>`_
 """
 

--- a/src/lean_spec/subspecs/networking/gossipsub/parameters.py
+++ b/src/lean_spec/subspecs/networking/gossipsub/parameters.py
@@ -52,7 +52,7 @@ The Ethereum consensus layer specifies:
 
 References:
 ----------
-- Ethereum P2P spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+- Ethereum P2P spec: https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md
 - Gossipsub v1.0: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md
 - Gossipsub v1.2: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.2.md
 """

--- a/src/lean_spec/subspecs/networking/gossipsub/topic.py
+++ b/src/lean_spec/subspecs/networking/gossipsub/topic.py
@@ -53,7 +53,7 @@ Topic Types
 
 References:
 ----------
-- Ethereum P2P: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+- Ethereum P2P: https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md
 """
 
 from __future__ import annotations

--- a/src/lean_spec/subspecs/networking/reqresp/codec.py
+++ b/src/lean_spec/subspecs/networking/reqresp/codec.py
@@ -64,7 +64,7 @@ This prevents decompression bombs (small compressed → huge uncompressed).
 
 References:
     Ethereum P2P spec:
-        https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+        https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md
     LEB128 encoding:
         https://en.wikipedia.org/wiki/LEB128
     Snappy framing:
@@ -210,7 +210,7 @@ class ResponseCode(IntEnum):
       - Codes 128-255: Treated as INVALID_REQUEST (invalid range).
 
     Reference:
-        https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+        https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md
     """
 
     SUCCESS = 0

--- a/src/lean_spec/subspecs/networking/reqresp/handler.py
+++ b/src/lean_spec/subspecs/networking/reqresp/handler.py
@@ -65,7 +65,7 @@ The protocol ID determines:
 
 References:
     Ethereum P2P spec:
-        https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+        https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md
     Wire format details:
         See codec.py in this package
 """

--- a/src/lean_spec/subspecs/networking/types.py
+++ b/src/lean_spec/subspecs/networking/types.py
@@ -81,7 +81,7 @@ class GoodbyeReason(IntEnum):
 
     References:
     -----------
-    - Goodbye spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#goodbye-v1
+    - Goodbye spec: https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md#goodbye-v1
     """
 
     CLIENT_SHUTDOWN = 1


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
