### PR TITLE
test(fc): add deep chain split reorg depth test 

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -220,6 +220,7 @@ class ForkChoiceTest(BaseConsensusFixture):
         # Process each step against the Store.
         # Store follows immutable pattern: each method returns a new Store.
         for i, step in enumerate(self.steps):
+            old_head = store.head
             try:
                 match step:
                     case TickStep():
@@ -310,6 +311,7 @@ class ForkChoiceTest(BaseConsensusFixture):
                         step_index=i,
                         block_registry=self._block_registry,
                         filled_block=filled_block,
+                        old_head=old_head,
                     )
 
             except Exception as e:

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -202,12 +202,35 @@ class StoreChecks(CamelModel):
     should be selected as the head.
     """
 
+    reorg_depth: int | None = None
+    """
+    Expected reorg depth after this step.
+
+    Reorg depth is the number of blocks reverted when the head switches
+    from the old chain to the new chain. Computed by finding the common
+    ancestor of the old and new heads, then counting blocks from the old
+    head back to that ancestor.
+
+    Only meaningful when the head actually changes. If the head didn't
+    change, the actual reorg depth is 0.
+    """
+
+    labels_in_store: list[str] | None = None
+    """
+    Block labels that must be present in the store's block tree.
+
+    Each label is resolved to a block root via the block registry,
+    then checked for presence in ``store.blocks``. This verifies
+    that blocks from abandoned forks are retained (not pruned).
+    """
+
     def validate_against_store(
         self,
         store: "Store",
         step_index: int,
         block_registry: dict[str, "Block"] | None = None,
         filled_block: "Block | None" = None,
+        old_head: "Bytes32 | None" = None,
     ) -> None:
         """
         Validate these checks against actual Store state.
@@ -219,6 +242,8 @@ class StoreChecks(CamelModel):
             step_index: Index of the step being validated (for error messages).
             block_registry: Optional labeled blocks for resolving label-based checks.
             filled_block: Optional block for validating block body attestations.
+            old_head: Previous head root before this step executed. Required
+                for reorg_depth checks.
         """
         fields = self.model_fields_set
 
@@ -351,6 +376,28 @@ class StoreChecks(CamelModel):
             StoreChecks._validate_lexicographic_head(
                 self.lexicographic_head_among, store, block_registry, step_index
             )
+
+        # Reorg depth
+        if "reorg_depth" in fields:
+            if old_head is None:
+                raise ValueError(
+                    f"Step {step_index}: reorg_depth specified but old_head not provided"
+                )
+            actual_depth = (
+                store.blocks.reorg_depth(old_head, store.head) if store.head != old_head else 0
+            )
+            _check("reorg_depth", actual_depth, self.reorg_depth)
+
+        # Verify labeled blocks are present in the store
+        if "labels_in_store" in fields:
+            assert self.labels_in_store is not None
+            for label in self.labels_in_store:
+                root = _resolve_label("labels_in_store", label)
+                if root not in store.blocks:
+                    raise AssertionError(
+                        f"Step {step_index}: block '{label}' (root=0x{root.hex()}) "
+                        f"not found in store.blocks"
+                    )
 
     @staticmethod
     def _validate_block_attestations(

--- a/tests/consensus/devnet/fc/test_fork_choice_reorgs.py
+++ b/tests/consensus/devnet/fc/test_fork_choice_reorgs.py
@@ -940,6 +940,137 @@ def test_back_and_forth_reorg_oscillation(
     )
 
 
+def test_reorg_depth_across_deep_chain_split(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Deep reorg: 10 blocks reverted when head switches to a competing fork.
+
+    Scenario
+    --------
+    - Slot 1: Common ancestor
+    - Slots 2-11: Fork A builds 10-block chain with 1 attestation (becomes head)
+    - Slots 2-11: Fork B builds 10-block chain (parallel, same slots)
+    - Slot 12: Fork B extended with 6/8 attestations → triggers deep reorg
+
+    Chain State Evolution:
+        Slot 1:  common
+        Slot 11: common ← a_2 ← ... ← a_11 (head, weight=1)
+                 common ← b_2 ← ... ← b_11
+        Slot 12: common ← a_2 ← ... ← a_11 (abandoned)
+                 common ← b_2 ← ... ← b_11 ← b_12 (head, weight=6 - REORG!)
+
+    Expected Behavior
+    -----------------
+    1. Fork A leads through slots 2-11 (anchored by explicit attestation)
+    2. Fork B blocks are added but don't overtake (lighter)
+    3. At slot 12, fork B extends with 6 attestations → head switches to B
+    4. Ten blocks reverted: a_2 through a_11 become non-canonical
+    5. Both forks remain in the store (no pruning without finalization)
+
+    Reorg Details:
+        - **Depth**: 10 blocks (a_2 through a_11)
+        - **Trigger**: Supermajority attestation weight on competing fork
+        - **Weight advantage**: Fork B has 6 explicit attestations vs fork A's 1
+    """
+    fork_choice_test(
+        anchor_state=generate_pre_state(num_validators=8),
+        steps=[
+            # Common ancestor at slot 1
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="common"),
+                checks=StoreChecks(
+                    head_slot=Slot(1),
+                    head_root_label="common",
+                ),
+            ),
+            # Fork A: slots 2-10 (no attestations)
+            *[
+                BlockStep(
+                    block=BlockSpec(
+                        slot=Slot(i),
+                        parent_label="common" if i == 2 else f"a_{i - 1}",
+                        label=f"a_{i}",
+                    ),
+                )
+                for i in range(2, 11)
+            ],
+            # Fork A: slot 11 with attestation to anchor fork A as head.
+            #
+            # Targets common (slot 1) so the attestation data stays within
+            # justified_slots range when fork B blocks are built later.
+            # This weight keeps fork A canonical while fork B is constructed.
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(11),
+                    parent_label="a_10",
+                    label="a_11",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[ValidatorIndex(7)],
+                            slot=Slot(1),
+                            target_slot=Slot(1),
+                            target_root_label="common",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(11),
+                    head_root_label="a_11",
+                ),
+            ),
+            # Fork B: slots 2-11, parent chain from "common"
+            *[
+                BlockStep(
+                    block=BlockSpec(
+                        slot=Slot(i),
+                        parent_label="common" if i == 2 else f"b_{i - 1}",
+                        label=f"b_{i}",
+                    ),
+                )
+                for i in range(2, 12)
+            ],
+            # Fork B: slot 12 with 6/8 attestations targeting b_11 → deep reorg.
+            #
+            # Six validators attest to b_11, overwhelming fork A's single
+            # attestation. Head switches from a_11 to b_12, reverting 10 blocks.
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(12),
+                    parent_label="b_11",
+                    label="b_12",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[
+                                ValidatorIndex(0),
+                                ValidatorIndex(1),
+                                ValidatorIndex(2),
+                                ValidatorIndex(3),
+                                ValidatorIndex(4),
+                                ValidatorIndex(5),
+                            ],
+                            slot=Slot(11),
+                            target_slot=Slot(11),
+                            target_root_label="b_11",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(12),
+                    head_root_label="b_12",
+                    reorg_depth=10,
+                    labels_in_store=[
+                        "a_2",
+                        "a_11",
+                        "b_2",
+                        "b_11",
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
 def test_reorg_on_newly_justified_slot(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:


### PR DESCRIPTION
## summary
<!-- Brief description of the changes introduced by this PR -->
 - **Add `reorg_depth` check to `StoreChecks`** — computes the number of blocks                                                                                                              
    reverted when the head switches chains, using `store.blocks.reorg_depth()`
  - **Add `labels_in_store` check to `StoreChecks`** — verifies that labeled blocks                                                                                                           
    remain in the store's block tree (e.g. blocks from abandoned forks aren't pruned)                                                                                                         
  - **Track `old_head` in the fixture loop** so reorg depth can be computed by                                                                                                                
    comparing pre-step and post-step heads                                                                                                                                                    
  - **Add `test_reorg_depth_across_deep_chain_split`** — a 10-block deep reorg                                                                                                                
    scenario where a competing fork overtakes with supermajority attestation weight   

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->
closes #584 

 ### Per-file changes                                                                                                                                                                        
                                                                                                                                                                                              
  | File | What changed |                                                                                                                                                                     
  |------|-------------|
  | `consensus_testing/test_types/store_checks.py` | Add `reorg_depth` and `labels_in_store` fields with validation logic in `validate_against_store()` |                                     
  | `consensus_testing/test_fixtures/fork_choice.py` | Track `old_head` before each step, pass it to `validate_against_store()` |                                                             
  | `tests/consensus/devnet/fc/test_fork_choice_reorgs.py` | Add `test_reorg_depth_across_deep_chain_split`: two 10-block forks diverge from a common ancestor, fork B wins with 6/8          
  attestations triggering a depth-10 reorg |      

  ## Test plan 
                                                                                                                                                                                            
  - [ ] New test generates fixtures: `uv run fill --fork=devnet --clean -n auto -k test_reorg_depth_across_deep`                                                                              
  - [ ] All tests pass (`uv run pytest`)                                                                                                                                                      
  - [ ] All quality checks pass (`uvx tox -e all-checks`)                                                                                                                                     
  - [ ] Reorg depth correctly reports 10 for the deep chain split scenario                                                                                                                    
  - [ ] Abandoned fork blocks (a_2, a_11) verified as retained in the store  