### PR TITLE
test(genesis): add test for single validator edge case (#579)

### DIFF
--- a/tests/consensus/devnet/state_transition/test_genesis.py
+++ b/tests/consensus/devnet/state_transition/test_genesis.py
@@ -162,35 +162,36 @@ def test_genesis_single_validator(
     state_transition_test: StateTransitionTestFiller,
 ) -> None:
     """
-    Test genesis state with exactly 1 validator.
+    Genesis with exactly 1 validator; justification and finalization in 3 blocks.
 
     Scenario
     --------
-    This is an edge case that tests boundary behavior:
-    - The single validator is the proposer for every slot (slot % 1 == 0, always)
-    - Supermajority threshold is trivially met (1/1 = 100% >= 66.7%)
-    - A single attestation from the only validator should justify and finalize
+    Single validator. Proposer for every slot (slot % 1 == 0, always).
+    Supermajority threshold trivially met: 3*1=3 >= 2*1=2.
 
-    Steps:
-    1. Generate genesis with 1 validator
-    2. Produce block at slot 1 (validator 0 is always the proposer)
-    3. Include attestation from the single validator
-    4. Verify justification happens immediately (1/1 = supermajority)
-    5. Produce another block to verify finalization
+    - Block 1: empty (creates attestation target)
+    - Block 2: V0 attests to slot 1 -> justifies slot 1
+    - Block 3: V0 attests to slot 2 -> justifies slot 2, finalizes slot 1
 
-    Expected Behavior
-    -----------------
-    - Validator count is 1
-    - Proposer index is always 0 (slot % 1 == 0)
-    - Justification threshold: 3 * 1 >= 2 * 1 -> 3 >= 2 -> True
-    - Single attestation justifies immediately
+    Expected post-state
+    -------------------
+    - Validator count: 1
+    - Justified slot: 2
+    - Finalized slot: 1
+    - Proposer index: always 0
     """
     state_transition_test(
         pre=generate_pre_state(num_validators=1, genesis_time=Uint64(0)),
         blocks=[
+            # Block 1: creates the attestation target for block 2.
             BlockSpec(slot=Slot(1), label="block_1"),
+            # Block 2: V0 attests to slot 1.
+            # Threshold: 3*1=3 >= 2*1=2 -> justifies slot 1.
+            # Finalization: range(0+1, 1) is empty -> finalizes source (slot 0).
+            # But finalized was already 0, so no visible advance.
             BlockSpec(
                 slot=Slot(2),
+                label="block_2",
                 attestations=[
                     AggregatedAttestationSpec(
                         validator_ids=[ValidatorIndex(0)],
@@ -200,11 +201,27 @@ def test_genesis_single_validator(
                     ),
                 ],
             ),
+            # Block 3: V0 attests to slot 2.
+            # Justifies slot 2 (source=1, target=2).
+            # Finalization: range(1+1, 2) is empty -> finalizes source = slot 1.
+            # This is the visible advance: finalized goes from 0 to 1.
+            BlockSpec(
+                slot=Slot(3),
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[ValidatorIndex(0)],
+                        slot=Slot(3),
+                        target_slot=Slot(2),
+                        target_root_label="block_2",
+                    ),
+                ],
+            ),
         ],
         post=StateExpectation(
-            slot=Slot(2),
+            slot=Slot(3),
             validator_count=1,
-            latest_justified_slot=Slot(1),
+            latest_justified_slot=Slot(2),
+            latest_finalized_slot=Slot(1),
             latest_block_header_proposer_index=0,
         ),
     )

--- a/tests/consensus/devnet/state_transition/test_genesis.py
+++ b/tests/consensus/devnet/state_transition/test_genesis.py
@@ -8,7 +8,13 @@ Tests for genesis state generation and initialization.
 """
 
 import pytest
-from consensus_testing import StateExpectation, StateTransitionTestFiller, generate_pre_state
+from consensus_testing import (
+    AggregatedAttestationSpec,
+    BlockSpec,
+    StateExpectation,
+    StateTransitionTestFiller,
+    generate_pre_state,
+)
 
 from lean_spec.subspecs.containers.block import BlockBody
 from lean_spec.subspecs.containers.block.types import AggregatedAttestations
@@ -19,6 +25,7 @@ from lean_spec.subspecs.containers.state.types import (
     JustificationValidators,
     JustifiedSlots,
 )
+from lean_spec.subspecs.containers.validator import ValidatorIndex
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.types import Bytes32, Uint64
 
@@ -147,5 +154,57 @@ def test_genesis_custom_validator_set(
             justified_slots=JustifiedSlots(data=[]),
             justifications_roots=JustificationRoots(data=[]),
             justifications_validators=JustificationValidators(data=[]),
+        ),
+    )
+
+
+def test_genesis_single_validator(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test genesis state with exactly 1 validator.
+
+    Scenario
+    --------
+    This is an edge case that tests boundary behavior:
+    - The single validator is the proposer for every slot (slot % 1 == 0, always)
+    - Supermajority threshold is trivially met (1/1 = 100% >= 66.7%)
+    - A single attestation from the only validator should justify and finalize
+
+    Steps:
+    1. Generate genesis with 1 validator
+    2. Produce block at slot 1 (validator 0 is always the proposer)
+    3. Include attestation from the single validator
+    4. Verify justification happens immediately (1/1 = supermajority)
+    5. Produce another block to verify finalization
+
+    Expected Behavior
+    -----------------
+    - Validator count is 1
+    - Proposer index is always 0 (slot % 1 == 0)
+    - Justification threshold: 3 * 1 >= 2 * 1 -> 3 >= 2 -> True
+    - Single attestation justifies immediately
+    """
+    state_transition_test(
+        pre=generate_pre_state(num_validators=1, genesis_time=Uint64(0)),
+        blocks=[
+            BlockSpec(slot=Slot(1), label="block_1"),
+            BlockSpec(
+                slot=Slot(2),
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[ValidatorIndex(0)],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(2),
+            validator_count=1,
+            latest_justified_slot=Slot(1),
+            latest_block_header_proposer_index=0,
         ),
     )


### PR DESCRIPTION
## Summary

Add a state transition filler test for genesis with exactly 1 validator.

## What's covered

- Genesis state with a single validator
- Single validator is always the proposer (slot % 1 == 0)
- Supermajority threshold is trivially met (1/1 = 100%)
- Justification happens immediately with the single attestation

## Changes

- `test_genesis.py`: Added `test_genesis_single_validator` test

## Test Results

- Test passes and fixture generated
- All quality checks pass (ruff, typecheck)

## Notes

Key assertions:
- `validator_count=1`
- `latest_justified_slot=Slot(1)` after single attestation
- `proposer_index=0` (always, since slot % 1 == 0)

Closes #579

/cc @tcoratger