### PR TITLE
framework: add spec-diff agent skill

### DIFF
--- a/.claude/skills/spec-diff/SKILL.md
+++ b/.claude/skills/spec-diff/SKILL.md
@@ -61,6 +61,14 @@ Categorize each item as:
 For modified items, briefly describe what changed (e.g. "added `deadline` parameter",
 "changed return type from `bool` to `Optional[bool]`").
 
+**Detecting renames**: A rename+change appears in the diff as a removal in one place and
+an addition in another. Before classifying something as `[Removed]` + `[New]`, check
+whether the removed item has a corresponding new item with a similar name, similar
+parameters, or similar objective. If so, report it as a single `[Modified]` entry:
+`old_name()` → renamed to `new_name()`, with a description of what else changed.
+Common rename patterns: prefix/suffix changes (`gossip_` → `attestation_`), class
+extraction (`function` → `Class.method`), split (`one_func` → `two_funcs`).
+
 ### 4. Analyze test vector changes
 
 For each changed consensus test file (`tests/consensus/`), run:


### PR DESCRIPTION
## 🗒️ Description

Adds an agent skill (`/spec-diff`) that generates spec diff between tagged devnet versions in VERSIONS.md. Use by calling within the agent `/spec-diff devnet3` or in natural language `"spec diff devnet3"` also works as well.

I name this spec-diff rather than changelog because this skill excludes framework changes so it's not really the full repo changelog, only a diff of specific parts.

## Usage

It's been useful so far for glossing over all the changes and much easier to understand than trying to `git diff ...`. I think it'll also be useful for both existing & new client teams to catch up with the changes. I'm also writing another skill that uses this skill to check integrity with the high level plan in https://github.com/leanEthereum/pm/tree/main/breakout-rooms/leanConsensus/pq-interop

## Example

```md
## Spec Changes: Devnet 3 → HEAD

Base: be853180 (Devnet 3) | Target: HEAD (spec-diff-skill)
Stats: 22 files changed, +1346 / -1113 lines

▎ Note: This diff covers spec code and consensus test vectors only. Node implementation changes (networking, sync,
storage, gossipsub, reqresp) are excluded.

---
### Dual-Key Validator Model

Each validator now carries two XMSS key pairs — one for attestations, one for block proposals — eliminating OTS
conflicts when a proposer needs to both sign a block and attest in the same slot.

- [Modified] Validator.pubkey → renamed to attestation_pubkey
- [New] Validator.proposal_pubkey field (Bytes52)
- [Modified] Validator.get_pubkey() → renamed to get_attestation_pubkey()
- [New] Validator.get_proposal_pubkey() method
- [New] GenesisValidatorEntry model — holds both pubkeys with hex parsing
- [Modified] GenesisConfig.genesis_validators — changed from list[Bytes52] to list[GenesisValidatorEntry]
- [Modified] ValidatorManifestEntry / ValidatorEntry — single key fields replaced with attestation + proposal key pairs
- [Modified] ValidatorRegistry.from_manifest() — loads two key files per validator
- [New] ValidatorKeyPair named tuple (attestation_public, attestation_secret, proposal_public, proposal_secret)

### Block Envelope Redesign

The proposer's attestation is no longer bundled inside the block. Proposers sign hash_tree_root(block) with their
proposal key; their attestation flows through normal gossip.

- [Removed] BlockWithAttestation container
- [Modified] SignedBlockWithAttestation → renamed to SignedBlock
- [Modified] SignedBlock now contains block: Block directly (was message: BlockWithAttestation)
- [Modified] SignedBlock.verify_signatures() — proposer verification checks block root signed with
get_proposal_pubkey(); body attestations use get_attestation_pubkey()

### Forkchoice Store

- [Modified] GossipSignatureEntry → renamed to AttestationSignatureEntry
- [Modified] Store.gossip_signatures → renamed to Store.attestation_signatures
- [Modified] Store.on_block() — no longer processes proposer attestation; parameter renamed to signed_block
- [Modified] Store.on_gossip_attestation() / on_gossip_aggregated_attestation() — use get_attestation_pubkey()
- [Modified] Store.aggregate_committee_signatures() → renamed to Store.aggregate() with new recursive: bool parameter
- [Modified] Store.produce_block_with_signatures() — passes aggregated_payloads directly to build_block()

### Block Building & Aggregation

- [Modified] State.build_block() — simplified signature; operates directly on aggregated_payloads using a fixed-point
loop
- [New] State._extend_proofs_greedily() — greedy set-cover algorithm for proof selection
- [Modified] State.aggregate_gossip_signatures() → renamed to State.aggregate() with redesigned signature
- [Removed] State.select_aggregated_proofs()
- [Modified] AggregatedSignatureProof.aggregate() — redesigned for recursive aggregation (children/raw_xmss instead of
flat lists)

### Validator Service

- [Modified] ValidatorService._sign_block() — signs block root with proposal key; returns SignedBlock
- [New] ValidatorService._sign_with_key() — unified signing for either key type
- [Removed] ValidatorService._ensure_prepared_for_slot() (absorbed into _sign_with_key)
- [Removed] ValidatorService._store_proposer_attestation_signature() (no longer needed)
- [Modified] ValidatorService._produce_attestations() — proposers now attest via normal gossip

### Module Exports

- [Removed] All re-exports from subspecs/__init__.py (ApiServer, GenesisConfig, etc.)
- [Removed] Several XMSS exports (Signature, HashTreeOpening, config constants)

---
### Test Vectors

**Fork Choice — Head & Reorgs** (4 files)
- [Modified] All fork choice tests rewritten to use explicit attestation weight instead of implicit
proposer-attestation/block-count weight
- [Modified] Equal-weight scenarios now use lexicographic_head_among instead of asserting a specific winner
- [Modified] Reorg tests driven by attestation counts (e.g. 4 vs 1) rather than block depth (e.g. 3 vs 2)

**Fork Choice — Attestation Target Selection** (1 file)
- [Modified] All blocks now include explicit AggregatedAttestationSpec with specific validator IDs

**Fork Choice — Lexicographic Tiebreaker** (1 file)
- [Modified] Forks at different slots with explicit attestations for equal weight

**Fork Choice — Signature Aggregation** (1 file)
- [Removed] test_auto_collect_proposer_attestations — auto-collection removed
- [Removed] test_auto_collect_combined_with_explicit_attestations — same reason

**SSZ Containers** (2 files)
- [Removed] test_block_with_attestation_minimal — container deleted
- [Modified] test_signed_block_with_attestation_minimal → renamed to test_signed_block_minimal
- [Modified] All Validator/State constructions use dual pubkeys

**Signature Verification** (2 files)
- [Modified] Docstring references updated to SignedBlock

---
### Summary

- 14 spec files, 9 test files changed
- Core design shift: dual-key validators (attestation + proposal) coupled with removal of the proposer attestation from
 the block envelope
- Fork choice weight model moves from implicit proposer-attestation weight to explicit on-chain attestation weight
- Aggregation API restructured to support future recursive aggregation via child proofs
- Block building simplified with greedy set-cover proof selection
 ```