### PR TITLE
perf: cache Poseidon1 engines in PoseidonXmss

### DIFF
--- a/src/lean_spec/subspecs/xmss/poseidon.py
+++ b/src/lean_spec/subspecs/xmss/poseidon.py
@@ -22,7 +22,7 @@ This file provides wrappers for the two primary ways Poseidon1 is used:
 
 from __future__ import annotations
 
-from pydantic import model_validator
+from pydantic import PrivateAttr, model_validator
 
 from lean_spec.types import StrictBaseModel
 
@@ -46,11 +46,24 @@ class PoseidonXmss(StrictBaseModel):
     params24: Poseidon1Params
     """Poseidon1 parameters for 24-width permutation."""
 
+    _engine16: Poseidon1 | None = PrivateAttr(default=None)
+    _engine24: Poseidon1 | None = PrivateAttr(default=None)
+
     @model_validator(mode="after")
     def _validate_strict_types(self) -> PoseidonXmss:
         """Reject subclasses to prevent type confusion attacks."""
         enforce_strict_types(self, params16=Poseidon1Params, params24=Poseidon1Params)
         return self
+
+    def _get_engine(self, width: int) -> Poseidon1:
+        """Return a cached Poseidon1 engine for the given width."""
+        if width == 16:
+            if self._engine16 is None:
+                self._engine16 = Poseidon1(self.params16)
+            return self._engine16
+        if self._engine24 is None:
+            self._engine24 = Poseidon1(self.params24)
+        return self._engine24
 
     def compress(self, input_vec: list[Fp], width: int, output_len: int) -> list[Fp]:
         """
@@ -85,8 +98,7 @@ class PoseidonXmss(StrictBaseModel):
         # Select the correct permutation parameters based on the state width.
         if width not in (16, 24):
             raise ValueError(f"Width must be 16 or 24, got {width}")
-        params = self.params16 if width == 16 else self.params24
-        engine = Poseidon1(params)
+        engine = self._get_engine(width)
 
         # Create a padded input by extending with zeros to match the state width.
         padded_input = list(input_vec) + [Fp(value=0)] * (width - len(input_vec))
@@ -175,7 +187,7 @@ class PoseidonXmss(StrictBaseModel):
         # Determine the permutation parameters and the size of the rate.
         if width not in (16, 24):
             raise ValueError(f"Width must be 16 or 24, got {width}")
-        params = self.params16 if width == 16 else self.params24
+        engine = self._get_engine(width)
         rate = width - len(capacity_value)
 
         # Pad the input vector with zeros to be an exact multiple of the rate size.
@@ -188,9 +200,6 @@ class PoseidonXmss(StrictBaseModel):
         cap_len = len(capacity_value)
         state = [Fp(value=0)] * width
         state[:cap_len] = capacity_value
-
-        # Create the engine once for efficiency.
-        engine = Poseidon1(params)
 
         # Absorb the input in rate-sized chunks via replacement.
         for i in range(0, len(padded_input), rate):


### PR DESCRIPTION
## Summary

- Cache `Poseidon1` engine instances in `PoseidonXmss` using Pydantic `PrivateAttr`, avoiding redundant MDS matrix construction and numpy array conversion on every `compress()`/`sponge()` call.

## Context

After #496 introduced recursive aggregation with Poseidon1, tests became noticeably slower. Profiling revealed that `compress()` and `sponge()` were creating a new `Poseidon1` engine on every call — each time rebuilding the 24×24 circulant MDS matrix and converting 744 round constants to numpy arrays.

Since `PoseidonXmss` instances (`PROD_POSEIDON`/`TEST_POSEIDON`) are module-level singletons and `Poseidon1` engines are stateless (fresh arrays per `permute` call), caching is safe and gives a measured **2–2.5× speedup** on pure Poseidon/XMSS operations.

## Benchmarks

| Test suite | Before | After | Speedup |
|---|---|---|---|
| Pure Poseidon/XMSS tests (no Rust FFI) | 3.71s | 1.65s | **2.25×** |
| `test_rejects_very_large_slot` | 1.04s | 0.41s | **2.5×** |
| `test_advance_preparation` | 0.25s | 0.10s | **2.5×** |
| Full XMSS suite (incl. Rust aggregation) | 25.07s | 21.51s | **1.17×** |

> The remaining ~21s in the full suite is dominated by `lean_multisig_py` recursive proof generation (Rust FFI), which is outside the scope of this PR.

## Test plan

- [x] `uv run pytest tests/lean_spec/subspecs/xmss/` — 121 passed
- [x] `uv run pytest tests/lean_spec/subspecs/poseidon1/` — 2 passed
- [x] `uvx tox -e all-checks` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)