### PR TITLE
fix: correct docs site URL to match repository name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: Lean Ethereum Specifications
 site_description: Reference implementations of the Lean Ethereum protocol
 site_author: Ethereum Foundation
-site_url: https://leanethereum.github.io/lean-spec/
+site_url: https://leanethereum.github.io/leanSpec/
 
-repo_name: leanEthereum/lean-spec
-repo_url: https://github.com/leanEthereum/lean-spec
+repo_name: leanEthereum/leanSpec
+repo_url: https://github.com/leanEthereum/leanSpec
 edit_uri: edit/main/docs/
 
 theme:
@@ -63,7 +63,7 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/leanEthereum/lean-spec
+      link: https://github.com/leanEthereum/leanSpec
 
 copyright: |
   &copy; 2025 Ethereum Foundation


### PR DESCRIPTION
Fixes #400.

The `mkdocs.yml` references `lean-spec` (kebab-case) in several URLs, but the repository is named `leanSpec` (camelCase). This causes GitHub Pages to return 404 since the deployment path is derived from the repo name.

Changes:
- `site_url`: `lean-spec` → `leanSpec`
- `repo_name`: `lean-spec` → `leanSpec`
- `repo_url`: `lean-spec` → `leanSpec`
- `extra.social.link`: `lean-spec` → `leanSpec`