### PR TITLE
test(networking): add Discovery v5 message RLP encoding test vectors

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -3,6 +3,20 @@
 from typing import Any, ClassVar
 
 from lean_spec.subspecs.containers.validator import SubnetId
+from lean_spec.subspecs.networking.discovery.codec import decode_message, encode_message
+from lean_spec.subspecs.networking.discovery.messages import (
+    Distance,
+    FindNode,
+    IPv4,
+    IPv6,
+    Nodes,
+    Ping,
+    Pong,
+    Port,
+    RequestId,
+    TalkReq,
+    TalkResp,
+)
 from lean_spec.subspecs.networking.enr.enr import ENR
 from lean_spec.subspecs.networking.gossipsub.message import GossipsubMessage
 from lean_spec.subspecs.networking.gossipsub.rpc import (
@@ -25,6 +39,7 @@ from lean_spec.subspecs.networking.reqresp.codec import (
     encode_request,
 )
 from lean_spec.subspecs.networking.transport.peer_id import KeyType, PeerId, PublicKeyProto
+from lean_spec.subspecs.networking.types import SeqNumber
 from lean_spec.subspecs.networking.varint import decode_varint, encode_varint
 
 from .base import BaseConsensusFixture
@@ -86,6 +101,8 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 output = self._make_enr()
             case "peer_id":
                 output = self._make_peer_id()
+            case "discv5_message":
+                output = self._make_discv5_message()
             case _:
                 raise ValueError(f"Unknown codec: {self.codec_name}")
         return self.model_copy(update={"output": output})
@@ -241,6 +258,60 @@ class NetworkingCodecTest(BaseConsensusFixture):
             "protobufEncoded": _to_hex(encoded_proto),
             "peerId": peer_id_str,
         }
+
+    def _make_discv5_message(self) -> dict[str, Any]:
+        """Encode a discv5 message as type byte + RLP, decode it back, assert roundtrip."""
+        msg = _build_discv5_message(self.input)
+        encoded = encode_message(msg)
+
+        # Decode and re-encode must produce identical bytes.
+        re_encoded = encode_message(decode_message(encoded))
+        assert encoded == re_encoded, "Discv5 message roundtrip produced different bytes"
+
+        return {"encoded": _to_hex(encoded)}
+
+
+def _build_discv5_message(
+    d: dict[str, Any],
+) -> Ping | Pong | FindNode | Nodes | TalkReq | TalkResp:
+    """Build a discv5 message dataclass from a JSON-friendly dict."""
+    request_id = RequestId(data=_from_hex(d["requestId"]))
+    match d["type"]:
+        case "ping":
+            return Ping(request_id=request_id, enr_seq=SeqNumber(d["enrSeq"]))
+        case "pong":
+            ip_bytes = _from_hex(d["recipientIp"])
+            ip = IPv4(ip_bytes) if len(ip_bytes) == 4 else IPv6(ip_bytes)
+            return Pong(
+                request_id=request_id,
+                enr_seq=SeqNumber(d["enrSeq"]),
+                recipient_ip=ip,
+                recipient_port=Port(d["recipientPort"]),
+            )
+        case "findnode":
+            return FindNode(
+                request_id=request_id,
+                distances=[Distance(x) for x in d["distances"]],
+            )
+        case "nodes":
+            return Nodes(
+                request_id=request_id,
+                total=d["total"],
+                enrs=[_from_hex(e) for e in d.get("enrs", [])],
+            )
+        case "talkreq":
+            return TalkReq(
+                request_id=request_id,
+                protocol=_from_hex(d["protocol"]),
+                request=_from_hex(d["request"]),
+            )
+        case "talkresp":
+            return TalkResp(
+                request_id=request_id,
+                response=_from_hex(d["response"]),
+            )
+        case _:
+            raise ValueError(f"Unknown discv5 message type: {d['type']}")
 
 
 def _build_rpc(d: dict[str, Any]) -> RPC:

--- a/tests/consensus/devnet/networking/test_discv5_messages.py
+++ b/tests/consensus/devnet/networking/test_discv5_messages.py
@@ -1,0 +1,187 @@
+"""Test vectors for Discovery v5 message RLP encoding."""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+IPV4_LOCALHOST = "0x7f000001"
+"""127.0.0.1 as 4 raw bytes."""
+
+IPV6_LOOPBACK = "0x00000000000000000000000000000001"
+"""::1 as 16 raw bytes."""
+
+
+# --- PING ---
+
+
+def test_ping_typical(networking_codec: NetworkingCodecTestFiller) -> None:
+    """PING with request_id=0x01 and enr_seq=1. Matches devp2p spec plaintext 01c20101."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={"type": "ping", "requestId": "0x01", "enrSeq": 1},
+    )
+
+
+def test_ping_leading_zeros_stripped(networking_codec: NetworkingCodecTestFiller) -> None:
+    """PING with 4-byte request_id containing leading zeros. Stripped to minimal encoding."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={"type": "ping", "requestId": "0x00000001", "enrSeq": 1},
+    )
+
+
+def test_ping_seq_zero(networking_codec: NetworkingCodecTestFiller) -> None:
+    """PING with enr_seq=0. Zero encodes as RLP empty bytes, not 0x00."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={"type": "ping", "requestId": "0x01", "enrSeq": 0},
+    )
+
+
+# --- PONG ---
+
+
+def test_pong_ipv4(networking_codec: NetworkingCodecTestFiller) -> None:
+    """PONG with IPv4 127.0.0.1 and port 30303."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={
+            "type": "pong",
+            "requestId": "0x01",
+            "enrSeq": 1,
+            "recipientIp": IPV4_LOCALHOST,
+            "recipientPort": 30303,
+        },
+    )
+
+
+def test_pong_ipv6(networking_codec: NetworkingCodecTestFiller) -> None:
+    """PONG with IPv6 loopback (::1). 16-byte IP discriminates from IPv4."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={
+            "type": "pong",
+            "requestId": "0x01",
+            "enrSeq": 1,
+            "recipientIp": IPV6_LOOPBACK,
+            "recipientPort": 9000,
+        },
+    )
+
+
+def test_pong_port_zero(networking_codec: NetworkingCodecTestFiller) -> None:
+    """PONG with port=0. Zero port encodes as RLP empty bytes."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={
+            "type": "pong",
+            "requestId": "0x01",
+            "enrSeq": 1,
+            "recipientIp": IPV4_LOCALHOST,
+            "recipientPort": 0,
+        },
+    )
+
+
+# --- FINDNODE ---
+
+
+def test_findnode_single_distance(networking_codec: NetworkingCodecTestFiller) -> None:
+    """FINDNODE requesting distance 256 (2-byte big-endian in nested RLP list)."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={"type": "findnode", "requestId": "0x01", "distances": [256]},
+    )
+
+
+def test_findnode_mixed_distances(networking_codec: NetworkingCodecTestFiller) -> None:
+    """FINDNODE with distances [0, 1, 256]. Tests zero and multi-byte encoding."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={"type": "findnode", "requestId": "0x01", "distances": [0, 1, 256]},
+    )
+
+
+def test_findnode_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+    """FINDNODE with empty distance list."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={"type": "findnode", "requestId": "0x01", "distances": []},
+    )
+
+
+# --- NODES ---
+
+
+def test_nodes_single_enr(networking_codec: NetworkingCodecTestFiller) -> None:
+    """NODES response with total=1 and one ENR (raw RLP bytes)."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={
+            "type": "nodes",
+            "requestId": "0x01",
+            "total": 1,
+            "enrs": ["0xdeadbeef"],
+        },
+    )
+
+
+def test_nodes_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+    """NODES response with total=0 and empty ENR list."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={"type": "nodes", "requestId": "0x01", "total": 0, "enrs": []},
+    )
+
+
+# --- TALKREQ ---
+
+
+def test_talkreq_typical(networking_codec: NetworkingCodecTestFiller) -> None:
+    """TALKREQ with protocol identifier and request payload."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={
+            "type": "talkreq",
+            "requestId": "0x01",
+            "protocol": "0x" + b"discv5-test".hex(),
+            "request": "0xdeadbeef",
+        },
+    )
+
+
+def test_talkreq_empty_payload(networking_codec: NetworkingCodecTestFiller) -> None:
+    """TALKREQ with empty request payload."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={
+            "type": "talkreq",
+            "requestId": "0x01",
+            "protocol": "0x" + b"discv5-test".hex(),
+            "request": "0x",
+        },
+    )
+
+
+# --- TALKRESP ---
+
+
+def test_talkresp_typical(networking_codec: NetworkingCodecTestFiller) -> None:
+    """TALKRESP with response payload."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={
+            "type": "talkresp",
+            "requestId": "0x01",
+            "response": "0xcafebabe",
+        },
+    )
+
+
+def test_talkresp_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+    """TALKRESP with empty response."""
+    networking_codec(
+        codec_name="discv5_message",
+        input={"type": "talkresp", "requestId": "0x01", "response": "0x"},
+    )


### PR DESCRIPTION
## Summary

- **15 known-answer test vectors** for the Discovery v5 message wire format (type byte + RLP), covering all 6 message types (PING, PONG, FINDNODE, NODES, TALKREQ, TALKRESP)
- Fills the gap left by the official devp2p test vectors, which cover crypto and packet decoding but **not** message-level encoding
- The PING typical vector produces `0x01c20101`, matching the devp2p spec's known plaintext byte-for-byte

### Edge cases covered

| Encoding decision | What the vector tests |
|---|---|
| Request ID minimization | Leading zeros stripped: `0x00000001` → `0x01` |
| Uint64 zero encoding | Encodes as RLP empty bytes (`0x80`), not `0x00` |
| Port zero encoding | Encodes as RLP empty bytes, not `0x0000` |
| FINDNODE distances | Nested RLP list with minimal big-endian integers |
| NODES total field | Single byte if > 0, empty bytes if 0 |
| IPv4 vs IPv6 | 4-byte vs 16-byte IP discriminates address family |

### Vectors by type

| Type | Count | Coverage |
|------|-------|---------|
| PING | 3 | typical, leading zeros stripped, enr_seq=0 |
| PONG | 3 | IPv4, IPv6 loopback, port=0 |
| FINDNODE | 3 | single distance 256, mixed [0,1,256], empty |
| NODES | 2 | single ENR, total=0 empty |
| TALKREQ | 2 | typical, empty payload |
| TALKRESP | 2 | typical, empty response |

## Test plan

- [x] `uvx tox -e all-checks` passes
- [x] `uv run fill --fork=devnet --clean -n auto -- tests/consensus/devnet/networking/` generates all 93 fixtures
- [x] Verified PING typical output `0x01c20101` matches devp2p spec plaintext
- [x] Verified seq=0 encodes as `0x80` (RLP empty), not `0x00`

🤖 Generated with [Claude Code](https://claude.com/claude-code)