### PR TITLE
limit number of attestation data in blocks

### DIFF
--- a/src/lean_spec/subspecs/chain/config.py
+++ b/src/lean_spec/subspecs/chain/config.py
@@ -2,7 +2,7 @@
 
 from typing import Final
 
-from lean_spec.types import Uint64
+from lean_spec.types import Uint8, Uint64
 
 INTERVALS_PER_SLOT: Final = Uint64(5)
 """Number of intervals per slot for forkchoice processing."""
@@ -32,3 +32,6 @@ VALIDATOR_REGISTRY_LIMIT: Final = Uint64(2**12)
 
 ATTESTATION_COMMITTEE_COUNT: Final = Uint64(1)
 """The number of attestation committees per slot."""
+
+MAX_ATTESTATIONS_DATA: Final = Uint8(16)
+"""Maximum number of distinct attestation data entries per block."""

--- a/src/lean_spec/subspecs/containers/state/state.py
+++ b/src/lean_spec/subspecs/containers/state/state.py
@@ -12,9 +12,11 @@ from lean_spec.types import (
     Boolean,
     Bytes32,
     Container,
+    Uint8,
     Uint64,
 )
 
+from ...chain.config import MAX_ATTESTATIONS_DATA
 from ..attestation import AggregatedAttestation, AttestationData
 from ..block import Block, BlockBody, BlockHeader
 from ..block.types import AggregatedAttestations
@@ -676,6 +678,12 @@ class State(Container):
                 for att_data, proofs in sorted(
                     aggregated_payloads.items(), key=lambda item: item[0].target.slot
                 ):
+                    if (
+                        Uint8(len(processed_att_data)) >= MAX_ATTESTATIONS_DATA
+                        and att_data not in processed_att_data
+                    ):
+                        break
+
                     if att_data.head.root not in known_block_roots:
                         continue
 

--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -14,6 +14,7 @@ from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import (
     INTERVALS_PER_SLOT,
     JUSTIFICATION_LOOKBACK_SLOTS,
+    MAX_ATTESTATIONS_DATA,
 )
 from lean_spec.subspecs.containers import (
     AggregationBits,
@@ -41,6 +42,7 @@ from lean_spec.subspecs.xmss.interface import TARGET_SIGNATURE_SCHEME, Generaliz
 from lean_spec.types import (
     ZERO_HASH,
     Bytes32,
+    Uint8,
     Uint64,
 )
 from lean_spec.types.base import StrictBaseModel
@@ -549,6 +551,10 @@ class Store(StrictBaseModel):
         assert len(att_data_set) == len(aggregated_attestations), (
             "Block contains duplicate AttestationData entries; "
             "each AttestationData must appear at most once"
+        )
+        assert Uint8(len(att_data_set)) <= MAX_ATTESTATIONS_DATA, (
+            f"Block contains {len(att_data_set)} distinct AttestationData entries; "
+            f"maximum is {MAX_ATTESTATIONS_DATA}"
         )
 
         # Copy the aggregated proof map for updates


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
