### PR TITLE
fix(test): avoid duplicate slot in test_head_switches_to_heavier_fork

### DIFF
--- a/tests/consensus/devnet/fc/test_fork_choice_head.py
+++ b/tests/consensus/devnet/fc/test_fork_choice_head.py
@@ -241,12 +241,13 @@ def test_head_switches_to_heavier_fork(
 
     Scenario
     --------
-    Create two forks at slot 2, then extend one fork to make it heavier.
+    Create two forks from a common ancestor at distinct slots, then extend
+    one fork to make it heavier.
 
     Expected Behavior:
-        - After fork A (slot 2): head = fork A
-        - After fork B (slot 2): head = still fork A (tie-breaker)
-        - After extending fork B (slot 3): head = slot 3 (fork B wins!)
+        - After fork A (slot 2): head = fork A (only fork)
+        - After fork B (slot 3): equal weight, tiebreaker decides
+        - After extending fork B (slot 4): head = fork B's child (fork B wins!)
 
     Why This Matters
     ----------------
@@ -277,34 +278,33 @@ def test_head_switches_to_heavier_fork(
                 ),
                 checks=StoreChecks(head_slot=Slot(2), head_root_label="fork_a"),
             ),
-            # Competing fork B at slot 2 (equal weight, tiebreaker decides)
+            # Fork B at slot 3 (same parent, equal weight, tiebreaker decides)
             BlockStep(
                 block=BlockSpec(
-                    slot=Slot(2),
+                    slot=Slot(3),
                     parent_label="common",
                     label="fork_b",
                 ),
                 checks=StoreChecks(
-                    head_slot=Slot(2),
                     lexicographic_head_among=["fork_a", "fork_b"],
                 ),
             ),
             # Extend fork B with an attestation for fork_b → gives it more weight
             BlockStep(
                 block=BlockSpec(
-                    slot=Slot(3),
+                    slot=Slot(4),
                     parent_label="fork_b",
-                    label="fork_b_3",
+                    label="fork_b_4",
                     attestations=[
                         AggregatedAttestationSpec(
                             validator_ids=[ValidatorIndex(2)],
-                            slot=Slot(2),
-                            target_slot=Slot(2),
+                            slot=Slot(3),
+                            target_slot=Slot(3),
                             target_root_label="fork_b",
                         ),
                     ],
                 ),
-                checks=StoreChecks(head_slot=Slot(3), head_root_label="fork_b_3"),
+                checks=StoreChecks(head_slot=Slot(4), head_root_label="fork_b_4"),
             ),
         ],
     )


### PR DESCRIPTION
## Summary

Fixes another test case identified in #470 (`Avoid multiple-blocks-same-slot in all test cases`).

- **`test_head_switches_to_heavier_fork`** created fork_a and fork_b at the same slot (2), violating the one-block-per-slot constraint.
- Moved fork_b from slot 2 to slot 3, and its child block from slot 3 to slot 4, so each block occupies a unique slot.
- Updated the attestation reference to target fork_b at its new slot (3).
- The test still validates the same LMD-GHOST property: extending a fork with a child block and attestation makes it heavier and switches the head.

## Test plan

- [x] `uv run fill tests/consensus/devnet/fc/test_fork_choice_head.py --fork=Devnet -v` -- all 6 tests pass

Addresses #470