### PR TITLE
refactor: inline aggregate_by_data into test infrastructure

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from lean_spec.subspecs.containers.attestation import (
@@ -21,7 +22,7 @@ from lean_spec.subspecs.containers.block.types import (
     AttestationSignatures,
 )
 from lean_spec.subspecs.containers.slot import Slot
-from lean_spec.subspecs.containers.validator import ValidatorIndex
+from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.types import Bytes32, CamelModel
@@ -331,8 +332,22 @@ class BlockSpec(CamelModel):
             state, block_registry, key_manager
         )
 
-        # Aggregate valid attestations into block body.
-        aggregated_attestations = AggregatedAttestation.aggregate_by_data(valid_attestations)
+        # Group attestations that share the same AttestationData.
+        # Validators seeing the same head/source/target produce identical data,
+        # so they can be merged into a single aggregated attestation.
+        data_to_validator_ids: dict[AttestationData, list[ValidatorIndex]] = defaultdict(list)
+        for attestation in valid_attestations:
+            data_to_validator_ids[attestation.data].append(attestation.validator_id)
+
+        # Build one AggregatedAttestation per unique data.
+        # Each carries a bitfield marking which validators participated.
+        aggregated_attestations = [
+            AggregatedAttestation(
+                aggregation_bits=ValidatorIndices(data=validator_ids).to_aggregation_bits(),
+                data=data,
+            )
+            for data, validator_ids in data_to_validator_ids.items()
+        ]
         attestation_sigs = key_manager.build_attestation_signatures(
             AggregatedAttestations(data=aggregated_attestations),
             signature_lookup=signature_lookup,

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -412,13 +412,12 @@ class BlockSpec(CamelModel):
 
         # Build attestations from this spec's attestation fields.
         parent_state = store.states[parent_root]
-        attestations, attestation_signatures, valid_attestations = self.build_attestations(
+        _, attestation_signatures, valid_attestations = self.build_attestations(
             parent_state, block_registry, key_manager
         )
 
         # Gossip valid attestation signatures into the Store.
         # This runs signature verification through the spec's validation path.
-        working_store = store
         for attestation in valid_attestations:
             sigs_for_data = attestation_signatures.get(attestation.data)
             if (
@@ -426,7 +425,7 @@ class BlockSpec(CamelModel):
                 or (signature := sigs_for_data.get(attestation.validator_id)) is None
             ):
                 continue
-            working_store = working_store.on_gossip_attestation(
+            store = store.on_gossip_attestation(
                 SignedAttestation(
                     validator_id=attestation.validator_id,
                     data=attestation.data,
@@ -437,7 +436,7 @@ class BlockSpec(CamelModel):
             )
 
         # Trigger Store aggregation to merge gossip signatures into known payloads.
-        aggregation_store, _ = working_store.aggregate()
+        aggregation_store, _ = store.aggregate()
         merged_store = aggregation_store.accept_new_attestations()
 
         # Build the block through the spec's State.build_block().

--- a/src/lean_spec/subspecs/containers/attestation/attestation.py
+++ b/src/lean_spec/subspecs/containers/attestation/attestation.py
@@ -13,10 +13,8 @@ Attestations can be aggregated by common data to save space and bandwidth.
 
 from __future__ import annotations
 
-from collections import defaultdict
-
 from lean_spec.subspecs.containers.slot import Slot
-from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.subspecs.containers.validator import ValidatorIndex
 from lean_spec.types import Container
 
 from ...xmss.aggregation import AggregatedSignatureProof
@@ -70,33 +68,6 @@ class AggregatedAttestation(Container):
     Multiple validator attestations are aggregated here without the complexity of
     committee assignments.
     """
-
-    @classmethod
-    def aggregate_by_data(
-        cls,
-        attestations: list[Attestation],
-    ) -> list[AggregatedAttestation]:
-        """
-        Aggregate plain per-validator attestations by their shared AttestationData.
-
-        Args:
-            attestations: Attestations to aggregate.
-
-        Returns:
-            One AggregatedAttestation per unique AttestationData, with aggregation
-            bits set for all participating validators.
-        """
-        data_to_validator_ids: dict[AttestationData, list[ValidatorIndex]] = defaultdict(list)
-        for attestation in attestations:
-            data_to_validator_ids[attestation.data].append(attestation.validator_id)
-
-        return [
-            cls(
-                aggregation_bits=ValidatorIndices(data=validator_ids).to_aggregation_bits(),
-                data=data,
-            )
-            for data, validator_ids in data_to_validator_ids.items()
-        ]
 
 
 class SignedAggregatedAttestation(Container):

--- a/tests/lean_spec/subspecs/containers/test_attestation_aggregation.py
+++ b/tests/lean_spec/subspecs/containers/test_attestation_aggregation.py
@@ -5,7 +5,6 @@ import pytest
 from lean_spec.subspecs.containers.attestation import (
     AggregatedAttestation,
     AggregationBits,
-    Attestation,
     AttestationData,
 )
 from lean_spec.subspecs.containers.checkpoint import Checkpoint
@@ -84,69 +83,3 @@ class TestAggregatedAttestation:
 
         recovered = agg.aggregation_bits.to_validator_indices()
         assert recovered == validator_ids
-
-
-class TestAggregateByData:
-    """Test aggregation of plain attestations by common data."""
-
-    def test_aggregate_attestations_by_common_data(self) -> None:
-        """Test that attestations with same data are properly aggregated."""
-        att_data1 = AttestationData(
-            slot=Slot(5),
-            head=Checkpoint(root=Bytes32.zero(), slot=Slot(4)),
-            target=Checkpoint(root=Bytes32.zero(), slot=Slot(3)),
-            source=Checkpoint(root=Bytes32.zero(), slot=Slot(2)),
-        )
-        att_data2 = AttestationData(
-            slot=Slot(6),
-            head=Checkpoint(root=Bytes32.zero(), slot=Slot(5)),
-            target=Checkpoint(root=Bytes32.zero(), slot=Slot(4)),
-            source=Checkpoint(root=Bytes32.zero(), slot=Slot(3)),
-        )
-
-        attestations = [
-            Attestation(validator_id=ValidatorIndex(1), data=att_data1),
-            Attestation(validator_id=ValidatorIndex(3), data=att_data1),
-            Attestation(validator_id=ValidatorIndex(5), data=att_data2),
-        ]
-
-        aggregated = AggregatedAttestation.aggregate_by_data(attestations)
-
-        # Should have 2 aggregated attestations (one per unique data)
-        assert len(aggregated) == 2
-
-        # Find the aggregated attestation with att_data1
-        agg1 = next(agg for agg in aggregated if agg.data == att_data1)
-        validator_ids1 = agg1.aggregation_bits.to_validator_indices()
-
-        # Should contain validators 1 and 3
-        assert set(validator_ids1) == {ValidatorIndex(1), ValidatorIndex(3)}
-
-        # Find the aggregated attestation with att_data2
-        agg2 = next(agg for agg in aggregated if agg.data == att_data2)
-        validator_ids2 = agg2.aggregation_bits.to_validator_indices()
-
-        # Should contain only validator 5
-        assert set(validator_ids2) == {ValidatorIndex(5)}
-
-    def test_aggregate_empty_attestations(self) -> None:
-        """Test aggregation with no attestations."""
-        aggregated = AggregatedAttestation.aggregate_by_data([])
-        assert len(aggregated) == 0
-
-    def test_aggregate_single_attestation(self) -> None:
-        """Test aggregation with a single attestation."""
-        att_data = AttestationData(
-            slot=Slot(5),
-            head=Checkpoint(root=Bytes32.zero(), slot=Slot(4)),
-            target=Checkpoint(root=Bytes32.zero(), slot=Slot(3)),
-            source=Checkpoint(root=Bytes32.zero(), slot=Slot(2)),
-        )
-
-        attestations = [Attestation(validator_id=ValidatorIndex(5), data=att_data)]
-
-        aggregated = AggregatedAttestation.aggregate_by_data(attestations)
-
-        assert len(aggregated) == 1
-        validator_ids = aggregated[0].aggregation_bits.to_validator_indices()
-        assert validator_ids == ValidatorIndices(data=[ValidatorIndex(5)])


### PR DESCRIPTION
## Summary

- Remove `aggregate_by_data` classmethod from `AggregatedAttestation` — it was only used in test infrastructure, not the spec
- Inline the grouping logic directly in `block_spec.py` with educational documentation
- Remove `TestAggregateByData` test class (tested the now-removed method)
- Clean up unused imports (`defaultdict`, `ValidatorIndices`, `Attestation`)

`AggregatedAttestation` is now a pure data container with no business logic.

## Test plan

- [x] `uv run pytest tests/lean_spec/subspecs/containers/test_attestation_aggregation.py` — 6 tests pass
- [x] `uvx tox -e all-checks` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)