### PR TITLE
test: add consensus-critical justification and finalization test vectors

### DIFF
--- a/tests/consensus/devnet/state_transition/test_justification.py
+++ b/tests/consensus/devnet/state_transition/test_justification.py
@@ -233,22 +233,22 @@ def test_repeated_validators_do_not_double_count_across_blocks(
 
     Scenario
     --------
-    1. Start from genesis with 6 validators
-    2. Process block_1 at slot 1 and block_2 at slot 2
-    3. Process block_2 with attestations from validators 0 and 1 targeting
-       block_1 at slot 1
-    4. Process block_3 with the same validators 0 and 1 targeting block_1 again
-    5. Process block_4 with new validators 2, 3, 4, and 5 targeting block_2 at slot 2
+    1. Start from genesis with 4 validators
+    2. Process block_1 at slot 1
+    3. Process block_2 at slot 2 with attestations from validators 0 and 1
+       targeting block_1 at slot 1
+    4. Process block_3 at slot 3 with the same validators 0 and 1 targeting
+       block_1 again
 
     Expected Behavior
     -----------------
-    1. Duplicate votes for block_1 do not create new validator weight
-    2. block_1 must not become justified from repeated participants alone
-    3. The later block_2 attestation still uses source slot 0
-    4. latest_justified_slot advances to slot 2 without finalizing slot 1
+    1. The first attestation set is below threshold on its own
+    2. Repeating the same validators in a later block does not add new weight
+    3. Unique support remains two of four validators, which is below two-thirds
+    4. latest_justified_slot stays at genesis
     """
     state_transition_test(
-        pre=generate_pre_state(num_validators=6),
+        pre=generate_pre_state(),
         blocks=[
             BlockSpec(slot=Slot(1), label="block_1"),
             BlockSpec(
@@ -283,28 +283,10 @@ def test_repeated_validators_do_not_double_count_across_blocks(
                     ),
                 ],
             ),
-            BlockSpec(
-                slot=Slot(4),
-                parent_label="block_3",
-                attestations=[
-                    AggregatedAttestationSpec(
-                        validator_ids=[
-                            ValidatorIndex(2),
-                            ValidatorIndex(3),
-                            ValidatorIndex(4),
-                            ValidatorIndex(5),
-                        ],
-                        slot=Slot(4),
-                        target_slot=Slot(2),
-                        target_root_label="block_2",
-                    ),
-                ],
-            ),
         ],
         post=StateExpectation(
-            slot=Slot(4),
-            latest_justified_slot=Slot(2),
-            latest_finalized_slot=Slot(0),
+            slot=Slot(3),
+            latest_justified_slot=Slot(0),
         ),
     )
 


### PR DESCRIPTION
## 🗒️ Description

Add 10 new state transition test vectors to `test_justification.py` exercising consensus-critical edge cases for justification and finalization:

- **Exact 2/3 threshold boundary:** Verifies that 4-of-6 validators, hitting the exact `>=` boundary, is sufficient to justify a target.
- **Below-threshold rejection:** Verifies that 3-of-6 validators, falling below the two-thirds threshold, does not advance justification.
- **Vote accumulation across blocks:** Verifies that pending votes from earlier blocks are preserved and eventually cross the threshold when new validators contribute in a later block.
- **Repeated validator dedup across blocks:** Verifies that the same validators voting twice for the same target across separate blocks do not inflate the tally.
- **Finalization on next justifiable step:** Verifies that justifying the immediately next justifiable slot after the source finalizes the source checkpoint.
- **No finalization with intermediate justifiable slot:** Verifies that justifying a distant target advances the justified checkpoint but does not finalize the source when intermediate justifiable slots exist in between.
- **Mid-block finalized-slot visibility:** Verifies that a second attestation within the same block can see the finalized-slot update caused by the first attestation during mid-block processing.
- **Pronic boundary acceptance:** Verifies that a target at pronic distance (delta 6 = 2×3) from the finalized slot is accepted for justification.
- **Non-justifiable boundary rejection:** Verifies that a target at non-justifiable distance (delta 7) from the finalized slot is rejected despite supermajority support.
- **Square boundary acceptance:** Verifies that a target at square distance (delta 9 = 3²) from the finalized slot is accepted for justification.

## 🔗 Related Issues or PRs

N/A

## ✅ Checklist

- [X] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [X] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.