### PR TITLE
test(networking): add standalone Snappy compression test vectors

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -2,6 +2,7 @@
 
 from typing import Any, ClassVar
 
+from lean_spec.snappy import compress, decompress, frame_compress, frame_decompress
 from lean_spec.subspecs.containers.validator import SubnetId
 from lean_spec.subspecs.networking.discovery.codec import decode_message, encode_message
 from lean_spec.subspecs.networking.discovery.messages import (
@@ -103,6 +104,10 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 output = self._make_peer_id()
             case "discv5_message":
                 output = self._make_discv5_message()
+            case "snappy_block":
+                output = self._make_snappy_block()
+            case "snappy_frame":
+                output = self._make_snappy_frame()
             case _:
                 raise ValueError(f"Unknown codec: {self.codec_name}")
         return self.model_copy(update={"output": output})
@@ -180,6 +185,34 @@ class NetworkingCodecTest(BaseConsensusFixture):
         assert decoded_data == ssz_data, "Response roundtrip produced different bytes"
 
         return {"encoded": _to_hex(encoded)}
+
+    def _make_snappy_block(self) -> dict[str, Any]:
+        """Compress with raw Snappy block format, decompress, assert roundtrip."""
+        data = _from_hex(self.input["data"])
+        compressed = compress(data)
+
+        decompressed = decompress(compressed)
+        assert decompressed == data, "Snappy block roundtrip produced different bytes"
+
+        return {
+            "compressed": _to_hex(compressed),
+            "compressedLength": len(compressed),
+            "uncompressedLength": len(data),
+        }
+
+    def _make_snappy_frame(self) -> dict[str, Any]:
+        """Compress with Snappy framing format (Ethereum wire format), decompress, roundtrip."""
+        data = _from_hex(self.input["data"])
+        framed = frame_compress(data)
+
+        decompressed = frame_decompress(framed)
+        assert decompressed == data, "Snappy frame roundtrip produced different bytes"
+
+        return {
+            "framed": _to_hex(framed),
+            "framedLength": len(framed),
+            "uncompressedLength": len(data),
+        }
 
     def _make_enr(self) -> dict[str, Any]:
         """Parse an ENR string, re-serialize, assert roundtrip, extract properties."""

--- a/tests/consensus/devnet/networking/test_snappy_codec.py
+++ b/tests/consensus/devnet/networking/test_snappy_codec.py
@@ -1,0 +1,130 @@
+"""Test vectors for standalone Snappy compression and decompression.
+
+Both raw block format and Ethereum framing format are tested.
+Client teams use these to verify their Snappy implementation
+produces identical output before integrating with reqresp or gossip.
+"""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+# --- Raw Snappy block format ---
+
+
+def test_snappy_block_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Empty input. Compressed output is just the varint-encoded uncompressed length (0)."""
+    networking_codec(codec_name="snappy_block", input={"data": "0x"})
+
+
+def test_snappy_block_single_byte(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Single byte. Too short for copy commands, must use a literal."""
+    networking_codec(codec_name="snappy_block", input={"data": "0x42"})
+
+
+def test_snappy_block_short_string(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Short ASCII string (17 bytes). Verifies literal encoding for small payloads."""
+    networking_codec(
+        codec_name="snappy_block",
+        input={"data": "0x" + b"Hello, Ethereum!".hex()},
+    )
+
+
+def test_snappy_block_repeated_data(networking_codec: NetworkingCodecTestFiller) -> None:
+    """1000 identical bytes. Highly compressible via copy commands."""
+    networking_codec(
+        codec_name="snappy_block",
+        input={"data": "0x" + (b"\x41" * 1000).hex()},
+    )
+
+
+def test_snappy_block_alternating_pattern(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Alternating two-byte pattern (1000 bytes). Tests copy offset=2 back-references."""
+    networking_codec(
+        codec_name="snappy_block",
+        input={"data": "0x" + (b"\xab\xcd" * 500).hex()},
+    )
+
+
+def test_snappy_block_incompressible(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Sequential bytes 0x00-0xFF (256 bytes). Low compressibility, mostly literals."""
+    networking_codec(
+        codec_name="snappy_block",
+        input={"data": "0x" + bytes(range(256)).hex()},
+    )
+
+
+def test_snappy_block_at_block_boundary(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Exactly 65536 bytes of repeated data. Tests behavior at the Snappy block size limit."""
+    networking_codec(
+        codec_name="snappy_block",
+        input={"data": "0x" + (b"\xfe" * 65536).hex()},
+    )
+
+
+def test_snappy_block_multi_block(networking_codec: NetworkingCodecTestFiller) -> None:
+    """65537 bytes (one past block boundary). Forces multi-block handling."""
+    networking_codec(
+        codec_name="snappy_block",
+        input={"data": "0x" + (b"\xfe" * 65537).hex()},
+    )
+
+
+# --- Snappy framing format (Ethereum wire format) ---
+
+
+def test_snappy_frame_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Empty payload. Output is just the stream identifier chunk."""
+    networking_codec(codec_name="snappy_frame", input={"data": "0x"})
+
+
+def test_snappy_frame_short(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Short payload (16 bytes). Fits in a single compressed chunk."""
+    networking_codec(
+        codec_name="snappy_frame",
+        input={"data": "0x" + b"Ethereum Snappy!".hex()},
+    )
+
+
+def test_snappy_frame_compressible(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Highly compressible data (2048 repeated bytes). Single compressed chunk."""
+    networking_codec(
+        codec_name="snappy_frame",
+        input={"data": "0x" + (b"\x00" * 2048).hex()},
+    )
+
+
+def test_snappy_frame_incompressible(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Sequential bytes (256). May produce an uncompressed chunk if expansion occurs."""
+    networking_codec(
+        codec_name="snappy_frame",
+        input={"data": "0x" + bytes(range(256)).hex()},
+    )
+
+
+def test_snappy_frame_at_chunk_boundary(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Exactly 65536 bytes. Tests chunk size limit in framing format."""
+    networking_codec(
+        codec_name="snappy_frame",
+        input={"data": "0x" + (b"\xab" * 65536).hex()},
+    )
+
+
+def test_snappy_frame_multi_chunk(networking_codec: NetworkingCodecTestFiller) -> None:
+    """65537 bytes. Forces multiple framing chunks."""
+    networking_codec(
+        codec_name="snappy_frame",
+        input={"data": "0x" + (b"\xab" * 65537).hex()},
+    )
+
+
+def test_snappy_frame_ssz_like_payload(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Realistic SSZ-like payload: fixed header + repeated zero padding (512 bytes)."""
+    header = bytes(range(64))
+    padding = b"\x00" * 448
+    networking_codec(
+        codec_name="snappy_frame",
+        input={"data": "0x" + (header + padding).hex()},
+    )


### PR DESCRIPTION
## Summary

- Extends `NetworkingCodecTest` with `snappy_block` and `snappy_frame` codec handlers
- Adds 15 test vectors covering raw Snappy block format and Ethereum framing format
- Vectors cover: empty, single byte, short strings, compressible/incompressible data, block/chunk boundaries, multi-block/chunk, SSZ-like payloads

## Test plan

- [x] `uv run fill --fork=Devnet --clean -n auto -k test_snappy` — all 15 tests pass
- [x] `uvx tox -e all-checks` — all quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)