### PR TITLE
chore: regenerate prod keys at leanSpec@2c691ba6

### DIFF
--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -68,8 +68,8 @@ SecretField = Literal["attestation_secret", "proposal_secret"]
 """Discriminator for which secret key to load from a validator key pair."""
 
 KEY_DOWNLOAD_URLS = {
-    "test": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-ad9a3226/test_scheme.tar.gz",
-    "prod": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-ad9a3226/prod_scheme.tar.gz",
+    "test": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-2c691ba6/test_scheme.tar.gz",
+    "prod": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-2c691ba6/prod_scheme.tar.gz",
 }
 """
 GitHub release URLs for pre-generated key archives.


### PR DESCRIPTION
## 🗒️ Description
Update prod test keys to https://github.com/leanEthereum/leansig-test-keys/releases/tag/leanSpec-2c691ba6 after https://github.com/leanEthereum/leanSpec/pull/496

## 🔗 Related Issues or PRs
https://github.com/leanEthereum/leanSpec/pull/496

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
