### PR TITLE
framework: add client-test skill

### DIFF
--- a/.claude/skills/client-test/SKILL.md
+++ b/.claude/skills/client-test/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: client-test
+description: Run leanSpec fixtures against a client implementation
+---
+
+# /client-test - Client Integration Testing
+
+Run generated leanSpec test fixtures against a client implementation.
+
+## Usage
+
+`/client-test <client-name>` e.g. `/client-test ream`
+
+## Steps
+
+### 1. Check fixtures exist
+
+Generated fixtures live at `fixtures/consensus/`. Verify it contains JSON files. If empty or missing, generate them:
+
+```bash
+uv run fill --fork=devnet --clean -n auto --scheme=prod
+```
+
+Fixtures for client testing must always use `--scheme=prod` (production signatures).
+
+### 2. Clone or update client
+
+Clone the client repo into `clients/` (gitignored). If already cloned, pull latest.
+
+### 3. Sync fixtures
+
+Remove old fixtures at the destination, then copy the contents of `fixtures/consensus/` to the destination (destination path is client-dependent).
+
+### 4. Run tests
+
+Run the test command from the client's test workdir (path is client-dependent). Show full output. Do not abort early on test failures.
+
+If zero tests ran, warn that the client may need to update its test runner to scan the new devnet fixture path.
+
+## Clients
+
+### ream
+
+- **Repo**: https://github.com/ReamLabs/ream.git
+- **Fixture destination** (relative to repo root): `testing/lean-spec-tests/fixtures/devnet4`
+- **Test workdir** (relative to repo root): `testing/lean-spec-tests`
+- **Test command**: `cargo test --release --features lean-spec-tests`
+
+### zeam
+
+- **Repo**: https://github.com/blockblaz/zeam.git
+- **Fixture destination** (relative to repo root): `leanSpec/fixtures/consensus` (leanSpec is a git submodule)
+- **Test workdir** (relative to repo root): `.` (repo root)
+- **Test commands** (run in order):
+  1. `zig build spectest:generate --summary all` (generate Zig test wrappers from JSON fixtures)
+  2. `zig build spectest:run --summary all` (run the spec tests)
+
+### qlean-mini
+
+- **Repo**: https://github.com/qdrvm/qlean-mini.git
+- **Branch**: `spec/test-vectors` (test vector infrastructure is not on master)
+- **Fixture destination** (relative to repo root): `tests/test_vectors/fixtures/consensus`
+- **Test workdir** (relative to repo root): `.` (repo root)
+- **Test commands** (run in order):
+  1. `cmake --preset default` (configure)
+  2. `cmake --build build -j` (build)
+  3. `ctest --test-dir build -R test_vectors_test --output-on-failure` (run spec tests)

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ scripts/
 
 # Claude Code
 .claude/settings.local.json
+
+# Client codebase used by Claude skill for running reference tests
+clients/


### PR DESCRIPTION
## 🗒️ Description

It's been tedious to update the test vectors, regenerate them, then test them with clients. This PR teaches Claude how perform this flow. Generally I can now just ask "run tests on ream" and it does it consistently.

Without this skill Claude could still do it, but it will spend a lot of time and tokens to figure out how to run the test vectors on a client.

Technically it's also possible to write this as a script but I find this much simpler to maintain given a script will need to accommodate different client's behavior + manage the files. Also this way there's less non-specs code in the repo.
