### PR TITLE
block: rename `message` to `block` in `SignedBlock`

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -263,7 +263,7 @@ class ForkChoiceTest(BaseConsensusFixture):
                         )
 
                         # Store the filled block for serialization.
-                        block = signed_block.message
+                        block = signed_block.block
                         step._filled_block = block
 
                         # Register labeled blocks for fork building.
@@ -449,7 +449,7 @@ class ForkChoiceTest(BaseConsensusFixture):
 
         # Assemble the signed block.
         return SignedBlock(
-            message=final_block,
+            block=final_block,
             signature=BlockSignatures(
                 attestation_signatures=attestation_signatures_blob,
                 proposer_signature=proposer_signature,

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -286,7 +286,7 @@ class VerifySignaturesTest(BaseConsensusFixture):
             proposer_signature = create_dummy_signature()
 
         return SignedBlock(
-            message=final_block,
+            block=final_block,
             signature=BlockSignatures(
                 attestation_signatures=attestation_signatures,
                 proposer_signature=proposer_signature,

--- a/src/lean_spec/subspecs/containers/block/block.py
+++ b/src/lean_spec/subspecs/containers/block/block.py
@@ -89,7 +89,7 @@ class BlockSignatures(Container):
 class SignedBlock(Container):
     """Envelope carrying a block and its aggregated signatures."""
 
-    message: Block
+    block: Block
     """The block being signed."""
 
     signature: BlockSignatures
@@ -116,9 +116,9 @@ class SignedBlock(Container):
         Raises:
             AssertionError: On verification failure.
         """
-        block = self.message
+        block = self.block
         signatures = self.signature
-        aggregated_attestations = block.body.attestations
+        aggregated_attestations = self.block.body.attestations
         attestation_signatures = signatures.attestation_signatures
 
         # Each attestation in the body must have a corresponding signature entry.

--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -489,7 +489,7 @@ class Store(StrictBaseModel):
         Raises:
             AssertionError: If parent block/state not found in store.
         """
-        block = signed_block.message
+        block = signed_block.block
         block_root = hash_tree_root(block)
 
         # Skip duplicate blocks (idempotent operation)

--- a/src/lean_spec/subspecs/networking/service/service.py
+++ b/src/lean_spec/subspecs/networking/service/service.py
@@ -212,7 +212,7 @@ class NetworkService:
         compressed = compress(ssz_bytes)
 
         await self.event_source.publish(topic.to_topic_id(), compressed)
-        logger.debug("Published block at slot %s", block.message.slot)
+        logger.debug("Published block at slot %s", block.block.slot)
 
     async def publish_attestation(
         self, attestation: SignedAttestation, subnet_id: SubnetId

--- a/src/lean_spec/subspecs/sync/block_cache.py
+++ b/src/lean_spec/subspecs/sync/block_cache.py
@@ -186,7 +186,7 @@ class BlockCache:
         Returns:
             The PendingBlock wrapper, either newly created or existing.
         """
-        block_inner = block.message
+        block_inner = block.block
         root = hash_tree_root(block_inner)
 
         # Deduplication: if we already have this block, return the existing entry.

--- a/src/lean_spec/subspecs/sync/head_sync.py
+++ b/src/lean_spec/subspecs/sync/head_sync.py
@@ -161,7 +161,7 @@ class HeadSync:
             Tuple of (result describing what happened, updated store).
             The store is unchanged if the block was cached.
         """
-        block_inner = block.message
+        block_inner = block.block
         block_root = hash_tree_root(block_inner)
         parent_root = block_inner.parent_root
         slot = block_inner.slot
@@ -234,8 +234,8 @@ class HeadSync:
         Returns:
             Result and updated store.
         """
-        block_root = hash_tree_root(block.message)
-        slot = block.message.slot
+        block_root = hash_tree_root(block.block)
+        slot = block.block.slot
         self._processing.add(block_root)
 
         try:
@@ -366,7 +366,7 @@ class HeadSync:
         Returns:
             Result indicating the block was cached, and unchanged store.
         """
-        block_inner = block.message
+        block_inner = block.block
         parent_root = block_inner.parent_root
 
         # Add to cache.

--- a/src/lean_spec/subspecs/sync/service.py
+++ b/src/lean_spec/subspecs/sync/service.py
@@ -272,7 +272,7 @@ class SyncService:
         # This is write-through: data is persisted synchronously after processing.
         # The database call is optional - nodes can run without persistence.
         if self.database is not None:
-            self._persist_block(new_store, block.message)
+            self._persist_block(new_store, block.block)
 
         return new_store
 
@@ -423,7 +423,7 @@ class SyncService:
         logger.info(
             "Block received from peer %s slot=%s (state=%s)",
             peer_id,
-            block.message.slot,
+            block.block.slot,
             self._state.name,
         )
 
@@ -445,8 +445,8 @@ class SyncService:
         #
         # A block may be cached instead of processed if its parent is unknown.
         if result.processed:
-            slot = block.message.slot
-            block_root = hash_tree_root(block.message)
+            slot = block.block.slot
+            block_root = hash_tree_root(block.block)
             logger.info(
                 "Block processed slot=%s root=%s from peer %s",
                 slot,

--- a/src/lean_spec/subspecs/validator/service.py
+++ b/src/lean_spec/subspecs/validator/service.py
@@ -405,7 +405,7 @@ class ValidatorService:
         )
 
         return SignedBlock(
-            message=block,
+            block=block,
             signature=signature,
         )
 

--- a/tests/consensus/devnet/ssz/test_consensus_containers.py
+++ b/tests/consensus/devnet/ssz/test_consensus_containers.py
@@ -297,7 +297,7 @@ def test_signed_block_minimal(ssz: SSZTestFiller) -> None:
     )
     ssz(
         type_name="SignedBlock",
-        value=SignedBlock(message=block, signature=signature),
+        value=SignedBlock(block=block, signature=signature),
     )
 
 

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -214,7 +214,7 @@ def make_signed_block(
     )
 
     return SignedBlock(
-        message=block,
+        block=block,
         signature=BlockSignatures(
             attestation_signatures=AttestationSignatures(data=[]),
             proposer_signature=make_mock_signature(),
@@ -458,7 +458,7 @@ def make_signed_block_from_store(
     attestation_signatures = key_manager.build_attestation_signatures(block.body.attestations)
 
     signed_block = SignedBlock(
-        message=block,
+        block=block,
         signature=BlockSignatures(
             attestation_signatures=attestation_signatures,
             proposer_signature=proposer_signature,

--- a/tests/lean_spec/helpers/mocks.py
+++ b/tests/lean_spec/helpers/mocks.py
@@ -48,7 +48,7 @@ class MockNetworkRequester:
 
     def add_block(self, block: SignedBlock) -> Bytes32:
         """Add a block to the mock network. Returns its root."""
-        root = hash_tree_root(block.message)
+        root = hash_tree_root(block.block)
         self.blocks_by_root[root] = block
         return root
 
@@ -119,10 +119,10 @@ class MockForkchoiceStore:
         **kwargs: object,
     ) -> MockForkchoiceStore:
         """Track block additions. Returns self for assignment chaining."""
-        root = hash_tree_root(block.message)
-        self.blocks[root] = block.message
+        root = hash_tree_root(block.block)
+        self.blocks[root] = block.block
         self.head = root
-        self.head_slot = block.message.slot
+        self.head_slot = block.block.slot
         return self
 
     def on_gossip_attestation(

--- a/tests/lean_spec/subspecs/forkchoice/test_attestation_target.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_attestation_target.py
@@ -558,7 +558,7 @@ class TestIntegrationScenarios:
         proposer_signature = key_manager.sign_block_root(proposer_1, slot_1, block_root)
 
         signed_block = SignedBlock(
-            message=block,
+            block=block,
             signature=BlockSignatures(
                 attestation_signatures=AttestationSignatures(data=signatures),
                 proposer_signature=proposer_signature,

--- a/tests/lean_spec/subspecs/forkchoice/test_compute_block_weights.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_compute_block_weights.py
@@ -36,7 +36,7 @@ def test_linear_chain_weight_accumulates_upward(base_store: Store) -> None:
         parent_root=genesis_root,
         state_root=make_bytes32(10),
     )
-    block1_root = hash_tree_root(block1.message)
+    block1_root = hash_tree_root(block1.block)
 
     block2 = make_signed_block(
         slot=Slot(2),
@@ -44,11 +44,11 @@ def test_linear_chain_weight_accumulates_upward(base_store: Store) -> None:
         parent_root=block1_root,
         state_root=make_bytes32(20),
     )
-    block2_root = hash_tree_root(block2.message)
+    block2_root = hash_tree_root(block2.block)
 
     new_blocks = dict(base_store.blocks)
-    new_blocks[block1_root] = block1.message
-    new_blocks[block2_root] = block2.message
+    new_blocks[block1_root] = block1.block
+    new_blocks[block2_root] = block2.block
 
     new_states = dict(base_store.states)
     genesis_state = base_store.states[genesis_root]
@@ -93,10 +93,10 @@ def test_multiple_attestations_accumulate(base_store: Store) -> None:
         parent_root=genesis_root,
         state_root=make_bytes32(10),
     )
-    block1_root = hash_tree_root(block1.message)
+    block1_root = hash_tree_root(block1.block)
 
     new_blocks = dict(base_store.blocks)
-    new_blocks[block1_root] = block1.message
+    new_blocks[block1_root] = block1.block
 
     new_states = dict(base_store.states)
     new_states[block1_root] = base_store.states[genesis_root]

--- a/tests/lean_spec/subspecs/networking/client/test_reqresp_client.py
+++ b/tests/lean_spec/subspecs/networking/client/test_reqresp_client.py
@@ -291,7 +291,7 @@ class TestReqRespClientBlocksByRoot:
         blocks = await client.request_blocks_by_root(peer_id, roots)
 
         assert len(blocks) == 1
-        assert blocks[0].message.slot == Slot(10)
+        assert blocks[0].block.slot == Slot(10)
 
     async def test_request_multiple_blocks_success(self) -> None:
         """Successfully request multiple blocks."""
@@ -312,7 +312,7 @@ class TestReqRespClientBlocksByRoot:
         blocks = await client.request_blocks_by_root(peer_id, roots)
 
         assert len(blocks) == 2
-        slots = {b.message.slot for b in blocks}
+        slots = {b.block.slot for b in blocks}
         assert Slot(10) in slots
         assert Slot(20) in slots
 
@@ -335,7 +335,7 @@ class TestReqRespClientBlocksByRoot:
 
         # Only one block returned, RESOURCE_UNAVAILABLE continues reading
         assert len(blocks) == 1
-        assert blocks[0].message.slot == Slot(10)
+        assert blocks[0].block.slot == Slot(10)
 
     async def test_request_blocks_empty_request(self) -> None:
         """Empty root list returns empty without request."""
@@ -535,7 +535,7 @@ class TestReqRespClientErrorHandling:
 
         # Only block before codec error is returned
         assert len(blocks) == 1
-        assert blocks[0].message.slot == Slot(10)
+        assert blocks[0].block.slot == Slot(10)
 
 
 class TestReqRespClientConcurrency:
@@ -615,7 +615,7 @@ class TestReqRespClientConcurrency:
         assert status is not None
         assert status.head.slot == Slot(200)
         assert len(blocks) == 1
-        assert blocks[0].message.slot == Slot(42)
+        assert blocks[0].block.slot == Slot(42)
 
 
 class TestReqRespClientStreamLifecycle:

--- a/tests/lean_spec/subspecs/networking/reqresp/test_handler.py
+++ b/tests/lean_spec/subspecs/networking/reqresp/test_handler.py
@@ -271,8 +271,8 @@ class TestRequestHandlerBlocksByRoot:
         decoded1 = SignedBlock.decode_bytes(response.successes[0])
         decoded2 = SignedBlock.decode_bytes(response.successes[1])
 
-        assert decoded1.message.slot == Slot(1)
-        assert decoded2.message.slot == Slot(2)
+        assert decoded1.block.slot == Slot(1)
+        assert decoded2.block.slot == Slot(2)
 
     async def test_handle_blocks_by_root_skips_missing_blocks(self) -> None:
         """Missing blocks are silently skipped."""
@@ -359,7 +359,7 @@ class TestRequestHandlerBlocksByRoot:
         assert len(response.successes) == 1
 
         decoded = SignedBlock.decode_bytes(response.successes[0])
-        assert decoded.message.slot == Slot(2)
+        assert decoded.block.slot == Slot(2)
 
 
 class TestReqRespServer:
@@ -423,7 +423,7 @@ class TestReqRespServer:
         assert code == ResponseCode.SUCCESS
 
         returned_block = SignedBlock.decode_bytes(ssz_data)
-        assert returned_block.message.slot == Slot(1)
+        assert returned_block.block.slot == Slot(1)
 
     async def test_empty_request_returns_error(self) -> None:
         """Empty request data returns INVALID_REQUEST error."""
@@ -618,7 +618,7 @@ class TestIntegration:
                 blocks.append(SignedBlock.decode_bytes(ssz_bytes))
 
         assert len(blocks) == 2
-        slots = {b.message.slot for b in blocks}
+        slots = {b.block.slot for b in blocks}
         assert Slot(10) in slots
         assert Slot(20) in slots
 
@@ -652,7 +652,7 @@ class TestIntegration:
 
         # Only one block returned
         assert len(blocks) == 1
-        assert blocks[0].message.slot == Slot(10)
+        assert blocks[0].block.slot == Slot(10)
 
 
 class TestStreamResponseAdapterMultipleResponses:
@@ -876,7 +876,7 @@ class TestRequestHandlerEdgeCases:
         assert len(response.successes) == 1
 
         decoded = SignedBlock.decode_bytes(response.successes[0])
-        assert decoded.message.slot == Slot(999)
+        assert decoded.block.slot == Slot(999)
 
     async def test_blocks_by_root_all_missing(self) -> None:
         """Request where all blocks are missing returns no success responses."""
@@ -938,8 +938,8 @@ class TestRequestHandlerEdgeCases:
         decoded1 = SignedBlock.decode_bytes(response.successes[0])
         decoded2 = SignedBlock.decode_bytes(response.successes[1])
 
-        assert decoded1.message.slot == Slot(1)
-        assert decoded2.message.slot == Slot(3)
+        assert decoded1.block.slot == Slot(1)
+        assert decoded2.block.slot == Slot(3)
 
     async def test_status_update_after_initialization(self) -> None:
         """Status can be updated after handler creation."""
@@ -1039,7 +1039,7 @@ class TestConcurrentRequestHandling:
         block_result = SignedBlock.decode_bytes(ssz_data)
 
         assert status_result.head.slot == Slot(200)
-        assert block_result.message.slot == Slot(42)
+        assert block_result.block.slot == Slot(42)
 
 
 class MockFailingStream:

--- a/tests/lean_spec/subspecs/networking/test_network_service.py
+++ b/tests/lean_spec/subspecs/networking/test_network_service.py
@@ -67,7 +67,7 @@ class TestBlockRoutingToForkchoice:
             parent_root=genesis_root,
             state_root=Bytes32.zero(),
         )
-        block_root = hash_tree_root(block.message)
+        block_root = hash_tree_root(block.block)
 
         # Verify block is NOT in store before processing
         assert block_root not in sync_service.store.blocks
@@ -105,7 +105,7 @@ class TestBlockRoutingToForkchoice:
             parent_root=genesis_root,
             state_root=Bytes32.zero(),
         )
-        expected_new_head = hash_tree_root(block.message)
+        expected_new_head = hash_tree_root(block.block)
 
         events: list[NetworkEvent] = [
             GossipBlockEvent(block=block, peer_id=peer_id, topic=block_topic),
@@ -342,7 +342,7 @@ class TestIntegrationEventSequence:
             parent_root=genesis_root,
             state_root=Bytes32.zero(),
         )
-        expected_head = hash_tree_root(block.message)
+        expected_head = hash_tree_root(block.block)
 
         events: list[NetworkEvent] = [
             PeerStatusEvent(peer_id=peer_id, status=status),
@@ -425,7 +425,7 @@ class TestIntegrationEventSequence:
             parent_root=genesis_root,
             state_root=Bytes32.zero(),
         )
-        block1_root = hash_tree_root(block1.message)
+        block1_root = hash_tree_root(block1.block)
 
         block2 = make_signed_block(
             slot=Slot(2),
@@ -433,7 +433,7 @@ class TestIntegrationEventSequence:
             parent_root=block1_root,
             state_root=Bytes32.zero(),
         )
-        block2_root = hash_tree_root(block2.message)
+        block2_root = hash_tree_root(block2.block)
 
         events: list[NetworkEvent] = [
             GossipBlockEvent(block=block1, peer_id=peer_id, topic=block_topic),

--- a/tests/lean_spec/subspecs/ssz/test_block.py
+++ b/tests/lean_spec/subspecs/ssz/test_block.py
@@ -24,7 +24,7 @@ def test_encode_decode_signed_block_roundtrip() -> None:
     )
 
     signed_block = SignedBlock(
-        message=block,
+        block=block,
         signature=BlockSignatures(
             attestation_signatures=AttestationSignatures(data=[]),
             proposer_signature=make_mock_signature(),

--- a/tests/lean_spec/subspecs/sync/test_block_cache.py
+++ b/tests/lean_spec/subspecs/sync/test_block_cache.py
@@ -26,13 +26,13 @@ class TestPendingBlock:
             parent_root=Bytes32.zero(),
             state_root=Bytes32.zero(),
         )
-        root = hash_tree_root(block.message)
+        root = hash_tree_root(block.block)
 
         pending = PendingBlock(
             block=block,
             root=root,
-            parent_root=block.message.parent_root,
-            slot=block.message.slot,
+            parent_root=block.block.parent_root,
+            slot=block.block.slot,
             received_from=peer_id,
         )
 
@@ -55,7 +55,7 @@ class TestPendingBlock:
             parent_root=Bytes32.zero(),
             state_root=Bytes32.zero(),
         )
-        root = hash_tree_root(block.message)
+        root = hash_tree_root(block.block)
 
         pending = PendingBlock(
             block=block,
@@ -76,7 +76,7 @@ class TestPendingBlock:
             parent_root=Bytes32.zero(),
             state_root=Bytes32.zero(),
         )
-        root = hash_tree_root(block.message)
+        root = hash_tree_root(block.block)
 
         pending = PendingBlock(
             block=block,
@@ -120,7 +120,7 @@ class TestBlockCacheBasicOperations:
 
         pending = cache.add(block, peer_id)
 
-        root = hash_tree_root(block.message)
+        root = hash_tree_root(block.block)
         assert len(cache) == 1
         assert pending == PendingBlock(
             block=block,
@@ -713,7 +713,7 @@ class TestBlockCacheBackfillDepth:
 
         pending = cache.add(block, peer_id, backfill_depth=10)
 
-        root = hash_tree_root(block.message)
+        root = hash_tree_root(block.block)
         assert pending == PendingBlock(
             block=block,
             root=root,
@@ -736,7 +736,7 @@ class TestBlockCacheBackfillDepth:
 
         pending = cache.add(block, peer_id)
 
-        root = hash_tree_root(block.message)
+        root = hash_tree_root(block.block)
         assert pending == PendingBlock(
             block=block,
             root=root,

--- a/tests/lean_spec/subspecs/sync/test_head_sync.py
+++ b/tests/lean_spec/subspecs/sync/test_head_sync.py
@@ -52,7 +52,7 @@ class TestGossipBlockProcessing:
         processed_blocks: list[Bytes32] = []
 
         def track_processing(s: Any, block: SignedBlock) -> Any:
-            root = hash_tree_root(block.message)
+            root = hash_tree_root(block.block)
             processed_blocks.append(root)
             new_store = MockStore(set(s.blocks.keys()) | {root})
             return new_store
@@ -69,7 +69,7 @@ class TestGossipBlockProcessing:
             parent_root=genesis_root,
             state_root=Bytes32.zero(),
         )
-        block_root = hash_tree_root(block.message)
+        block_root = hash_tree_root(block.block)
 
         result, new_store = await head_sync.on_gossip_block(block, peer_id, store)
 
@@ -103,7 +103,7 @@ class TestGossipBlockProcessing:
             parent_root=unknown_parent,
             state_root=Bytes32.zero(),
         )
-        block_root = hash_tree_root(block.message)
+        block_root = hash_tree_root(block.block)
 
         result, _ = await head_sync.on_gossip_block(block, peer_id, store)
 
@@ -132,8 +132,8 @@ class TestGossipBlockProcessing:
             parent_root=genesis_root,
             state_root=Bytes32.zero(),
         )
-        block_root = hash_tree_root(block.message)
-        store.blocks[block_root] = block.message
+        block_root = hash_tree_root(block.block)
+        store.blocks[block_root] = block.block
 
         process_block = MagicMock()
         head_sync = HeadSync(
@@ -174,7 +174,7 @@ class TestDescendantProcessing:
             parent_root=genesis_root,
             state_root=Bytes32(b"\x01" * 32),
         )
-        parent_root = hash_tree_root(parent.message)
+        parent_root = hash_tree_root(parent.block)
 
         child = make_signed_block(
             slot=Slot(2),
@@ -182,7 +182,7 @@ class TestDescendantProcessing:
             parent_root=parent_root,
             state_root=Bytes32(b"\x02" * 32),
         )
-        child_root = hash_tree_root(child.message)
+        child_root = hash_tree_root(child.block)
 
         # Pre-cache the child (waiting for parent)
         block_cache.add(child, peer_id)
@@ -190,7 +190,7 @@ class TestDescendantProcessing:
         processing_order: list[Bytes32] = []
 
         def track_processing(s: Any, block: SignedBlock) -> Any:
-            root = hash_tree_root(block.message)
+            root = hash_tree_root(block.block)
             processing_order.append(root)
             new_store = MockStore(set(s.blocks.keys()) | {root})
             return new_store
@@ -235,7 +235,7 @@ class TestDescendantProcessing:
                 state_root=Bytes32(bytes([i]) * 32),
             )
             blocks.append(block)
-            parent_root = hash_tree_root(block.message)
+            parent_root = hash_tree_root(block.block)
 
         # Cache all except the first (which will be gossiped)
         for block in blocks[1:]:
@@ -244,8 +244,8 @@ class TestDescendantProcessing:
         processing_order: list[int] = []
 
         def track_processing(s: Any, block: SignedBlock) -> Any:
-            processing_order.append(int(block.message.slot))
-            root = hash_tree_root(block.message)
+            processing_order.append(int(block.block.slot))
+            root = hash_tree_root(block.block)
             new_store = MockStore(set(s.blocks.keys()) | {root})
             return new_store
 
@@ -303,7 +303,7 @@ class TestProcessAllProcessable:
         def count_processing(s: Any, block: SignedBlock) -> Any:
             nonlocal processed_count
             processed_count += 1
-            root = hash_tree_root(block.message)
+            root = hash_tree_root(block.block)
             new_store = MockStore(set(s.blocks.keys()) | {root})
             return new_store
 
@@ -336,7 +336,7 @@ class TestProcessAllProcessable:
             parent_root=genesis_root,
             state_root=Bytes32.zero(),
         )
-        block_root = hash_tree_root(block.message)
+        block_root = hash_tree_root(block.block)
         block_cache.add(block, peer_id)
 
         def fail_processing(s: Any, b: SignedBlock) -> Any:
@@ -429,7 +429,7 @@ class TestErrorHandling:
         def fail_first(s: Any, block: SignedBlock) -> Any:
             nonlocal call_count
             call_count += 1
-            root = hash_tree_root(block.message)
+            root = hash_tree_root(block.block)
             if call_count == 1:
                 raise Exception("First fails")
             successful_roots.add(root)
@@ -470,7 +470,7 @@ class TestStorePropagation:
             parent_root=genesis_root,
             state_root=Bytes32(b"\x01" * 32),
         )
-        parent_root = hash_tree_root(parent.message)
+        parent_root = hash_tree_root(parent.block)
 
         child1 = make_signed_block(
             slot=Slot(2),
@@ -478,7 +478,7 @@ class TestStorePropagation:
             parent_root=parent_root,
             state_root=Bytes32(b"\x02" * 32),
         )
-        child1_root = hash_tree_root(child1.message)
+        child1_root = hash_tree_root(child1.block)
 
         child2 = make_signed_block(
             slot=Slot(3),
@@ -486,14 +486,14 @@ class TestStorePropagation:
             parent_root=child1_root,
             state_root=Bytes32(b"\x03" * 32),
         )
-        child2_root = hash_tree_root(child2.message)
+        child2_root = hash_tree_root(child2.block)
 
         # Pre-cache descendants.
         block_cache.add(child1, peer_id)
         block_cache.add(child2, peer_id)
 
         def track_processing(s: Any, block: SignedBlock) -> Any:
-            root = hash_tree_root(block.message)
+            root = hash_tree_root(block.block)
             new_store = MockStore(set(s.blocks.keys()) | {root})
             return new_store
 
@@ -539,7 +539,7 @@ class TestReentrantGuard:
             parent_root=genesis_root,
             state_root=Bytes32.zero(),
         )
-        block_root = hash_tree_root(block.message)
+        block_root = hash_tree_root(block.block)
 
         # Simulate reentrant call by pre-adding to _processing.
         head_sync._processing.add(block_root)
@@ -577,7 +577,7 @@ class TestProcessAllProcessableConvergence:
             parent_root=genesis_root,
             state_root=Bytes32(b"\x01" * 32),
         )
-        root_a = hash_tree_root(block_a.message)
+        root_a = hash_tree_root(block_a.block)
 
         block_b = make_signed_block(
             slot=Slot(2),
@@ -585,7 +585,7 @@ class TestProcessAllProcessableConvergence:
             parent_root=root_a,
             state_root=Bytes32(b"\x02" * 32),
         )
-        root_b = hash_tree_root(block_b.message)
+        root_b = hash_tree_root(block_b.block)
 
         block_c = make_signed_block(
             slot=Slot(3),
@@ -601,8 +601,8 @@ class TestProcessAllProcessableConvergence:
         processing_order: list[int] = []
 
         def track_processing(s: Any, block: SignedBlock) -> Any:
-            processing_order.append(int(block.message.slot))
-            root = hash_tree_root(block.message)
+            processing_order.append(int(block.block.slot))
+            root = hash_tree_root(block.block)
             new_store = MockStore(set(s.blocks.keys()) | {root})
             return new_store
 

--- a/tests/lean_spec/subspecs/sync/test_service.py
+++ b/tests/lean_spec/subspecs/sync/test_service.py
@@ -217,7 +217,7 @@ class TestGossipBlockHandling:
             parent_root=Bytes32(b"\x01" * 32),
             state_root=Bytes32.zero(),
         )
-        block_root = hash_tree_root(block.message)
+        block_root = hash_tree_root(block.block)
 
         await sync_service.on_gossip_block(block, peer_id)
 

--- a/tests/lean_spec/subspecs/validator/test_service.py
+++ b/tests/lean_spec/subspecs/validator/test_service.py
@@ -510,17 +510,17 @@ class TestValidatorServiceIntegration:
         signed_block = blocks_produced[0]
 
         # Verify block structure
-        assert signed_block.message.slot == Slot(1)
-        assert signed_block.message.proposer_index == ValidatorIndex(1)
+        assert signed_block.block.slot == Slot(1)
+        assert signed_block.block.proposer_index == ValidatorIndex(1)
 
         # Verify proposer signature is cryptographically valid
-        proposer_index = signed_block.message.proposer_index
-        block_root = hash_tree_root(signed_block.message)
+        proposer_index = signed_block.block.proposer_index
+        block_root = hash_tree_root(signed_block.block)
         proposer_public_key = key_manager[proposer_index].proposal_public
 
         is_valid = TARGET_SIGNATURE_SCHEME.verify(
             pk=proposer_public_key,
-            slot=signed_block.message.slot,
+            slot=signed_block.block.slot,
             message=block_root,
             sig=signed_block.signature.proposer_signature,
         )
@@ -642,13 +642,13 @@ class TestValidatorServiceIntegration:
         assert len(blocks_produced) == 1
         signed_block = blocks_produced[0]
 
-        proposer_index = signed_block.message.proposer_index
-        block_root = hash_tree_root(signed_block.message)
+        proposer_index = signed_block.block.proposer_index
+        block_root = hash_tree_root(signed_block.block)
         public_key = key_manager[proposer_index].proposal_public
 
         is_valid = TARGET_SIGNATURE_SCHEME.verify(
             pk=public_key,
-            slot=signed_block.message.slot,
+            slot=signed_block.block.slot,
             message=block_root,
             sig=signed_block.signature.proposer_signature,
         )
@@ -724,7 +724,7 @@ class TestValidatorServiceIntegration:
         signed_block = blocks_produced[0]
 
         # Block should contain the pending attestations
-        body_attestations = signed_block.message.body.attestations
+        body_attestations = signed_block.block.body.attestations
         assert len(body_attestations) > 0
 
         # Verify the attestation signatures are included and valid
@@ -811,7 +811,7 @@ class TestValidatorServiceIntegration:
 
         # One block should be produced
         assert len(blocks_produced) == 1
-        assert blocks_produced[0].message.proposer_index == proposer_index
+        assert blocks_produced[0].block.proposer_index == proposer_index
 
         # ALL validators should have attested (including proposer)
         attestation_validator_ids = {att.validator_id for att in attestations_produced}
@@ -845,7 +845,7 @@ class TestValidatorServiceIntegration:
         await service._maybe_produce_block(Slot(4))
 
         assert len(blocks_produced) == 1
-        produced_block = blocks_produced[0].message
+        produced_block = blocks_produced[0].block
 
         # The state root should not be zero (it was computed)
         assert produced_block.state_root != Bytes32.zero()


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

I feel like this is more natural, what do you think @anshalshukla ?

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
