### PR TITLE
refactor: remove AttestationData.data_root_bytes in favor of hash_tree_root

### DIFF
--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -47,6 +47,7 @@ from lean_spec.subspecs.containers.block.types import (
 )
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.koalabear import Fp
+from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.subspecs.xmss.constants import TARGET_CONFIG
 from lean_spec.subspecs.xmss.containers import PublicKey, SecretKey, Signature, ValidatorKeyPair
@@ -456,7 +457,7 @@ class XmssKeyManager:
         return self._sign_with_secret(
             validator_id,
             attestation_data.slot,
-            attestation_data.data_root_bytes(),
+            hash_tree_root(attestation_data),
             "attestation_secret",
         )
 
@@ -516,7 +517,7 @@ class XmssKeyManager:
             xmss_participants=xmss_participants,
             children=[],
             raw_xmss=raw_xmss,
-            message=attestation_data.data_root_bytes(),
+            message=hash_tree_root(attestation_data),
             slot=attestation_data.slot,
         )
 
@@ -572,7 +573,7 @@ class XmssKeyManager:
                 xmss_participants=agg.aggregation_bits,
                 children=[],
                 raw_xmss=list(zip(public_keys, signatures, strict=True)),
-                message=agg.data.data_root_bytes(),
+                message=hash_tree_root(agg.data),
                 slot=agg.data.slot,
             )
             proofs.append(proof)

--- a/src/lean_spec/subspecs/containers/attestation/attestation.py
+++ b/src/lean_spec/subspecs/containers/attestation/attestation.py
@@ -17,8 +17,7 @@ from collections import defaultdict
 
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
-from lean_spec.subspecs.ssz import hash_tree_root
-from lean_spec.types import Bytes32, Container
+from lean_spec.types import Container
 
 from ...xmss.aggregation import AggregatedSignatureProof
 from ...xmss.containers import Signature
@@ -40,10 +39,6 @@ class AttestationData(Container):
 
     source: Checkpoint
     """The checkpoint representing the source block as observed by the validator."""
-
-    def data_root_bytes(self) -> Bytes32:
-        """The root of the attestation data."""
-        return hash_tree_root(self)
 
 
 class Attestation(Container):

--- a/src/lean_spec/subspecs/containers/block/block.py
+++ b/src/lean_spec/subspecs/containers/block/block.py
@@ -141,7 +141,7 @@ class SignedBlock(Container):
 
             # The signed message is the attestation data root.
             # All validators in this group signed this exact data.
-            attestation_data_root = aggregated_attestation.data.data_root_bytes()
+            attestation_data_root = hash_tree_root(aggregated_attestation.data)
 
             for validator_id in validator_ids:
                 num_validators = Uint64(len(validators))

--- a/src/lean_spec/subspecs/containers/state/state.py
+++ b/src/lean_spec/subspecs/containers/state/state.py
@@ -760,7 +760,7 @@ class State(Container):
                         xmss_participants=None,
                         children=children,
                         raw_xmss=[],
-                        message=att_data.data_root_bytes(),
+                        message=hash_tree_root(att_data),
                         slot=att_data.slot,
                     )
                 aggregated_signatures.append(sig)

--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -372,7 +372,7 @@ class Store(StrictBaseModel):
         public_key = key_state.validators[validator_id].get_attestation_pubkey()
 
         assert signature.verify(
-            public_key, attestation_data.slot, attestation_data.data_root_bytes(), scheme
+            public_key, attestation_data.slot, hash_tree_root(attestation_data), scheme
         ), "Signature verification failed"
 
         # Store signature and attestation data for later aggregation.
@@ -444,7 +444,7 @@ class Store(StrictBaseModel):
         try:
             proof.verify(
                 public_keys=public_keys,
-                message=data.data_root_bytes(),
+                message=hash_tree_root(data),
                 slot=data.slot,
             )
         except AggregationError as exc:
@@ -1046,7 +1046,7 @@ class Store(StrictBaseModel):
                 xmss_participants=xmss_participants,
                 children=children,
                 raw_xmss=raw_xmss,
-                message=data.data_root_bytes(),
+                message=hash_tree_root(data),
                 slot=data.slot,
             )
             new_aggregates.append(SignedAggregatedAttestation(data=data, proof=proof))

--- a/src/lean_spec/subspecs/validator/service.py
+++ b/src/lean_spec/subspecs/validator/service.py
@@ -443,7 +443,7 @@ class ValidatorService:
         _, signature = self._sign_with_key(
             entry,
             attestation_data.slot,
-            attestation_data.data_root_bytes(),
+            hash_tree_root(attestation_data),
             "attestation_secret_key",
         )
 

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -420,7 +420,7 @@ def make_aggregated_proof(
     attestation_data: AttestationData,
 ) -> AggregatedSignatureProof:
     """Create a valid aggregated signature proof for the given participants."""
-    data_root = attestation_data.data_root_bytes()
+    data_root = hash_tree_root(attestation_data)
     xmss_participants = ValidatorIndices(data=participants).to_aggregation_bits()
     raw_xmss = list(
         zip(

--- a/tests/lean_spec/subspecs/containers/test_state_aggregation.py
+++ b/tests/lean_spec/subspecs/containers/test_state_aggregation.py
@@ -52,7 +52,7 @@ def test_aggregated_signatures_prefers_full_gossip_payload(
     ]
     results[0].proof.verify(
         public_keys=public_keys,
-        message=att_data.data_root_bytes(),
+        message=hash_tree_root(att_data),
         slot=att_data.slot,
     )
 
@@ -73,7 +73,7 @@ def test_build_block_collects_valid_available_attestations(
         target=target,
         source=source,
     )
-    data_root = att_data.data_root_bytes()
+    data_root = hash_tree_root(att_data)
 
     proof = make_aggregated_proof(container_key_manager, [ValidatorIndex(0)], att_data)
     aggregated_payloads = {att_data: {proof}}
@@ -183,7 +183,7 @@ def test_aggregated_signatures_with_multiple_data_groups(
         public_keys = [head_state.validators[vid].get_attestation_pubkey() for vid in participants]
         signed_att.proof.verify(
             public_keys=public_keys,
-            message=signed_att.data.data_root_bytes(),
+            message=hash_tree_root(signed_att.data),
             slot=signed_att.data.slot,
         )
 

--- a/tests/lean_spec/subspecs/forkchoice/test_store_attestations.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_store_attestations.py
@@ -15,6 +15,7 @@ from lean_spec.subspecs.containers.checkpoint import Checkpoint
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
 from lean_spec.subspecs.forkchoice import AttestationSignatureEntry
+from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.types import ByteListMiB, Bytes32, Uint64
 from tests.lean_spec.helpers import (
@@ -273,7 +274,7 @@ class TestOnGossipAggregatedAttestation:
             key_manager, num_validators=4, validator_id=ValidatorIndex(0)
         )
 
-        data_root = attestation_data.data_root_bytes()
+        data_root = hash_tree_root(attestation_data)
 
         # Create valid aggregated proof
         xmss_participants = ValidatorIndices(data=participants).to_aggregation_bits()
@@ -319,7 +320,7 @@ class TestOnGossipAggregatedAttestation:
             key_manager, num_validators=4, validator_id=ValidatorIndex(0)
         )
 
-        data_root = attestation_data.data_root_bytes()
+        data_root = hash_tree_root(attestation_data)
 
         xmss_participants = ValidatorIndices(data=participants).to_aggregation_bits()
         raw_xmss = list(
@@ -359,7 +360,7 @@ class TestOnGossipAggregatedAttestation:
             key_manager, num_validators=4, validator_id=ValidatorIndex(0)
         )
 
-        data_root = attestation_data.data_root_bytes()
+        data_root = hash_tree_root(attestation_data)
 
         xmss_participants = ValidatorIndices(data=signers).to_aggregation_bits()
         raw_xmss = list(
@@ -405,7 +406,7 @@ class TestOnGossipAggregatedAttestation:
             key_manager, num_validators=4, validator_id=ValidatorIndex(0)
         )
 
-        data_root = attestation_data.data_root_bytes()
+        data_root = hash_tree_root(attestation_data)
 
         # First proof: validators 1 and 2
         participants_1 = [ValidatorIndex(1), ValidatorIndex(2)]
@@ -529,7 +530,7 @@ class TestAggregateCommitteeSignatures:
         # Verify the proof is valid
         proof.verify(
             public_keys=public_keys,
-            message=attestation_data.data_root_bytes(),
+            message=hash_tree_root(attestation_data),
             slot=attestation_data.slot,
         )
 
@@ -746,7 +747,7 @@ class TestEndToEndAggregationFlow:
         )
 
         attestation_data = store.produce_attestation_data(Slot(1))
-        data_root = attestation_data.data_root_bytes()
+        data_root = hash_tree_root(attestation_data)
 
         # Step 1: Receive gossip attestations from validators 1 and 2
         # (all in same subnet since ATTESTATION_COMMITTEE_COUNT=1 by default)

--- a/tests/lean_spec/subspecs/forkchoice/test_validator.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_validator.py
@@ -130,7 +130,7 @@ class TestBlockProduction:
             public_keys = [key_manager[vid].attestation_public for vid in participants]
             proof.verify(
                 public_keys=public_keys,
-                message=agg_att.data.data_root_bytes(),
+                message=hash_tree_root(agg_att.data),
                 slot=agg_att.data.slot,
             )
 
@@ -247,7 +247,7 @@ class TestBlockProduction:
             public_keys = [key_manager[vid].attestation_public for vid in participants]
             proof.verify(
                 public_keys=public_keys,
-                message=agg_att.data.data_root_bytes(),
+                message=hash_tree_root(agg_att.data),
                 slot=agg_att.data.slot,
             )
 

--- a/tests/lean_spec/subspecs/validator/test_service.py
+++ b/tests/lean_spec/subspecs/validator/test_service.py
@@ -226,7 +226,7 @@ class TestSignAttestation:
         assert TARGET_SIGNATURE_SCHEME.verify(
             pk=public_key,
             slot=att_data.slot,
-            message=att_data.data_root_bytes(),
+            message=hash_tree_root(att_data),
             sig=result.signature,
         )
 
@@ -242,7 +242,7 @@ class TestSignAttestation:
         assert TARGET_SIGNATURE_SCHEME.verify(
             pk=attestation_pk,
             slot=att_data.slot,
-            message=att_data.data_root_bytes(),
+            message=hash_tree_root(att_data),
             sig=result.signature,
         )
 
@@ -1010,7 +1010,7 @@ class TestValidatorServiceIntegration:
         for signed_att in attestations_produced:
             validator_id = signed_att.validator_id
             public_key = key_manager[validator_id].attestation_public
-            message_bytes = signed_att.data.data_root_bytes()
+            message_bytes = hash_tree_root(signed_att.data)
 
             is_valid = TARGET_SIGNATURE_SCHEME.verify(
                 pk=public_key,
@@ -1107,7 +1107,7 @@ class TestValidatorServiceIntegration:
         """
         store = real_sync_service.store
         attestation_data = store.produce_attestation_data(Slot(0))
-        data_root = attestation_data.data_root_bytes()
+        data_root = hash_tree_root(attestation_data)
 
         participants = [ValidatorIndex(3), ValidatorIndex(4)]
         public_keys = []
@@ -1289,7 +1289,7 @@ class TestValidatorServiceIntegration:
         for signed_att in attestations_produced:
             validator_id = signed_att.validator_id
             public_key = key_manager[validator_id].attestation_public
-            message_bytes = signed_att.data.data_root_bytes()
+            message_bytes = hash_tree_root(signed_att.data)
 
             is_valid = TARGET_SIGNATURE_SCHEME.verify(
                 pk=public_key,

--- a/tests/lean_spec/subspecs/xmss/test_aggregation.py
+++ b/tests/lean_spec/subspecs/xmss/test_aggregation.py
@@ -8,6 +8,7 @@ from consensus_testing.keys import XmssKeyManager
 from lean_spec.subspecs.containers.checkpoint import Checkpoint
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof, AggregationError
 from lean_spec.types import ByteListMiB
 from tests.lean_spec.helpers import make_attestation_data_simple, make_bytes32
@@ -21,7 +22,7 @@ def _sign_and_aggregate(
     """Sign attestation data with the given validators and aggregate."""
     slot, head, target, source = att_data_args
     att_data = make_attestation_data_simple(slot, make_bytes32(head), make_bytes32(target), source)
-    data_root = att_data.data_root_bytes()
+    data_root = hash_tree_root(att_data)
 
     xmss_participants = ValidatorIndices(data=validator_ids).to_aggregation_bits()
     raw_xmss = list(
@@ -72,7 +73,7 @@ def test_aggregate_multiple_signatures(key_manager: XmssKeyManager) -> None:
         xmss_participants=xmss_participants,
         children=[],
         raw_xmss=raw_xmss,
-        message=att_data.data_root_bytes(),
+        message=hash_tree_root(att_data),
         slot=att_data.slot,
     )
 
@@ -81,7 +82,7 @@ def test_aggregate_multiple_signatures(key_manager: XmssKeyManager) -> None:
     public_keys = [key_manager[vid].attestation_public for vid in vids]
     proof.verify(
         public_keys=public_keys,
-        message=att_data.data_root_bytes(),
+        message=hash_tree_root(att_data),
         slot=att_data.slot,
     )
 
@@ -112,7 +113,7 @@ def test_aggregate_children_with_raw_signatures(key_manager: XmssKeyManager) -> 
         xmss_participants=xmss_participants,
         children=[(child, [key_manager[ValidatorIndex(i)].attestation_public for i in range(2)])],
         raw_xmss=raw_xmss,
-        message=att_data.data_root_bytes(),
+        message=hash_tree_root(att_data),
         slot=att_data.slot,
     )
 
@@ -122,7 +123,7 @@ def test_aggregate_children_with_raw_signatures(key_manager: XmssKeyManager) -> 
     public_keys = [key_manager[ValidatorIndex(i)].attestation_public for i in range(4)]
     parent.verify(
         public_keys=public_keys,
-        message=att_data.data_root_bytes(),
+        message=hash_tree_root(att_data),
         slot=att_data.slot,
     )
 
@@ -147,7 +148,7 @@ def test_aggregate_three_children(key_manager: XmssKeyManager) -> None:
         xmss_participants=None,
         children=[(child_a, child_a_pks), (child_b, child_b_pks), (child_c, child_c_pks)],
         raw_xmss=[],
-        message=att_data.data_root_bytes(),
+        message=hash_tree_root(att_data),
         slot=att_data.slot,
     )
 
@@ -157,7 +158,7 @@ def test_aggregate_three_children(key_manager: XmssKeyManager) -> None:
     public_keys = [key_manager[ValidatorIndex(i)].attestation_public for i in range(3)]
     parent.verify(
         public_keys=public_keys,
-        message=att_data.data_root_bytes(),
+        message=hash_tree_root(att_data),
         slot=att_data.slot,
     )
 
@@ -169,7 +170,7 @@ def test_aggregate_children_of_children(key_manager: XmssKeyManager) -> None:
     att_data = make_attestation_data_simple(
         att_args[0], make_bytes32(att_args[1]), make_bytes32(att_args[2]), att_args[3]
     )
-    msg = att_data.data_root_bytes()
+    msg = hash_tree_root(att_data)
 
     # Level 0: four individual leaf proofs
     leaf_a = _sign_and_aggregate(key_manager, [ValidatorIndex(0)], att_args)
@@ -222,7 +223,7 @@ def test_aggregate_mixed_children_and_raw_multiple(key_manager: XmssKeyManager) 
     att_data = make_attestation_data_simple(
         att_args[0], make_bytes32(att_args[1]), make_bytes32(att_args[2]), att_args[3]
     )
-    msg = att_data.data_root_bytes()
+    msg = hash_tree_root(att_data)
 
     # Two child proofs
     child_a = _sign_and_aggregate(key_manager, [ValidatorIndex(0)], att_args)
@@ -276,7 +277,7 @@ def test_aggregate_wrong_message_fails_verification(key_manager: XmssKeyManager)
         xmss_participants=xmss_participants,
         children=[],
         raw_xmss=raw_xmss,
-        message=att_data.data_root_bytes(),
+        message=hash_tree_root(att_data),
         slot=att_data.slot,
     )
 
@@ -307,14 +308,14 @@ def test_aggregate_wrong_slot_fails_verification(key_manager: XmssKeyManager) ->
         xmss_participants=xmss_participants,
         children=[],
         raw_xmss=raw_xmss,
-        message=att_data.data_root_bytes(),
+        message=hash_tree_root(att_data),
         slot=att_data.slot,
     )
 
     with pytest.raises(AggregationError, match="verification failed"):
         proof.verify(
             public_keys=[key_manager[vid].attestation_public],
-            message=att_data.data_root_bytes(),
+            message=hash_tree_root(att_data),
             slot=Slot(99),
         )
 
@@ -343,7 +344,7 @@ def test_aggregate_corrupted_proof_fails_verification(key_manager: XmssKeyManage
     with pytest.raises(AggregationError, match="verification failed"):
         corrupted_proof.verify(
             public_keys=[key_manager[vid].attestation_public],
-            message=att_data.data_root_bytes(),
+            message=hash_tree_root(att_data),
             slot=att_data.slot,
         )
 
@@ -371,7 +372,7 @@ def test_aggregate_child_signed_different_message_fails(key_manager: XmssKeyMana
             xmss_participants=None,
             children=[(child_a, child_a_pks), (child_b, child_b_pks)],
             raw_xmss=[],
-            message=att_data_b.data_root_bytes(),
+            message=hash_tree_root(att_data_b),
             slot=att_data_b.slot,
         )
 
@@ -419,6 +420,6 @@ def test_aggregate_rejects_mismatched_participant_count(
             xmss_participants=xmss_participants,
             children=[],
             raw_xmss=raw_xmss,
-            message=att_data.data_root_bytes(),
+            message=hash_tree_root(att_data),
             slot=att_data.slot,
         )


### PR DESCRIPTION
## Summary

- Remove `AttestationData.data_root_bytes()` method, a trivial wrapper around `hash_tree_root(self)` that added unnecessary weight to the spec
- Replace all 37 call sites across 12 files with direct `hash_tree_root(...)` calls

## Test plan

- [x] All linter checks pass (`uvx tox -e all-checks`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)