### PR TITLE
test: cover skipped attestation with mismatched historical root

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/aggregated_attestation_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/aggregated_attestation_spec.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from lean_spec.subspecs.containers.attestation import AggregatedAttestation, AttestationData
 from lean_spec.subspecs.containers.block.block import Block
 from lean_spec.subspecs.containers.block.types import AggregatedAttestations
+from lean_spec.subspecs.containers.checkpoint import Checkpoint
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.state.state import State
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
-from lean_spec.types import ByteListMiB, CamelModel
+from lean_spec.types import ByteListMiB, Bytes32, CamelModel
 
 from ..keys import XmssKeyManager
 from .utils import resolve_checkpoint
@@ -32,12 +33,33 @@ class AggregatedAttestationSpec(CamelModel):
     target_slot: Slot
     """The slot of the target block being attested to (required)."""
 
-    target_root_label: str
+    target_root_label: str | None = None
     """
-    Label referencing a previously created block as the target (required).
+    Label referencing a previously created block as the target.
 
     The block must exist in the block registry with this label.
     """
+
+    target_root: Bytes32 | None = None
+    """Optional explicit target root (bypasses label lookup)."""
+
+    head_root_label: str | None = None
+    """Optional label for the head checkpoint."""
+
+    head_root: Bytes32 | None = None
+    """Optional explicit head root."""
+
+    head_slot: Slot | None = None
+    """Optional override for the head checkpoint slot."""
+
+    source_root_label: str | None = None
+    """Optional label for the source checkpoint."""
+
+    source_root: Bytes32 | None = None
+    """Optional explicit source root."""
+
+    source_slot: Slot | None = None
+    """Optional override for the source checkpoint slot."""
 
     valid_signature: bool = True
     """
@@ -80,15 +102,54 @@ class AggregatedAttestationSpec(CamelModel):
             Attestation data shared by all validators in the aggregation.
 
         Raises:
-            ValueError: If target label not found in registry.
+            ValueError: If no target root source is provided.
         """
-        target = resolve_checkpoint(self.target_root_label, self.target_slot, block_registry)
+        if self.target_root is not None:
+            target = Checkpoint(root=self.target_root, slot=self.target_slot)
+        elif self.target_root_label is not None:
+            target = resolve_checkpoint(self.target_root_label, self.target_slot, block_registry)
+        else:
+            raise ValueError("aggregated attestation spec requires a target root")
+
+        if self.head_root is not None:
+            head = Checkpoint(
+                root=self.head_root,
+                slot=self.head_slot if self.head_slot is not None else self.target_slot,
+            )
+        elif self.head_root_label is not None:
+            head = resolve_checkpoint(self.head_root_label, self.head_slot, block_registry)
+        else:
+            head = Checkpoint(
+                root=target.root,
+                slot=self.head_slot if self.head_slot is not None else target.slot,
+            )
+
+        if self.source_root is not None:
+            source = Checkpoint(
+                root=self.source_root,
+                slot=(
+                    self.source_slot
+                    if self.source_slot is not None
+                    else state.latest_justified.slot
+                ),
+            )
+        elif self.source_root_label is not None:
+            source = resolve_checkpoint(self.source_root_label, self.source_slot, block_registry)
+        else:
+            source = Checkpoint(
+                root=state.latest_justified.root,
+                slot=(
+                    self.source_slot
+                    if self.source_slot is not None
+                    else state.latest_justified.slot
+                ),
+            )
 
         return AttestationData(
             slot=self.slot,
-            head=target,
+            head=head,
             target=target,
-            source=state.latest_justified,
+            source=source,
         )
 
     def build_invalid_proof(

--- a/tests/consensus/devnet/state_transition/test_justification.py
+++ b/tests/consensus/devnet/state_transition/test_justification.py
@@ -16,7 +16,7 @@ from lean_spec.subspecs.containers.state.types import (
     JustifiedSlots,
 )
 from lean_spec.subspecs.containers.validator import ValidatorIndex
-from lean_spec.types import Boolean
+from lean_spec.types import Boolean, Bytes32
 
 pytestmark = pytest.mark.valid_until("Devnet")
 
@@ -1075,6 +1075,58 @@ def test_supermajority_with_mismatched_target_root_is_ignored(
         ],
         post=StateExpectation(
             slot=Slot(3),
+            latest_justified_slot=Slot(0),
+            latest_finalized_slot=Slot(0),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
+        ),
+    )
+
+
+def test_attestation_with_target_root_not_in_historical_hashes_is_skipped(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test that an attestation with a fabricated target root is silently skipped.
+
+    Scenario
+    --------
+    1. Start from genesis with 4 validators
+    2. Process block_1 at slot 1
+    3. Process block_2 at slot 2 with attestations from validators 0, 1, and 2
+       targeting slot 1 with a valid Bytes32 root that does not match block_1
+
+    Expected Behavior
+    -----------------
+    1. The block at slot 2 is processed successfully
+    2. The attestation reaches state processing because its head stays canonical
+    3. The target root fails the historical_block_hashes check and is skipped
+    4. latest_justified_slot stays at genesis
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[
+            BlockSpec(slot=Slot(1), label="block_1"),
+            BlockSpec(
+                slot=Slot(2),
+                parent_label="block_1",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root=Bytes32(b"\x42" * 32),
+                        head_root_label="block_1",
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(2),
             latest_justified_slot=Slot(0),
             latest_finalized_slot=Slot(0),
             justifications_roots=JustificationRoots(data=[]),


### PR DESCRIPTION
 ## Summary

  Add coverage for state-transition attestations whose target root does not match the canonical root recorded in `historical_block_hashes`.

  This extends the aggregated state-transition test helper so tests can inject explicit checkpoint roots without changing the default label-based path, then adds a devnet STF test that
  verifies a fabricated `Bytes32` target root is silently skipped during attestation processing.

  Closes #578

  ## Changes

  - extend `AggregatedAttestationSpec` with optional explicit `target`, `head`, and `source` checkpoint overrides
  - preserve existing helper behavior when overrides are not used
  - add `test_attestation_with_target_root_not_in_historical_hashes_is_skipped`
  - verify the block still processes successfully and no justification state is updated

  ## Verification

  - `uv run fill --fork=devnet --clean -n auto -k test_attestation_with_target_root_not_in`
  - `uv run fill --fork=devnet --clean -n auto -k test_supermajority_with_mismatched_target_root_is_ignored`

