### PR TITLE
test(fc): produce block includes pending attestations

### DIFF
--- a/tests/consensus/devnet/fc/test_block_production.py
+++ b/tests/consensus/devnet/fc/test_block_production.py
@@ -233,3 +233,84 @@ def test_block_builder_fixed_point_advances_justification(
             ),
         ],
     )
+
+
+def test_produce_block_includes_pending_attestations(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Block production includes attestations accumulated via gossip.
+
+    Scenario
+    --------
+    Four validators. Linear chain through slot 2::
+
+        genesis(0) -> block_1(1) -> block_2(2)
+
+    One gossip aggregated attestation from validators {1, 2} targeting
+    block_2.  The next block (slot 3) is produced without explicit
+    attestations — the builder reads from the store's known payload pool.
+
+    Timing
+    ------
+    ::
+
+        10s = interval 12 = slot 2, interval 2 (aggregate)
+              Pool is empty, so aggregation is a no-op.
+
+        12s = interval 15 = slot 3, interval 0
+              Advances time so the block at slot 3 is valid.
+
+    The tick alone does not migrate pending payloads to known.
+    The block builder merges and processes pending payloads internally
+    before selecting attestations for the block body.
+
+    Expected
+    --------
+    - 1 aggregated attestation in the block body
+    - Covers validators {1, 2}
+    - Target slot 2
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), label="block_2"),
+                checks=StoreChecks(head_slot=Slot(2)),
+            ),
+            # Advance past the aggregate interval while the pool is empty.
+            TickStep(time=10),
+            # Validators 1 & 2 gossip an aggregated attestation targeting block_2.
+            # slot=3 is one slot ahead of current (slot 2): within the allowed margin.
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(1), ValidatorIndex(2)],
+                    slot=Slot(3),
+                    target_slot=Slot(2),
+                    target_root_label="block_2",
+                ),
+            ),
+            # Advance time to slot 3 so the block proposal is valid.
+            TickStep(time=12),
+            # Produce block without explicit attestations.
+            # The block builder merges pending gossip payloads before calling
+            # the state transition, so the gossip attestation above is included.
+            BlockStep(
+                block=BlockSpec(slot=Slot(3), label="block_3"),
+                checks=StoreChecks(
+                    head_slot=Slot(3),
+                    block_attestation_count=1,
+                    block_attestations=[
+                        AggregatedAttestationCheck(
+                            participants={1, 2},
+                            attestation_slot=Slot(3),
+                            target_slot=Slot(2),
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )


### PR DESCRIPTION
Closes #563

## 🗒️ Description

Adds a fork choice filler that tests the end-to-end block production path where gossip-accumulated attestations are included in a produced block.

Before this PR, every filler in this file used `BlockSpec.attestations` to supply attestations explicitly. That path bypasses the store's gossip pipeline entirely. This test exercises the real path: validators gossip an aggregated attestation, and the next block builder picks it up from the store's known payload pool.

**What the test does:**

1. Builds a short chain: `genesis(0) → block_1(1) → block_2(2)`
2. Ticks past the aggregate interval while the pool is empty (no-op)
3. Gossips an aggregated attestation from validators {1, 2} targeting `block_2`
4. Ticks to slot 3
5. Produces block at slot 3 with no explicit attestations
6. Asserts the block body contains exactly one aggregated attestation covering validators {1, 2} with target slot 2

**Key implementation note:**

The new → known migration does not happen via the tick. The block builder merges and processes pending gossip payloads internally before passing them to the state transition. This is why no explicit migration step is needed between the gossip and the block production.

## 🔗 Related Issues or PRs

Closes #563

## ✅ Checklist

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.