### PR TITLE
Update Devnet 3 version and link in VERSIONS.md

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,4 +3,4 @@
 | Devnet 0 | 4b750f2748a3718fe3e1e9cdb3c65e3a7ddabff5 | https://github.com/leanEthereum/leanSpec/tree/4b750f2748a3718fe3e1e9cdb3c65e3a7ddabff5 |
 | Devnet 1 | 050fa4a18881d54d7dc07601fe59e34eb20b9630 | https://github.com/leanEthereum/leanSpec/tree/050fa4a18881d54d7dc07601fe59e34eb20b9630 |
 | Devnet 2 | 4edcf7bc9271e6a70ded8aff17710d68beac4266 | https://github.com/leanEthereum/leanSpec/tree/4edcf7bc9271e6a70ded8aff17710d68beac4266 |
-| Devnet 3 | 3a34e7fae5ed8cd13acc5881207aee4fb1508cc1 | https://github.com/leanEthereum/leanSpec/tree/3a34e7fae5ed8cd13acc5881207aee4fb1508cc1 |
+| Devnet 3 | 8b7636bb8a95fe4bec414cc4c24e74079e6256b6 | https://github.com/leanEthereum/leanSpec/tree/8b7636bb8a95fe4bec414cc4c24e74079e6256b6 |


### PR DESCRIPTION
## 🗒️ Description

Update the Devnet 3 leanSpec version hash from `3a34e7fae5ed8cd13acc5881207aee4fb1508cc1` to `8b7636bb8a95fe4bec414cc4c24e74079e6256b6` in VERSIONS.md, pointing to the latest spec revision.

## 🔗 Related Issues or PRs
N/A

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
