### PR TITLE
test(st): attestation with already-justified target is silently skipped

### DIFF
--- a/tests/consensus/devnet/state_transition/test_justification.py
+++ b/tests/consensus/devnet/state_transition/test_justification.py
@@ -1405,3 +1405,80 @@ def test_target_at_or_before_source_is_ignored(
             ),
         ),
     )
+
+
+def test_attestation_with_already_justified_target_is_silently_skipped(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Attestation targeting an already-justified slot is ignored without error.
+
+    Scenario
+    --------
+    1. Start from genesis with 4 validators
+    2. Process block_1 at slot 1
+    3. Process block_2 at slot 2 with attestations from validators 0, 1, and 2
+       targeting block_1 at slot 1, justifying slot 1
+    4. Process block_3 at slot 3 with an attestation from validator 3
+       targeting block_1 at slot 1 (already justified)
+
+    Expected Behavior
+    -----------------
+    1. Slot 1 becomes justified after block_2
+    2. The attestation in block_3 targets an already-justified slot
+    3. The duplicate attestation is silently skipped with no state change
+    4. The block containing the duplicate attestation is accepted as valid
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[
+            # Step 1 — Build chain and justify slot X
+            BlockSpec(slot=Slot(1), label="block_1"),
+            BlockSpec(
+                slot=Slot(2),
+                parent_label="block_1",
+                label="block_2",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                    ),
+                ],
+            ),
+            # Step 2 — Include duplicate attestation targeting slot X
+            # Step 3 — Apply state transition
+            # Assertion C — No errors during processing
+            BlockSpec(
+                slot=Slot(3),
+                parent_label="block_2",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(3),
+                        ],
+                        slot=Slot(3),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(3),
+            # Assertion A — Justification preserved
+            latest_justified_slot=Slot(1),
+            latest_finalized_slot=Slot(0),
+            # Assertion B — No additional state change from the duplicate attestation
+            justified_slots=JustifiedSlots(data=[]).model_copy(
+                update={"data": [Boolean(True), Boolean(False)]}
+            ),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
+        ),
+    )


### PR DESCRIPTION
 ## Summary                                                                                                                                                                   
                                                                                                                                                                               
  - Add `test_attestation_with_already_justified_target_is_silently_skipped` to `test_justification.py`                                                                        
  - Justifies slot 1 via supermajority (validators 0–2), then includes a late attestation from validator 3 targeting the same already-justified slot 1                         
  - Verifies the duplicate attestation is silently skipped: no error, no double-counting, no pending vote residue                                                              
                                                                                                                                                 
## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->
closes #576 

## Design notes

  The test uses the simplest possible chain (4 validators, 3 slots) to isolate the skip path at `State.process_attestations` where `justified_slots.is_slot_justified(...)`    
  returns `True` and the attestation is dropped via `continue`.
                                                                                                                                                                               
  Post-state assertions confirm:                                                                                                                                               
  - `latest_justified_slot` stays at 1 (no regression)
  - `justifications_roots` and `justifications_validators` are empty (pending votes were cleared on justification and the skipped attestation created no new ones)             
  - `justified_slots` is unchanged (no double-marking)                                                                                                                         
   
  ## Test plan                                                                                                                                                                 
                                                                                                                                                                             
  - [x] `uv run fill --fork=devnet --clean -n auto -k test_attestation_with_already_justified` passes                                                                          
  - [x] Full suite `uv run fill --fork=devnet --clean -n auto` passes (no regressions)
  - [x] `uvx tox -e all-checks` — ruff, ty, codespell, mdformat all pass                                                                                                       
                                                                          