### PR TITLE
tooling: add keygen-benchmark CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,38 +90,6 @@ jobs:
       - name: Fill test fixtures
         run: uv run fill --fork=Devnet --clean -n auto
 
-  keygen-benchmark:
-    name: Keygen benchmark - ${{ matrix.scheme }} scheme
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        scheme: [test, prod]
-    steps:
-      - name: Checkout leanSpec
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-
-      - name: Sync dependencies
-        run: uv sync --no-progress
-
-      - name: Generate 1 key (${{ matrix.scheme }} scheme)
-        run: |
-          time uv run python -m consensus_testing.keys \
-            --scheme ${{ matrix.scheme }} \
-            --count 1 \
-            --max-slot 100
-
   interop-tests:
     name: Interop tests - Multi-node consensus
     runs-on: ubuntu-latest
@@ -151,3 +119,36 @@ jobs:
             --log-cli-level=INFO
         env:
           LEAN_ENV: test
+
+  keygen-benchmark:
+    name: Keygen benchmark - ${{ matrix.scheme }} scheme
+    needs: [lint, test, fill-tests, interop-tests]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        scheme: [test, prod]
+    steps:
+      - name: Checkout leanSpec
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Sync dependencies
+        run: uv sync --no-progress
+
+      - name: Generate 1 key (${{ matrix.scheme }} scheme)
+        run: |
+          time uv run python -m consensus_testing.keys \
+            --scheme ${{ matrix.scheme }} \
+            --count 1 \
+            --max-slot 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,38 @@ jobs:
       - name: Fill test fixtures
         run: uv run fill --fork=Devnet --clean -n auto
 
+  keygen-benchmark:
+    name: Keygen benchmark - ${{ matrix.scheme }} scheme
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        scheme: [test, prod]
+    steps:
+      - name: Checkout leanSpec
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Sync dependencies
+        run: uv sync --no-progress
+
+      - name: Generate 1 key (${{ matrix.scheme }} scheme)
+        run: |
+          time uv run python -m consensus_testing.keys \
+            --scheme ${{ matrix.scheme }} \
+            --count 1 \
+            --max-slot 100
+
   interop-tests:
     name: Interop tests - Multi-node consensus
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🗒️ Description

Track test/prod keygen time so we can detect regression. This job runs after lint, test, etc. so it should not affect turnaround time to merge a PR.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
