### PR TITLE
Add duplicate block fork choice test

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -126,6 +126,15 @@ class StoreChecks(CamelModel):
     The framework resolves this label to the actual block root.
     """
 
+    filled_block_root_label: str | None = None
+    """
+    Expected root of the block built for this step, resolved by label.
+
+    This is useful when a test needs to prove that the fixture rebuilt or
+    resubmitted an exact previously known block rather than merely producing a
+    different block that leaves the head unchanged.
+    """
+
     latest_justified_slot: Slot | None = None
     """Expected latest justified checkpoint slot."""
 
@@ -287,6 +296,15 @@ class StoreChecks(CamelModel):
             assert self.head_root_label is not None
             expected = _resolve_label("head_root_label", self.head_root_label)
             _check("head.root", store.head, expected)
+        if "filled_block_root_label" in fields:
+            if filled_block is None:
+                raise ValueError(
+                    f"Step {step_index}: filled_block_root_label specified but "
+                    f"filled_block not provided"
+                )
+            assert self.filled_block_root_label is not None
+            expected = _resolve_label("filled_block_root_label", self.filled_block_root_label)
+            _check("filled_block.root", hash_tree_root(filled_block), expected)
         if "latest_justified_root_label" in fields:
             assert self.latest_justified_root_label is not None
             expected = _resolve_label(

--- a/tests/consensus/devnet/fc/test_fork_choice_head.py
+++ b/tests/consensus/devnet/fc/test_fork_choice_head.py
@@ -174,6 +174,71 @@ def test_head_with_large_gaps(
     )
 
 
+def test_duplicate_block_processed_idempotently(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Processing the same block twice leaves the fork choice store unchanged.
+
+    Scenario
+    --------
+    Process a block at slot 1, then process the exact same block again.
+
+    Expected Behavior:
+        - Both block processing steps succeed
+        - The second step reuses the same block root as the first
+        - Head, justified checkpoint, and finalized checkpoint remain unchanged
+
+    Why This Matters
+    ----------------
+    Duplicate block delivery is normal in real networks:
+    - gossip can deliver the same block multiple times
+    - syncing from multiple peers can produce duplicates
+
+    The store must be idempotent for already-known blocks. Reprocessing a
+    duplicate must return the store unchanged instead of erroring or mutating.
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(1),
+                    proposer_index=ValidatorIndex(1),
+                    parent_label="genesis",
+                    label="block_1",
+                ),
+                valid=True,
+                checks=StoreChecks(
+                    head_slot=Slot(1),
+                    head_root_label="block_1",
+                    latest_justified_slot=Slot(0),
+                    latest_justified_root_label="genesis",
+                    latest_finalized_slot=Slot(0),
+                    latest_finalized_root_label="genesis",
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(1),
+                    proposer_index=ValidatorIndex(1),
+                    parent_label="genesis",
+                    label="block_1_dup",
+                ),
+                valid=True,
+                checks=StoreChecks(
+                    head_slot=Slot(1),
+                    head_root_label="block_1",
+                    filled_block_root_label="block_1",
+                    latest_justified_slot=Slot(0),
+                    latest_justified_root_label="genesis",
+                    latest_finalized_slot=Slot(0),
+                    latest_finalized_root_label="genesis",
+                ),
+            ),
+        ],
+    )
+
+
 def test_head_with_two_competing_forks(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:

--- a/tests/consensus/devnet/fc/test_fork_choice_head.py
+++ b/tests/consensus/devnet/fc/test_fork_choice_head.py
@@ -182,57 +182,92 @@ def test_duplicate_block_processed_idempotently(
 
     Scenario
     --------
-    Process a block at slot 1, then process the exact same block again.
+    Four validators. Build a chain, then re-submit the last block::
 
-    Expected Behavior:
-        - Both block processing steps succeed
-        - The second step reuses the same block root as the first
-        - Head, justified checkpoint, and finalized checkpoint remain unchanged
+        genesis -> block_1(1) -> block_2(2) -> block_2_dup(2)
+                                                 (same root)
 
-    Why This Matters
-    ----------------
-    Duplicate block delivery is normal in real networks:
-    - gossip can deliver the same block multiple times
-    - syncing from multiple peers can produce duplicates
+    Block 2 carries attestations from V0-V2 targeting slot 1.
+    This crosses the 2/3 threshold and justifies slot 1.
 
-    The store must be idempotent for already-known blocks. Reprocessing a
-    duplicate must return the store unchanged instead of erroring or mutating.
+    Then block 2 is re-submitted with identical parameters.
+    The store detects the duplicate root and returns unchanged.
+
+    Expected post-state
+    -------------------
+    - Both steps succeed (no error)
+    - Second block has the same root as the first (filled_block_root_label)
+    - Head, justified, finalized all unchanged after the duplicate
+    - No double-counting of attestation votes
     """
     fork_choice_test(
         steps=[
             BlockStep(
-                block=BlockSpec(
-                    slot=Slot(1),
-                    proposer_index=ValidatorIndex(1),
-                    parent_label="genesis",
-                    label="block_1",
-                ),
-                valid=True,
-                checks=StoreChecks(
-                    head_slot=Slot(1),
-                    head_root_label="block_1",
-                    latest_justified_slot=Slot(0),
-                    latest_justified_root_label="genesis",
-                    latest_finalized_slot=Slot(0),
-                    latest_finalized_root_label="genesis",
-                ),
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1)),
             ),
+            # Block 2 with attestations that justify slot 1.
+            # Threshold: 3*3=9 >= 2*4=8 -> justifies.
             BlockStep(
                 block=BlockSpec(
-                    slot=Slot(1),
-                    proposer_index=ValidatorIndex(1),
-                    parent_label="genesis",
-                    label="block_1_dup",
+                    slot=Slot(2),
+                    parent_label="block_1",
+                    label="block_2",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[
+                                ValidatorIndex(0),
+                                ValidatorIndex(1),
+                                ValidatorIndex(2),
+                            ],
+                            slot=Slot(2),
+                            target_slot=Slot(1),
+                            target_root_label="block_1",
+                        ),
+                    ],
                 ),
-                valid=True,
                 checks=StoreChecks(
-                    head_slot=Slot(1),
-                    head_root_label="block_1",
-                    filled_block_root_label="block_1",
-                    latest_justified_slot=Slot(0),
-                    latest_justified_root_label="genesis",
+                    head_slot=Slot(2),
+                    head_root_label="block_2",
+                    latest_justified_slot=Slot(1),
+                    latest_justified_root_label="block_1",
                     latest_finalized_slot=Slot(0),
-                    latest_finalized_root_label="genesis",
+                ),
+            ),
+            # Re-submit the exact same block.
+            # Same slot, same parent, same proposer, same attestations
+            # -> deterministic state_root -> same block root.
+            #
+            # The store's on_block checks: block_root in self.blocks.
+            # It finds the root from step 2 -> returns self unchanged.
+            #
+            # filled_block_root_label="block_2" proves the roots match.
+            # The unchanged justified/finalized proves no double-counting.
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(2),
+                    parent_label="block_1",
+                    label="block_2_dup",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[
+                                ValidatorIndex(0),
+                                ValidatorIndex(1),
+                                ValidatorIndex(2),
+                            ],
+                            slot=Slot(2),
+                            target_slot=Slot(1),
+                            target_root_label="block_1",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    head_root_label="block_2",
+                    filled_block_root_label="block_2",
+                    latest_justified_slot=Slot(1),
+                    latest_justified_root_label="block_1",
+                    latest_finalized_slot=Slot(0),
                 ),
             ),
         ],


### PR DESCRIPTION
• ## Summary
Add a devnet fork choice test for duplicate block processing idempotency.

  Closes #571

  ## What changed
  - Add a filler that processes the same slot 1 block twice
  - Assert both block steps succeed
  - Assert the second submission rebuilds the same block root
  - Assert head, justified, and finalized state remain unchanged after the duplicate

  ## Why
Duplicate block delivery is expected during gossip and sync, and fork choice must treat already-processed blocks as a no-op.