### PR TITLE
framework: auto generate and publish test/prod scheme keys

### DIFF
--- a/.github/workflows/generate-keys.yml
+++ b/.github/workflows/generate-keys.yml
@@ -1,0 +1,69 @@
+name: Generate Keys
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      LEANSIG_TEST_KEYS_REPO_TOKEN:
+        required: true
+
+# This workflow does not need any write permission to leanSpec repo
+permissions:
+  contents: read
+
+# Cancels any ongoing key generation when a new key generation is triggered (likely with newer changes)
+concurrency:
+  group: generate-keys
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout leanSpec
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Sync dependencies
+        run: uv sync --no-progress
+
+      - name: Generate test scheme keys
+        run: uv run python -m consensus_testing.keys --scheme test
+
+      - name: Generate prod scheme keys
+        run: LEAN_ENV=prod uv run python -m consensus_testing.keys --scheme prod
+
+      - name: Publish to leansig-test-keys
+        run: |
+          cd packages/testing/src/consensus_testing/test_keys
+          tar czf /tmp/test_scheme.tar.gz test_scheme
+          tar czf /tmp/prod_scheme.tar.gz prod_scheme
+          gh release delete latest --repo leanEthereum/leansig-test-keys --yes || true
+          gh release create latest /tmp/test_scheme.tar.gz /tmp/prod_scheme.tar.gz \
+            --repo leanEthereum/leansig-test-keys \
+            --title "Latest keys from leanSpec" \
+            --notes "Auto-generated from leanSpec@${{ github.sha }}"
+        env:
+          GH_TOKEN: ${{ secrets.LEANSIG_TEST_KEYS_REPO_TOKEN }}
+
+      - name: Save test key cache
+        uses: actions/cache/save@v4
+        with:
+          path: packages/testing/src/consensus_testing/test_keys/test_scheme
+          key: test-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon2/**') }}
+
+      - name: Save prod key cache
+        uses: actions/cache/save@v4
+        with:
+          path: packages/testing/src/consensus_testing/test_keys/prod_scheme
+          key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon2/**') }}

--- a/.github/workflows/prod-vectors.yml
+++ b/.github/workflows/prod-vectors.yml
@@ -3,14 +3,53 @@ name: Production Test Vectors
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  fill-prod-vectors:
-    name: Fill production test fixtures - Python 3.14
+  check:
+    name: Check key availability
     runs-on: ubuntu-latest
+    outputs:
+      scheme-changed: ${{ steps.scheme-diff.outputs.changed }}
+      cache-hit: ${{ steps.key-cache.outputs.cache-hit }}
+    steps:
+      - name: Checkout leanSpec
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if scheme changed
+        id: scheme-diff
+        run: |
+          if git diff HEAD~1 --name-only | grep -qE '^src/lean_spec/subspecs/(xmss|poseidon2)/'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check prod key cache
+        id: key-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/prod-keys-probe
+          key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon2/**') }}
+          lookup-only: true
+
+  keygen:
+    name: Generate keys
+    needs: check
+    if: needs.check.outputs.cache-hit != 'true' && needs.check.outputs.scheme-changed == 'true'
+    uses: ./.github/workflows/generate-keys.yml
+    secrets: inherit
+
+  fill:
+    name: Fill production test fixtures
+    needs: [check, keygen]
+    # Trick to run even when keygen was skipped, but not on failure or cancel.
+    if: always() && !failure() && !cancelled()
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout leanSpec
         uses: actions/checkout@v4
@@ -29,28 +68,33 @@ jobs:
       - name: Sync dependencies
         run: uv sync --no-progress
 
-      - name: Get production keys URL hash
-        id: prod-keys-url
-        run: |
-          URL=$(uv run python -c "from consensus_testing.keys import KEY_DOWNLOAD_URLS; print(KEY_DOWNLOAD_URLS['prod'])")
-          HASH=$(echo -n "$URL" | sha256sum | awk '{print $1}')
-          echo "hash=$HASH" >> $GITHUB_OUTPUT
-
-      - name: Cache production keys
-        id: cache-prod-keys
-        uses: actions/cache@v4
+      - name: Restore prod key cache
+        id: key-cache
+        uses: actions/cache/restore@v4
         with:
           path: packages/testing/src/consensus_testing/test_keys/prod_scheme
-          key: prod-keys-${{ steps.prod-keys-url.outputs.hash }}
+          key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon2/**') }}
 
-      - name: Download production keys
-        if: steps.cache-prod-keys.outputs.cache-hit != 'true'
+      - name: Download keys
+        if: steps.key-cache.outputs.cache-hit != 'true'
         run: uv run python -m consensus_testing.keys --download --scheme prod
+
+      - name: Save key cache
+        if: steps.key-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: packages/testing/src/consensus_testing/test_keys/prod_scheme
+          key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon2/**') }}
 
       - name: Fill production test fixtures
         run: uv run fill --fork=Devnet --scheme prod --clean -n auto
 
-      - name: Upload production test fixtures
+      - name: Bundle keys with fixtures
+        run: |
+          mkdir -p fixtures/keys
+          cp -r packages/testing/src/consensus_testing/test_keys/prod_scheme fixtures/keys/
+
+      - name: Upload fixtures + keys
         uses: actions/upload-artifact@v4
         with:
           name: fixtures-prod-scheme

--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -68,8 +68,8 @@ SecretField = Literal["attestation_secret", "proposal_secret"]
 """Discriminator for which secret key to load from a validator key pair."""
 
 KEY_DOWNLOAD_URLS = {
-    "test": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-ad9a3226/test_scheme.tar.gz",
-    "prod": "https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-ad9a3226/prod_scheme.tar.gz",
+    "test": "https://github.com/leanEthereum/leansig-test-keys/releases/download/latest/test_scheme.tar.gz",
+    "prod": "https://github.com/leanEthereum/leansig-test-keys/releases/download/latest/prod_scheme.tar.gz",
 }
 """
 GitHub release URLs for pre-generated key archives.


### PR DESCRIPTION
## 🗒️ Description

This PR introduces auto generation of test and prod keys so when a change is made to the signature scheme, a new set of keys for both test and prod schemes are auto generated and published to https://github.com/leanEthereum/leansig-test-keys.

The leanSpec and leansig-test-keys are still two repos because otherwise we need to create releases on the leanSpec repo. Technically it's simpler to have the keys as releases in leanSpec repo but then we're not doing releases in leanSpec and having one just for the test keys could be confusing. 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
