### PR TITLE
test(fc): add attestation target walkback bound filler

### DIFF
--- a/tests/consensus/devnet/fc/test_attestation_target_selection.py
+++ b/tests/consensus/devnet/fc/test_attestation_target_selection.py
@@ -497,11 +497,12 @@ def test_attestation_target_walkback_bounded_by_lookback(
 
     Why This Matters
     ----------------
-    The walkback bound prevents validators from always targeting the same
-    old block when the head runs far ahead of safe target.
+    The walkback bound keeps the attestation target conservatively behind
+    head, anchored toward safe target.
 
-    Without the bound, the target would collapse to genesis and the
-    justification frontier would never advance.
+    Without the bound, validators would target blocks too close to head,
+    bypassing the safe target governor and attesting to blocks without
+    sufficient supermajority endorsement.
     """
     lookback = int(JUSTIFICATION_LOOKBACK_SLOTS)
 

--- a/tests/consensus/devnet/fc/test_attestation_target_selection.py
+++ b/tests/consensus/devnet/fc/test_attestation_target_selection.py
@@ -9,6 +9,7 @@ from consensus_testing import (
     StoreChecks,
 )
 
+from lean_spec.subspecs.chain.config import JUSTIFICATION_LOOKBACK_SLOTS
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex
 
@@ -471,4 +472,56 @@ def test_attestation_target_justifiable_constraint(
             )
         )
 
+    fork_choice_test(steps=steps)
+
+
+def test_attestation_target_walkback_bounded_by_lookback(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Attestation target walks back at most JUSTIFICATION_LOOKBACK_SLOTS from head.
+
+    Scenario
+    --------
+    Build a long chain (10+ blocks) with no attestations so the safe target
+    stays at genesis. Pick the smallest such head where
+    (head - JUSTIFICATION_LOOKBACK_SLOTS) is justifiable from genesis, so the
+    bounded walk lands cleanly without the secondary justifiability walk
+    altering the result.
+
+    Expected:
+        - Head far ahead of safe target
+        - Safe target at genesis (slot 0)
+        - Attestation target at (head - JUSTIFICATION_LOOKBACK_SLOTS)
+        - NOT at the safe target (slot 0)
+
+    Why This Matters
+    ----------------
+    The walkback bound prevents validators from always targeting the same
+    old block when the head runs far ahead of safe target.
+
+    Without the bound, the target would collapse to genesis and the
+    justification frontier would never advance.
+    """
+    lookback = int(JUSTIFICATION_LOOKBACK_SLOTS)
+
+    # Smallest "long chain" head where the bounded walk lands on a
+    # justifiable slot, so the secondary justifiability walk is a no-op.
+    head = 10
+    while not Slot(head - lookback).is_justifiable_after(Slot(0)):
+        head += 1
+    head_slot = Slot(head)
+    target_slot = Slot(head - lookback)
+
+    steps = [
+        BlockStep(
+            block=BlockSpec(slot=Slot(s), label=f"block_{s}"),
+            checks=(
+                StoreChecks(head_slot=head_slot, attestation_target_slot=target_slot)
+                if Slot(s) == head_slot
+                else None
+            ),
+        )
+        for s in range(1, head + 1)
+    ]
     fork_choice_test(steps=steps)


### PR DESCRIPTION
## Summary                                                                                                                                                            
                                                                                                                                                                        
  Adds `test_attestation_target_walkback_bounded_by_lookback` to `tests/consensus/devnet/fc/test_attestation_target_selection.py`, verifying that                       
  `Store.get_attestation_target` caps its walk from head at `JUSTIFICATION_LOOKBACK_SLOTS` and does not collapse the target back to `safe_target` when the head runs far
   ahead.                                                                                                                                                               
                                                                                                                                                                        
  ## Motivation                                                                                                                                                         
                                                                                                                                                                        
  The existing target-selection fillers exercise `get_attestation_target` end-to-end but none isolate the bounded-walk property in a "head far ahead of safe_target"    
  configuration. Without explicit coverage, a regression that removed or weakened the lookback bound (e.g. letting the walk run all the way back to `safe_target`) would
   not be caught — the justification frontier would silently collapse.                                                                                                  
                                                                                                                                                                        
  ## What the test does                                                                                                                                                 
                                                                                                                                                                        
  - Builds a long chain (currently 12 blocks, ≥ the issue's "10+" threshold) with **no attestations**, so `safe_target` provably stays at genesis.                      
  - After the final block, asserts via `StoreChecks(attestation_target_slot=...)` that the target sits exactly `JUSTIFICATION_LOOKBACK_SLOTS` slots behind head, **not**
   at `safe_target`.                          
                                                                                                                                                                        
  ## Note on the issue's literal example (head=10, target=7)
                                                                                                                                                                        
  The issue's example numbers (`head=10` → `attestation_target_slot=Slot(7)`) do **not** hold against the current implementation. After the bounded walk,
  `get_attestation_target` continues backward until the result is justifiable (`store.py:1240-1243`). At head=10 with `safe_target=0`, `head - LOOKBACK = 7` and `delta 
  = 7` is not ≤5, not a perfect square, and not pronic — so the algorithm walks further back to slot 6 (pronic). The existing
  `test_attestation_target_justifiable_constraint` already verifies this at line 423.                                                                                   
                                                            
  The new test bumps head to **12** — the smallest "long chain" head where `head - LOOKBACK = 9` is justifiable from genesis (perfect square) — so the bounded-walk     
  property can be asserted cleanly without the secondary justifiability walk masking the result.

  ## Why it is symbolic, not hardcoded                                                                                                                                  
                                          
  Both `head` and `target_slot` are derived from `JUSTIFICATION_LOOKBACK_SLOTS` and `Slot.is_justifiable_after` via a short inline loop, mirroring the convention from  
  `tests/consensus/devnet/fc/test_block_attestation_limits.py:15,35`. If either the constant or the justifiability rules change, the loop recomputes a valid head and   
  the test continues to express the same property — no edits required.


closes #560 