### PR TITLE
devnet-4, recursive aggregation

### DIFF
--- a/src/lean_spec/subspecs/containers/state/state.py
+++ b/src/lean_spec/subspecs/containers/state/state.py
@@ -861,17 +861,18 @@ class State(Container):
 
         return final_block, post_state, aggregated_attestations, aggregated_signatures
 
-    def aggregate_gossip_signatures(
+    def aggregate(
         self,
         attestations: Collection[Attestation],
         gossip_signatures: dict[SignatureKey, "Signature"] | None = None,
+        children_payloads: dict[SignatureKey, list[AggregatedSignatureProof]] | None = None,
     ) -> list[tuple[AggregatedAttestation, AggregatedSignatureProof]]:
         """
-        Collect aggregated signatures from gossip network and aggregate them.
+        Collect signatures from gossip network and children payloads to aggregate them.
 
         For each attestation group, attempt to collect individual XMSS signatures
-        from the gossip network. These are fresh signatures that validators
-        broadcast when they attest.
+        from the gossip network and children payloads. These are fresh signatures that validators
+        broadcast when they attest and both new and known children payloads.
 
         Parameters
         ----------
@@ -879,6 +880,8 @@ class State(Container):
             Individual attestations to aggregate and sign.
         gossip_signatures : dict[SignatureKey, Signature] | None
             Per-validator XMSS signatures learned from the gossip network.
+        children_payloads : dict[SignatureKey, list[AggregatedSignatureProof]] | None
+            Aggregated proofs, contains both new and known children payloads.
 
         Returns:
         -------
@@ -925,22 +928,39 @@ class State(Container):
                         gossip_keys.append(self.validators[vid].get_pubkey())
                         gossip_ids.append(vid)
 
-            # If we collected any gossip signatures, aggregate them into a proof.
+            children_pls: set[AggregatedSignatureProof] = set()
+
+            # Attempt to collect child proofs from aggregated payloads.
             #
-            # The aggregation combines multiple XMSS signatures into a single
-            # compact proof that can verify all participants signed the message.
-            if gossip_ids:
-                participants = AggregationBits.from_validator_indices(
-                    ValidatorIndices(data=gossip_ids)
+            # Skip validators already covered by gossip
+            gossip_id_set = set(gossip_ids)
+            if children_payloads:
+                for vid in validator_ids:
+                    if vid in gossip_id_set:
+                        continue
+                    key = SignatureKey(vid, data_root)
+                    if (pls := children_payloads.get(key)) is not None:
+                        children_pls.update(pls)
+
+            # If we collected any gossip signatures or multiple child proofs,
+            # coalesce them into a single proof (recursive aggregation).
+            if gossip_ids or len(children_pls) > 1:
+                gossip_participants = (
+                    AggregationBits.from_validator_indices(ValidatorIndices(data=gossip_ids))
+                    if gossip_ids
+                    else None
                 )
                 proof = AggregatedSignatureProof.aggregate(
-                    participants=participants,
-                    public_keys=gossip_keys,
-                    signatures=gossip_sigs,
+                    participants=gossip_participants,
+                    children=list(children_pls),
+                    raw_xmss=list(zip(gossip_keys, gossip_sigs, strict=True)),
                     message=data_root,
                     slot=data.slot,
                 )
-                attestation = AggregatedAttestation(aggregation_bits=participants, data=data)
+                attestation = AggregatedAttestation(
+                    aggregation_bits=proof.participants,
+                    data=data,
+                )
                 results.append((attestation, proof))
 
         return results

--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -827,19 +827,10 @@ class Store(Container):
         Returns:
             New Store with migrated aggregated payloads and updated head.
         """
-        # Merge new aggregated payloads into known aggregated payloads
-        merged_aggregated_payloads = dict(self.latest_known_aggregated_payloads)
-        for sig_key, proofs in self.latest_new_aggregated_payloads.items():
-            if sig_key in merged_aggregated_payloads:
-                # Merge proof lists for the same signature key
-                merged_aggregated_payloads[sig_key] = merged_aggregated_payloads[sig_key] + proofs
-            else:
-                merged_aggregated_payloads[sig_key] = proofs
-
         # Create store with migrated aggregated payloads
         store = self.model_copy(
             update={
-                "latest_known_aggregated_payloads": merged_aggregated_payloads,
+                "latest_known_aggregated_payloads": self._merged_aggregated_payloads(),
                 "latest_new_aggregated_payloads": {},
             }
         )
@@ -910,20 +901,7 @@ class Store(Container):
         #
         # Without this merge, those attestations would be invisible to the
         # safe target calculation, causing it to undercount support.
-        #
-        # The technique: start with a shallow copy of "known", then overlay
-        # every entry from "new" on top. When both pools contain proofs for
-        # the same signature key, concatenate the proof lists.
-        all_payloads: dict[SignatureKey, list[AggregatedSignatureProof]] = dict(
-            self.latest_known_aggregated_payloads
-        )
-        for sig_key, proofs in self.latest_new_aggregated_payloads.items():
-            if sig_key in all_payloads:
-                # Both pools have proofs for this key. Combine them.
-                all_payloads[sig_key] = all_payloads[sig_key] + proofs
-            else:
-                # Only "new" has proofs for this key. Add them directly.
-                all_payloads[sig_key] = proofs
+        all_payloads = self._merged_aggregated_payloads()
 
         # Convert the merged aggregated payloads into per-validator votes.
         #
@@ -951,37 +929,85 @@ class Store(Container):
         # The head and attestation pools remain unchanged.
         return self.model_copy(update={"safe_target": safe_target})
 
-    def aggregate_committee_signatures(self) -> tuple["Store", list[SignedAggregatedAttestation]]:
-        """
-        Aggregate committee signatures for attestations in committee_signatures.
+    def _merged_aggregated_payloads(
+        self,
+    ) -> dict[SignatureKey, list[AggregatedSignatureProof]]:
+        """Merge new and known aggregated payloads into a single view.
 
-        This method aggregates signatures from the gossip_signatures map.
-        Attestations are reconstructed from gossip_signatures using attestation_data_by_root.
+        Starts with a shallow copy of known payloads, then overlays new payloads.
+        When both pools contain proofs for the same key, their lists are concatenated.
+        """
+        merged = dict(self.latest_known_aggregated_payloads)
+        for sig_key, proofs in self.latest_new_aggregated_payloads.items():
+            if sig_key in merged:
+                merged[sig_key] = merged[sig_key] + proofs
+            else:
+                merged[sig_key] = proofs
+        return merged
+
+    def _attestations_from_gossip_and_payloads(self) -> list[Attestation]:
+        """Build attestation list from gossip and aggregated payloads for recursive aggregation.
+
+        Known payloads are only included when their data root also appears in the
+        gossip or new payload sets, so that we combine fresh contributions with
+        previously accepted ones instead of re-aggregating stale data every interval.
+        """
+        # Collect data roots that have fresh contributions.
+        fresh_data_roots: set[Bytes32] = {
+            sk.data_root for sk in self.gossip_signatures
+        } | {sk.data_root for sk in self.latest_new_aggregated_payloads}
+
+        # Union all signature keys, deduplicating validators that appear
+        # across multiple maps. Known payloads are only included when their
+        # data root has fresh contributions.
+        all_keys: set[SignatureKey] = (
+            set(self.gossip_signatures)
+            | set(self.latest_new_aggregated_payloads)
+            | {
+                sk
+                for sk in self.latest_known_aggregated_payloads
+                if sk.data_root in fresh_data_roots
+            }
+        )
+
+        attestation_list: list[Attestation] = []
+        for sig_key in all_keys:
+            attestation_data = self.attestation_data_by_root.get(sig_key.data_root)
+            if attestation_data is not None:
+                attestation_list.append(
+                    Attestation(validator_id=sig_key.validator_id, data=attestation_data)
+                )
+        return attestation_list
+
+    def aggregate_committee_signatures_and_payloads(self) -> tuple["Store", list[SignedAggregatedAttestation]]:
+        """
+        Aggregate committee signatures for attestations in committee_signatures
+        and aggregated payloads from latest_new_aggregated_payloads and latest_known_aggregated_payloads.
+
+        Aggregates from gossip_signatures and from existing aggregated payloads
+        (latest_new and latest_known). Attestations are reconstructed from
+        attestation_data_by_root so that recursive aggregation can coalesce
+        gossip signatures and children payloads into a single proof per group.
 
         Returns:
             Tuple of (new Store with updated payloads, list of new SignedAggregatedAttestation).
         """
         new_aggregated_payloads = dict(self.latest_new_aggregated_payloads)
 
-        # Extract attestations from gossip_signatures
-        # Each SignatureKey contains (validator_id, data_root)
-        # We look up the full AttestationData from attestation_data_by_root
-        attestation_list: list[Attestation] = []
-        for sig_key in self.gossip_signatures:
-            data_root = sig_key.data_root
-            attestation_data = self.attestation_data_by_root.get(data_root)
-            if attestation_data is not None:
-                attestation_list.append(
-                    Attestation(validator_id=sig_key.validator_id, data=attestation_data)
-                )
+        # Build attestation list from all sources so State.aggregate can group by data
+        # and coalesce gossip + children payloads (recursive aggregation).
+        attestation_list = self._attestations_from_gossip_and_payloads()
 
         committee_signatures = self.gossip_signatures
 
+        committee_aggregated_payloads = self._merged_aggregated_payloads()
+
         head_state = self.states[self.head]
         # Perform aggregation
-        aggregated_results = head_state.aggregate_gossip_signatures(
+        aggregated_results = head_state.aggregate(
             attestation_list,
             committee_signatures,
+            committee_aggregated_payloads,
         )
 
         # Create list of aggregated attestations for broadcasting

--- a/src/lean_spec/subspecs/xmss/aggregation.py
+++ b/src/lean_spec/subspecs/xmss/aggregation.py
@@ -6,20 +6,24 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Self
 
-from lean_multisig_py import (
-    aggregate_signatures,
-    setup_prover,
-    setup_verifier,
-    verify_aggregated_signatures,
-)
+# from lean_multisig_py import (
+#     aggregate_signatures,
+#     setup_prover,
+#     setup_verifier,
+#     verify_aggregated_signatures,
+# )
 
 from lean_spec.config import LEAN_ENV, LeanEnvMode
 from lean_spec.subspecs.containers.attestation import AggregationBits
 from lean_spec.subspecs.containers.slot import Slot
-from lean_spec.subspecs.containers.validator import ValidatorIndex
+from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
 from lean_spec.types import ByteListMiB, Bytes32, Container
 
 from .containers import PublicKey, Signature
+from .types import BytecodePointOption
+
+INV_PROOF_SIZE: int = 2
+"""Protocol-level inverse proof size parameter for aggregation (range 1-4)."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,49 +75,96 @@ class AggregatedSignatureProof(Container):
     proof_data: ByteListMiB
     """The raw aggregated proof bytes from leanVM."""
 
+    bytecode_point: BytecodePointOption = BytecodePointOption(selector=0, value=None)
+    """
+    Serialized bytecode-point claim data from recursive aggregation.
+
+    Union: selector 0 = None (non-recursive), selector 1 = ByteListMiB (recursive).
+    """
+
     @classmethod
     def aggregate(
         cls,
-        participants: AggregationBits,
-        public_keys: Sequence[PublicKey],
-        signatures: Sequence[Signature],
+        participants: AggregationBits | None,
+        children: Sequence[Self],
+        raw_xmss: Sequence[tuple[PublicKey, Signature]],
         message: Bytes32,
         slot: Slot,
         mode: LeanEnvMode | None = None,
+        dummy: bool = True,
     ) -> Self:
         """
         Aggregate individual XMSS signatures into a single proof.
 
         Args:
-            participants: Bitfield of validators whose signatures are included.
-            public_keys: Public keys of the signers (must match signatures order).
-            signatures: Individual XMSS signatures to aggregate.
+            participants: Bitfield for validator IDs represented by `raw_xmss`.
+            children: Already-aggregated child proofs to recursively aggregate.
+            raw_xmss: Raw `(public_key, signature)` pairs for this aggregation step.
             message: The 32-byte message that was signed.
             slot: The slot in which the signatures were created.
             mode: The mode to use for the aggregation (test or prod).
+            dummy: If True, return a minimal dummy proof for local/test usage.
 
         Returns:
-            An aggregated signature proof covering all participants.
+            An aggregated signature proof covering raw signers and all child participants.
 
         Raises:
             AggregationError: If aggregation fails.
         """
-        mode = mode or LEAN_ENV
-        setup_prover(mode=mode)
-        try:
-            proof_bytes = aggregate_signatures(
-                [pk.encode_bytes() for pk in public_keys],
-                [sig.encode_bytes() for sig in signatures],
-                message,
-                slot,
-                mode=mode,
+        if not raw_xmss and not children:
+            raise AggregationError("At least one raw signature or child proof is required")
+
+        if raw_xmss and participants is None:
+            raise AggregationError("participants is required when raw_xmss is provided")
+
+        if not raw_xmss and len(children) < 2:
+            raise AggregationError(
+                "At least two child proofs are required when no raw signatures are provided"
             )
+
+        if dummy:
+            all_indices: set[ValidatorIndex] = set()
+            if participants is not None:
+                all_indices.update(participants.to_validator_indices().data)
+            for child in children:
+                all_indices.update(child.participants.to_validator_indices().data)
+
+            merged_participants = AggregationBits.from_validator_indices(
+                ValidatorIndices(data=list(all_indices))
+            )
+
+            bytecode_point = (
+                BytecodePointOption(selector=1, value=ByteListMiB(data=b"\x00" * 1))
+                if children
+                else BytecodePointOption(selector=0, value=None)
+            )
+
             return cls(
-                participants=participants,
-                proof_data=ByteListMiB(data=proof_bytes),
+                participants=merged_participants,
+                proof_data=ByteListMiB(data=b"\x00" * 1),
+                bytecode_point=bytecode_point,
             )
-        except Exception as exc:
-            raise AggregationError(f"Signature aggregation failed: {exc}") from exc
+
+        raise AggregationError("recursive aggregation is unavailable in current lean_multisig_py bindings")
+
+        # mode = mode or LEAN_ENV
+        # setup_prover(mode=mode)
+        # try:
+        #     proof_bytes = aggregate_signatures(
+        #         [pk.encode_bytes() for pk, _ in raw_xmss],
+        #         [sig.encode_bytes() for _, sig in raw_xmss],
+        #         message,
+        #         slot,
+        #         mode=mode,
+        #     )
+        #     if participants is None:
+        #         participants = AggregationBits.from_validator_indices(ValidatorIndices(data=[]))
+        #     return cls(
+        #         participants=participants,
+        #         proof_data=ByteListMiB(data=proof_bytes),
+        #     )
+        # except Exception as exc:
+        #     raise AggregationError(f"Signature aggregation failed: {exc}") from e
 
     def verify(
         self,
@@ -121,6 +172,7 @@ class AggregatedSignatureProof(Container):
         message: Bytes32,
         slot: Slot,
         mode: LeanEnvMode | None = None,
+        dummy: bool = True,
     ) -> None:
         """
         Verify this aggregated signature proof.
@@ -130,19 +182,30 @@ class AggregatedSignatureProof(Container):
             message: The 32-byte message that was signed.
             slot: The slot in which the signatures were created.
             mode: The mode to use for the verification (test or prod).
+            dummy: If True, use lightweight local validation checks only.
 
         Raises:
             AggregationError: If verification fails.
         """
-        mode = mode or LEAN_ENV
-        setup_verifier(mode=mode)
-        try:
-            verify_aggregated_signatures(
-                [pk.encode_bytes() for pk in public_keys],
-                message,
-                self.proof_data.encode_bytes(),
-                slot,
-                mode=mode,
+        if dummy:
+            if len(self.participants.to_validator_indices()) == len(public_keys):
+                return
+            raise AggregationError(
+                "Dummy proof verification requires the number of public keys "
+                "to match the number of participants"
             )
-        except Exception as exc:
-            raise AggregationError(f"Signature verification failed: {exc}") from exc
+    
+        raise AggregationError("recursive aggregation verification is unavailable in current lean_multisig_py bindings")
+
+        # mode = mode or LEAN_ENV
+        # setup_verifier(mode=mode)
+        # try:
+        #     verify_aggregated_signatures(
+        #         [pk.encode_bytes() for pk in public_keys],
+        #         message,
+        #         self.proof_data.encode_bytes(),
+        #         slot,
+        #         mode=mode,
+        #     )
+        # except Exception as exc:
+        #     raise AggregationError(f"Signature verification failed: {exc}") from exc

--- a/src/lean_spec/subspecs/xmss/types.py
+++ b/src/lean_spec/subspecs/xmss/types.py
@@ -1,10 +1,10 @@
 """Base types for the XMSS signature scheme."""
 
-from typing import Final
+from typing import ClassVar, Final
 
 from lean_spec.subspecs.koalabear import Fp
 
-from ...types import Uint64
+from ...types import ByteListMiB, SSZUnion, Uint64
 from ...types.byte_arrays import BaseBytes
 from ...types.collections import SSZList, SSZVector
 from ...types.container import Container
@@ -111,6 +111,16 @@ class HashTreeOpening(Container):
 
     siblings: HashDigestList
     """SSZ-compliant list of sibling hashes, from bottom to top."""
+
+
+class BytecodePointOption(SSZUnion):
+    """
+    Optional ByteListMiB for recursive aggregation.
+
+    SSZ Union: selector 0 = None (non-recursive), selector 1 = ByteListMiB (recursive).
+    """
+
+    OPTIONS: ClassVar[tuple[type[ByteListMiB] | None, ...]] = (None, ByteListMiB)
 
 
 class HashTreeLayer(Container):


### PR DESCRIPTION
## 🗒️ Description
draft PR for devnet-4
- updates aggregation API to support recursive aggregation
- adds a temporary dummy flag which will be used to later fix the tests once the design is finalized
- the bindings cannot be updated due to incompatibility between leanMultisig xmss and leanSig
- INV_PROOF_SIZE should be a protocol level parameter imo, unlike a aggregator paramater as defined in high level doc

- changes `aggregate_gossip_signatures` to `aggregate` as it will no longer just aggregates gossip signatures but also recursively aggregates children_payloads with them

- changes `aggregate_gossip_signatures` to `aggregate_committee_signatures_and_payloads`, it includes both committee gossip signatures and payloads (no committee) and recursively aggregate them using `aggregate`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
