### PR TITLE
test(chain): add slot clock timing test vectors

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -10,6 +10,7 @@ from .test_fixtures import (
     ForkChoiceTest,
     GossipsubHandlerTest,
     NetworkingCodecTest,
+    SlotClockTest,
     SSZTest,
     StateTransitionTest,
     VerifySignaturesTest,
@@ -38,6 +39,7 @@ SSZTestFiller = Type[SSZTest]
 NetworkingCodecTestFiller = Type[NetworkingCodecTest]
 GossipsubHandlerTestFiller = Type[GossipsubHandlerTest]
 ApiEndpointTestFiller = Type[ApiEndpointTest]
+SlotClockTestFiller = Type[SlotClockTest]
 
 __all__ = [
     # Public API
@@ -57,6 +59,7 @@ __all__ = [
     "NetworkingCodecTest",
     "GossipsubHandlerTest",
     "ApiEndpointTest",
+    "SlotClockTest",
     # Test types
     "BaseForkChoiceStep",
     "TickStep",
@@ -76,4 +79,5 @@ __all__ = [
     "NetworkingCodecTestFiller",
     "GossipsubHandlerTestFiller",
     "ApiEndpointTestFiller",
+    "SlotClockTestFiller",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -5,6 +5,7 @@ from .base import BaseConsensusFixture
 from .fork_choice import ForkChoiceTest
 from .gossipsub_handler import GossipsubHandlerTest
 from .networking_codec import NetworkingCodecTest
+from .slot_clock import SlotClockTest
 from .ssz import SSZTest
 from .state_transition import StateTransitionTest
 from .verify_signatures import VerifySignaturesTest
@@ -18,4 +19,5 @@ __all__ = [
     "NetworkingCodecTest",
     "GossipsubHandlerTest",
     "ApiEndpointTest",
+    "SlotClockTest",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
@@ -1,0 +1,98 @@
+"""Slot clock test fixture for timing conformance testing.
+
+Generates JSON test vectors that verify slot/interval computation from
+wall-clock timestamps. Every client must compute identical slot boundaries
+to coordinate block proposals and attestations.
+"""
+
+from typing import Any, ClassVar
+
+from lean_spec.subspecs.chain.clock import Interval, SlotClock
+from lean_spec.subspecs.chain.config import (
+    INTERVALS_PER_SLOT,
+    MILLISECONDS_PER_INTERVAL,
+    SECONDS_PER_SLOT,
+)
+from lean_spec.types import Uint64
+
+from .base import BaseConsensusFixture
+
+
+class SlotClockTest(BaseConsensusFixture):
+    """Fixture for slot clock timing conformance.
+
+    Tests time-to-slot and time-to-interval conversions that every
+    consensus client must implement identically.
+
+    JSON output: operation, input, config, output.
+    """
+
+    format_name: ClassVar[str] = "slot_clock"
+    description: ClassVar[str] = "Tests slot clock time-to-slot/interval conversion"
+
+    operation: str
+    """Operation under test: from_unix_time, from_slot, current_slot,
+    current_interval, or total_intervals."""
+
+    input: dict[str, Any]
+    """Operation-specific input parameters."""
+
+    output: dict[str, Any] = {}
+    """Computed output. Filled by make_fixture."""
+
+    def make_fixture(self) -> "SlotClockTest":
+        """Dispatch to the operation handler and produce computed output."""
+        config = {
+            "secondsPerSlot": int(SECONDS_PER_SLOT),
+            "intervalsPerSlot": int(INTERVALS_PER_SLOT),
+            "millisecondsPerInterval": int(MILLISECONDS_PER_INTERVAL),
+        }
+        match self.operation:
+            case "from_unix_time":
+                result = self._make_from_unix_time()
+            case "from_slot":
+                result = self._make_from_slot()
+            case "current_slot":
+                result = self._make_current_slot()
+            case "current_interval":
+                result = self._make_current_interval()
+            case "total_intervals":
+                result = self._make_total_intervals()
+            case _:
+                raise ValueError(f"Unknown operation: {self.operation}")
+        output = {"config": config, **result}
+        return self.model_copy(update={"output": output})
+
+    def _make_from_unix_time(self) -> dict[str, Any]:
+        """Convert unix timestamp to interval count since genesis."""
+        unix_seconds = Uint64(self.input["unixSeconds"])
+        genesis_time = Uint64(self.input["genesisTime"])
+        interval = Interval.from_unix_time(unix_seconds, genesis_time)
+        return {"interval": int(interval)}
+
+    def _make_from_slot(self) -> dict[str, Any]:
+        """Convert slot number to interval at that slot's start."""
+        slot = Uint64(self.input["slot"])
+        interval = Interval.from_slot(slot)
+        return {"interval": int(interval)}
+
+    def _make_current_slot(self) -> dict[str, Any]:
+        """Compute current slot from genesis time and current timestamp."""
+        genesis_time = Uint64(self.input["genesisTime"])
+        current_time = float(self.input["currentTimeMs"]) / 1000.0
+        clock = SlotClock(genesis_time=genesis_time, time_fn=lambda: current_time)
+        return {"slot": int(clock.current_slot())}
+
+    def _make_current_interval(self) -> dict[str, Any]:
+        """Compute current interval within the slot (0-4)."""
+        genesis_time = Uint64(self.input["genesisTime"])
+        current_time = float(self.input["currentTimeMs"]) / 1000.0
+        clock = SlotClock(genesis_time=genesis_time, time_fn=lambda: current_time)
+        return {"interval": int(clock.current_interval())}
+
+    def _make_total_intervals(self) -> dict[str, Any]:
+        """Compute total intervals elapsed since genesis."""
+        genesis_time = Uint64(self.input["genesisTime"])
+        current_time = float(self.input["currentTimeMs"]) / 1000.0
+        clock = SlotClock(genesis_time=genesis_time, time_fn=lambda: current_time)
+        return {"totalIntervals": int(clock.total_intervals())}

--- a/tests/consensus/devnet/chain/test_slot_clock.py
+++ b/tests/consensus/devnet/chain/test_slot_clock.py
@@ -1,0 +1,217 @@
+"""Test vectors for slot clock timing computations.
+
+Every consensus client must derive identical slot and interval numbers
+from wall-clock timestamps. These vectors verify the conversion logic
+for a 4-second slot with 5 intervals of 800 ms each.
+"""
+
+import pytest
+from consensus_testing import SlotClockTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+GENESIS = 1700000000
+"""Arbitrary genesis timestamp (seconds) used across most vectors."""
+
+
+# --- Interval.from_unix_time ---
+
+
+def test_from_unix_time_at_genesis(slot_clock: SlotClockTestFiller) -> None:
+    """At genesis, zero seconds elapsed yields interval 0."""
+    slot_clock(
+        operation="from_unix_time",
+        input={"unixSeconds": GENESIS, "genesisTime": GENESIS},
+    )
+
+
+def test_from_unix_time_one_second(slot_clock: SlotClockTestFiller) -> None:
+    """One second = 1000 ms. floor(1000 / 800) = 1 interval."""
+    slot_clock(
+        operation="from_unix_time",
+        input={"unixSeconds": GENESIS + 1, "genesisTime": GENESIS},
+    )
+
+
+def test_from_unix_time_one_slot(slot_clock: SlotClockTestFiller) -> None:
+    """One slot = 4 seconds = 4000 ms. 4000 / 800 = 5 intervals."""
+    slot_clock(
+        operation="from_unix_time",
+        input={"unixSeconds": GENESIS + 4, "genesisTime": GENESIS},
+    )
+
+
+def test_from_unix_time_two_seconds(slot_clock: SlotClockTestFiller) -> None:
+    """Two seconds = 2000 ms. floor(2000 / 800) = 2 intervals."""
+    slot_clock(
+        operation="from_unix_time",
+        input={"unixSeconds": GENESIS + 2, "genesisTime": GENESIS},
+    )
+
+
+def test_from_unix_time_three_seconds(slot_clock: SlotClockTestFiller) -> None:
+    """Three seconds = 3000 ms. floor(3000 / 800) = 3 intervals."""
+    slot_clock(
+        operation="from_unix_time",
+        input={"unixSeconds": GENESIS + 3, "genesisTime": GENESIS},
+    )
+
+
+def test_from_unix_time_ten_slots(slot_clock: SlotClockTestFiller) -> None:
+    """Ten slots = 40 seconds = 50 intervals."""
+    slot_clock(
+        operation="from_unix_time",
+        input={"unixSeconds": GENESIS + 40, "genesisTime": GENESIS},
+    )
+
+
+def test_from_unix_time_one_day(slot_clock: SlotClockTestFiller) -> None:
+    """One day = 86400 seconds = 108000 intervals."""
+    slot_clock(
+        operation="from_unix_time",
+        input={"unixSeconds": GENESIS + 86400, "genesisTime": GENESIS},
+    )
+
+
+def test_from_unix_time_genesis_zero(slot_clock: SlotClockTestFiller) -> None:
+    """Genesis at Unix epoch 0. 100 seconds elapsed = 125 intervals."""
+    slot_clock(
+        operation="from_unix_time",
+        input={"unixSeconds": 100, "genesisTime": 0},
+    )
+
+
+# --- Interval.from_slot ---
+
+
+def test_from_slot_zero(slot_clock: SlotClockTestFiller) -> None:
+    """Slot 0 starts at interval 0."""
+    slot_clock(operation="from_slot", input={"slot": 0})
+
+
+def test_from_slot_one(slot_clock: SlotClockTestFiller) -> None:
+    """Slot 1 starts at interval 5."""
+    slot_clock(operation="from_slot", input={"slot": 1})
+
+
+def test_from_slot_ten(slot_clock: SlotClockTestFiller) -> None:
+    """Slot 10 starts at interval 50."""
+    slot_clock(operation="from_slot", input={"slot": 10})
+
+
+def test_from_slot_hundred(slot_clock: SlotClockTestFiller) -> None:
+    """Slot 100 starts at interval 500."""
+    slot_clock(operation="from_slot", input={"slot": 100})
+
+
+# --- SlotClock.current_slot ---
+
+
+def test_current_slot_at_genesis(slot_clock: SlotClockTestFiller) -> None:
+    """Exactly at genesis: slot 0."""
+    slot_clock(
+        operation="current_slot",
+        input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000},
+    )
+
+
+def test_current_slot_before_genesis(slot_clock: SlotClockTestFiller) -> None:
+    """Before genesis: clamped to slot 0."""
+    slot_clock(
+        operation="current_slot",
+        input={"genesisTime": GENESIS, "currentTimeMs": (GENESIS - 10) * 1000},
+    )
+
+
+def test_current_slot_mid_slot(slot_clock: SlotClockTestFiller) -> None:
+    """2 seconds into slot 0: still slot 0."""
+    slot_clock(
+        operation="current_slot",
+        input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 2000},
+    )
+
+
+def test_current_slot_at_boundary(slot_clock: SlotClockTestFiller) -> None:
+    """Exactly at slot 1 boundary (4 seconds): slot 1."""
+    slot_clock(
+        operation="current_slot",
+        input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 4000},
+    )
+
+
+def test_current_slot_before_boundary(slot_clock: SlotClockTestFiller) -> None:
+    """One ms before slot 1 boundary: still slot 0 (integer division floors)."""
+    slot_clock(
+        operation="current_slot",
+        input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 3999},
+    )
+
+
+# --- SlotClock.current_interval ---
+
+
+def test_current_interval_at_slot_start(slot_clock: SlotClockTestFiller) -> None:
+    """Exactly at slot start: interval 0."""
+    slot_clock(
+        operation="current_interval",
+        input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000},
+    )
+
+
+def test_current_interval_800ms(slot_clock: SlotClockTestFiller) -> None:
+    """800 ms into slot: interval 1."""
+    slot_clock(
+        operation="current_interval",
+        input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 800},
+    )
+
+
+def test_current_interval_1600ms(slot_clock: SlotClockTestFiller) -> None:
+    """1600 ms into slot: interval 2."""
+    slot_clock(
+        operation="current_interval",
+        input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 1600},
+    )
+
+
+def test_current_interval_3200ms(slot_clock: SlotClockTestFiller) -> None:
+    """3200 ms into slot: interval 4."""
+    slot_clock(
+        operation="current_interval",
+        input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 3200},
+    )
+
+
+def test_current_interval_wraps_at_next_slot(slot_clock: SlotClockTestFiller) -> None:
+    """4000 ms = next slot start: interval wraps back to 0."""
+    slot_clock(
+        operation="current_interval",
+        input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 4000},
+    )
+
+
+def test_current_interval_before_genesis(slot_clock: SlotClockTestFiller) -> None:
+    """Before genesis: interval 0."""
+    slot_clock(
+        operation="current_interval",
+        input={"genesisTime": GENESIS, "currentTimeMs": (GENESIS - 5) * 1000},
+    )
+
+
+# --- SlotClock.total_intervals ---
+
+
+def test_total_intervals_multi_slot(slot_clock: SlotClockTestFiller) -> None:
+    """14.4 seconds = 18 intervals (14400 ms / 800 ms)."""
+    slot_clock(
+        operation="total_intervals",
+        input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 14400},
+    )
+
+
+def test_total_intervals_before_genesis(slot_clock: SlotClockTestFiller) -> None:
+    """Before genesis: 0 intervals."""
+    slot_clock(
+        operation="total_intervals",
+        input={"genesisTime": GENESIS, "currentTimeMs": (GENESIS - 1) * 1000},
+    )


### PR DESCRIPTION
## Summary

- Introduces new `SlotClockTest` fixture type for timing conformance testing
- Adds 25 test vectors covering `from_unix_time`, `from_slot`, `current_slot`, `current_interval`, and `total_intervals` operations
- Each fixture includes config constants (secondsPerSlot, intervalsPerSlot, millisecondsPerInterval) for consumer verification

## Test plan

- [x] `uv run fill --fork=Devnet --clean -n auto -k test_slot_clock` — all 25 tests pass
- [x] `uvx tox -e all-checks` — all quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)