### PR TITLE
config: extract LIBP2P_ALPN_PROTOCOL constant and add spec test

### DIFF
--- a/src/lean_spec/subspecs/networking/config.py
+++ b/src/lean_spec/subspecs/networking/config.py
@@ -64,3 +64,11 @@ before attempting to re-graft. This prevents rapid mesh churn.
 
 MAX_ERROR_MESSAGE_SIZE: Final[int] = 256
 """Maximum error message size in bytes per Ethereum P2P spec (ErrorMessage: List[byte, 256])."""
+
+LIBP2P_ALPN_PROTOCOL: Final[str] = "libp2p"
+"""ALPN protocol identifier for libp2p connections.
+
+Per the libp2p TLS spec (https://github.com/libp2p/specs/blob/master/tls/tls.md):
+"libp2p" is the Application-Layer Protocol Negotiation (ALPN) value used
+during the TLS 1.3 handshake to identify libp2p connections.
+"""

--- a/src/lean_spec/subspecs/networking/transport/quic/connection.py
+++ b/src/lean_spec/subspecs/networking/transport/quic/connection.py
@@ -41,6 +41,7 @@ from aioquic.quic.events import (
     StreamReset,
 )
 
+from lean_spec.subspecs.networking.config import LIBP2P_ALPN_PROTOCOL
 from lean_spec.subspecs.networking.types import ProtocolId
 
 from ..identity import IdentityKeypair
@@ -520,7 +521,7 @@ class QuicConnectionManager:
 
         # Configure QUIC.
         config = QuicConfiguration(
-            alpn_protocols=["libp2p"],
+            alpn_protocols=[LIBP2P_ALPN_PROTOCOL],
             is_client=True,
             verify_mode=ssl.CERT_NONE,  # We verify via libp2p extension, not CA
         )
@@ -640,7 +641,7 @@ class QuicConnectionManager:
 
         # Create server configuration.
         server_config = QuicConfiguration(
-            alpn_protocols=["libp2p"],
+            alpn_protocols=[LIBP2P_ALPN_PROTOCOL],
             is_client=False,
             verify_mode=ssl.CERT_NONE,  # We verify via libp2p extension
         )

--- a/tests/lean_spec/subspecs/networking/transport/quic/test_connection.py
+++ b/tests/lean_spec/subspecs/networking/transport/quic/test_connection.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from lean_spec.subspecs.networking.config import LIBP2P_ALPN_PROTOCOL
 from lean_spec.subspecs.networking.transport.peer_id import PeerId
 from lean_spec.subspecs.networking.transport.quic.connection import (
     ConnectionTerminated,
@@ -174,6 +175,27 @@ class TestParseMultiaddr:
         """Multiaddr without quic/quic-v1 component returns None transport."""
         host, port, transport, _ = parse_multiaddr("/ip4/10.0.0.1/udp/3000")
         assert (host, port, transport) == ("10.0.0.1", 3000, None)
+
+
+# ---------------------------------------------------------------------------
+# ALPN protocol — per the libp2p TLS spec
+#
+# https://github.com/libp2p/specs/blob/master/tls/tls.md
+# "Endpoints MUST NOT send (and MUST NOT accept) any ALPN extension that
+#  does not include "libp2p" as the ALPN protocol string."
+# ---------------------------------------------------------------------------
+
+
+class TestAlpnProtocol:
+    """Verify the ALPN protocol value per the libp2p TLS spec."""
+
+    def test_alpn_is_libp2p(self) -> None:
+        """The ALPN value is 'libp2p' as mandated by the libp2p TLS spec.
+
+        Spec reference (https://github.com/libp2p/specs/blob/master/tls/tls.md):
+        the ALPN extension MUST include "libp2p" as the protocol string.
+        """
+        assert LIBP2P_ALPN_PROTOCOL == "libp2p"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extract hardcoded `"libp2p"` ALPN string into `LIBP2P_ALPN_PROTOCOL` constant in `networking/config.py`
- Replace both inline usages in `QuicConnectionManager` (client + server config)
- Add test asserting the value matches the libp2p TLS spec requirement

## Spec reference

From the [libp2p TLS spec](https://github.com/libp2p/specs/blob/master/tls/tls.md):

> Endpoints MUST NOT send (and MUST NOT accept) any ALPN extension that does not include "libp2p" as the ALPN protocol string.

This was the only spec-mandated property identified as untested during review of #497.

## Test plan

- [x] `uvx tox -e all-checks` passes
- [x] 54 QUIC connection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)