### PR TITLE
test(networking): add gossipsub RPC protobuf encoding test vectors

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -4,7 +4,20 @@ from typing import Any, ClassVar
 
 from lean_spec.subspecs.containers.validator import SubnetId
 from lean_spec.subspecs.networking.gossipsub.message import GossipsubMessage
+from lean_spec.subspecs.networking.gossipsub.rpc import (
+    RPC,
+    ControlGraft,
+    ControlIDontWant,
+    ControlIHave,
+    ControlIWant,
+    ControlMessage,
+    ControlPrune,
+    Message,
+    PrunePeerInfo,
+    SubOpts,
+)
 from lean_spec.subspecs.networking.gossipsub.topic import GossipTopic, TopicKind
+from lean_spec.subspecs.networking.gossipsub.types import TopicId
 from lean_spec.subspecs.networking.varint import decode_varint, encode_varint
 
 from .base import BaseConsensusFixture
@@ -56,6 +69,8 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 output = self._make_gossip_topic()
             case "gossip_message_id":
                 output = self._make_gossip_message_id()
+            case "gossipsub_rpc":
+                output = self._make_gossipsub_rpc()
             case _:
                 raise ValueError(f"Unknown codec: {self.codec_name}")
         return self.model_copy(update={"output": output})
@@ -98,3 +113,86 @@ class NetworkingCodecTest(BaseConsensusFixture):
         message_id = GossipsubMessage.compute_id(topic, data, domain=domain)
 
         return {"messageId": _to_hex(message_id)}
+
+    def _make_gossipsub_rpc(self) -> dict[str, Any]:
+        """Encode an RPC message as protobuf, decode it back, assert roundtrip."""
+        rpc = _build_rpc(self.input)
+        encoded = rpc.encode()
+
+        # Decode and re-encode must produce identical bytes.
+        re_encoded = RPC.decode(encoded).encode()
+        assert encoded == re_encoded, "RPC roundtrip produced different bytes"
+
+        return {"encoded": _to_hex(encoded)}
+
+
+def _build_rpc(d: dict[str, Any]) -> RPC:
+    """Build an RPC from a JSON-friendly dict."""
+    subs = [_build_sub_opts(s) for s in d.get("subscriptions", [])]
+    msgs = [_build_message(m) for m in d.get("publish", [])]
+    ctrl = _build_control(d["control"]) if d.get("control") else None
+    return RPC(subscriptions=subs, publish=msgs, control=ctrl)
+
+
+def _build_sub_opts(d: dict[str, Any]) -> SubOpts:
+    """Build a SubOpts from a dict."""
+    return SubOpts(subscribe=d["subscribe"], topic_id=TopicId(d["topicId"]))
+
+
+def _build_message(d: dict[str, Any]) -> Message:
+    """Build a Message from a dict. Bytes fields are hex-encoded."""
+    return Message(
+        from_peer=_from_hex(d["fromPeer"]) if d.get("fromPeer") else b"",
+        data=_from_hex(d["data"]) if d.get("data") else b"",
+        seqno=_from_hex(d["seqno"]) if d.get("seqno") else b"",
+        topic=TopicId(d.get("topic", "")),
+        signature=_from_hex(d["signature"]) if d.get("signature") else b"",
+        key=_from_hex(d["key"]) if d.get("key") else b"",
+    )
+
+
+def _build_control(d: dict[str, Any]) -> ControlMessage:
+    """Build a ControlMessage from a dict."""
+    return ControlMessage(
+        ihave=[_build_ihave(x) for x in d.get("ihave", [])],
+        iwant=[_build_iwant(x) for x in d.get("iwant", [])],
+        graft=[ControlGraft(topic_id=TopicId(x["topicId"])) for x in d.get("graft", [])],
+        prune=[_build_prune(x) for x in d.get("prune", [])],
+        idontwant=[_build_idontwant(x) for x in d.get("idontwant", [])],
+    )
+
+
+def _build_ihave(d: dict[str, Any]) -> ControlIHave:
+    """Build a ControlIHave from a dict."""
+    return ControlIHave(
+        topic_id=TopicId(d.get("topicId", "")),
+        message_ids=[_from_hex(mid) for mid in d.get("messageIds", [])],
+    )
+
+
+def _build_iwant(d: dict[str, Any]) -> ControlIWant:
+    """Build a ControlIWant from a dict."""
+    return ControlIWant(message_ids=[_from_hex(mid) for mid in d.get("messageIds", [])])
+
+
+def _build_prune(d: dict[str, Any]) -> ControlPrune:
+    """Build a ControlPrune from a dict."""
+    peers = [_build_prune_peer(p) for p in d.get("peers", [])]
+    return ControlPrune(
+        topic_id=TopicId(d.get("topicId", "")),
+        peers=peers,
+        backoff=d.get("backoff", 0),
+    )
+
+
+def _build_prune_peer(p: dict[str, Any]) -> PrunePeerInfo:
+    """Build a PrunePeerInfo from a dict."""
+    return PrunePeerInfo(
+        peer_id=_from_hex(p["peerId"]) if p.get("peerId") else b"",
+        signed_peer_record=(_from_hex(p["signedPeerRecord"]) if p.get("signedPeerRecord") else b""),
+    )
+
+
+def _build_idontwant(d: dict[str, Any]) -> ControlIDontWant:
+    """Build a ControlIDontWant from a dict."""
+    return ControlIDontWant(message_ids=[_from_hex(mid) for mid in d.get("messageIds", [])])

--- a/tests/consensus/devnet/networking/test_gossipsub_rpc.py
+++ b/tests/consensus/devnet/networking/test_gossipsub_rpc.py
@@ -1,0 +1,398 @@
+"""Test vectors for gossipsub RPC protobuf encoding."""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+TOPIC_A = "/leanconsensus/0x12345678/block/ssz_snappy"
+TOPIC_B = "/leanconsensus/0x12345678/aggregation/ssz_snappy"
+MSG_ID_1 = "0x" + "aa" * 20
+MSG_ID_2 = "0x" + "bb" * 20
+MSG_ID_3 = "0x" + "cc" * 20
+PEER_ID = "0x" + "dd" * 32
+
+
+# --- SubOpts ---
+
+
+def test_sub_opts_subscribe(networking_codec: NetworkingCodecTestFiller) -> None:
+    """SubOpts encoding for a topic subscription."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [{"subscribe": True, "topicId": TOPIC_A}],
+            "publish": [],
+        },
+    )
+
+
+def test_sub_opts_unsubscribe(networking_codec: NetworkingCodecTestFiller) -> None:
+    """SubOpts encoding for a topic unsubscription."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [{"subscribe": False, "topicId": TOPIC_A}],
+            "publish": [],
+        },
+    )
+
+
+def test_sub_opts_empty_topic(networking_codec: NetworkingCodecTestFiller) -> None:
+    """SubOpts with an empty topic string."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [{"subscribe": True, "topicId": ""}],
+            "publish": [],
+        },
+    )
+
+
+# --- Message ---
+
+
+def test_message_topic_only(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Published message with only the topic field set."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [{"topic": TOPIC_A}],
+        },
+    )
+
+
+def test_message_all_fields(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Published message with every optional field populated."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [
+                {
+                    "fromPeer": "0x" + "01" * 32,
+                    "data": "0xdeadbeef",
+                    "seqno": "0x0000000000000001",
+                    "topic": TOPIC_A,
+                    "signature": "0x" + "ff" * 64,
+                    "key": "0x" + "02" * 33,
+                }
+            ],
+        },
+    )
+
+
+def test_message_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Published message with no fields set. Encodes as zero bytes."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [{}],
+        },
+    )
+
+
+# --- ControlGraft ---
+
+
+def test_graft_single_topic(networking_codec: NetworkingCodecTestFiller) -> None:
+    """GRAFT requesting mesh membership for one topic."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {"graft": [{"topicId": TOPIC_A}]},
+        },
+    )
+
+
+def test_graft_empty_topic(networking_codec: NetworkingCodecTestFiller) -> None:
+    """GRAFT with an empty topic string."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {"graft": [{"topicId": ""}]},
+        },
+    )
+
+
+# --- ControlIHave ---
+
+
+def test_ihave_single_id(networking_codec: NetworkingCodecTestFiller) -> None:
+    """IHAVE advertising one cached message ID."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "ihave": [{"topicId": TOPIC_A, "messageIds": [MSG_ID_1]}],
+            },
+        },
+    )
+
+
+def test_ihave_multiple_ids(networking_codec: NetworkingCodecTestFiller) -> None:
+    """IHAVE advertising three cached message IDs."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "ihave": [{"topicId": TOPIC_A, "messageIds": [MSG_ID_1, MSG_ID_2, MSG_ID_3]}],
+            },
+        },
+    )
+
+
+def test_ihave_empty_ids(networking_codec: NetworkingCodecTestFiller) -> None:
+    """IHAVE with a topic but no message IDs."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "ihave": [{"topicId": TOPIC_A, "messageIds": []}],
+            },
+        },
+    )
+
+
+# --- ControlIWant ---
+
+
+def test_iwant_single_id(networking_codec: NetworkingCodecTestFiller) -> None:
+    """IWANT requesting one message by ID."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "iwant": [{"messageIds": [MSG_ID_1]}],
+            },
+        },
+    )
+
+
+def test_iwant_multiple_ids(networking_codec: NetworkingCodecTestFiller) -> None:
+    """IWANT requesting two messages by ID."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "iwant": [{"messageIds": [MSG_ID_1, MSG_ID_2]}],
+            },
+        },
+    )
+
+
+# --- ControlPrune ---
+
+
+def test_prune_topic_only(networking_codec: NetworkingCodecTestFiller) -> None:
+    """PRUNE with topic but no peer exchange or backoff."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "prune": [{"topicId": TOPIC_A}],
+            },
+        },
+    )
+
+
+def test_prune_with_backoff(networking_codec: NetworkingCodecTestFiller) -> None:
+    """PRUNE with a 60-second backoff duration."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "prune": [{"topicId": TOPIC_A, "backoff": 60}],
+            },
+        },
+    )
+
+
+def test_prune_with_peer_exchange(networking_codec: NetworkingCodecTestFiller) -> None:
+    """PRUNE with peer exchange information and backoff."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "prune": [
+                    {
+                        "topicId": TOPIC_A,
+                        "backoff": 120,
+                        "peers": [
+                            {"peerId": PEER_ID, "signedPeerRecord": "0xcafebabe"},
+                        ],
+                    }
+                ],
+            },
+        },
+    )
+
+
+# --- ControlIDontWant ---
+
+
+def test_idontwant_single_id(networking_codec: NetworkingCodecTestFiller) -> None:
+    """IDONTWANT declining one message. Gossipsub v1.2 extension."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "idontwant": [{"messageIds": [MSG_ID_1]}],
+            },
+        },
+    )
+
+
+def test_idontwant_multiple_ids(networking_codec: NetworkingCodecTestFiller) -> None:
+    """IDONTWANT declining two messages."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "idontwant": [{"messageIds": [MSG_ID_1, MSG_ID_2]}],
+            },
+        },
+    )
+
+
+# --- ControlMessage ---
+
+
+def test_control_single_graft(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Control message containing only a single GRAFT."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {"graft": [{"topicId": TOPIC_A}]},
+        },
+    )
+
+
+def test_control_all_types(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Control message with one of each control type."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "ihave": [{"topicId": TOPIC_A, "messageIds": [MSG_ID_1]}],
+                "iwant": [{"messageIds": [MSG_ID_2]}],
+                "graft": [{"topicId": TOPIC_A}],
+                "prune": [{"topicId": TOPIC_B, "backoff": 60}],
+                "idontwant": [{"messageIds": [MSG_ID_3]}],
+            },
+        },
+    )
+
+
+def test_control_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Empty control message. All repeated fields empty, encodes to zero bytes."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {},
+        },
+    )
+
+
+# --- Full RPC ---
+
+
+def test_rpc_subscriptions_only(networking_codec: NetworkingCodecTestFiller) -> None:
+    """RPC with only subscription changes."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [
+                {"subscribe": True, "topicId": TOPIC_A},
+                {"subscribe": True, "topicId": TOPIC_B},
+            ],
+            "publish": [],
+        },
+    )
+
+
+def test_rpc_publish_only(networking_codec: NetworkingCodecTestFiller) -> None:
+    """RPC with only published messages."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [
+                {"topic": TOPIC_A, "data": "0xdeadbeef"},
+                {"topic": TOPIC_B, "data": "0xcafebabe"},
+            ],
+        },
+    )
+
+
+def test_rpc_control_only(networking_codec: NetworkingCodecTestFiller) -> None:
+    """RPC with only control messages."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+            "control": {
+                "graft": [{"topicId": TOPIC_A}],
+                "prune": [{"topicId": TOPIC_B, "backoff": 60}],
+            },
+        },
+    )
+
+
+def test_rpc_full(networking_codec: NetworkingCodecTestFiller) -> None:
+    """RPC with subscriptions, published messages, and control all present."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [{"subscribe": True, "topicId": TOPIC_A}],
+            "publish": [{"topic": TOPIC_A, "data": "0xdeadbeef"}],
+            "control": {
+                "graft": [{"topicId": TOPIC_B}],
+                "idontwant": [{"messageIds": [MSG_ID_1]}],
+            },
+        },
+    )
+
+
+def test_rpc_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Empty RPC. No subscriptions, messages, or control."""
+    networking_codec(
+        codec_name="gossipsub_rpc",
+        input={
+            "subscriptions": [],
+            "publish": [],
+        },
+    )


### PR DESCRIPTION
## Summary

- **26 new test vectors** for the gossipsub RPC protobuf wire format, covering all 10 dataclasses in the hand-rolled encoder/decoder (`rpc.py`)
- **First-ever test coverage** for ControlIDontWant (gossipsub v1.2 extension)
- Each vector encodes an RPC, decodes it back, asserts byte-identical roundtrip, and writes the reference protobuf bytes to a JSON fixture
- Extends the `NetworkingCodecTest` fixture with a `gossipsub_rpc` codec handler and builder functions for all RPC types

### Components covered

| Type | Vectors | What it tests |
|------|---------|---------------|
| SubOpts | 3 | subscribe, unsubscribe, empty topic |
| Message | 3 | topic only, all 6 fields, empty |
| ControlGraft | 2 | single topic, empty topic |
| ControlIHave | 3 | single ID, multiple IDs, empty list |
| ControlIWant | 2 | single ID, multiple IDs |
| ControlPrune | 3 | topic only, with backoff, with peer exchange |
| ControlIDontWant | 2 | single ID, multiple IDs |
| ControlMessage | 3 | single type, all types combined, empty |
| Full RPC | 5 | subs only, publish only, control only, full, empty |

## Test plan

- [x] `uvx tox -e all-checks` passes
- [x] `uv run fill --fork=devnet --clean -n auto -- tests/consensus/devnet/networking/` generates all 56 fixtures (30 Phase 1 + 26 new)
- [x] Verified JSON output contains codecName, structured input, and hex-encoded protobuf output
- [x] Verified roundtrip assertion catches encode/decode mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)