### PR TITLE
test: add justification gate check test vectors for client implementations

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -4,7 +4,7 @@ from typing import Any, ClassVar, List
 
 from pydantic import ConfigDict, PrivateAttr, field_serializer
 
-from lean_spec.subspecs.containers.attestation import AttestationData
+from lean_spec.subspecs.containers.attestation import AggregatedAttestation, AttestationData
 from lean_spec.subspecs.containers.attestation.aggregation_bits import AggregationBits
 from lean_spec.subspecs.containers.block.block import Block, BlockBody
 from lean_spec.subspecs.containers.block.types import AggregatedAttestations
@@ -284,6 +284,29 @@ class StateTransitionTest(BaseConsensusFixture):
                 body=spec.body or BlockBody(attestations=aggregated_attestations),
             ), None
 
+        # Some state-transition tests need to inject attestations whose source or
+        # checkpoint roots intentionally do not match the current justified
+        # checkpoint. State.build_block() drops those entries before
+        # process_attestations() sees them, so blocks using explicit attestation
+        # overrides are assembled directly here.
+        if spec.attestations and any(
+            self._aggregated_attestation_spec_has_overrides(attestation_spec)
+            for attestation_spec in spec.attestations
+        ):
+            explicit_attestations = self._build_aggregated_attestations_from_spec(
+                spec.attestations, state, block_registry
+            )
+            block = Block(
+                slot=spec.slot,
+                proposer_index=proposer_index,
+                parent_root=parent_root,
+                state_root=Bytes32.zero(),
+                body=BlockBody(attestations=AggregatedAttestations(data=explicit_attestations)),
+            )
+            post_state = (temp_state or state).process_block(block)
+            block = block.model_copy(update={"state_root": hash_tree_root(post_state)})
+            return block, post_state
+
         # Build aggregated payloads from spec.attestations if provided
         aggregated_payloads: dict[AttestationData, set[AggregatedSignatureProof]] = {}
         if spec.attestations:
@@ -302,6 +325,16 @@ class StateTransitionTest(BaseConsensusFixture):
             aggregated_payloads=aggregated_payloads,
         )
         return block, post_state
+
+    @staticmethod
+    def _aggregated_attestation_spec_has_overrides(spec: AggregatedAttestationSpec) -> bool:
+        """Return whether an aggregated attestation spec uses explicit checkpoints."""
+        return (
+            spec.source_root_label is not None
+            or spec.source_slot is not None
+            or spec.target_root_override is not None
+            or spec.source_root_override is not None
+        )
 
     def _build_aggregated_payloads_from_spec(
         self,
@@ -370,6 +403,40 @@ class StateTransitionTest(BaseConsensusFixture):
 
         return payloads
 
+    def _build_aggregated_attestations_from_spec(
+        self,
+        attestation_specs: list[AggregatedAttestationSpec],
+        state: State,
+        block_registry: dict[str, Block],
+    ) -> list[AggregatedAttestation]:
+        """
+        Build aggregated attestations directly from test specifications.
+
+        This path is used only when a spec includes explicit checkpoint
+        overrides and the block must carry the attestations exactly as written.
+        """
+        attestations: list[AggregatedAttestation] = []
+
+        for spec in attestation_specs:
+            if not spec.valid_signature:
+                raise NotImplementedError(
+                    "valid_signature=False not yet supported in StateTransitionTest"
+                )
+            if spec.signer_ids is not None:
+                raise NotImplementedError("signer_ids not yet supported in StateTransitionTest")
+
+            attestation_data = self._build_attestation_data_from_spec(spec, block_registry, state)
+            attestations.append(
+                AggregatedAttestation(
+                    aggregation_bits=AggregationBits.from_validator_indices(
+                        ValidatorIndices(data=spec.validator_ids)
+                    ),
+                    data=attestation_data,
+                )
+            )
+
+        return attestations
+
     def _resolve_checkpoint(
         self,
         label: str,
@@ -430,6 +497,24 @@ class StateTransitionTest(BaseConsensusFixture):
             ValueError: If target label not found in registry.
         """
         target = self._resolve_checkpoint(spec.target_root_label, spec.target_slot, block_registry)
+        if spec.target_root_override is not None:
+            target = Checkpoint(root=spec.target_root_override, slot=target.slot)
+
+        if spec.source_root_label is not None:
+            source = self._resolve_checkpoint(
+                spec.source_root_label, spec.source_slot, block_registry
+            )
+        else:
+            source = Checkpoint(
+                root=state.latest_justified.root,
+                slot=(
+                    spec.source_slot
+                    if spec.source_slot is not None
+                    else state.latest_justified.slot
+                ),
+            )
+        if spec.source_root_override is not None:
+            source = Checkpoint(root=spec.source_root_override, slot=source.slot)
 
         # In simplified tests, head equals target for convenience.
         #
@@ -438,5 +523,5 @@ class StateTransitionTest(BaseConsensusFixture):
             slot=spec.slot,
             head=target,
             target=target,
-            source=state.latest_justified,
+            source=source,
         )

--- a/packages/testing/src/consensus_testing/test_types/aggregated_attestation_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/aggregated_attestation_spec.py
@@ -2,7 +2,7 @@
 
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex
-from lean_spec.types import CamelModel
+from lean_spec.types import Bytes32, CamelModel
 
 
 class AggregatedAttestationSpec(CamelModel):
@@ -27,6 +27,36 @@ class AggregatedAttestationSpec(CamelModel):
     Label referencing a previously created block as the target (required).
 
     The block must exist in the block registry with this label.
+    """
+
+    source_root_label: str | None = None
+    """
+    Optional label referencing a previously created block as the source.
+
+    When None (default), the source checkpoint is derived from the parent state.
+    When specified, resolves to a different block for source override tests.
+    """
+
+    source_slot: Slot | None = None
+    """
+    Optional override for the source checkpoint slot.
+
+    When None (default), uses the actual slot of the source checkpoint.
+    When specified, creates a source/slot mismatch for guard testing.
+    """
+
+    target_root_override: Bytes32 | None = None
+    """
+    Raw root override for the target checkpoint.
+
+    Bypasses label resolution. Used to inject a non-canonical target root.
+    """
+
+    source_root_override: Bytes32 | None = None
+    """
+    Raw root override for the source checkpoint.
+
+    Bypasses label resolution. Used to inject a non-canonical source root.
     """
 
     valid_signature: bool = True

--- a/tests/consensus/devnet/state_transition/test_justification.py
+++ b/tests/consensus/devnet/state_transition/test_justification.py
@@ -11,6 +11,7 @@ from consensus_testing import (
 
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex
+from lean_spec.types import ZERO_HASH, Bytes32
 
 pytestmark = pytest.mark.valid_until("Devnet")
 
@@ -682,6 +683,254 @@ def test_square_boundary_acceptance(
         post=StateExpectation(
             slot=Slot(10),
             latest_justified_slot=Slot(9),
+            latest_finalized_slot=Slot(0),
+        ),
+    )
+
+
+def test_unjustified_source_rejected(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test that an unjustified source checkpoint is rejected.
+
+    Scenario
+    --------
+    1. Start from genesis with 4 validators
+    2. Process block_1 at slot 1 and block_2 at slot 2
+    3. Process block_3 at slot 3 with attestations from validators 0, 1, and 2
+       targeting block_2 at slot 2 but sourcing from block_1 at slot 1
+
+    Expected Behavior
+    -----------------
+    1. The source slot 1 is neither justified nor finalized
+    2. Three of four validators form a supermajority
+    3. The attestation is ignored because its source is not trusted
+    4. latest_justified_slot stays at genesis
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[
+            BlockSpec(slot=Slot(1), label="block_1"),
+            BlockSpec(slot=Slot(2), parent_label="block_1", label="block_2"),
+            BlockSpec(
+                slot=Slot(3),
+                parent_label="block_2",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(3),
+                        target_slot=Slot(2),
+                        target_root_label="block_2",
+                        source_root_label="block_1",
+                        source_slot=Slot(1),
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(3),
+            latest_justified_slot=Slot(0),
+            latest_finalized_slot=Slot(0),
+        ),
+    )
+
+
+def test_wrong_source_or_target_root_rejected(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test that non-canonical source or target roots are rejected.
+
+    Scenario
+    --------
+    1. Start from genesis with 4 validators
+    2. Process block_1 at slot 1
+    3. Process block_2 at slot 2 with two supermajority attestations:
+       - one with a non-canonical source root for slot 0
+       - one with a non-canonical target root for slot 1
+
+    Expected Behavior
+    -----------------
+    1. The source and target slots are otherwise eligible for voting
+    2. Three of four validators form a supermajority in each attestation
+    3. Votes whose roots do not match canonical history are ignored
+    4. latest_justified_slot stays at genesis
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[
+            BlockSpec(slot=Slot(1), label="block_1"),
+            BlockSpec(
+                slot=Slot(2),
+                parent_label="block_1",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                        source_root_override=Bytes32(b"\xaa" * 32),
+                    ),
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                        target_root_override=Bytes32(b"\xbb" * 32),
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(2),
+            latest_justified_slot=Slot(0),
+            latest_finalized_slot=Slot(0),
+        ),
+    )
+
+
+def test_target_slot_at_or_before_source_slot_rejected(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test that a target at or before its source slot is rejected.
+
+    Scenario
+    --------
+    1. Start from genesis with 4 validators
+    2. Process block_1 at slot 1 and block_2 at slot 2
+    3. Process block_3 at slot 3 with attestations from validators 0, 1, and 2
+       targeting block_2 at slot 2, which justifies slot 2
+    4. Process block_4 at slot 4 with attestations from validators 0, 1, and 2
+       targeting block_1 at slot 1 from source block_2 at slot 2
+
+    Expected Behavior
+    -----------------
+    1. Slot 2 is justified naturally via supermajority in block_3
+    2. The source slot 2 passes the trusted-source gate
+    3. The target slot 1 is not already justified
+    4. The attestation is ignored because target.slot <= source.slot
+    5. latest_justified_slot stays at slot 2
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[
+            BlockSpec(slot=Slot(1), label="block_1"),
+            BlockSpec(slot=Slot(2), parent_label="block_1", label="block_2"),
+            BlockSpec(
+                slot=Slot(3),
+                parent_label="block_2",
+                label="block_3",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(3),
+                        target_slot=Slot(2),
+                        target_root_label="block_2",
+                    ),
+                ],
+            ),
+            BlockSpec(
+                slot=Slot(4),
+                parent_label="block_3",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(4),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                        source_root_label="block_2",
+                        source_slot=Slot(2),
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(4),
+            latest_justified_slot=Slot(2),
+            latest_finalized_slot=Slot(0),
+        ),
+    )
+
+
+def test_zero_hash_source_or_target_root_rejected(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test that zero-hash source or target roots are rejected.
+
+    Scenario
+    --------
+    1. Start from genesis with 4 validators
+    2. Process block_1 at slot 1
+    3. Process block_2 at slot 2 with two supermajority attestations:
+       - one with ZERO_HASH as the source root
+       - one with ZERO_HASH as the target root
+
+    Expected Behavior
+    -----------------
+    1. The source and target slots are otherwise eligible for voting
+    2. Three of four validators form a supermajority in each attestation
+    3. Votes referencing ZERO_HASH are ignored
+    4. latest_justified_slot stays at genesis
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[
+            BlockSpec(slot=Slot(1), label="block_1"),
+            BlockSpec(
+                slot=Slot(2),
+                parent_label="block_1",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                        source_root_override=ZERO_HASH,
+                    ),
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                        target_root_override=ZERO_HASH,
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(2),
+            latest_justified_slot=Slot(0),
             latest_finalized_slot=Slot(0),
         ),
     )


### PR DESCRIPTION
## 🗒️ Description

Add four consensus spec tests exercising the pre-justification rejection paths in `process_attestations`, generating test vectors that client implementations can validate against.

The existing test suite validates that the system **accepts** correct attestations, but does not test that it **rejects** malformed ones. These new tests cover:

- **Unjustified source rejected** — attestations with a source that is neither justified nor finalized are silently ignored, even with supermajority support
- **Wrong source or target root rejected** — attestations with roots that don't match canonical chain history are ignored, preventing cross-fork vote injection
- **Target slot at or before source slot rejected** — attestations where time flows backwards (target <= source) are ignored
- **Zero-hash source or target root rejected** — attestations referencing `ZERO_HASH` as source or target root are ignored

To support these tests, the test fixture infrastructure was extended with checkpoint override fields (`source_root_override`, `target_root_override`, `source_root_label`, `source_slot`) on `AggregatedAttestationSpec`. When any override is present, the fixture assembles blocks directly rather than going through `State.build_block()`, which would filter out the intentionally malformed attestations before `process_attestations` sees them.

## 🔗 Related Issues or PRs

N/A

## ✅ Checklist

- [X] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [X] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.