### PR TITLE
test(networking): add ENR and PeerId test vectors

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -3,6 +3,7 @@
 from typing import Any, ClassVar
 
 from lean_spec.subspecs.containers.validator import SubnetId
+from lean_spec.subspecs.networking.enr.enr import ENR
 from lean_spec.subspecs.networking.gossipsub.message import GossipsubMessage
 from lean_spec.subspecs.networking.gossipsub.rpc import (
     RPC,
@@ -23,6 +24,7 @@ from lean_spec.subspecs.networking.reqresp.codec import (
     decode_request,
     encode_request,
 )
+from lean_spec.subspecs.networking.transport.peer_id import KeyType, PeerId, PublicKeyProto
 from lean_spec.subspecs.networking.varint import decode_varint, encode_varint
 
 from .base import BaseConsensusFixture
@@ -80,6 +82,10 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 output = self._make_reqresp_request()
             case "reqresp_response":
                 output = self._make_reqresp_response()
+            case "enr":
+                output = self._make_enr()
+            case "peer_id":
+                output = self._make_peer_id()
             case _:
                 raise ValueError(f"Unknown codec: {self.codec_name}")
         return self.model_copy(update={"output": output})
@@ -157,6 +163,79 @@ class NetworkingCodecTest(BaseConsensusFixture):
         assert decoded_data == ssz_data, "Response roundtrip produced different bytes"
 
         return {"encoded": _to_hex(encoded)}
+
+    def _make_enr(self) -> dict[str, Any]:
+        """Parse an ENR string, re-serialize, assert roundtrip, extract properties."""
+        enr_string = self.input["enrString"]
+        enr = ENR.from_string(enr_string)
+
+        # Text roundtrip: parse → serialize → must match original.
+        assert enr.to_string() == enr_string, "ENR text roundtrip failed"
+
+        # RLP roundtrip: serialize → parse → serialize → must match.
+        rlp_bytes = enr.to_rlp()
+        assert ENR.from_rlp(rlp_bytes).to_rlp() == rlp_bytes, "ENR RLP roundtrip failed"
+
+        # Extract all properties into the output.
+        output: dict[str, Any] = {
+            "rlp": _to_hex(rlp_bytes),
+            "seq": int(enr.seq),
+            "identityScheme": enr.identity_scheme,
+        }
+
+        if enr.node_id:
+            output["nodeId"] = _to_hex(enr.node_id)
+        if enr.public_key:
+            output["publicKey"] = _to_hex(enr.public_key)
+        if enr.ip4:
+            output["ip4"] = enr.ip4
+        if enr.udp_port is not None:
+            output["udpPort"] = int(enr.udp_port)
+        if enr.ip6:
+            output["ip6"] = enr.ip6
+        if enr.quic_port is not None:
+            output["quicPort"] = int(enr.quic_port)
+        if (ma := enr.multiaddr()) is not None:
+            output["multiaddr"] = str(ma)
+        if (eth2 := enr.eth2_data) is not None:
+            output["eth2Data"] = {
+                "forkDigest": _to_hex(eth2.fork_digest),
+                "nextForkVersion": _to_hex(eth2.next_fork_version),
+                "nextForkEpoch": int(eth2.next_fork_epoch),
+            }
+        if (subnets := enr.attestation_subnets) is not None:
+            output["attestationSubnets"] = [int(s) for s in subnets.subscribed_subnets()]
+        if (sync := enr.sync_committee_subnets) is not None:
+            output["syncCommitteeSubnets"] = [int(s) for s in sync.subscribed_subnets()]
+        output["signatureValid"] = enr.verify_signature()
+        output["isValid"] = enr.is_valid()
+
+        return output
+
+    def _make_peer_id(self) -> dict[str, Any]:
+        """Derive a PeerId from a public key, output protobuf encoding and Base58 string."""
+        key_type_map = {
+            "ed25519": KeyType.ED25519,
+            "secp256k1": KeyType.SECP256K1,
+            "ecdsa": KeyType.ECDSA,
+            "rsa": KeyType.RSA,
+        }
+        key_type = key_type_map[self.input["keyType"]]
+        key_data = _from_hex(self.input["publicKey"])
+
+        proto = PublicKeyProto(key_type=key_type, key_data=key_data)
+        encoded_proto = proto.encode()
+        peer_id = PeerId.from_public_key(proto)
+        peer_id_str = str(peer_id)
+
+        # Roundtrip: Base58 decode → re-encode must match.
+        roundtrip = PeerId.from_base58(peer_id_str)
+        assert roundtrip == peer_id, "PeerId Base58 roundtrip failed"
+
+        return {
+            "protobufEncoded": _to_hex(encoded_proto),
+            "peerId": peer_id_str,
+        }
 
 
 def _build_rpc(d: dict[str, Any]) -> RPC:

--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -191,10 +191,14 @@ class NetworkingCodecTest(BaseConsensusFixture):
             output["ip4"] = enr.ip4
         if enr.udp_port is not None:
             output["udpPort"] = int(enr.udp_port)
+        if enr.udp6_port is not None:
+            output["udp6Port"] = int(enr.udp6_port)
         if enr.ip6:
             output["ip6"] = enr.ip6
         if enr.quic_port is not None:
             output["quicPort"] = int(enr.quic_port)
+        if enr.quic6_port is not None:
+            output["quic6Port"] = int(enr.quic6_port)
         if (ma := enr.multiaddr()) is not None:
             output["multiaddr"] = str(ma)
         if (eth2 := enr.eth2_data) is not None:
@@ -207,6 +211,7 @@ class NetworkingCodecTest(BaseConsensusFixture):
             output["attestationSubnets"] = [int(s) for s in subnets.subscribed_subnets()]
         if (sync := enr.sync_committee_subnets) is not None:
             output["syncCommitteeSubnets"] = [int(s) for s in sync.subscribed_subnets()]
+        output["isAggregator"] = enr.is_aggregator
         output["signatureValid"] = enr.verify_signature()
         output["isValid"] = enr.is_valid()
 

--- a/tests/consensus/devnet/networking/test_enr_and_peer_id.py
+++ b/tests/consensus/devnet/networking/test_enr_and_peer_id.py
@@ -10,15 +10,41 @@ OFFICIAL_ENR = (
     "CBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQ"
     "PKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
 )
-"""Official EIP-778 test vector."""
+"""Official EIP-778 test vector with valid signature."""
+
+ENR_WITH_EXTENSIONS = (
+    "enr:-NK4QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFh2F0dG5ldHOIgQAAAAAAAICEZXRoMpASNF"
+    "Z4q83vAGQAAAAAAAAAgmlkgnY0gmlwhAoAAAGDaXA2kCABDbgAAAAAAAAAAAAAAAG"
+    "EcXVpY4IjKYlzZWNwMjU2azGhA8pjTK4NSay0Adikxrb-jFW3DRFb9AB2nMFADzJY"
+    "zTE4iHN5bmNuZXRzCoN1ZHCCdl8"
+)
+"""Constructed ENR with eth2 data, attestation subnets, sync subnets, IPv6, and QUIC."""
+
+ENR_MINIMAL = (
+    "enr:-HW4QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAACAgmlkgnY0iXNlY3AyNTZrMaEDymNMrg1JrL"
+    "QB2KTGtv6MVbcNEVv0AHacwUAPMljNMTg"
+)
+"""Minimal ENR with seq=0 and only required keys."""
 
 
 # --- ENR ---
 
 
 def test_enr_official_eip778(networking_codec: NetworkingCodecTestFiller) -> None:
-    """Official EIP-778 test vector. Verifies text/RLP roundtrip and all properties."""
+    """Official EIP-778 vector. Exercises node_id, ip4, udp_port, multiaddr, signature."""
     networking_codec(codec_name="enr", input={"enrString": OFFICIAL_ENR})
+
+
+def test_enr_with_extensions(networking_codec: NetworkingCodecTestFiller) -> None:
+    """ENR with eth2 data, attestation subnets, sync subnets, IPv6, and QUIC port."""
+    networking_codec(codec_name="enr", input={"enrString": ENR_WITH_EXTENSIONS})
+
+
+def test_enr_minimal_seq_zero(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Minimal ENR with seq=0. Only required keys (id + secp256k1)."""
+    networking_codec(codec_name="enr", input={"enrString": ENR_MINIMAL})
 
 
 # --- PeerId ---
@@ -47,7 +73,7 @@ def test_peer_id_secp256k1(networking_codec: NetworkingCodecTestFiller) -> None:
 
 
 def test_peer_id_ecdsa(networking_codec: NetworkingCodecTestFiller) -> None:
-    """ECDSA PeerId from libp2p spec. 91-byte key, crosses 42-byte threshold, SHA256 multihash."""
+    """ECDSA PeerId from libp2p spec. 91-byte key, SHA256 multihash (over 42 bytes)."""
     networking_codec(
         codec_name="peer_id",
         input={

--- a/tests/consensus/devnet/networking/test_enr_and_peer_id.py
+++ b/tests/consensus/devnet/networking/test_enr_and_peer_id.py
@@ -13,13 +13,14 @@ OFFICIAL_ENR = (
 """Official EIP-778 test vector with valid signature."""
 
 ENR_WITH_EXTENSIONS = (
-    "enr:-NK4QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    "enr:-PK4QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFh2F0dG5ldHOIgQAAAAAAAICEZXRoMpASNF"
     "Z4q83vAGQAAAAAAAAAgmlkgnY0gmlwhAoAAAGDaXA2kCABDbgAAAAAAAAAAAAAAAG"
-    "EcXVpY4IjKYlzZWNwMjU2azGhA8pjTK4NSay0Adikxrb-jFW3DRFb9AB2nMFADzJY"
-    "zTE4iHN5bmNuZXRzCoN1ZHCCdl8"
+    "NaXNfYWdncmVnYXRvcgGEcXVpY4IjKYVxdWljNoIjKolzZWNwMjU2azGhA8pjTK4N"
+    "Say0Adikxrb-jFW3DRFb9AB2nMFADzJYzTE4iHN5bmNuZXRzCoN1ZHCCdl-EdWRwN"
+    "oJ2YA"
 )
-"""Constructed ENR with eth2 data, attestation subnets, sync subnets, IPv6, and QUIC."""
+"""Constructed ENR with all EIP-778 + consensus extension keys."""
 
 ENR_MINIMAL = (
     "enr:-HW4QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -38,7 +39,7 @@ def test_enr_official_eip778(networking_codec: NetworkingCodecTestFiller) -> Non
 
 
 def test_enr_with_extensions(networking_codec: NetworkingCodecTestFiller) -> None:
-    """ENR with eth2 data, attestation subnets, sync subnets, IPv6, and QUIC port."""
+    """ENR with all extension keys: eth2, subnets, IPv6, QUIC, udp6, quic6, is_aggregator."""
     networking_codec(codec_name="enr", input={"enrString": ENR_WITH_EXTENSIONS})
 
 

--- a/tests/consensus/devnet/networking/test_enr_and_peer_id.py
+++ b/tests/consensus/devnet/networking/test_enr_and_peer_id.py
@@ -1,0 +1,73 @@
+"""Test vectors for ENR encoding and PeerId derivation."""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+OFFICIAL_ENR = (
+    "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjz"
+    "CBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQ"
+    "PKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
+)
+"""Official EIP-778 test vector."""
+
+
+# --- ENR ---
+
+
+def test_enr_official_eip778(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Official EIP-778 test vector. Verifies text/RLP roundtrip and all properties."""
+    networking_codec(codec_name="enr", input={"enrString": OFFICIAL_ENR})
+
+
+# --- PeerId ---
+
+
+def test_peer_id_ed25519(networking_codec: NetworkingCodecTestFiller) -> None:
+    """ED25519 PeerId from libp2p spec. 32-byte key, identity multihash."""
+    networking_codec(
+        codec_name="peer_id",
+        input={
+            "keyType": "ed25519",
+            "publicKey": "0x1ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e",
+        },
+    )
+
+
+def test_peer_id_secp256k1(networking_codec: NetworkingCodecTestFiller) -> None:
+    """secp256k1 PeerId from libp2p spec. 33-byte key, identity multihash."""
+    networking_codec(
+        codec_name="peer_id",
+        input={
+            "keyType": "secp256k1",
+            "publicKey": "0x037777e994e452c21604f91de093ce415f5432f701dd8cd1a7a6fea0e630bfca99",
+        },
+    )
+
+
+def test_peer_id_ecdsa(networking_codec: NetworkingCodecTestFiller) -> None:
+    """ECDSA PeerId from libp2p spec. 91-byte key, crosses 42-byte threshold, SHA256 multihash."""
+    networking_codec(
+        codec_name="peer_id",
+        input={
+            "keyType": "ecdsa",
+            "publicKey": (
+                "0x3059301306072a8648ce3d020106082a8648ce3d030107034200"
+                "04de3d300fa36ae0e8f5d530899d83abab44abf3161f162a4bc901d8e6ec"
+                "da020e8b6d5f8da30525e71d6851510c098e5c47c646a597fb4dcec034e9"
+                "f77c409e62"
+            ),
+        },
+    )
+
+
+def test_peer_id_secp256k1_from_enr(networking_codec: NetworkingCodecTestFiller) -> None:
+    """secp256k1 PeerId using the public key from the official EIP-778 ENR."""
+    networking_codec(
+        codec_name="peer_id",
+        input={
+            "keyType": "secp256k1",
+            "publicKey": "0x03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138",
+        },
+    )


### PR DESCRIPTION
## Summary

- **ENR (EIP-778) test vector**: parses the official EIP-778 ENR string, asserts text + RLP roundtrip, and extracts all properties into the JSON fixture (node_id, seq, IP, port, multiaddr, identity scheme, public key, signature validity)
- **PeerId test vectors**: uses the three official libp2p spec vectors (ED25519, secp256k1, ECDSA) to verify the full derivation chain — raw public key bytes → protobuf encoding → multihash selection (identity for ≤42 bytes, SHA256 for >42) → Base58 string
- **Cross-reference vector**: derives PeerId from the EIP-778 ENR's secp256k1 public key, linking the two identity primitives

### Vectors

| Test | What it verifies |
|------|-----------------|
| ENR official EIP-778 | Text/RLP roundtrip, all property extraction, signature verification |
| PeerId ED25519 | 32-byte key → 36-byte protobuf → identity multihash → "12D3KooW..." |
| PeerId secp256k1 | 33-byte key → 37-byte protobuf → identity multihash → "16Uiu2..." |
| PeerId ECDSA | 91-byte key → 95-byte protobuf → SHA256 multihash → "Qm..." |
| PeerId from ENR pubkey | Official ENR's secp256k1 key → PeerId derivation |

### Spec references

- ENR: [EIP-778](https://eips.ethereum.org/EIPS/eip-778)
- PeerId: [libp2p peer-ids spec](https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md)

## Test plan

- [x] `uvx tox -e all-checks` passes
- [x] `uv run fill --fork=devnet --clean -n auto -- tests/consensus/devnet/networking/` generates all 61 fixtures
- [x] Verified ENR node_id matches official value `a448f24c...17f7`
- [x] Verified all three PeerId outputs match libp2p spec test vectors exactly
- [x] Verified 42-byte threshold: ED25519 (36B) and secp256k1 (37B) use identity, ECDSA (95B) uses SHA256

🤖 Generated with [Claude Code](https://claude.com/claude-code)