### PR TITLE
Update commit hash for Devnet 3

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,4 +3,4 @@
 | Devnet 0 | 4b750f2748a3718fe3e1e9cdb3c65e3a7ddabff5 | https://github.com/leanEthereum/leanSpec/tree/4b750f2748a3718fe3e1e9cdb3c65e3a7ddabff5 |
 | Devnet 1 | 050fa4a18881d54d7dc07601fe59e34eb20b9630 | https://github.com/leanEthereum/leanSpec/tree/050fa4a18881d54d7dc07601fe59e34eb20b9630 |
 | Devnet 2 | 4edcf7bc9271e6a70ded8aff17710d68beac4266 | https://github.com/leanEthereum/leanSpec/tree/4edcf7bc9271e6a70ded8aff17710d68beac4266 |
-| Devnet 3 | be853180d21aa36d6401b8c1541aa6fcaad5008d | https://github.com/leanEthereum/leanSpec/tree/be853180d21aa36d6401b8c1541aa6fcaad5008d |
+| Devnet 3 | 97485335033443be6a68481d68851826ec22e6b8 | https://github.com/leanEthereum/leanSpec/tree/97485335033443be6a68481d68851826ec22e6b8 |


### PR DESCRIPTION
## 🗒️ Description
Updated the commit hash and link for Devnet 3 to `97485335033443be6a68481d68851826ec22e6b8`.

## 🔗 Related Issues or PRs
Given that the PR [#482](https://github.com/leanEthereum/leanSpec/pull/482) was recently merged for devnet-3, we can update the pinned commit hash for devnet-3 in the `VERSIONS.md` file.
