### PR TITLE
test: add consensus-critical justification test vectors

### DIFF
--- a/tests/consensus/devnet/state_transition/test_justification.py
+++ b/tests/consensus/devnet/state_transition/test_justification.py
@@ -316,10 +316,9 @@ def test_repeated_validator_does_not_double_count_within_same_block(
 
     Expected Behavior
     -----------------
-    1. The two attestations do not merge because their attestation-data slots differ
-    2. Justification tallies are keyed by target root, not by raw attestation count
-    3. Validator 0 contributes only one unit of support toward block_1
-    4. Unique support remains three of six validators, below the threshold
+    1. Justification tallies are keyed by target root, not by raw attestation count
+    2. Validator 0 contributes only one unit of support toward block_1
+    3. Unique support remains three of six validators, below the threshold
     """
     state_transition_test(
         pre=generate_pre_state(num_validators=6),
@@ -520,13 +519,7 @@ def test_pending_justification_survives_finalization_rebase(
             latest_justified_slot=Slot(2),
             latest_finalized_slot=Slot(1),
             justified_slots=JustifiedSlots(data=[]).model_copy(
-                update={
-                    "data": [
-                        Boolean(True),
-                        Boolean(False),
-                        Boolean(False),
-                    ]
-                }
+                update={"data": [Boolean(True), Boolean(False), Boolean(False)]}
             ),
             justifications_validators=JustificationValidators(
                 data=[
@@ -922,6 +915,9 @@ def test_split_supermajority_aggregations_in_same_block_justify(
             slot=Slot(2),
             latest_justified_slot=Slot(1),
             latest_finalized_slot=Slot(0),
+            justified_slots=JustifiedSlots(data=[]).model_copy(update={"data": [Boolean(True)]}),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
         ),
     )
 
@@ -971,6 +967,9 @@ def test_odd_validator_threshold_boundary_justifies(
             slot=Slot(2),
             latest_justified_slot=Slot(1),
             latest_finalized_slot=Slot(0),
+            justified_slots=JustifiedSlots(data=[]).model_copy(update={"data": [Boolean(True)]}),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
         ),
     )
 
@@ -1019,6 +1018,16 @@ def test_odd_validator_threshold_boundary_does_not_justify(
             slot=Slot(2),
             latest_justified_slot=Slot(0),
             latest_finalized_slot=Slot(0),
+            justified_slots=JustifiedSlots(data=[]).model_copy(update={"data": [Boolean(False)]}),
+            justifications_validators=JustificationValidators(
+                data=[
+                    Boolean(True),
+                    Boolean(True),
+                    Boolean(True),
+                    Boolean(False),
+                    Boolean(False),
+                ]
+            ),
         ),
     )
 
@@ -1068,6 +1077,8 @@ def test_supermajority_with_mismatched_target_root_is_ignored(
             slot=Slot(3),
             latest_justified_slot=Slot(0),
             latest_finalized_slot=Slot(0),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
         ),
     )
 


### PR DESCRIPTION
## 🗒️ Description

Add 9 new consensus-critical justification tests to `test_justification.py`. All tests use the `StateTransitionTestFiller` pattern, generating JSON fixtures for client implementations.

**New tests:**

| Test | Rule Covered |
|---|---|
| `test_repeated_validator_does_not_double_count_within_same_block` | Same validator in two attestations within one block counts once |
| `test_pending_justification_survives_finalization_rebase` | Pending votes for valid targets survive when finalization rebases the window |
| `test_split_supermajority_aggregations_in_same_block_justify` | Multiple aggregates for the same target merge within a single block |
| `test_odd_validator_threshold_boundary_justifies` | 4/5 validators (80%) meets the 2/3 integer threshold |
| `test_odd_validator_threshold_boundary_does_not_justify` | 3/5 validators (60%) does not meet the 2/3 integer threshold |
| `test_supermajority_with_mismatched_target_root_is_ignored` | Supermajority with wrong canonical root is rejected |
| `test_justification_clears_only_the_resolved_target_votes` | Justifying one target clears only that target's pending votes |
| `test_finalization_prunes_stale_pending_votes_and_rebases_window` | Finalization prunes stale pending votes and shifts the tracking window |
| `test_target_at_or_before_source_is_ignored` | Votes targeting a slot at or before the source are rejected |

**Additional changes:**
- Enhanced `test_votes_accumulate_across_blocks` with pending vote cleanup assertions (`justifications_roots`, `justifications_validators`)
- Renamed `test_exact_two_thirds_threshold_justifies` to `test_even_validator_threshold_boundary` to pair with the new odd-validator counterpart

## 🔗 Related Issues or PRs

N/A

## ✅ Checklist

- [X] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [X] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.