### PR TITLE
refactor: simplify SSZ roundtrip decode

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -56,8 +56,7 @@ class SSZTest(BaseConsensusFixture):
         ssz_bytes = self.value.encode_bytes()
 
         # Deserialize back
-        container_cls = type(self.value)
-        decoded = container_cls.decode_bytes(ssz_bytes)
+        decoded = self.value.decode_bytes(ssz_bytes)
 
         # Verify roundtrip
         assert decoded == self.value, (


### PR DESCRIPTION
## Summary
- Call `decode_bytes` directly on the instance instead of extracting the class with `type()` first — same behavior, one fewer line.

## Test plan
- [ ] Existing SSZ roundtrip tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)