### PR TITLE
Test/stf attestation unjustified source skip

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -4,10 +4,11 @@ from typing import Any, ClassVar
 
 from pydantic import ConfigDict, PrivateAttr, field_serializer
 
-from lean_spec.subspecs.containers.attestation import AttestationData
+from lean_spec.subspecs.containers.attestation import AggregatedAttestation, AttestationData
 from lean_spec.subspecs.containers.block.block import Block, BlockBody
 from lean_spec.subspecs.containers.block.types import AggregatedAttestations
 from lean_spec.subspecs.containers.state.state import State
+from lean_spec.subspecs.containers.validator import ValidatorIndices
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.types import Bytes32
@@ -189,72 +190,109 @@ class StateTransitionTest(BaseConsensusFixture):
         """
         Build a Block from a BlockSpec, optionally caching the post-state.
 
+        Three construction paths:
+
+        1. Explicit state_root -- caller controls the root, no transition
+        2. Invalid or skip-slot -- placeholder zero root, no transition
+        3. Normal -- full build_block with computed state root
+
+        After construction, any forced attestations are appended to the
+        body. These bypass the builder's filtering so they reach
+        process_attestations directly (e.g., unjustified source tests).
+
         Args:
             spec: Block specification with optional field overrides.
             state: Current state to build against.
-            block_registry: Labels to previously built blocks for resolving parents
-                and attestation targets.
+            block_registry: Labeled blocks for parent and target resolution.
 
         Returns:
             Block and cached post-state (None if not computed).
         """
         proposer_index = spec.resolve_proposer_index(len(state.validators))
 
-        temp_state: State | None = None
+        # Advance slots unless the spec intentionally skips slot processing.
+        slot_advanced_state: State | None = None
         if not spec.skip_slot_processing:
-            temp_state = state.process_slots(spec.slot)
+            slot_advanced_state = state.process_slots(spec.slot)
 
         # Resolve the parent root.
-        # The default is the latest block header from the slot-advanced state.
-        source_state = temp_state or state
+        # Default: latest block header from the slot-advanced state.
+        source_state = slot_advanced_state or state
         parent_root = spec.resolve_parent_root(
             block_registry,
             default_root=hash_tree_root(source_state.latest_block_header),
         )
 
-        # Extract attestations from body if provided
-        aggregated_attestations = (
-            spec.body.attestations if spec.body else AggregatedAttestations(data=[])
-        )
+        body = spec.body or BlockBody(attestations=AggregatedAttestations(data=[]))
+        post_state: State | None = None
 
-        # Handle explicit state root override
+        # Path 1: explicit state root override -- no state transition needed.
         if spec.state_root is not None:
             block = Block(
                 slot=spec.slot,
                 proposer_index=proposer_index,
                 parent_root=parent_root,
                 state_root=spec.state_root,
-                body=spec.body or BlockBody(attestations=aggregated_attestations),
+                body=body,
             )
-            return block, None
 
-        # For invalid tests, return incomplete block without processing
-        if self.expect_exception is not None or spec.skip_slot_processing:
-            return Block(
+        # Path 2: invalid test or skip-slot -- placeholder root, no transition.
+        elif self.expect_exception is not None or spec.skip_slot_processing:
+            block = Block(
                 slot=spec.slot,
                 proposer_index=proposer_index,
                 parent_root=parent_root,
                 state_root=Bytes32.zero(),
-                body=spec.body or BlockBody(attestations=aggregated_attestations),
-            ), None
-
-        # Build aggregated payloads from spec.attestations if provided
-        aggregated_payloads: dict[AttestationData, set[AggregatedSignatureProof]] = {}
-        if spec.attestations:
-            aggregated_payloads = StateTransitionTest._build_aggregated_payloads_from_spec(
-                spec.attestations, state, block_registry
+                body=body,
             )
 
-        # Collect known block roots for attestation validation in build_block
-        known_block_roots = frozenset(hash_tree_root(block) for block in block_registry.values())
+        # Path 3: normal block construction via the spec's builder.
+        else:
+            aggregated_payloads: dict[AttestationData, set[AggregatedSignatureProof]] = {}
+            if spec.attestations:
+                aggregated_payloads = StateTransitionTest._build_aggregated_payloads_from_spec(
+                    spec.attestations, state, block_registry
+                )
 
-        block, post_state, _, _ = state.build_block(
-            slot=spec.slot,
-            proposer_index=proposer_index,
-            parent_root=parent_root,
-            known_block_roots=known_block_roots,
-            aggregated_payloads=aggregated_payloads,
-        )
+            known_block_roots = frozenset(hash_tree_root(b) for b in block_registry.values())
+
+            block, post_state, _, _ = state.build_block(
+                slot=spec.slot,
+                proposer_index=proposer_index,
+                parent_root=parent_root,
+                known_block_roots=known_block_roots,
+                aggregated_payloads=aggregated_payloads,
+            )
+
+        # Append forced attestations if any.
+        # These bypass the builder's filtering so they reach the state
+        # transition even when the builder would exclude them.
+        if spec.forced_attestations:
+            forced = [
+                AggregatedAttestation(
+                    aggregation_bits=ValidatorIndices(data=fa.validator_ids).to_aggregation_bits(),
+                    data=fa.build_attestation_data(block_registry, state),
+                )
+                for fa in spec.forced_attestations
+            ]
+            block = block.model_copy(
+                update={
+                    "body": block.body.model_copy(
+                        update={
+                            "attestations": AggregatedAttestations(
+                                data=[*block.body.attestations.data, *forced]
+                            )
+                        }
+                    )
+                }
+            )
+
+            # The body changed, so re-run the transition to get the correct
+            # post-state and state root.
+            if post_state is not None:
+                post_state = state.process_slots(spec.slot).process_block(block)
+                block = block.model_copy(update={"state_root": hash_tree_root(post_state)})
+
         return block, post_state
 
     @staticmethod

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -85,6 +85,15 @@ class BlockSpec(CamelModel):
     If body is provided, this field is ignored.
     """
 
+    forced_attestations: list[AggregatedAttestationSpec] | None = None
+    """
+    Raw aggregated attestations appended directly to the final block body.
+
+    Unlike attestations, these entries bypass the block builder's filtering.
+    Use this only for STF coverage when the builder would pre-filter the
+    attestation before state processing (e.g., unjustified source).
+    """
+
     label: str | None = None
     """
     Optional label to tag this block for later reference.

--- a/packages/testing/src/consensus_testing/test_types/state_expectation.py
+++ b/packages/testing/src/consensus_testing/test_types/state_expectation.py
@@ -49,7 +49,9 @@ class StateExpectation(CamelModel):
         "historical_block_hashes": lambda s: s.historical_block_hashes,
         "justified_slots": lambda s: s.justified_slots,
         "justifications_roots": lambda s: s.justifications_roots,
+        "justifications_roots_count": lambda s: len(s.justifications_roots),
         "justifications_validators": lambda s: s.justifications_validators,
+        "justifications_validators_count": lambda s: len(s.justifications_validators),
     }
 
     slot: Slot | None = None
@@ -100,8 +102,14 @@ class StateExpectation(CamelModel):
     justifications_roots: JustificationRoots | None = None
     """Expected justifications roots collection."""
 
+    justifications_roots_count: int | None = None
+    """Expected number of pending justification target roots."""
+
     justifications_validators: JustificationValidators | None = None
     """Expected justifications validators bitlist."""
+
+    justifications_validators_count: int | None = None
+    """Expected number of entries in the flat justification voters bitlist."""
 
     def validate_against_state(self, state: "State") -> None:
         """

--- a/tests/consensus/devnet/state_transition/test_justification.py
+++ b/tests/consensus/devnet/state_transition/test_justification.py
@@ -1691,3 +1691,135 @@ def test_attestation_with_zero_hash_target_root_is_skipped(
             justifications_validators=JustificationValidators(data=[]),
         ),
     )
+
+
+def test_attestation_with_unjustified_source_is_silently_skipped(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Attestation whose source slot is not justified is ignored without error.
+
+    Scenario
+    --------
+    Four validators. Justify slot 1 in block 2, then in block 4 include:
+
+    - Valid: V0, V1 with source=slot 1 (justified), target=slot 2
+    - Forced: V2, V3 with source=slot 2 (NOT justified), target=slot 3
+
+    The forced attestation bypasses the block builder (which would
+    filter it out) so it reaches the state transition directly.
+
+    Expected post-state
+    -------------------
+    - Justified slot: 1 (unchanged, valid attestation is 2/4 = below threshold)
+    - Pending votes: [True, True, False, False] (only V0, V1 recorded)
+    - No pending votes from V2, V3 (their attestation was skipped)
+
+    Why this test is precise
+    ------------------------
+    The forced attestation is crafted so that EVERY guard in the
+    attestation processing EXCEPT the source-justified check would pass:
+
+    - Source root matches historical hashes (real block_2 root)
+    - Target root matches historical hashes (real block_3 root)
+    - Neither root is zero-hash
+    - Chronological order holds (target slot 3 > source slot 2)
+    - Target is justifiable (delta=3 from finalized=0, within window)
+
+    Only the source-justified guard (slot 2 is not justified) rejects it.
+    The 4-entry pending votes (not 8) proves it was skipped.
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[
+            BlockSpec(slot=Slot(1), label="block_1"),
+            # Justify slot 1: 3/4 validators attest.
+            # Threshold: 3*3=9 >= 2*4=8 -> passes.
+            BlockSpec(
+                slot=Slot(2),
+                parent_label="block_1",
+                label="block_2",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                    ),
+                ],
+            ),
+            # Empty block. Slot 2 stays unjustified.
+            BlockSpec(
+                slot=Slot(3),
+                parent_label="block_2",
+                label="block_3",
+            ),
+            # Two attestations: one valid (through builder), one forced (bypasses builder).
+            #
+            # Valid: V0, V1 with justified source=1, target=2.
+            #   2/4 below threshold -> creates pending votes, no justification.
+            #
+            # Forced: V2, V3 with unjustified source=2, target=3.
+            #   Source slot 2 is NOT justified -> skipped at the first guard.
+            #   If not skipped, it would create a second set of pending votes
+            #   (8 total entries). The 4-entry result proves the skip.
+            BlockSpec(
+                slot=Slot(4),
+                parent_label="block_3",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                        ],
+                        slot=Slot(4),
+                        target_slot=Slot(2),
+                        target_root_label="block_2",
+                    ),
+                ],
+                forced_attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(2),
+                            ValidatorIndex(3),
+                        ],
+                        slot=Slot(4),
+                        target_slot=Slot(3),
+                        target_root_label="block_3",
+                        source_root_label="block_2",
+                        source_slot=Slot(2),
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(4),
+            latest_justified_slot=Slot(1),
+            latest_finalized_slot=Slot(0),
+            # Slot 1 justified, slots 2 and 3 not.
+            justified_slots=JustifiedSlots(data=[]).model_copy(
+                update={"data": [Boolean(True), Boolean(False), Boolean(False)]}
+            ),
+            # Exactly 1 pending target root (the valid attestation's target = block_2).
+            # If the forced attestation had been processed, there would be 2 roots
+            # (block_2 and block_3).
+            justifications_roots_count=1,
+            # 4 entries = 1 target x 4 validators.
+            # V0 and V1 voted (True), V2 and V3 did not (False).
+            # If the forced attestation had been processed, there would be
+            # 8 entries (2 targets x 4 validators).
+            justifications_validators_count=4,
+            justifications_validators=JustificationValidators(
+                data=[
+                    Boolean(True),
+                    Boolean(True),
+                    Boolean(False),
+                    Boolean(False),
+                ]
+            ),
+        ),
+    )


### PR DESCRIPTION
  ## Summary

  Adds STF coverage for process_attestations when an attestation is silently ignored because its source.slot is not justified in the current state.

  To make that path testable, this also adds a narrow fixture-builder escape hatch: forced_attestations. It allows a test to append raw aggregated attestations directly to the block body
  after State.build_block() would normally filter them out.

  ## Why

  State.process_attestations is expected to skip attestations whose source checkpoint is not justified:

  if not self.justified_slots.is_slot_justified(finalized_slot, source.slot):
      continue

  That behavior matters because:

  - blocks containing such attestations should still be accepted
  - the attestation is ineffective, not invalid
  - we need explicit STF coverage proving the skip path is exercised while valid attestations in the same block are still processed

  A regular BlockSpec.attestations test is not enough here, because State.build_block() only includes attestations whose source matches the currently justified checkpoint. The unjustified-
  source case would be filtered out before state transition processing and the skip logic would never run.

  ## What Changed

  - added forced_attestations to BlockSpec
  - updated StateTransitionTest to append forced attestations after block construction and recompute the block state_root
  - added a justification test that:
      - builds a chain where slot 2 is not justified
      - includes one valid attestation in the block
      - includes one forced attestation with unjustified source slot 2
      - verifies block processing succeeds
      - verifies only the valid attestation affects post-state

  ## Test Coverage

  Ran:

  uv run fill --fork=devnet --clean -n auto -k test_attestation_with_unjustified_source

  Result:

  
<img width="1706" height="256" alt="image" src="https://github.com/user-attachments/assets/a7b4242d-7b36-423c-a6bc-4e573d81bc4f" />



closes #575