### PR TITLE
Add fork choice store pruning test

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -289,6 +289,9 @@ class ForkChoiceTest(BaseConsensusFixture):
                         store = store.on_gossip_attestation(
                             signed_attestation,
                             scheme=LEAN_ENV_TO_SCHEMES[self.lean_env],
+                            # Fork choice fillers need raw gossip signatures to remain in the
+                            # store so tests can cover aggregation and pruning behavior.
+                            is_aggregator=True,
                         )
 
                     case GossipAggregatedAttestationStep():

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -289,9 +289,7 @@ class ForkChoiceTest(BaseConsensusFixture):
                         store = store.on_gossip_attestation(
                             signed_attestation,
                             scheme=LEAN_ENV_TO_SCHEMES[self.lean_env],
-                            # Fork choice fillers need raw gossip signatures to remain in the
-                            # store so tests can cover aggregation and pruning behavior.
-                            is_aggregator=True,
+                            is_aggregator=step.is_aggregator,
                         )
 
                     case GossipAggregatedAttestationStep():

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -149,6 +149,15 @@ class AttestationStep(BaseForkChoiceStep):
     The framework fills in the attestation data and signature during make_fixture().
     """
 
+    is_aggregator: bool = False
+    """
+    Whether the node holds the aggregator role for this attestation.
+
+    Only aggregator nodes store gossip signatures in the raw signature pool.
+    Defaults to False so existing fillers preserve the behavior where gossip
+    attestations are validated but not stored.
+    """
+
     _filled_attestation: SignedAttestation | None = PrivateAttr(default=None)
     """The filled SignedAttestation, processed through the spec."""
 

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -182,7 +182,7 @@ class StoreChecks(CamelModel):
 
     attestation_signature_target_slots: list[Slot] | None = None
     """
-    Expected target slots present in ``attestation_signatures``.
+    Expected target slots present in attestation_signatures.
 
     Compares the exact set of target checkpoint slots keyed in the raw gossip
     signature map, independent of how many validators signed each target.
@@ -190,7 +190,7 @@ class StoreChecks(CamelModel):
 
     latest_new_aggregated_target_slots: list[Slot] | None = None
     """
-    Expected target slots present in ``latest_new_aggregated_payloads``.
+    Expected target slots present in latest_new_aggregated_payloads.
 
     Compares the exact set of target checkpoint slots keyed in the pending
     aggregated proof map.
@@ -198,7 +198,7 @@ class StoreChecks(CamelModel):
 
     latest_known_aggregated_target_slots: list[Slot] | None = None
     """
-    Expected target slots present in ``latest_known_aggregated_payloads``.
+    Expected target slots present in latest_known_aggregated_payloads.
 
     Compares the exact set of target checkpoint slots keyed in the accepted
     aggregated proof map.

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -180,6 +180,30 @@ class StoreChecks(CamelModel):
     attestation_checks: list[AttestationCheck] | None = None
     """Optional list of attestation content checks for specific validators."""
 
+    attestation_signature_target_slots: list[Slot] | None = None
+    """
+    Expected target slots present in ``attestation_signatures``.
+
+    Compares the exact set of target checkpoint slots keyed in the raw gossip
+    signature map, independent of how many validators signed each target.
+    """
+
+    latest_new_aggregated_target_slots: list[Slot] | None = None
+    """
+    Expected target slots present in ``latest_new_aggregated_payloads``.
+
+    Compares the exact set of target checkpoint slots keyed in the pending
+    aggregated proof map.
+    """
+
+    latest_known_aggregated_target_slots: list[Slot] | None = None
+    """
+    Expected target slots present in ``latest_known_aggregated_payloads``.
+
+    Compares the exact set of target checkpoint slots keyed in the accepted
+    aggregated proof map.
+    """
+
     block_attestation_count: int | None = None
     """
     Expected number of aggregated attestations in the block body.
@@ -350,6 +374,24 @@ class StoreChecks(CamelModel):
                         f"{label}_aggregated_payloads"
                     )
                 check.validate_attestation(extracted[check.validator], label, step_index)
+
+        if "attestation_signature_target_slots" in fields:
+            assert self.attestation_signature_target_slots is not None
+            actual = sorted({data.target.slot for data in store.attestation_signatures})
+            expected = sorted(self.attestation_signature_target_slots)
+            _check("attestation_signatures.target_slots", actual, expected)
+
+        if "latest_new_aggregated_target_slots" in fields:
+            assert self.latest_new_aggregated_target_slots is not None
+            actual = sorted({data.target.slot for data in store.latest_new_aggregated_payloads})
+            expected = sorted(self.latest_new_aggregated_target_slots)
+            _check("latest_new_aggregated_payloads.target_slots", actual, expected)
+
+        if "latest_known_aggregated_target_slots" in fields:
+            assert self.latest_known_aggregated_target_slots is not None
+            actual = sorted({data.target.slot for data in store.latest_known_aggregated_payloads})
+            expected = sorted(self.latest_known_aggregated_target_slots)
+            _check("latest_known_aggregated_payloads.target_slots", actual, expected)
 
         # Block body attestation count
         if "block_attestation_count" in fields:

--- a/tests/consensus/devnet/fc/test_store_pruning.py
+++ b/tests/consensus/devnet/fc/test_store_pruning.py
@@ -62,6 +62,7 @@ def test_finalization_prunes_stale_aggregated_payloads(
     """
     fork_choice_test(
         steps=[
+            # Phase 1: Build chain and achieve finalized=1, justified=2
             BlockStep(
                 block=BlockSpec(slot=Slot(1), label="block_1"),
                 checks=StoreChecks(head_slot=Slot(1)),
@@ -70,6 +71,7 @@ def test_finalization_prunes_stale_aggregated_payloads(
                 block=BlockSpec(slot=Slot(2), label="block_2"),
                 checks=StoreChecks(head_slot=Slot(2)),
             ),
+            # Justify slot 1: supermajority (3/4) with source=genesis/0, target=block_1/1
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(3),
@@ -97,6 +99,8 @@ def test_finalization_prunes_stale_aggregated_payloads(
                 block=BlockSpec(slot=Slot(4), label="block_4"),
                 checks=StoreChecks(head_slot=Slot(4)),
             ),
+            # Justify slot 2: supermajority (3/4) with source=block_1/1, target=block_2/2
+            # Finalization: range(1+1, 2) = [] -> finalizes slot 1
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(5),
@@ -120,7 +124,20 @@ def test_finalization_prunes_stale_aggregated_payloads(
                     latest_finalized_slot=Slot(1),
                 ),
             ),
+            # Phase 2: Fire aggregate interval on empty pool, then submit gossip
+            #
+            # aggregate() at interval 2 discards lone child proofs from "new".
+            # Gossip must be submitted AFTER the aggregate interval so that
+            # the subsequent acceptance interval (slot 5, interval 4) can
+            # migrate them from "new" to "known" during the block_6 tick.
+            #
+            # time=22 => floor(22000/800) = interval 27 = slot 5, interval 2.
+            # Pool is empty at this point so aggregate is a no-op.
             TickStep(time=22),
+            # Store time is now interval 27 (slot 5, interval 2).
+            # Both attestations go into latest_new_aggregated_payloads.
+            #
+            # Stale gossip: target=1 (at finalized slot), should be pruned later
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -135,6 +152,8 @@ def test_finalization_prunes_stale_aggregated_payloads(
                     source_root_label="genesis",
                 ),
             ),
+            # Fresh gossip: target=5 (above finalized), should survive pruning
+            # V3 is unique to this attestation (not in stale)
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -163,6 +182,20 @@ def test_finalization_prunes_stale_aggregated_payloads(
                     ],
                 ),
             ),
+            # Phase 3: Advance finalization to trigger pruning
+            #
+            # block_6 carries supermajority (V0,V1,V2) justifying slot 3
+            # Source auto-resolves to parent state's justified = (block_2, slot 2)
+            #
+            # BlockStep auto-ticks from interval 27 to interval 30 (slot 6 start),
+            # passing through interval 29 (slot 5, interval 4) which calls
+            # accept_new_attestations() -- gossip migrates from "new" to "known"
+            #
+            # on_block processes block_6:
+            # - In-block attestation justifies slot 3, source=2 -> finalizes slot 2
+            # - prune_stale_attestation_data is called
+            # - Stale (target=1 <= finalized=2): REMOVED
+            # - Fresh (target=5 > finalized=2): KEPT in "known"
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(6),
@@ -203,27 +236,43 @@ def test_finalization_prunes_stale_attestation_signatures(
 
     Scenario
     --------
-    1. Build a canonical chain through slot 5 and reach finalized slot 2
-    2. Populate raw gossip signatures, pending aggregated payloads, and known
-       aggregated payloads with attestation targets at slots 1 through 5
-    3. Process block 6, which justifies slot 4 and advances finalization to slot 3
+    Eight validators. Linear chain through slot 6.
 
-    Expected Behavior
-    -----------------
-    1. Before finalization advances, all three attestation pools contain targets
-       at slots 1, 2, 3, 4, and 5
-    2. After finalization reaches slot 3, targets 1, 2, and 3 are pruned
-    3. Targets 4 and 5 remain in all three pools
+    Phase 1 -- Build chain and reach finalized=2, justified=3::
+
+        genesis(0) -> block_1(1) -> block_2(2) -> block_3(3) -> block_4(4) -> block_5(5)
+
+    - block_2 carries supermajority (6/8) justifying slot 1 -> finalized=0
+    - block_3 carries supermajority (6/8) justifying slot 2 -> finalized=1
+    - block_4 carries supermajority (6/8) justifying slot 3 -> finalized=2
+    - block_5 is empty (no further finalization advance)
+
+    Phase 2 -- Populate all three attestation pools with targets 1-5:
+
+    - TickStep to time=23 (slot 5, interval 3): safe target update interval
+    - First batch (V0-V2): gossip aggregated attestations for each target
+    - TickStep to time=24 (slot 6, interval 0): passes through slot 5 interval 4,
+      which calls accept_new_attestations() -- first batch migrates to "known"
+    - Second batch (V3-V5): gossip aggregated attestations -> land in "new"
+    - Individual gossip (V6): attestation signatures with is_aggregator=True
+
+    Phase 3 -- Advance finalization to slot 3 and verify pruning:
+
+    - block_6 carries supermajority (6/8) justifying slot 4 -> finalized=3
+    - Targets 1, 2, 3 (at or below finalized): pruned from all pools
+    - Targets 4, 5 (above finalized): kept in all pools
     """
     all_targets = [Slot(i) for i in range(1, 6)]
 
     fork_choice_test(
         anchor_state=generate_pre_state(num_validators=8),
         steps=[
+            # Phase 1: Build chain and achieve finalized=2, justified=3
             BlockStep(
                 block=BlockSpec(slot=Slot(1), label="block_1"),
                 checks=StoreChecks(head_slot=Slot(1)),
             ),
+            # Justify slot 1: supermajority (6/8) with source=genesis, target=block_1
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(2),
@@ -244,6 +293,8 @@ def test_finalization_prunes_stale_attestation_signatures(
                     latest_finalized_slot=Slot(0),
                 ),
             ),
+            # Justify slot 2: supermajority (6/8) with source=block_1/1, target=block_2/2
+            # Consecutive justification (1->2) finalizes slot 1
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(3),
@@ -264,6 +315,8 @@ def test_finalization_prunes_stale_attestation_signatures(
                     latest_finalized_slot=Slot(1),
                 ),
             ),
+            # Justify slot 3: supermajority (6/8) with source=block_2/2, target=block_3/3
+            # Consecutive justification (2->3) finalizes slot 2
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(4),
@@ -296,7 +349,16 @@ def test_finalization_prunes_stale_attestation_signatures(
                     latest_finalized_slot=Slot(2),
                 ),
             ),
+            # Phase 2: Populate all three attestation pools with targets 1-5
+            #
+            # time=23 => floor(23000/800) = interval 28 = slot 5, interval 3.
+            # This is the safe target update interval.
             TickStep(time=23),
+            # First batch (V0-V2): gossip aggregated attestations for all targets.
+            # These land in latest_new_aggregated_payloads.
+            # Source checkpoints use genesis for stale targets (1,2) and the
+            # correct justified checkpoint for targets that were justified at
+            # their respective slots.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
@@ -313,8 +375,8 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(2),
                     target_root_label="block_2",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_1",
+                    source_slot=Slot(1),
                 ),
             ),
             GossipAggregatedAttestationStep(
@@ -323,8 +385,8 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(3),
                     target_root_label="block_3",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_2",
+                    source_slot=Slot(2),
                 ),
             ),
             GossipAggregatedAttestationStep(
@@ -333,8 +395,8 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(4),
                     target_root_label="block_4",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_3",
+                    source_slot=Slot(3),
                 ),
             ),
             GossipAggregatedAttestationStep(
@@ -343,10 +405,13 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(5),
                     target_root_label="block_5",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_3",
+                    source_slot=Slot(3),
                 ),
             ),
+            # time=24 => floor(24000/800) = interval 30 = slot 6, interval 0.
+            # Ticking from 28 to 30 passes through interval 29 (slot 5, interval 4)
+            # which calls accept_new_attestations() -- first batch migrates to "known".
             TickStep(
                 time=24,
                 checks=StoreChecks(
@@ -356,6 +421,8 @@ def test_finalization_prunes_stale_attestation_signatures(
                     latest_known_aggregated_target_slots=all_targets,
                 ),
             ),
+            # Second batch (V3-V5): gossip aggregated attestations for all targets.
+            # These land in latest_new_aggregated_payloads (first batch already migrated).
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[ValidatorIndex(3), ValidatorIndex(4), ValidatorIndex(5)],
@@ -372,8 +439,8 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(2),
                     target_root_label="block_2",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_1",
+                    source_slot=Slot(1),
                 ),
             ),
             GossipAggregatedAttestationStep(
@@ -382,8 +449,8 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(3),
                     target_root_label="block_3",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_2",
+                    source_slot=Slot(2),
                 ),
             ),
             GossipAggregatedAttestationStep(
@@ -392,8 +459,8 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(4),
                     target_root_label="block_4",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_3",
+                    source_slot=Slot(3),
                 ),
             ),
             GossipAggregatedAttestationStep(
@@ -402,10 +469,12 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(5),
                     target_root_label="block_5",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_3",
+                    source_slot=Slot(3),
                 ),
             ),
+            # Individual gossip signatures (V6) with is_aggregator=True.
+            # These populate attestation_signatures (the raw signature pool).
             AttestationStep(
                 attestation=GossipAttestationSpec(
                     validator_id=ValidatorIndex(6),
@@ -415,6 +484,7 @@ def test_finalization_prunes_stale_attestation_signatures(
                     source_root_label="genesis",
                     source_slot=Slot(0),
                 ),
+                is_aggregator=True,
             ),
             AttestationStep(
                 attestation=GossipAttestationSpec(
@@ -422,9 +492,10 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(2),
                     target_root_label="block_2",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_1",
+                    source_slot=Slot(1),
                 ),
+                is_aggregator=True,
             ),
             AttestationStep(
                 attestation=GossipAttestationSpec(
@@ -432,9 +503,10 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(3),
                     target_root_label="block_3",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_2",
+                    source_slot=Slot(2),
                 ),
+                is_aggregator=True,
             ),
             AttestationStep(
                 attestation=GossipAttestationSpec(
@@ -442,19 +514,22 @@ def test_finalization_prunes_stale_attestation_signatures(
                     slot=Slot(6),
                     target_slot=Slot(4),
                     target_root_label="block_4",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_3",
+                    source_slot=Slot(3),
                 ),
+                is_aggregator=True,
             ),
+            # Pre-finalization check: all three pools contain targets 1-5
             AttestationStep(
                 attestation=GossipAttestationSpec(
                     validator_id=ValidatorIndex(6),
                     slot=Slot(6),
                     target_slot=Slot(5),
                     target_root_label="block_5",
-                    source_root_label="genesis",
-                    source_slot=Slot(0),
+                    source_root_label="block_3",
+                    source_slot=Slot(3),
                 ),
+                is_aggregator=True,
                 checks=StoreChecks(
                     latest_finalized_slot=Slot(2),
                     attestation_signature_target_slots=all_targets,
@@ -462,6 +537,20 @@ def test_finalization_prunes_stale_attestation_signatures(
                     latest_known_aggregated_target_slots=all_targets,
                 ),
             ),
+            # Phase 3: Advance finalization to trigger pruning
+            #
+            # build_signed_block_with_store aggregates the gossip pool and includes
+            # all known payloads in block_6. The block carries attestations for ALL
+            # targets 1-5 (from gossip pools) plus the explicit target=4 spec.
+            #
+            # State transition processes them in order:
+            # - Targets 1, 2, 3: already justified, skipped
+            # - Target 4 (source=3): supermajority -> justified, no gap -> finalizes 3
+            # - Target 5 (source=3): supermajority -> justified, gap at slot 4 -> no
+            #   further finalization
+            #
+            # Result: justified=5, finalized=3
+            # prune_stale_attestation_data removes targets <= 3 from all pools
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(6),
@@ -478,7 +567,7 @@ def test_finalization_prunes_stale_attestation_signatures(
                 ),
                 checks=StoreChecks(
                     head_slot=Slot(6),
-                    latest_justified_slot=Slot(4),
+                    latest_justified_slot=Slot(5),
                     latest_finalized_slot=Slot(3),
                     attestation_signature_target_slots=[Slot(4), Slot(5)],
                     latest_new_aggregated_target_slots=[Slot(4), Slot(5)],

--- a/tests/consensus/devnet/fc/test_store_pruning.py
+++ b/tests/consensus/devnet/fc/test_store_pruning.py
@@ -1,16 +1,19 @@
-"""Fork Choice: Finalization prunes stale aggregated payloads."""
+"""Fork Choice: Store pruning on finalization."""
 
 import pytest
 from consensus_testing import (
     AggregatedAttestationSpec,
     AttestationCheck,
+    AttestationStep,
     BlockSpec,
     BlockStep,
     ForkChoiceTestFiller,
     GossipAggregatedAttestationSpec,
     GossipAggregatedAttestationStep,
+    GossipAttestationSpec,
     StoreChecks,
     TickStep,
+    generate_pre_state,
 )
 
 from lean_spec.subspecs.containers.slot import Slot
@@ -59,7 +62,6 @@ def test_finalization_prunes_stale_aggregated_payloads(
     """
     fork_choice_test(
         steps=[
-            # Phase 1: Build chain and achieve finalized=1, justified=2
             BlockStep(
                 block=BlockSpec(slot=Slot(1), label="block_1"),
                 checks=StoreChecks(head_slot=Slot(1)),
@@ -68,7 +70,6 @@ def test_finalization_prunes_stale_aggregated_payloads(
                 block=BlockSpec(slot=Slot(2), label="block_2"),
                 checks=StoreChecks(head_slot=Slot(2)),
             ),
-            # Justify slot 1: supermajority (3/4) with source=genesis/0, target=block_1/1
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(3),
@@ -96,8 +97,6 @@ def test_finalization_prunes_stale_aggregated_payloads(
                 block=BlockSpec(slot=Slot(4), label="block_4"),
                 checks=StoreChecks(head_slot=Slot(4)),
             ),
-            # Justify slot 2: supermajority (3/4) with source=block_1/1, target=block_2/2
-            # Finalization: range(1+1, 2) = [] -> finalizes slot 1
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(5),
@@ -121,20 +120,7 @@ def test_finalization_prunes_stale_aggregated_payloads(
                     latest_finalized_slot=Slot(1),
                 ),
             ),
-            # Phase 2: Fire aggregate interval on empty pool, then submit gossip
-            #
-            # aggregate() at interval 2 discards lone child proofs from "new".
-            # Gossip must be submitted AFTER the aggregate interval so that
-            # the subsequent acceptance interval (slot 5, interval 4) can
-            # migrate them from "new" to "known" during the block_6 tick.
-            #
-            # time=22 => floor(22000/800) = interval 27 = slot 5, interval 2.
-            # Pool is empty at this point so aggregate is a no-op.
             TickStep(time=22),
-            # Store time is now interval 27 (slot 5, interval 2).
-            # Both attestations go into latest_new_aggregated_payloads.
-            #
-            # Stale gossip: target=1 (at finalized slot), should be pruned later
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -149,8 +135,6 @@ def test_finalization_prunes_stale_aggregated_payloads(
                     source_root_label="genesis",
                 ),
             ),
-            # Fresh gossip: target=5 (above finalized), should survive pruning
-            # V3 is unique to this attestation (not in stale)
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -179,20 +163,6 @@ def test_finalization_prunes_stale_aggregated_payloads(
                     ],
                 ),
             ),
-            # Phase 3: Advance finalization to trigger pruning
-            #
-            # block_6 carries supermajority (V0,V1,V2) justifying slot 3
-            # Source auto-resolves to parent state's justified = (block_2, slot 2)
-            #
-            # BlockStep auto-ticks from interval 27 to interval 30 (slot 6 start),
-            # passing through interval 29 (slot 5, interval 4) which calls
-            # accept_new_attestations() -- gossip migrates from "new" to "known"
-            #
-            # on_block processes block_6:
-            # - In-block attestation justifies slot 3, source=2 -> finalizes slot 2
-            # - prune_stale_attestation_data is called
-            # - Stale (target=1 <= finalized=2): REMOVED
-            # - Fresh (target=5 > finalized=2): KEPT in "known"
             BlockStep(
                 block=BlockSpec(
                     slot=Slot(6),
@@ -219,6 +189,300 @@ def test_finalization_prunes_stale_aggregated_payloads(
                             target_slot=Slot(5),
                         ),
                     ],
+                ),
+            ),
+        ],
+    )
+
+
+def test_finalization_prunes_stale_attestation_signatures(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Finalization prunes stale attestation data across all store pools.
+
+    Scenario
+    --------
+    1. Build a canonical chain through slot 5 and reach finalized slot 2
+    2. Populate raw gossip signatures, pending aggregated payloads, and known
+       aggregated payloads with attestation targets at slots 1 through 5
+    3. Process block 6, which justifies slot 4 and advances finalization to slot 3
+
+    Expected Behavior
+    -----------------
+    1. Before finalization advances, all three attestation pools contain targets
+       at slots 1, 2, 3, 4, and 5
+    2. After finalization reaches slot 3, targets 1, 2, and 3 are pruned
+    3. Targets 4 and 5 remain in all three pools
+    """
+    all_targets = [Slot(i) for i in range(1, 6)]
+
+    fork_choice_test(
+        anchor_state=generate_pre_state(num_validators=8),
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(2),
+                    label="block_2",
+                    parent_label="block_1",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(2),
+                            target_slot=Slot(1),
+                            target_root_label="block_1",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    latest_justified_slot=Slot(1),
+                    latest_finalized_slot=Slot(0),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(3),
+                    label="block_3",
+                    parent_label="block_2",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(3),
+                            target_slot=Slot(2),
+                            target_root_label="block_2",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(3),
+                    latest_justified_slot=Slot(2),
+                    latest_finalized_slot=Slot(1),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(4),
+                    label="block_4",
+                    parent_label="block_3",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(4),
+                            target_slot=Slot(3),
+                            target_root_label="block_3",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(4),
+                    latest_justified_slot=Slot(3),
+                    latest_finalized_slot=Slot(2),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(5),
+                    label="block_5",
+                    parent_label="block_4",
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(5),
+                    latest_justified_slot=Slot(3),
+                    latest_finalized_slot=Slot(2),
+                ),
+            ),
+            TickStep(time=23),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
+                    slot=Slot(6),
+                    target_slot=Slot(1),
+                    target_root_label="block_1",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
+                    slot=Slot(6),
+                    target_slot=Slot(2),
+                    target_root_label="block_2",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
+                    slot=Slot(6),
+                    target_slot=Slot(3),
+                    target_root_label="block_3",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
+                    slot=Slot(6),
+                    target_slot=Slot(4),
+                    target_root_label="block_4",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
+                    slot=Slot(6),
+                    target_slot=Slot(5),
+                    target_root_label="block_5",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            TickStep(
+                time=24,
+                checks=StoreChecks(
+                    latest_finalized_slot=Slot(2),
+                    attestation_signature_target_slots=[],
+                    latest_new_aggregated_target_slots=[],
+                    latest_known_aggregated_target_slots=all_targets,
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(3), ValidatorIndex(4), ValidatorIndex(5)],
+                    slot=Slot(6),
+                    target_slot=Slot(1),
+                    target_root_label="block_1",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(3), ValidatorIndex(4), ValidatorIndex(5)],
+                    slot=Slot(6),
+                    target_slot=Slot(2),
+                    target_root_label="block_2",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(3), ValidatorIndex(4), ValidatorIndex(5)],
+                    slot=Slot(6),
+                    target_slot=Slot(3),
+                    target_root_label="block_3",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(3), ValidatorIndex(4), ValidatorIndex(5)],
+                    slot=Slot(6),
+                    target_slot=Slot(4),
+                    target_root_label="block_4",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(3), ValidatorIndex(4), ValidatorIndex(5)],
+                    slot=Slot(6),
+                    target_slot=Slot(5),
+                    target_root_label="block_5",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            AttestationStep(
+                attestation=GossipAttestationSpec(
+                    validator_id=ValidatorIndex(6),
+                    slot=Slot(6),
+                    target_slot=Slot(1),
+                    target_root_label="block_1",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            AttestationStep(
+                attestation=GossipAttestationSpec(
+                    validator_id=ValidatorIndex(6),
+                    slot=Slot(6),
+                    target_slot=Slot(2),
+                    target_root_label="block_2",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            AttestationStep(
+                attestation=GossipAttestationSpec(
+                    validator_id=ValidatorIndex(6),
+                    slot=Slot(6),
+                    target_slot=Slot(3),
+                    target_root_label="block_3",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            AttestationStep(
+                attestation=GossipAttestationSpec(
+                    validator_id=ValidatorIndex(6),
+                    slot=Slot(6),
+                    target_slot=Slot(4),
+                    target_root_label="block_4",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+            ),
+            AttestationStep(
+                attestation=GossipAttestationSpec(
+                    validator_id=ValidatorIndex(6),
+                    slot=Slot(6),
+                    target_slot=Slot(5),
+                    target_root_label="block_5",
+                    source_root_label="genesis",
+                    source_slot=Slot(0),
+                ),
+                checks=StoreChecks(
+                    latest_finalized_slot=Slot(2),
+                    attestation_signature_target_slots=all_targets,
+                    latest_new_aggregated_target_slots=all_targets,
+                    latest_known_aggregated_target_slots=all_targets,
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(6),
+                    label="block_6",
+                    parent_label="block_5",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(6),
+                            target_slot=Slot(4),
+                            target_root_label="block_4",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(6),
+                    latest_justified_slot=Slot(4),
+                    latest_finalized_slot=Slot(3),
+                    attestation_signature_target_slots=[Slot(4), Slot(5)],
+                    latest_new_aggregated_target_slots=[Slot(4), Slot(5)],
+                    latest_known_aggregated_target_slots=[Slot(4), Slot(5)],
                 ),
             ),
         ],


### PR DESCRIPTION

## Summary
Add a fork choice filler for store pruning on finalization.

  Closes #567

  ## What changed
  - Add a devnet fork choice test covering pruning after finalization advances to slot 3
  - Verify stale attestation data targeting slots 1, 2, and 3 is removed
  - Verify attestation data targeting slots 4 and 5 is preserved
  - Extend `StoreChecks` with exact target-slot assertions for raw, new, and known attestation pools
  - Update fork choice attestation steps to retain raw gossip signatures so pruning can be tested end to end

  ## Why
Pruning stale attestation data is required to avoid unbounded memory growth and to ensure finalized targets no longer influence fork choice state.