### PR TITLE
test: add gossip_proposer_attestation=True to fix test_reorg_on_newly_justified_slot

### DIFF
--- a/tests/consensus/devnet/fc/test_fork_choice_reorgs.py
+++ b/tests/consensus/devnet/fc/test_fork_choice_reorgs.py
@@ -871,6 +871,7 @@ def test_reorg_on_newly_justified_slot(
                 ),
             ),
             # Fork A: slot 2
+            # Fork A is the heaviest chain (1 block from justified slot)
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(2),
@@ -884,6 +885,7 @@ def test_reorg_on_newly_justified_slot(
                 ),
             ),
             # Fork A: slot 3
+            # Fork A is the heaviest chain (2 blocks from justified slot)
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(3),


### PR DESCRIPTION
## 🗒️ Description

A test vector (test_reorg_on_newly_justified_slot) is still failing even after the key regen in #455. This is caused by a spec's behavior change in #449 where we no longer embed the proposer's attestation as part of the block proposal (they're now gossiped like non-proposer's attestations) so a block proposal no longer carries 1 attestation weight from the proposer so fork A never gets any fork choice weight (so it was using lexicographical order hence the random pass/failure).

This PR is a quick fix to get the test vectors working again. A better solution might be to make `gossip_proposer_attestation=True` the default behavior for all test cases but that's a much bigger change.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
