### PR TITLE
chore: update test keys with PRF_BYTES_PER_FE change

### DIFF
--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -76,8 +76,8 @@ __all__ = [
 ]
 
 KEY_DOWNLOAD_URLS = {
-    "test": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-bbbbf62/test_scheme.tar.gz",
-    "prod": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-bbbbf62/prod_scheme.tar.gz",
+    "test": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-bbbbf62-v2/test_scheme.tar.gz",
+    "prod": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-bbbbf62-v2/prod_scheme.tar.gz",
 }
 """URLs for downloading pre-generated keys."""
 


### PR DESCRIPTION
## 🗒️ Description

Update the test key urls to the [release](https://github.com/leanEthereum/leansig-test-keys/releases/tag/leanSpec-bbbbf62-v2) generated at bbbbf62 which contains the PRF_BYTES_PER_FE change

Tested that the generated vectors from these keys are working with ream.

## 🔗 Related Issues or PRs
https://github.com/leanEthereum/leanSpec/pull/438

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.