### PR TITLE
networking: stronger typing for transport keypair

### DIFF
--- a/src/lean_spec/subspecs/networking/transport/__init__.py
+++ b/src/lean_spec/subspecs/networking/transport/__init__.py
@@ -25,9 +25,9 @@ References:
 from .identity import (
     NOISE_IDENTITY_PREFIX,
     IdentityKeypair,
+    Secp256k1PublicKey,
     create_identity_proof,
     verify_identity_proof,
-    verify_signature,
 )
 from .peer_id import Base58, KeyType, Multihash, MultihashCode, PeerId, PublicKeyProto
 from .quic import (
@@ -47,7 +47,7 @@ __all__ = [
     "generate_libp2p_certificate",
     # Identity (secp256k1 keypair)
     "IdentityKeypair",
-    "verify_signature",
+    "Secp256k1PublicKey",
     "NOISE_IDENTITY_PREFIX",
     "create_identity_proof",
     "verify_identity_proof",

--- a/src/lean_spec/subspecs/networking/transport/identity/__init__.py
+++ b/src/lean_spec/subspecs/networking/transport/identity/__init__.py
@@ -12,7 +12,7 @@ This separation follows the libp2p-noise specification and matches
 the approach used by ream and zeam.
 """
 
-from .keypair import IdentityKeypair, verify_signature
+from .keypair import IdentityKeypair, Secp256k1PublicKey
 from .signature import (
     NOISE_IDENTITY_PREFIX,
     create_identity_proof,
@@ -21,7 +21,7 @@ from .signature import (
 
 __all__ = [
     "IdentityKeypair",
-    "verify_signature",
+    "Secp256k1PublicKey",
     "NOISE_IDENTITY_PREFIX",
     "create_identity_proof",
     "verify_identity_proof",

--- a/src/lean_spec/subspecs/networking/transport/identity/keypair.py
+++ b/src/lean_spec/subspecs/networking/transport/identity/keypair.py
@@ -22,7 +22,64 @@ from ..peer_id import KeyType, PeerId, PublicKeyProto
 
 __all__ = [
     "IdentityKeypair",
+    "Secp256k1PublicKey",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class Secp256k1PublicKey:
+    """Compressed secp256k1 public key (33 bytes)."""
+
+    _key: ec.EllipticCurvePublicKey
+    """The cryptography library's public key object"""
+
+    @classmethod
+    def from_bytes(cls, data: Bytes33) -> Secp256k1PublicKey:
+        """
+        Load from 33-byte compressed SEC1 format.
+
+        Args:
+            data: 33-byte compressed secp256k1 public key.
+
+        Returns:
+            Parsed public key.
+        """
+        key = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256K1(), data)
+        return cls(_key=key)
+
+    def to_bytes(self) -> Bytes33:
+        """
+        Return the 33-byte compressed SEC1 encoding.
+
+        The compressed format starts with 0x02 (even y) or 0x03 (odd y),
+        followed by the 32-byte x coordinate.
+
+        Returns:
+            33-byte compressed public key.
+        """
+        return Bytes33(
+            self._key.public_bytes(
+                encoding=serialization.Encoding.X962,
+                format=serialization.PublicFormat.CompressedPoint,
+            )
+        )
+
+    def verify(self, message: bytes, signature: bytes) -> bool:
+        """
+        Verify an ECDSA-SHA256 signature.
+
+        Args:
+            message: Original message that was signed.
+            signature: DER-encoded ECDSA signature.
+
+        Returns:
+            True if signature is valid, False otherwise.
+        """
+        try:
+            self._key.verify(signature, message, ec.ECDSA(hashes.SHA256()))
+            return True
+        except InvalidSignature:
+            return False
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,12 +88,12 @@ class IdentityKeypair:
     secp256k1 keypair for libp2p identity.
 
     Used to derive PeerId and sign identity proofs during QUIC TLS handshake.
-
-    Attributes:
-        private_key: The secp256k1 private key.
     """
 
     private_key: ec.EllipticCurvePrivateKey
+    """The secp256k1 private key"""
+    public_key: Secp256k1PublicKey
+    """The corresponding secp256k1 public key"""
 
     @classmethod
     def generate(cls) -> IdentityKeypair:
@@ -47,7 +104,8 @@ class IdentityKeypair:
             A fresh identity keypair.
         """
         private_key = ec.generate_private_key(ec.SECP256K1())
-        return cls(private_key=private_key)
+        public_key = Secp256k1PublicKey(_key=private_key.public_key())
+        return cls(private_key=private_key, public_key=public_key)
 
     @classmethod
     def from_bytes(cls, data: Bytes32) -> IdentityKeypair:
@@ -64,7 +122,8 @@ class IdentityKeypair:
             int.from_bytes(data, "big"),
             ec.SECP256K1(),
         )
-        return cls(private_key=private_key)
+        public_key = Secp256k1PublicKey(_key=private_key.public_key())
+        return cls(private_key=private_key, public_key=public_key)
 
     def private_key_bytes(self) -> Bytes32:
         """
@@ -75,24 +134,6 @@ class IdentityKeypair:
         """
         private_numbers = self.private_key.private_numbers()
         return Bytes32(private_numbers.private_value.to_bytes(32, "big"))
-
-    def public_key_bytes(self) -> Bytes33:
-        """
-        Return the compressed secp256k1 public key (33 bytes).
-
-        The compressed format starts with 0x02 (even y) or 0x03 (odd y),
-        followed by the 32-byte x coordinate.
-
-        Returns:
-            33-byte compressed public key.
-        """
-        public_key = self.private_key.public_key()
-        return Bytes33(
-            public_key.public_bytes(
-                encoding=serialization.Encoding.X962,
-                format=serialization.PublicFormat.CompressedPoint,
-            )
-        )
 
     def sign(self, message: bytes) -> bytes:
         """
@@ -120,34 +161,6 @@ class IdentityKeypair:
         """
         proto = PublicKeyProto(
             key_type=KeyType.SECP256K1,
-            key_data=self.public_key_bytes(),
+            key_data=self.public_key.to_bytes(),
         )
         return PeerId.from_public_key(proto)
-
-
-def verify_signature(
-    public_key_bytes: Bytes33,
-    message: bytes,
-    signature: bytes,
-) -> bool:
-    """
-    Verify an ECDSA-SHA256 signature.
-
-    Args:
-        public_key_bytes: 33-byte compressed secp256k1 public key.
-        message: Original message that was signed.
-        signature: DER-encoded ECDSA signature.
-
-    Returns:
-        True if signature is valid, False otherwise.
-    """
-    public_key = ec.EllipticCurvePublicKey.from_encoded_point(
-        ec.SECP256K1(),
-        public_key_bytes,
-    )
-
-    try:
-        public_key.verify(signature, message, ec.ECDSA(hashes.SHA256()))
-        return True
-    except InvalidSignature:
-        return False

--- a/src/lean_spec/subspecs/networking/transport/identity/signature.py
+++ b/src/lean_spec/subspecs/networking/transport/identity/signature.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final
 
-from lean_spec.types import Bytes32, Bytes33
+from lean_spec.types import Bytes32
 
-from .keypair import verify_signature
+from .keypair import Secp256k1PublicKey
 
 if TYPE_CHECKING:
     from .keypair import IdentityKeypair
@@ -56,7 +56,7 @@ def create_identity_proof(
 
 
 def verify_identity_proof(
-    identity_public_key: Bytes33,
+    identity_public_key: Secp256k1PublicKey,
     public_key: Bytes32,
     signature: bytes,
 ) -> bool:
@@ -66,7 +66,7 @@ def verify_identity_proof(
     Called during QUIC TLS handshake to verify the remote peer's identity claim.
 
     Args:
-        identity_public_key: 33-byte compressed secp256k1 public key.
+        identity_public_key: The secp256k1 public key claiming identity.
         public_key: 32-byte TLS public key.
         signature: DER-encoded ECDSA signature.
 
@@ -74,4 +74,4 @@ def verify_identity_proof(
         True if the signature is valid, False otherwise.
     """
     message = NOISE_IDENTITY_PREFIX + public_key
-    return verify_signature(identity_public_key, message, signature)
+    return identity_public_key.verify(message, signature)

--- a/src/lean_spec/subspecs/networking/transport/quic/tls.py
+++ b/src/lean_spec/subspecs/networking/transport/quic/tls.py
@@ -162,7 +162,7 @@ def _create_extension_payload(
         }
     """
     # Get compressed public key (33 bytes for secp256k1).
-    public_key_compressed = identity_key.public_key_bytes()
+    public_key_compressed = identity_key.public_key.to_bytes()
 
     # Create signature over (prefix + tls_public_bytes).
     #

--- a/tests/lean_spec/subspecs/networking/transport/identity/test_keypair.py
+++ b/tests/lean_spec/subspecs/networking/transport/identity/test_keypair.py
@@ -1,10 +1,53 @@
 """Tests for secp256k1 identity keypair."""
 
+import pytest
+
 from lean_spec.subspecs.networking.transport.identity import (
     IdentityKeypair,
-    verify_signature,
+    Secp256k1PublicKey,
 )
 from lean_spec.subspecs.networking.transport.peer_id import KeyType
+from lean_spec.types import Bytes33
+
+
+class TestSecp256k1PublicKey:
+    """Tests for Secp256k1PublicKey class."""
+
+    def test_from_bytes_roundtrip(self) -> None:
+        """Public key can be loaded from raw bytes and re-serialized."""
+        keypair = IdentityKeypair.generate()
+        raw = keypair.public_key.to_bytes()
+
+        restored = Secp256k1PublicKey.from_bytes(raw)
+        assert restored.to_bytes() == raw
+
+    def test_verify_valid_signature(self) -> None:
+        """Valid signature passes verification."""
+        keypair = IdentityKeypair.generate()
+        message = b"test message"
+        signature = keypair.sign(message)
+
+        assert keypair.public_key.verify(message, signature)
+
+    def test_verify_wrong_message(self) -> None:
+        """Verification fails with wrong message."""
+        keypair = IdentityKeypair.generate()
+        signature = keypair.sign(b"original message")
+
+        assert not keypair.public_key.verify(b"different message", signature)
+
+    def test_verify_wrong_key(self) -> None:
+        """Verification fails with wrong public key."""
+        keypair1 = IdentityKeypair.generate()
+        keypair2 = IdentityKeypair.generate()
+        signature = keypair1.sign(b"test message")
+
+        assert not keypair2.public_key.verify(b"test message", signature)
+
+    def test_from_bytes_invalid(self) -> None:
+        """Invalid bytes raise an error."""
+        with pytest.raises(ValueError):
+            Secp256k1PublicKey.from_bytes(Bytes33(bytes(33)))
 
 
 class TestIdentityKeypair:
@@ -14,7 +57,7 @@ class TestIdentityKeypair:
         """Generated keypair has valid structure."""
         keypair = IdentityKeypair.generate()
 
-        public_key = keypair.public_key_bytes()
+        public_key = keypair.public_key.to_bytes()
         assert len(public_key) == 33
         assert public_key[0] in (0x02, 0x03)
 
@@ -26,14 +69,14 @@ class TestIdentityKeypair:
         keypair1 = IdentityKeypair.generate()
         keypair2 = IdentityKeypair.generate()
 
-        assert keypair1.public_key_bytes() != keypair2.public_key_bytes()
+        assert keypair1.public_key.to_bytes() != keypair2.public_key.to_bytes()
         assert keypair1.private_key_bytes() != keypair2.private_key_bytes()
 
     def test_from_bytes_roundtrip(self) -> None:
         """Keypair can be loaded from raw bytes."""
         original = IdentityKeypair.generate()
         restored = IdentityKeypair.from_bytes(original.private_key_bytes())
-        assert restored.public_key_bytes() == original.public_key_bytes()
+        assert restored.public_key.to_bytes() == original.public_key.to_bytes()
         assert restored.private_key_bytes() == original.private_key_bytes()
 
     def test_sign_and_verify(self) -> None:
@@ -43,27 +86,7 @@ class TestIdentityKeypair:
 
         signature = keypair.sign(message)
 
-        assert verify_signature(keypair.public_key_bytes(), message, signature)
-
-    def test_verify_wrong_message(self) -> None:
-        """Verification fails with wrong message."""
-        keypair = IdentityKeypair.generate()
-        message = b"original message"
-        wrong_message = b"different message"
-
-        signature = keypair.sign(message)
-
-        assert not verify_signature(keypair.public_key_bytes(), wrong_message, signature)
-
-    def test_verify_wrong_key(self) -> None:
-        """Verification fails with wrong public key."""
-        keypair1 = IdentityKeypair.generate()
-        keypair2 = IdentityKeypair.generate()
-        message = b"test message"
-
-        signature = keypair1.sign(message)
-
-        assert not verify_signature(keypair2.public_key_bytes(), message, signature)
+        assert keypair.public_key.verify(message, signature)
 
     def test_to_peer_id(self) -> None:
         """PeerId derivation produces valid result."""
@@ -96,7 +119,7 @@ class TestIdentityKeypair:
     def test_compressed_public_key_format(self) -> None:
         """Public key is in compressed SEC1 format."""
         keypair = IdentityKeypair.generate()
-        public_key = keypair.public_key_bytes()
+        public_key = keypair.public_key.to_bytes()
 
         assert len(public_key) == 33
         assert public_key[0] in (0x02, 0x03)

--- a/tests/lean_spec/subspecs/networking/transport/identity/test_signature.py
+++ b/tests/lean_spec/subspecs/networking/transport/identity/test_signature.py
@@ -21,7 +21,7 @@ class TestIdentityProof:
 
         proof = create_identity_proof(identity_key, public_key)
         assert verify_identity_proof(
-            identity_key.public_key_bytes(),
+            identity_key.public_key,
             public_key,
             proof,
         )
@@ -34,7 +34,7 @@ class TestIdentityProof:
 
         proof = create_identity_proof(identity_key, public_key)
         assert not verify_identity_proof(
-            identity_key.public_key_bytes(),
+            identity_key.public_key,
             wrong_key,
             proof,
         )
@@ -47,7 +47,7 @@ class TestIdentityProof:
 
         proof = create_identity_proof(identity_key1, public_key)
         assert not verify_identity_proof(
-            identity_key2.public_key_bytes(),
+            identity_key2.public_key,
             public_key,
             proof,
         )
@@ -60,8 +60,8 @@ class TestIdentityProof:
         proof1 = create_identity_proof(identity_key, public_key)
         proof2 = create_identity_proof(identity_key, public_key)
 
-        assert verify_identity_proof(identity_key.public_key_bytes(), public_key, proof1)
-        assert verify_identity_proof(identity_key.public_key_bytes(), public_key, proof2)
+        assert verify_identity_proof(identity_key.public_key, public_key, proof1)
+        assert verify_identity_proof(identity_key.public_key, public_key, proof2)
 
     def test_noise_identity_prefix(self) -> None:
         """NOISE_IDENTITY_PREFIX matches libp2p-noise spec."""
@@ -76,12 +76,12 @@ class TestIdentityProof:
         proof = create_identity_proof(identity_key_real, public_key)
 
         assert verify_identity_proof(
-            identity_key_real.public_key_bytes(),
+            identity_key_real.public_key,
             public_key,
             proof,
         )
         assert not verify_identity_proof(
-            identity_key_attacker.public_key_bytes(),
+            identity_key_attacker.public_key,
             public_key,
             proof,
         )

--- a/tests/lean_spec/subspecs/networking/transport/test_peer_id.py
+++ b/tests/lean_spec/subspecs/networking/transport/test_peer_id.py
@@ -245,7 +245,7 @@ class TestDerivePeerId:
     def test_derive_from_secp256k1(self) -> None:
         """Derive PeerId from secp256k1 public key."""
         keypair = IdentityKeypair.generate()
-        peer_id = PeerId.from_secp256k1(keypair.public_key_bytes())
+        peer_id = PeerId.from_secp256k1(keypair.public_key.to_bytes())
 
         # Result should be a valid Base58 string
         peer_id_str = str(peer_id)
@@ -257,7 +257,7 @@ class TestDerivePeerId:
     def test_derive_deterministic(self) -> None:
         """Same key always produces same PeerId."""
         keypair = IdentityKeypair.generate()
-        public_key_bytes = keypair.public_key_bytes()
+        public_key_bytes = keypair.public_key.to_bytes()
 
         peer_id1 = PeerId.from_secp256k1(public_key_bytes)
         peer_id2 = PeerId.from_secp256k1(public_key_bytes)
@@ -269,8 +269,8 @@ class TestDerivePeerId:
         keypair1 = IdentityKeypair.generate()
         keypair2 = IdentityKeypair.generate()
 
-        peer_id1 = PeerId.from_secp256k1(keypair1.public_key_bytes())
-        peer_id2 = PeerId.from_secp256k1(keypair2.public_key_bytes())
+        peer_id1 = PeerId.from_secp256k1(keypair1.public_key.to_bytes())
+        peer_id2 = PeerId.from_secp256k1(keypair2.public_key.to_bytes())
 
         assert str(peer_id1) != str(peer_id2)
 
@@ -282,7 +282,7 @@ class TestPeerIdFormat:
         """Small encoded keys use identity multihash."""
         # secp256k1 key: 33 bytes, encoded is 37 bytes (< 42)
         keypair = IdentityKeypair.generate()
-        peer_id = PeerId.from_secp256k1(keypair.public_key_bytes())
+        peer_id = PeerId.from_secp256k1(keypair.public_key.to_bytes())
 
         # Decode to verify structure
         decoded = Base58.decode(str(peer_id))
@@ -491,7 +491,7 @@ class TestKnownVectors:
     def test_peer_id_length_reasonable(self) -> None:
         """PeerId length is reasonable (not too long)."""
         keypair = IdentityKeypair.generate()
-        peer_id = PeerId.from_secp256k1(keypair.public_key_bytes())
+        peer_id = PeerId.from_secp256k1(keypair.public_key.to_bytes())
 
         # Identity-hash PeerId should be around 52-60 characters
         # (Base58 encoding of ~39 bytes: 2 multihash header + 37 encoded key)
@@ -504,7 +504,7 @@ class TestIntegration:
     def test_derive_from_generated_keypair(self) -> None:
         """Derive PeerId from freshly generated keypair."""
         keypair = IdentityKeypair.generate()
-        peer_id = PeerId.from_secp256k1(keypair.public_key_bytes())
+        peer_id = PeerId.from_secp256k1(keypair.public_key.to_bytes())
 
         assert len(str(peer_id)) > 0
         # Verify structure
@@ -516,7 +516,7 @@ class TestIntegration:
         keypair = IdentityKeypair.generate()
 
         peer_id1 = keypair.to_peer_id()
-        peer_id2 = PeerId.from_secp256k1(keypair.public_key_bytes())
+        peer_id2 = PeerId.from_secp256k1(keypair.public_key.to_bytes())
 
         assert str(peer_id1) == str(peer_id2)
 
@@ -525,7 +525,7 @@ class TestIntegration:
         peer_ids = set()
         for _ in range(10):
             keypair = IdentityKeypair.generate()
-            peer_id = PeerId.from_secp256k1(keypair.public_key_bytes())
+            peer_id = PeerId.from_secp256k1(keypair.public_key.to_bytes())
             peer_ids.add(str(peer_id))
 
         # All 10 should be unique


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
