### PR TITLE
refactor: move generate_pre_state to consensus_testing package root

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -3,6 +3,7 @@
 from typing import Type
 
 from . import forks
+from .genesis import generate_pre_state
 from .test_fixtures import (
     BaseConsensusFixture,
     ForkChoiceTest,
@@ -25,7 +26,6 @@ from .test_types import (
     StateExpectation,
     StoreChecks,
     TickStep,
-    generate_pre_state,
 )
 
 StateTransitionTestFiller = Type[StateTransitionTest]

--- a/packages/testing/src/consensus_testing/genesis.py
+++ b/packages/testing/src/consensus_testing/genesis.py
@@ -4,7 +4,7 @@ from lean_spec.subspecs.containers.state import State, Validators
 from lean_spec.subspecs.containers.validator import Validator, ValidatorIndex
 from lean_spec.types import Bytes52, Uint64
 
-from ..keys import XmssKeyManager
+from .keys import XmssKeyManager
 
 _DEFAULT_GENESIS_TIME = Uint64(0)
 
@@ -13,30 +13,28 @@ def generate_pre_state(
     genesis_time: Uint64 = _DEFAULT_GENESIS_TIME,
     num_validators: int = 4,
 ) -> State:
-    """
-    Generate a default pre-state for consensus tests.
+    """Generate a default pre-state for consensus tests.
 
     Args:
-        genesis_time: The genesis timestamp (defaults to Uint64(0)).
-        num_validators: Number of validators (defaults to 4).
+        genesis_time: The genesis timestamp.
+        num_validators: Number of validators to include.
 
     Returns:
         A properly initialized consensus state.
     """
     key_manager = XmssKeyManager.shared()
-    available_keys = len(key_manager)
 
-    assert num_validators <= available_keys, (
-        f"Not enough keys to generate state. "
-        f"Expecting a minimum of {num_validators} validators "
-        f"but the key manager has only {available_keys} keys"
-    )
+    if num_validators > len(key_manager):
+        raise ValueError(
+            f"Not enough keys: need {num_validators} validators "
+            f"but the key manager has only {len(key_manager)} keys"
+        )
 
-    validator_list = []
+    validators = []
     for i in range(num_validators):
         idx = ValidatorIndex(i)
         attestation_pubkey, proposal_pubkey = key_manager.get_public_keys(idx)
-        validator_list.append(
+        validators.append(
             Validator(
                 attestation_pubkey=Bytes52(attestation_pubkey.encode_bytes()),
                 proposal_pubkey=Bytes52(proposal_pubkey.encode_bytes()),
@@ -44,6 +42,4 @@ def generate_pre_state(
             )
         )
 
-    return State.generate_genesis(
-        genesis_time=genesis_time, validators=Validators(data=validator_list)
-    )
+    return State.generate_genesis(genesis_time=genesis_time, validators=Validators(data=validators))

--- a/packages/testing/src/consensus_testing/test_types/__init__.py
+++ b/packages/testing/src/consensus_testing/test_types/__init__.py
@@ -2,7 +2,6 @@
 
 from .aggregated_attestation_spec import AggregatedAttestationSpec
 from .block_spec import BlockSpec
-from .genesis import generate_pre_state
 from .gossip_aggregated_attestation_spec import GossipAggregatedAttestationSpec
 from .gossip_attestation_spec import GossipAttestationSpec
 from .state_expectation import StateExpectation
@@ -31,5 +30,4 @@ __all__ = [
     "AttestationStep",
     "ForkChoiceStep",
     "GossipAggregatedAttestationStep",
-    "generate_pre_state",
 ]


### PR DESCRIPTION
## Summary

- **Move** `generate_pre_state` from `consensus_testing/test_types/genesis.py` to `consensus_testing/genesis.py` — the `test_types/` package is exclusively Pydantic model definitions, and a factory function doesn't belong there. The new location sits alongside `keys.py`, its main dependency.
- **Replace `assert` with `ValueError`** for input validation — `assert` gets stripped by `python -O` and this validates caller input, not an internal invariant.
- **Clean up** docstring (remove default value restating) and rename `validator_list` → `validators`.

No downstream changes needed — all callers import from `consensus_testing` directly, so the public API is unchanged.

## Test plan

- [x] `uvx tox -e all-checks` passes (ruff, ty, codespell, mdformat)
- [ ] `uv run pytest` confirms no import breakage
- [ ] `uv run fill --fork=devnet --clean -n auto` generates fixtures successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)