### PR TITLE
feat: strengthen typing and remove suppressions

### DIFF
--- a/src/lean_spec/subspecs/networking/discovery/transport.py
+++ b/src/lean_spec/subspecs/networking/discovery/transport.py
@@ -135,7 +135,8 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
 
     def connection_made(self, transport: asyncio.transports.BaseTransport) -> None:
         """Called when UDP socket is ready."""
-        self._transport = transport  # type: ignore[assignment]
+        assert isinstance(transport, asyncio.DatagramTransport)
+        self._transport = transport
 
     def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
         """Called when a UDP packet is received."""
@@ -219,8 +220,10 @@ class DiscoveryTransport:
             lambda: DiscoveryProtocol(self),
             local_addr=(host, port),
         )
-        self._transport = transport  # type: ignore[assignment]
-        self._protocol = protocol  # type: ignore[assignment]
+        assert isinstance(transport, asyncio.DatagramTransport)
+        assert isinstance(protocol, DiscoveryProtocol)
+        self._transport = transport
+        self._protocol = protocol
 
         self._running = True
         logger.info("Discovery transport started on %s:%d", host, port)

--- a/src/lean_spec/subspecs/node/node.py
+++ b/src/lean_spec/subspecs/node/node.py
@@ -470,8 +470,8 @@ class Node:
             )
             j = store.latest_justified
             f = store.latest_finalized
-            j_root = j.root.hex() if hasattr(j.root, "hex") else str(j.root)
-            f_root = f.root.hex() if hasattr(f.root, "hex") else str(f.root)
+            j_root = j.root.hex()
+            f_root = f.root.hex()
             logger.info("=" * 64)
             logger.info(
                 "Peers=%s | Justified slot=%s root=%s | Finalized slot=%s root=%s",

--- a/src/lean_spec/subspecs/sync/service.py
+++ b/src/lean_spec/subspecs/sync/service.py
@@ -40,7 +40,7 @@ import asyncio
 import logging
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from lean_spec.subspecs.chain.clock import SlotClock
 from lean_spec.subspecs.containers import (
@@ -162,7 +162,7 @@ class SyncService:
     )
     """Block processor function. Defaults to the store's block processing."""
 
-    _publish_agg_fn: Callable[[SignedAggregatedAttestation], Coroutine[Any, Any, None]] = field(
+    _publish_agg_fn: Callable[[SignedAggregatedAttestation], Coroutine[None, None, None]] = field(
         default=_noop_publish_agg
     )
     """Callback for publishing aggregated attestations to the network."""
@@ -202,7 +202,7 @@ class SyncService:
     """
 
     def set_publish_agg_fn(
-        self, fn: Callable[[SignedAggregatedAttestation], Coroutine[Any, Any, None]]
+        self, fn: Callable[[SignedAggregatedAttestation], Coroutine[None, None, None]]
     ) -> None:
         """Wire the aggregated attestation publisher after construction.
 

--- a/tests/lean_spec/subspecs/networking/discovery/test_transport.py
+++ b/tests/lean_spec/subspecs/networking/discovery/test_transport.py
@@ -42,7 +42,7 @@ class TestDiscoveryProtocol:
         mock_handler = MagicMock()
         protocol = DiscoveryProtocol(mock_handler)
 
-        mock_transport = MagicMock()
+        mock_transport = MagicMock(spec=asyncio.DatagramTransport)
         protocol.connection_made(mock_transport)
 
         assert protocol._transport is mock_transport
@@ -189,8 +189,8 @@ class TestDiscoveryTransport:
         )
 
         # Mock the event loop's create_datagram_endpoint.
-        mock_transport_obj = MagicMock()
-        mock_protocol_obj = MagicMock()
+        mock_transport_obj = MagicMock(spec=asyncio.DatagramTransport)
+        mock_protocol_obj = MagicMock(spec=DiscoveryProtocol)
 
         with patch.object(
             asyncio.get_event_loop(),
@@ -213,8 +213,8 @@ class TestDiscoveryTransport:
             local_enr=local_enr,
         )
 
-        mock_transport_obj = MagicMock()
-        mock_protocol_obj = MagicMock()
+        mock_transport_obj = MagicMock(spec=asyncio.DatagramTransport)
+        mock_protocol_obj = MagicMock(spec=DiscoveryProtocol)
 
         with patch.object(
             asyncio.get_event_loop(),
@@ -238,8 +238,8 @@ class TestDiscoveryTransport:
             local_enr=local_enr,
         )
 
-        mock_transport_obj = MagicMock()
-        mock_protocol_obj = MagicMock()
+        mock_transport_obj = MagicMock(spec=asyncio.DatagramTransport)
+        mock_protocol_obj = MagicMock(spec=DiscoveryProtocol)
 
         with patch.object(
             asyncio.get_event_loop(),
@@ -262,8 +262,8 @@ class TestDiscoveryTransport:
             local_enr=local_enr,
         )
 
-        mock_transport_obj = MagicMock()
-        mock_protocol_obj = MagicMock()
+        mock_transport_obj = MagicMock(spec=asyncio.DatagramTransport)
+        mock_protocol_obj = MagicMock(spec=DiscoveryProtocol)
 
         with patch.object(
             asyncio.get_event_loop(),
@@ -347,8 +347,8 @@ class TestSendResponse:
             local_enr=local_enr,
         )
 
-        mock_transport_obj = MagicMock()
-        mock_protocol_obj = MagicMock()
+        mock_transport_obj = MagicMock(spec=asyncio.DatagramTransport)
+        mock_protocol_obj = MagicMock(spec=DiscoveryProtocol)
 
         with patch.object(
             asyncio.get_event_loop(),
@@ -767,8 +767,8 @@ class TestPendingRequestsManagement:
             local_enr=local_enr,
         )
 
-        mock_transport_obj = MagicMock()
-        mock_protocol_obj = MagicMock()
+        mock_transport_obj = MagicMock(spec=asyncio.DatagramTransport)
+        mock_protocol_obj = MagicMock(spec=DiscoveryProtocol)
 
         with patch.object(
             asyncio.get_event_loop(),
@@ -809,8 +809,8 @@ class TestPendingRequestsManagement:
             local_enr=local_enr,
         )
 
-        mock_transport_obj = MagicMock()
-        mock_protocol_obj = MagicMock()
+        mock_transport_obj = MagicMock(spec=asyncio.DatagramTransport)
+        mock_protocol_obj = MagicMock(spec=DiscoveryProtocol)
 
         with patch.object(
             asyncio.get_event_loop(),
@@ -871,11 +871,11 @@ class TestSendPing:
             config=config,
         )
 
-        mock_udp = MagicMock()
+        mock_udp = MagicMock(spec=asyncio.DatagramTransport)
         with patch.object(
             asyncio.get_event_loop(),
             "create_datagram_endpoint",
-            new=AsyncMock(return_value=(mock_udp, MagicMock())),
+            new=AsyncMock(return_value=(mock_udp, MagicMock(spec=DiscoveryProtocol))),
         ):
             await transport.start("127.0.0.1", 9000)
 
@@ -899,11 +899,11 @@ class TestSendPing:
             config=config,
         )
 
-        mock_udp = MagicMock()
+        mock_udp = MagicMock(spec=asyncio.DatagramTransport)
         with patch.object(
             asyncio.get_event_loop(),
             "create_datagram_endpoint",
-            new=AsyncMock(return_value=(mock_udp, MagicMock())),
+            new=AsyncMock(return_value=(mock_udp, MagicMock(spec=DiscoveryProtocol))),
         ):
             await transport.start("127.0.0.1", 9000)
 
@@ -929,11 +929,11 @@ class TestSendPing:
             config=config,
         )
 
-        mock_udp = MagicMock()
+        mock_udp = MagicMock(spec=asyncio.DatagramTransport)
         with patch.object(
             asyncio.get_event_loop(),
             "create_datagram_endpoint",
-            new=AsyncMock(return_value=(mock_udp, MagicMock())),
+            new=AsyncMock(return_value=(mock_udp, MagicMock(spec=DiscoveryProtocol))),
         ):
             await transport.start("127.0.0.1", 9000)
 
@@ -975,11 +975,11 @@ class TestSendFindNode:
             config=config,
         )
 
-        mock_udp = MagicMock()
+        mock_udp = MagicMock(spec=asyncio.DatagramTransport)
         with patch.object(
             asyncio.get_event_loop(),
             "create_datagram_endpoint",
-            new=AsyncMock(return_value=(mock_udp, MagicMock())),
+            new=AsyncMock(return_value=(mock_udp, MagicMock(spec=DiscoveryProtocol))),
         ):
             await transport.start("127.0.0.1", 9000)
 
@@ -1003,11 +1003,11 @@ class TestSendFindNode:
             config=config,
         )
 
-        mock_udp = MagicMock()
+        mock_udp = MagicMock(spec=asyncio.DatagramTransport)
         with patch.object(
             asyncio.get_event_loop(),
             "create_datagram_endpoint",
-            new=AsyncMock(return_value=(mock_udp, MagicMock())),
+            new=AsyncMock(return_value=(mock_udp, MagicMock(spec=DiscoveryProtocol))),
         ):
             await transport.start("127.0.0.1", 9000)
 
@@ -1052,11 +1052,11 @@ class TestSendTalkReq:
             config=config,
         )
 
-        mock_udp = MagicMock()
+        mock_udp = MagicMock(spec=asyncio.DatagramTransport)
         with patch.object(
             asyncio.get_event_loop(),
             "create_datagram_endpoint",
-            new=AsyncMock(return_value=(mock_udp, MagicMock())),
+            new=AsyncMock(return_value=(mock_udp, MagicMock(spec=DiscoveryProtocol))),
         ):
             await transport.start("127.0.0.1", 9000)
 
@@ -1303,11 +1303,11 @@ class TestSendWhoareyou:
             local_enr=local_enr,
         )
 
-        mock_udp = MagicMock()
+        mock_udp = MagicMock(spec=asyncio.DatagramTransport)
         with patch.object(
             asyncio.get_event_loop(),
             "create_datagram_endpoint",
-            new=AsyncMock(return_value=(mock_udp, MagicMock())),
+            new=AsyncMock(return_value=(mock_udp, MagicMock(spec=DiscoveryProtocol))),
         ):
             await transport.start("127.0.0.1", 9000)
 
@@ -1338,11 +1338,11 @@ class TestSendWhoareyou:
         )
         transport.register_enr(remote_node_id, remote_enr)
 
-        mock_udp = MagicMock()
+        mock_udp = MagicMock(spec=asyncio.DatagramTransport)
         with patch.object(
             asyncio.get_event_loop(),
             "create_datagram_endpoint",
-            new=AsyncMock(return_value=(mock_udp, MagicMock())),
+            new=AsyncMock(return_value=(mock_udp, MagicMock(spec=DiscoveryProtocol))),
         ):
             await transport.start("127.0.0.1", 9000)
 


### PR DESCRIPTION
  
This PR is a pure cleanup pass that strengthens typing and removes `# type: ignore` suppressions across three modules, making the code more Pythonic without introducing any behavioral changes. 

### Changes made
1. **Discovery Transport:** 
   - Replaced `# type: ignore[assignment]` suppressions with explicit `assert isinstance(x, asyncio.DatagramTransport)` type narrowing guards in [transport.py](cci:7://file:///home/luckify/protocol/leanSpec/src/lean_spec/subspecs/networking/discovery/transport.py:0:0-0:0). This ensures it fails fast if an unexpected transport type is received.
2. **Node logging:** 
   - Removed defensive duck-typing (`hasattr` checks) in [node.py](cci:7://file:///home/luckify/protocol/leanSpec/src/lean_spec/subspecs/node/node.py:0:0-0:0). `Checkpoint.root` is explicitly typed as `Bytes32`, which always provides `.hex()`.
3. **Sync Service:** 
   - Narrowed the [_publish_agg_fn](cci:1://file:///home/luckify/protocol/leanSpec/src/lean_spec/subspecs/sync/service.py:203:4-212:33) callback from `Coroutine[Any, Any, None]` to `Coroutine[None, None, None]` in [service.py](cci:7://file:///home/luckify/protocol/leanSpec/src/lean_spec/subspecs/sync/service.py:0:0-0:0), since these coroutines are never `.send()`-ed into. 
   - Removed the `typing.Any` import.
 
### Verification
- `uvx tox -e all-checks` passes successfully (formatting, linting, MyPy check).
- `uvx tox -e pytest` (full suite of 2,672 tests) passes successfully with no regressions.
