### PR TITLE
test(networking): add req/resp wire codec test vectors

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -18,6 +18,11 @@ from lean_spec.subspecs.networking.gossipsub.rpc import (
 )
 from lean_spec.subspecs.networking.gossipsub.topic import GossipTopic, TopicKind
 from lean_spec.subspecs.networking.gossipsub.types import TopicId
+from lean_spec.subspecs.networking.reqresp.codec import (
+    ResponseCode,
+    decode_request,
+    encode_request,
+)
 from lean_spec.subspecs.networking.varint import decode_varint, encode_varint
 
 from .base import BaseConsensusFixture
@@ -71,6 +76,10 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 output = self._make_gossip_message_id()
             case "gossipsub_rpc":
                 output = self._make_gossipsub_rpc()
+            case "reqresp_request":
+                output = self._make_reqresp_request()
+            case "reqresp_response":
+                output = self._make_reqresp_response()
             case _:
                 raise ValueError(f"Unknown codec: {self.codec_name}")
         return self.model_copy(update={"output": output})
@@ -122,6 +131,30 @@ class NetworkingCodecTest(BaseConsensusFixture):
         # Decode and re-encode must produce identical bytes.
         re_encoded = RPC.decode(encoded).encode()
         assert encoded == re_encoded, "RPC roundtrip produced different bytes"
+
+        return {"encoded": _to_hex(encoded)}
+
+    def _make_reqresp_request(self) -> dict[str, Any]:
+        """Encode an SSZ request as varint + snappy, decode it back, assert roundtrip."""
+        ssz_data = _from_hex(self.input["sszData"])
+        encoded = encode_request(ssz_data)
+
+        # Decode must recover the original SSZ bytes.
+        decoded = decode_request(encoded)
+        assert decoded == ssz_data, "Request roundtrip produced different bytes"
+
+        return {"encoded": _to_hex(encoded)}
+
+    def _make_reqresp_response(self) -> dict[str, Any]:
+        """Encode an SSZ response with code, decode it back, assert roundtrip."""
+        code = ResponseCode(self.input["responseCode"])
+        ssz_data = _from_hex(self.input["sszData"])
+        encoded = code.encode(ssz_data)
+
+        # Decode must recover both the response code and SSZ bytes.
+        decoded_code, decoded_data = ResponseCode.decode(encoded)
+        assert decoded_code == code, f"Code mismatch: {decoded_code} != {code}"
+        assert decoded_data == ssz_data, "Response roundtrip produced different bytes"
 
         return {"encoded": _to_hex(encoded)}
 

--- a/tests/consensus/devnet/networking/test_reqresp_codec.py
+++ b/tests/consensus/devnet/networking/test_reqresp_codec.py
@@ -1,0 +1,126 @@
+"""Test vectors for req/resp wire format encoding."""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+# --- Request encoding ---
+
+
+def test_request_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Request with empty SSZ payload. Varint prefix is 0x00."""
+    networking_codec(codec_name="reqresp_request", input={"sszData": "0x"})
+
+
+def test_request_small(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Request with 4-byte SSZ payload."""
+    networking_codec(codec_name="reqresp_request", input={"sszData": "0x01020304"})
+
+
+def test_request_varint_one_byte_max(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Request with 127-byte payload. Largest single-byte varint prefix."""
+    networking_codec(
+        codec_name="reqresp_request",
+        input={"sszData": "0x" + "ab" * 127},
+    )
+
+
+def test_request_varint_two_byte_min(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Request with 128-byte payload. Smallest two-byte varint prefix."""
+    networking_codec(
+        codec_name="reqresp_request",
+        input={"sszData": "0x" + "cd" * 128},
+    )
+
+
+def test_request_compressible(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Request with 1 KB of repeated data. Exercises Snappy copy tags."""
+    networking_codec(
+        codec_name="reqresp_request",
+        input={"sszData": "0x" + "deadbeef" * 256},
+    )
+
+
+def test_request_sequential(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Request with 256 sequential bytes. Low compression ratio."""
+    networking_codec(
+        codec_name="reqresp_request",
+        input={"sszData": "0x" + bytes(range(256)).hex()},
+    )
+
+
+def test_request_all_zeros(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Request with 32 zero bytes. Tests CRC32C on uniform input."""
+    networking_codec(
+        codec_name="reqresp_request",
+        input={"sszData": "0x" + "00" * 32},
+    )
+
+
+# --- Response encoding ---
+
+
+def test_response_success_small(networking_codec: NetworkingCodecTestFiller) -> None:
+    """SUCCESS response with 4-byte SSZ payload."""
+    networking_codec(
+        codec_name="reqresp_response",
+        input={"responseCode": 0, "sszData": "0x01020304"},
+    )
+
+
+def test_response_success_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+    """SUCCESS response with empty payload."""
+    networking_codec(
+        codec_name="reqresp_response",
+        input={"responseCode": 0, "sszData": "0x"},
+    )
+
+
+def test_response_invalid_request(networking_codec: NetworkingCodecTestFiller) -> None:
+    """INVALID_REQUEST response with UTF-8 error message."""
+    networking_codec(
+        codec_name="reqresp_response",
+        input={"responseCode": 1, "sszData": "0x" + b"bad request".hex()},
+    )
+
+
+def test_response_server_error(networking_codec: NetworkingCodecTestFiller) -> None:
+    """SERVER_ERROR response with UTF-8 error message."""
+    networking_codec(
+        codec_name="reqresp_response",
+        input={"responseCode": 2, "sszData": "0x" + b"internal error".hex()},
+    )
+
+
+def test_response_resource_unavailable(networking_codec: NetworkingCodecTestFiller) -> None:
+    """RESOURCE_UNAVAILABLE response with UTF-8 error message."""
+    networking_codec(
+        codec_name="reqresp_response",
+        input={"responseCode": 3, "sszData": "0x" + b"block not found".hex()},
+    )
+
+
+def test_response_success_sequential(networking_codec: NetworkingCodecTestFiller) -> None:
+    """SUCCESS response with 256 sequential bytes."""
+    networking_codec(
+        codec_name="reqresp_response",
+        input={"responseCode": 0, "sszData": "0x" + bytes(range(256)).hex()},
+    )
+
+
+def test_response_success_compressible(networking_codec: NetworkingCodecTestFiller) -> None:
+    """SUCCESS response with 1 KB of repeated data."""
+    networking_codec(
+        codec_name="reqresp_response",
+        input={"responseCode": 0, "sszData": "0x" + "cafebabe" * 256},
+    )
+
+
+def test_response_success_all_ff(networking_codec: NetworkingCodecTestFiller) -> None:
+    """SUCCESS response with 32 bytes of 0xFF."""
+    networking_codec(
+        codec_name="reqresp_response",
+        input={"responseCode": 0, "sszData": "0x" + "ff" * 32},
+    )


### PR DESCRIPTION
## Summary

- **15 new test vectors** for the req/resp wire format (varint length prefix + Snappy framing)
- Covers both request encoding (`reqresp_request`) and response encoding (`reqresp_response`)
- Each vector encodes SSZ bytes into the full wire format, decodes back, and asserts byte-identical roundtrip
- Completes the networking "wire format trilogy": gossip topics/IDs (Phase 1) + gossipsub RPC protobuf (Phase 2) + req/resp (Phase 3)

### Why this matters

The req/resp wire format composes three layers that must all agree byte-for-byte: varint prefix, Snappy framing, and response code. The leanSpec Snappy implementation is pure Python — these vectors let C/Rust client implementations verify their compressed output matches the reference encoding exactly.

### Vectors

| Category | Count | Coverage |
|----------|-------|----------|
| Request: empty | 1 | Zero-length varint + snappy stream |
| Request: payload sizes | 4 | 4B, 127B (1-byte varint max), 128B (2-byte varint min), 256B |
| Request: compression | 2 | Highly compressible (1 KB repeated), all-zeros (uniform CRC32C) |
| Response: all codes | 4 | SUCCESS, INVALID_REQUEST, SERVER_ERROR, RESOURCE_UNAVAILABLE |
| Response: payloads | 4 | Empty, sequential, compressible (1 KB), all-0xFF |

## Test plan

- [x] `uvx tox -e all-checks` passes
- [x] `uv run fill --fork=devnet --clean -n auto -- tests/consensus/devnet/networking/` generates all 71 fixtures
- [x] Verified request output starts with varint + snappy stream identifier (`0xff060000734e615079`)
- [x] Verified response output prepends 1-byte response code before the request wire format

🤖 Generated with [Claude Code](https://claude.com/claude-code)