### PR TITLE
docs: include prod scheme in fill command

### DIFF
--- a/.claude/skills/fill/SKILL.md
+++ b/.claude/skills/fill/SKILL.md
@@ -17,6 +17,7 @@ uvx tox -e fill
 
 Pass additional arguments after `--`:
 
+- `/fill -- --scheme=prod` - Use production signature scheme (slower)
 - `/fill -- --fork=Electra` - Generate for Electra fork
 - `/fill -- path/to/test.py` - Generate fixtures for specific test file
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ subspecifications that the Lean Ethereum protocol relies on.
 ```bash
 uv sync                           # Install dependencies
 uv run pytest                     # Run unit tests
-uv run fill --fork=devnet --clean -n auto # Generate test vectors
+uv run fill --fork=devnet --clean -n auto                # Generate test vectors
+uv run fill --fork=devnet --clean -n auto --scheme=prod  # Generate test vectors with production scheme
 # Note: execution layer support is planned for future, infrastructure is ready
 # for now, `--layer=consensus` is default and the only value used.
 ```

--- a/README.md
+++ b/README.md
@@ -110,11 +110,13 @@ uv run pytest -n 4
 uv run pytest -m "not slow"
 
 # Fill test vectors from pytest specs.
-# Usage: uv run fill --clean --fork=devnet [--output=<dir>]
+# Usage: uv run fill --clean --fork=devnet [--scheme=<scheme>] [--output=<dir>]
 #   --clean  Overwrite existing fixtures
 #   --fork   Target fork (default: devnet)
+#   --scheme XMSS signature scheme: "test" (default, fast) or "prod" (prod config, slower)
 #   --output Optional directory for filled fixtures
 uv run fill --clean --fork=devnet
+uv run fill --clean --fork=devnet --scheme=prod
 
 # Run API conformance tests against an external client implementation
 # Usage: uv run apitest <server-url> [pytest-args]


### PR DESCRIPTION
## 🗒️ Description
I was too lazy to recall & type the fill command so I asked claude to do it. This is what it returned:

> What do you mean by "prod fill"? I'm not sure what distinguishes it from the default fill.

This PR adds fill command documentation for prod scheme.
