### PR TITLE
refactor: move from_validator_indices to ValidatorIndices.to_aggregation_bits

### DIFF
--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -41,7 +41,6 @@ from typing import ClassVar, Literal
 
 from lean_spec.config import LEAN_ENV
 from lean_spec.subspecs.containers import AttestationData, ValidatorIndex, ValidatorIndices
-from lean_spec.subspecs.containers.attestation.aggregation_bits import AggregationBits
 from lean_spec.subspecs.containers.block.types import (
     AggregatedAttestations,
     AttestationSignatures,
@@ -511,9 +510,7 @@ class XmssKeyManager:
             for vid in validator_ids
         ]
 
-        xmss_participants = AggregationBits.from_validator_indices(
-            ValidatorIndices(data=validator_ids)
-        )
+        xmss_participants = ValidatorIndices(data=validator_ids).to_aggregation_bits()
 
         return AggregatedSignatureProof.aggregate(
             xmss_participants=xmss_participants,

--- a/packages/testing/src/consensus_testing/test_types/aggregated_attestation_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/aggregated_attestation_spec.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from lean_spec.subspecs.containers.attestation import AggregatedAttestation, AttestationData
-from lean_spec.subspecs.containers.attestation.aggregation_bits import AggregationBits
 from lean_spec.subspecs.containers.block.block import Block
 from lean_spec.subspecs.containers.block.types import AggregatedAttestations
 from lean_spec.subspecs.containers.slot import Slot
@@ -123,9 +122,7 @@ class AggregatedAttestationSpec(CamelModel):
         """
         attestation_data = self.build_attestation_data(block_registry, state)
 
-        aggregation_bits = AggregationBits.from_validator_indices(
-            ValidatorIndices(data=self.validator_ids)
-        )
+        aggregation_bits = ValidatorIndices(data=self.validator_ids).to_aggregation_bits()
         invalid_aggregated = AggregatedAttestation(
             aggregation_bits=aggregation_bits,
             data=attestation_data,
@@ -134,9 +131,7 @@ class AggregatedAttestationSpec(CamelModel):
         if not self.valid_signature:
             # Cryptographically invalid proof (zeroed-out bytes).
             invalid_proof = AggregatedSignatureProof(
-                participants=AggregationBits.from_validator_indices(
-                    ValidatorIndices(data=self.validator_ids)
-                ),
+                participants=ValidatorIndices(data=self.validator_ids).to_aggregation_bits(),
                 proof_data=ByteListMiB(data=b"\x00" * 32),
             )
         elif self.signer_ids is not None:
@@ -148,9 +143,7 @@ class AggregatedAttestationSpec(CamelModel):
             )
         else:
             invalid_proof = AggregatedSignatureProof(
-                participants=AggregationBits.from_validator_indices(
-                    ValidatorIndices(data=self.validator_ids)
-                ),
+                participants=ValidatorIndices(data=self.validator_ids).to_aggregation_bits(),
                 proof_data=ByteListMiB(data=b"\x00" * 32),
             )
 

--- a/packages/testing/src/consensus_testing/test_types/gossip_aggregated_attestation_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/gossip_aggregated_attestation_spec.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from lean_spec.subspecs.containers.attestation import AttestationData
-from lean_spec.subspecs.containers.attestation.aggregation_bits import AggregationBits
 from lean_spec.subspecs.containers.attestation.attestation import SignedAggregatedAttestation
 from lean_spec.subspecs.containers.checkpoint import Checkpoint
 from lean_spec.subspecs.containers.slot import Slot
@@ -190,9 +189,7 @@ class GossipAggregatedAttestationSpec(CamelModel):
         # Exercises signature verification rejection.
         if not self.valid_signature:
             proof = AggregatedSignatureProof(
-                participants=AggregationBits.from_validator_indices(
-                    ValidatorIndices(data=validator_ids)
-                ),
+                participants=ValidatorIndices(data=validator_ids).to_aggregation_bits(),
                 proof_data=ByteListMiB(data=b"\x00" * 32),
             )
             return SignedAggregatedAttestation(data=attestation_data, proof=proof)
@@ -209,9 +206,7 @@ class GossipAggregatedAttestationSpec(CamelModel):
         # The store must detect and reject this inconsistency.
         if self.signer_ids and self.signer_ids != self.validator_ids:
             proof = AggregatedSignatureProof(
-                participants=AggregationBits.from_validator_indices(
-                    ValidatorIndices(data=validator_ids)
-                ),
+                participants=ValidatorIndices(data=validator_ids).to_aggregation_bits(),
                 proof_data=proof.proof_data,
             )
 

--- a/src/lean_spec/subspecs/containers/attestation/aggregation_bits.py
+++ b/src/lean_spec/subspecs/containers/attestation/aggregation_bits.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from lean_spec.subspecs.chain.config import VALIDATOR_REGISTRY_LIMIT
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
-from lean_spec.types import Boolean
 from lean_spec.types.bitfields import BaseBitlist
 
 
@@ -17,41 +16,6 @@ class AggregationBits(BaseBitlist):
     """
 
     LIMIT = int(VALIDATOR_REGISTRY_LIMIT)
-
-    @classmethod
-    def from_validator_indices(cls, indices: ValidatorIndices) -> AggregationBits:
-        """
-        Construct aggregation bits from a set of validator indices.
-
-        Args:
-            indices: Validator indices to set in the bitlist.
-
-        Returns:
-            AggregationBits with the corresponding indices set to True.
-
-        Raises:
-            AssertionError: If no indices are provided.
-            AssertionError: If any index is outside the supported LIMIT.
-        """
-        index_list = indices.data
-
-        # Require at least one validator for a valid aggregation.
-        if not index_list:
-            raise AssertionError("Aggregated attestation must reference at least one validator")
-
-        # Convert to a set of native ints.
-        #
-        # This combines int conversion and deduplication in a single O(N) pass.
-        ids = {int(i) for i in index_list}
-
-        # Validate bounds: max index must be within registry limit.
-        if (max_id := max(ids)) >= cls.LIMIT:
-            raise AssertionError("Validator index out of range for aggregation bits")
-
-        # Build bit list:
-        # - True at positions present in indices,
-        # - False elsewhere.
-        return cls(data=[Boolean(i in ids) for i in range(max_id + 1)])
 
     def to_validator_indices(self) -> ValidatorIndices:
         """

--- a/src/lean_spec/subspecs/containers/attestation/attestation.py
+++ b/src/lean_spec/subspecs/containers/attestation/attestation.py
@@ -97,9 +97,7 @@ class AggregatedAttestation(Container):
 
         return [
             cls(
-                aggregation_bits=AggregationBits.from_validator_indices(
-                    ValidatorIndices(data=validator_ids)
-                ),
+                aggregation_bits=ValidatorIndices(data=validator_ids).to_aggregation_bits(),
                 data=data,
             )
             for data, validator_ids in data_to_validator_ids.items()

--- a/src/lean_spec/subspecs/containers/validator.py
+++ b/src/lean_spec/subspecs/containers/validator.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import lean_spec.subspecs.containers.attestation.aggregation_bits as _aggregation_bits
 from lean_spec.subspecs.chain.config import VALIDATOR_REGISTRY_LIMIT
-from lean_spec.types import Bytes52, Container, SSZList, Uint64
+from lean_spec.types import Boolean, Bytes52, Container, SSZList, Uint64
 
 from ..xmss.containers import PublicKey
 from .slot import Slot
@@ -44,6 +45,39 @@ class ValidatorIndices(SSZList[ValidatorIndex]):
     """List of validator indices up to registry limit."""
 
     LIMIT = int(VALIDATOR_REGISTRY_LIMIT)
+
+    def to_aggregation_bits(self) -> _aggregation_bits.AggregationBits:
+        """
+        Convert to aggregation bits marking which validators are present.
+
+        Returns:
+            AggregationBits with the corresponding indices set to True.
+
+        Raises:
+            AssertionError: If no indices are provided.
+            AssertionError: If any index is outside the supported LIMIT.
+        """
+        index_list = self.data
+
+        # Require at least one validator for a valid aggregation.
+        if not index_list:
+            raise AssertionError("Aggregated attestation must reference at least one validator")
+
+        # Convert to a set of native ints.
+        #
+        # This combines int conversion and deduplication in a single O(N) pass.
+        ids = {int(i) for i in index_list}
+
+        # Validate bounds: max index must be within registry limit.
+        if (max_id := max(ids)) >= _aggregation_bits.AggregationBits.LIMIT:
+            raise AssertionError("Validator index out of range for aggregation bits")
+
+        # Build bit list:
+        # - True at positions present in indices,
+        # - False elsewhere.
+        return _aggregation_bits.AggregationBits(
+            data=[Boolean(i in ids) for i in range(max_id + 1)]
+        )
 
 
 class Validator(Container):

--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -17,7 +17,6 @@ from lean_spec.subspecs.chain.config import (
     MAX_ATTESTATIONS_DATA,
 )
 from lean_spec.subspecs.containers import (
-    AggregationBits,
     AttestationData,
     Block,
     Checkpoint,
@@ -1018,9 +1017,9 @@ class Store(StrictBaseModel):
                 continue
 
             # Encode the set of raw signers as a compact bitfield.
-            xmss_participants = AggregationBits.from_validator_indices(
-                ValidatorIndices(data=[vid for vid, _, _ in raw_entries])
-            )
+            xmss_participants = ValidatorIndices(
+                data=[vid for vid, _, _ in raw_entries]
+            ).to_aggregation_bits()
             raw_xmss = [(pk, sig) for _, pk, sig in raw_entries]
 
             # Phase 3: Aggregate

--- a/src/lean_spec/subspecs/xmss/aggregation.py
+++ b/src/lean_spec/subspecs/xmss/aggregation.py
@@ -106,9 +106,7 @@ class AggregatedSignatureProof(Container):
         # Include child participants in the aggregated participants
         for child_proof, _ in children:
             aggregated_validator_ids.update(child_proof.participants.to_validator_indices())
-        participants = AggregationBits.from_validator_indices(
-            ValidatorIndices(data=list(aggregated_validator_ids))
-        )
+        participants = ValidatorIndices(data=list(aggregated_validator_ids)).to_aggregation_bits()
 
         mode = mode or LEAN_ENV
         setup_prover(mode=mode)

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -22,7 +22,7 @@ from lean_spec.subspecs.containers import (
     State,
     Validator,
 )
-from lean_spec.subspecs.containers.attestation import AggregatedAttestation, AggregationBits
+from lean_spec.subspecs.containers.attestation import AggregatedAttestation
 from lean_spec.subspecs.containers.block import BlockSignatures
 from lean_spec.subspecs.containers.block.types import AggregatedAttestations, AttestationSignatures
 from lean_spec.subspecs.containers.slot import Slot
@@ -239,9 +239,7 @@ def make_aggregated_attestation(
     )
 
     return AggregatedAttestation(
-        aggregation_bits=AggregationBits.from_validator_indices(
-            ValidatorIndices(data=participant_ids)
-        ),
+        aggregation_bits=ValidatorIndices(data=participant_ids).to_aggregation_bits(),
         data=data,
     )
 
@@ -423,7 +421,7 @@ def make_aggregated_proof(
 ) -> AggregatedSignatureProof:
     """Create a valid aggregated signature proof for the given participants."""
     data_root = attestation_data.data_root_bytes()
-    xmss_participants = AggregationBits.from_validator_indices(ValidatorIndices(data=participants))
+    xmss_participants = ValidatorIndices(data=participants).to_aggregation_bits()
     raw_xmss = list(
         zip(
             [key_manager.get_public_keys(vid)[0] for vid in participants],

--- a/tests/lean_spec/subspecs/containers/test_attestation_aggregation.py
+++ b/tests/lean_spec/subspecs/containers/test_attestation_aggregation.py
@@ -39,12 +39,12 @@ class TestAggregationBits:
             data=[ValidatorIndex(0), ValidatorIndex(2), ValidatorIndex(3)]
         )
 
-    def test_from_validator_indices_roundtrip(self) -> None:
-        """Test that from_validator_indices and to_validator_indices are inverses."""
+    def test_to_aggregation_bits_roundtrip(self) -> None:
+        """Test that to_aggregation_bits and to_validator_indices are inverses."""
         original_indices = ValidatorIndices(
             data=[ValidatorIndex(1), ValidatorIndex(5), ValidatorIndex(7)]
         )
-        bits = AggregationBits.from_validator_indices(original_indices)
+        bits = original_indices.to_aggregation_bits()
         recovered_indices = bits.to_validator_indices()
         assert recovered_indices == original_indices
 
@@ -61,9 +61,7 @@ class TestAggregatedAttestation:
             source=Checkpoint(root=Bytes32.zero(), slot=Slot(2)),
         )
 
-        bits = AggregationBits.from_validator_indices(
-            ValidatorIndices(data=[ValidatorIndex(2), ValidatorIndex(7)])
-        )
+        bits = ValidatorIndices(data=[ValidatorIndex(2), ValidatorIndex(7)]).to_aggregation_bits()
         agg = AggregatedAttestation(aggregation_bits=bits, data=att_data)
 
         # Verify we can extract validator indices
@@ -81,7 +79,7 @@ class TestAggregatedAttestation:
         )
 
         validator_ids = ValidatorIndices(data=[ValidatorIndex(i) for i in [0, 5, 10, 15, 20, 25]])
-        bits = AggregationBits.from_validator_indices(validator_ids)
+        bits = validator_ids.to_aggregation_bits()
         agg = AggregatedAttestation(aggregation_bits=bits, data=att_data)
 
         recovered = agg.aggregation_bits.to_validator_indices()

--- a/tests/lean_spec/subspecs/containers/test_state_process_attestations.py
+++ b/tests/lean_spec/subspecs/containers/test_state_process_attestations.py
@@ -41,7 +41,6 @@ from __future__ import annotations
 
 from lean_spec.subspecs.containers.attestation import (
     AggregatedAttestation,
-    AggregationBits,
     AttestationData,
 )
 from lean_spec.subspecs.containers.checkpoint import Checkpoint
@@ -126,9 +125,9 @@ class TestProcessAttestationsBoundsCheck:
 
         attestation = AggregatedAttestation(
             # Two validators participate in this attestation.
-            aggregation_bits=AggregationBits.from_validator_indices(
-                ValidatorIndices(data=[ValidatorIndex(0), ValidatorIndex(1)])
-            ),
+            aggregation_bits=ValidatorIndices(
+                data=[ValidatorIndex(0), ValidatorIndex(1)]
+            ).to_aggregation_bits(),
             data=att_data,
         )
 
@@ -208,9 +207,9 @@ class TestProcessAttestationsBoundsCheck:
         )
 
         attestation = AggregatedAttestation(
-            aggregation_bits=AggregationBits.from_validator_indices(
-                ValidatorIndices(data=[ValidatorIndex(0), ValidatorIndex(1)])
-            ),
+            aggregation_bits=ValidatorIndices(
+                data=[ValidatorIndex(0), ValidatorIndex(1)]
+            ).to_aggregation_bits(),
             data=att_data,
         )
 

--- a/tests/lean_spec/subspecs/forkchoice/test_compute_block_weights.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_compute_block_weights.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from lean_spec.subspecs.containers.attestation import AggregationBits, AttestationData
+from lean_spec.subspecs.containers.attestation import AttestationData
 from lean_spec.subspecs.containers.checkpoint import Checkpoint
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
@@ -16,7 +16,7 @@ from tests.lean_spec.helpers import make_bytes32, make_signed_block
 def _make_empty_proof(participants: list[ValidatorIndex]) -> AggregatedSignatureProof:
     """Create an aggregated proof with empty proof data for testing."""
     return AggregatedSignatureProof(
-        participants=AggregationBits.from_validator_indices(ValidatorIndices(data=participants)),
+        participants=ValidatorIndices(data=participants).to_aggregation_bits(),
         proof_data=ByteListMiB(data=b""),
     )
 

--- a/tests/lean_spec/subspecs/forkchoice/test_store_attestations.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_store_attestations.py
@@ -7,7 +7,6 @@ from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.subspecs.chain.config import INTERVALS_PER_SLOT
 from lean_spec.subspecs.containers.attestation import (
-    AggregationBits,
     AttestationData,
     SignedAggregatedAttestation,
     SignedAttestation,
@@ -277,9 +276,7 @@ class TestOnGossipAggregatedAttestation:
         data_root = attestation_data.data_root_bytes()
 
         # Create valid aggregated proof
-        xmss_participants = AggregationBits.from_validator_indices(
-            ValidatorIndices(data=participants)
-        )
+        xmss_participants = ValidatorIndices(data=participants).to_aggregation_bits()
         raw_xmss = list(
             zip(
                 [key_manager[vid].attestation_public for vid in participants],
@@ -324,9 +321,7 @@ class TestOnGossipAggregatedAttestation:
 
         data_root = attestation_data.data_root_bytes()
 
-        xmss_participants = AggregationBits.from_validator_indices(
-            ValidatorIndices(data=participants)
-        )
+        xmss_participants = ValidatorIndices(data=participants).to_aggregation_bits()
         raw_xmss = list(
             zip(
                 [key_manager[vid].attestation_public for vid in participants],
@@ -366,7 +361,7 @@ class TestOnGossipAggregatedAttestation:
 
         data_root = attestation_data.data_root_bytes()
 
-        xmss_participants = AggregationBits.from_validator_indices(ValidatorIndices(data=signers))
+        xmss_participants = ValidatorIndices(data=signers).to_aggregation_bits()
         raw_xmss = list(
             zip(
                 [key_manager[vid].attestation_public for vid in signers],
@@ -414,7 +409,7 @@ class TestOnGossipAggregatedAttestation:
 
         # First proof: validators 1 and 2
         participants_1 = [ValidatorIndex(1), ValidatorIndex(2)]
-        xmss_1 = AggregationBits.from_validator_indices(ValidatorIndices(data=participants_1))
+        xmss_1 = ValidatorIndices(data=participants_1).to_aggregation_bits()
         raw_xmss_1 = list(
             zip(
                 [key_manager[vid].attestation_public for vid in participants_1],
@@ -435,7 +430,7 @@ class TestOnGossipAggregatedAttestation:
 
         # Second proof: validators 1 and 3 (validator 1 overlaps)
         participants_2 = [ValidatorIndex(1), ValidatorIndex(3)]
-        xmss_2 = AggregationBits.from_validator_indices(ValidatorIndices(data=participants_2))
+        xmss_2 = ValidatorIndices(data=participants_2).to_aggregation_bits()
         raw_xmss_2 = list(
             zip(
                 [key_manager[vid].attestation_public for vid in participants_2],

--- a/tests/lean_spec/subspecs/forkchoice/test_store_pruning.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_store_pruning.py
@@ -1,6 +1,5 @@
 """Tests for Store attestation data pruning."""
 
-from lean_spec.subspecs.containers.attestation import AggregationBits
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
 from lean_spec.subspecs.forkchoice import AttestationSignatureEntry, Store
@@ -140,9 +139,7 @@ def test_prunes_related_structures_together(pruning_store: Store) -> None:
 
     # Create mock aggregated proof (empty proof data for testing)
     mock_proof = AggregatedSignatureProof(
-        participants=AggregationBits.from_validator_indices(
-            ValidatorIndices(data=[ValidatorIndex(1)])
-        ),
+        participants=ValidatorIndices(data=[ValidatorIndex(1)]).to_aggregation_bits(),
         proof_data=ByteListMiB(data=b""),
     )
 

--- a/tests/lean_spec/subspecs/validator/test_service.py
+++ b/tests/lean_spec/subspecs/validator/test_service.py
@@ -17,7 +17,6 @@ from lean_spec.subspecs.containers import (
     ValidatorIndex,
     ValidatorIndices,
 )
-from lean_spec.subspecs.containers.attestation import AggregationBits
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.forkchoice import Store
 from lean_spec.subspecs.ssz.hash import hash_tree_root
@@ -1119,9 +1118,7 @@ class TestValidatorServiceIntegration:
             signatures.append(sig)
             public_keys.append(key_manager[vid].attestation_public)
 
-        xmss_participants = AggregationBits.from_validator_indices(
-            ValidatorIndices(data=participants)
-        )
+        xmss_participants = ValidatorIndices(data=participants).to_aggregation_bits()
         proof = AggregatedSignatureProof.aggregate(
             xmss_participants=xmss_participants,
             children=[],

--- a/tests/lean_spec/subspecs/xmss/test_aggregation.py
+++ b/tests/lean_spec/subspecs/xmss/test_aggregation.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pytest
 from consensus_testing.keys import XmssKeyManager
 
-from lean_spec.subspecs.containers.attestation import AggregationBits
 from lean_spec.subspecs.containers.checkpoint import Checkpoint
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
@@ -24,7 +23,7 @@ def _sign_and_aggregate(
     att_data = make_attestation_data_simple(slot, make_bytes32(head), make_bytes32(target), source)
     data_root = att_data.data_root_bytes()
 
-    xmss_participants = AggregationBits.from_validator_indices(ValidatorIndices(data=validator_ids))
+    xmss_participants = ValidatorIndices(data=validator_ids).to_aggregation_bits()
     raw_xmss = list(
         zip(
             [key_manager[vid].attestation_public for vid in validator_ids],
@@ -60,7 +59,7 @@ def test_aggregate_multiple_signatures(key_manager: XmssKeyManager) -> None:
     att_data = make_attestation_data_simple(Slot(2), make_bytes32(11), make_bytes32(12), source)
     vids = [ValidatorIndex(i) for i in range(4)]
 
-    xmss_participants = AggregationBits.from_validator_indices(ValidatorIndices(data=vids))
+    xmss_participants = ValidatorIndices(data=vids).to_aggregation_bits()
     raw_xmss = list(
         zip(
             [key_manager[vid].attestation_public for vid in vids],
@@ -100,7 +99,7 @@ def test_aggregate_children_with_raw_signatures(key_manager: XmssKeyManager) -> 
 
     # Additional raw signatures: validators 2, 3
     extra_vids = [ValidatorIndex(2), ValidatorIndex(3)]
-    xmss_participants = AggregationBits.from_validator_indices(ValidatorIndices(data=extra_vids))
+    xmss_participants = ValidatorIndices(data=extra_vids).to_aggregation_bits()
     raw_xmss = list(
         zip(
             [key_manager[vid].attestation_public for vid in extra_vids],
@@ -234,7 +233,7 @@ def test_aggregate_mixed_children_and_raw_multiple(key_manager: XmssKeyManager) 
 
     # Additional raw signatures from validators 2 and 3
     extra_vids = [ValidatorIndex(2), ValidatorIndex(3)]
-    xmss_participants = AggregationBits.from_validator_indices(ValidatorIndices(data=extra_vids))
+    xmss_participants = ValidatorIndices(data=extra_vids).to_aggregation_bits()
     raw_xmss = list(
         zip(
             [key_manager[vid].attestation_public for vid in extra_vids],
@@ -265,7 +264,7 @@ def test_aggregate_wrong_message_fails_verification(key_manager: XmssKeyManager)
     att_data = make_attestation_data_simple(Slot(1), make_bytes32(121), make_bytes32(122), source)
     vid = ValidatorIndex(0)
 
-    xmss_participants = AggregationBits.from_validator_indices(ValidatorIndices(data=[vid]))
+    xmss_participants = ValidatorIndices(data=[vid]).to_aggregation_bits()
     raw_xmss = [
         (
             key_manager[vid].attestation_public,
@@ -296,7 +295,7 @@ def test_aggregate_wrong_slot_fails_verification(key_manager: XmssKeyManager) ->
     att_data = make_attestation_data_simple(Slot(2), make_bytes32(131), make_bytes32(132), source)
     vid = ValidatorIndex(1)
 
-    xmss_participants = AggregationBits.from_validator_indices(ValidatorIndices(data=[vid]))
+    xmss_participants = ValidatorIndices(data=[vid]).to_aggregation_bits()
     raw_xmss = [
         (
             key_manager[vid].attestation_public,
@@ -381,9 +380,7 @@ def test_aggregate_rejects_single_child_without_raw(key_manager: XmssKeyManager)
     """A single child without raw signatures is rejected (need at least two children)."""
     # Create a stub child proof without calling the Rust bindings
     stub_child = AggregatedSignatureProof(
-        participants=AggregationBits.from_validator_indices(
-            ValidatorIndices(data=[ValidatorIndex(0)])
-        ),
+        participants=ValidatorIndices(data=[ValidatorIndex(0)]).to_aggregation_bits(),
         proof_data=ByteListMiB(data=b"\x00"),
     )
 
@@ -407,9 +404,9 @@ def test_aggregate_rejects_mismatched_participant_count(
     att_data = make_attestation_data_simple(Slot(7), make_bytes32(61), make_bytes32(62), source)
 
     # Claim 2 participants but only provide 1 signature
-    xmss_participants = AggregationBits.from_validator_indices(
-        ValidatorIndices(data=[ValidatorIndex(0), ValidatorIndex(1)])
-    )
+    xmss_participants = ValidatorIndices(
+        data=[ValidatorIndex(0), ValidatorIndex(1)]
+    ).to_aggregation_bits()
     raw_xmss = [
         (
             key_manager[ValidatorIndex(0)].attestation_public,


### PR DESCRIPTION
## Summary

- Moves `AggregationBits.from_validator_indices()` to `ValidatorIndices.to_aggregation_bits()` — the conversion reads more naturally on the source type
- Removes the classmethod from `AggregationBits`, updates all 16 call sites across source, tests, and test fixtures
- Uses a module import (`import ... as _aggregation_bits`) in `validator.py` to handle the circular dependency with `aggregation_bits.py`

## Test plan

- [x] All quality checks pass (`uvx tox -e all-checks`)
- [ ] Full test suite passes (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)