### PR TITLE
fix: match fork digest in gossip spec tests

### DIFF
--- a/src/lean_spec/subspecs/networking/gossipsub/topic.py
+++ b/src/lean_spec/subspecs/networking/gossipsub/topic.py
@@ -17,7 +17,7 @@ Topics follow a structured format::
 
     /{prefix}/{fork_digest}/{topic_name}/{encoding}
 
-    Example: /leanconsensus/0x12345678/block/ssz_snappy
+    Example: /leanconsensus/12345678/block/ssz_snappy
 
 **Components:**
 
@@ -26,7 +26,7 @@ Topics follow a structured format::
 +================+==========================================================+
 | prefix         | Network identifier (`leanconsensus`)                   |
 +----------------+----------------------------------------------------------+
-| fork_digest    | 4-byte fork identifier as hex (`0x12345678`)           |
+| fork_digest    | 4-byte fork identifier as hex (`12345678`)             |
 +----------------+----------------------------------------------------------+
 | topic_name     | Message type (`blocks`, `attestation`)               |
 +----------------+----------------------------------------------------------+
@@ -148,7 +148,7 @@ class GossipTopic:
     """
 
     fork_digest: str
-    """Fork digest as 0x-prefixed hex string.
+    """Fork digest as hex string (no 0x prefix), like the beacon chain.
 
     Identifies the fork this topic belongs to.
 
@@ -181,7 +181,7 @@ class GossipTopic:
         Validate that the topic's fork_digest matches expected.
 
         Args:
-            expected_fork_digest: Expected fork digest (0x-prefixed hex).
+            expected_fork_digest: Expected fork digest (hex string (no 0x prefix)).
 
         Raises:
             ForkMismatchError: If fork_digest does not match.
@@ -240,7 +240,7 @@ class GossipTopic:
 
         Args:
             topic_str: Full topic string to parse.
-            expected_fork_digest: Expected fork digest (0x-prefixed hex).
+            expected_fork_digest: Expected fork digest (hex string (no 0x prefix)).
 
         Returns:
             Parsed GossipTopic instance.
@@ -258,7 +258,7 @@ class GossipTopic:
         """Create a block topic for the given fork.
 
         Args:
-            fork_digest: Fork digest as 0x-prefixed hex string.
+            fork_digest: Fork digest as hex string (no 0x prefix) string.
 
         Returns:
             GossipTopic for block messages.
@@ -270,7 +270,7 @@ class GossipTopic:
         """Create a committee aggregation topic for the given fork.
 
         Args:
-            fork_digest: Fork digest as 0x-prefixed hex string.
+            fork_digest: Fork digest as hex string (no 0x prefix) string.
 
         Returns:
             GossipTopic for committee aggregation messages.
@@ -282,7 +282,7 @@ class GossipTopic:
         """Create an attestation subnet topic for the given fork and subnet.
 
         Args:
-            fork_digest: Fork digest as 0x-prefixed hex string.
+            fork_digest: Fork digest as hex string (no 0x prefix) string.
             subnet_id: Subnet ID for the attestation topic.
 
         Returns:

--- a/tests/consensus/devnet/networking/test_gossip_message_id.py
+++ b/tests/consensus/devnet/networking/test_gossip_message_id.py
@@ -11,7 +11,7 @@ VALID_SNAPPY = "0x01000000"
 INVALID_SNAPPY = "0x00000000"
 """Domain prefix for messages where snappy decompression failed."""
 
-BLOCK_TOPIC = "0x" + b"/leanconsensus/0x12345678/block/ssz_snappy".hex()
+BLOCK_TOPIC = "0x" + b"/leanconsensus/12345678/block/ssz_snappy".hex()
 """Hex-encoded topic bytes for a typical block topic string."""
 
 

--- a/tests/consensus/devnet/networking/test_gossip_topic.py
+++ b/tests/consensus/devnet/networking/test_gossip_topic.py
@@ -5,7 +5,7 @@ from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Devnet")
 
-FORK_DIGEST = "0x12345678"
+FORK_DIGEST = "12345678"
 """Arbitrary fork digest used across topic tests."""
 
 
@@ -24,7 +24,7 @@ def test_block_topic_different_digest(networking_codec: NetworkingCodecTestFille
     """Block topic with a different fork digest to verify digest embedding."""
     networking_codec(
         codec_name="gossip_topic",
-        input={"kind": "block", "forkDigest": "0xaabbccdd"},
+        input={"kind": "block", "forkDigest": "aabbccdd"},
     )
 
 
@@ -73,7 +73,7 @@ def test_block_topic_zero_digest(networking_codec: NetworkingCodecTestFiller) ->
     """Block topic with all-zero fork digest."""
     networking_codec(
         codec_name="gossip_topic",
-        input={"kind": "block", "forkDigest": "0x00000000"},
+        input={"kind": "block", "forkDigest": "00000000"},
     )
 
 
@@ -81,5 +81,5 @@ def test_block_topic_max_digest(networking_codec: NetworkingCodecTestFiller) -> 
     """Block topic with all-0xff fork digest."""
     networking_codec(
         codec_name="gossip_topic",
-        input={"kind": "block", "forkDigest": "0xffffffff"},
+        input={"kind": "block", "forkDigest": "ffffffff"},
     )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
Addresses #619 

Matches the fork digest to the existing digest in the spec as well as the one implemented in other clients.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```