### PR TITLE
chore: add per-key logging for keygen

### DIFF
--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -616,14 +616,27 @@ def _generate_single_keypair(
     Returns:
         Complete key pair with both attestation and proposal keys.
     """
-    print(f"Starting key #{index} generation...")
+    import sys
+    import time
 
     # Generate two independent key pairs: one for attestations, one for proposals.
     #
     # Separate keys allow signing both roles within the same slot
     # without exhausting a one-time leaf.
+    start = time.monotonic()
+    print(f"[key #{index}] generating attestation key...", flush=True)
     att_pk, att_sk = scheme.key_gen(Slot(0), Uint64(num_slots))
+
+    elapsed = time.monotonic() - start
+    print(
+        f"[key #{index}] attestation key done ({elapsed:.0f}s), "
+        f"generating proposal key...",
+        flush=True,
+    )
     prop_pk, prop_sk = scheme.key_gen(Slot(0), Uint64(num_slots))
+
+    elapsed = time.monotonic() - start
+    print(f"[key #{index}] done ({elapsed:.0f}s)", file=sys.stderr, flush=True)
 
     return ValidatorKeyPair(
         attestation_public=att_pk,
@@ -665,14 +678,20 @@ def _generate_keys(lean_env: str, count: int, max_slot: int) -> None:
 
     # Generate key pairs in parallel across all CPU cores.
     # Results arrive in index order thanks to executor.map.
+    import time
+
+    gen_start = time.monotonic()
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
         worker_func = partial(_generate_single_keypair, scheme, num_slots)
         for idx, key_pair in enumerate(executor.map(worker_func, range(count))):
-            # Serialize and write each key pair as a separate JSON file named by index.
+            elapsed = time.monotonic() - gen_start
+            print(f"[{idx + 1}/{count}] saved key #{idx} ({elapsed:.0f}s elapsed)")
+
             key_file = keys_dir / f"{idx}.json"
             key_file.write_text(json.dumps(key_pair.to_dict(), indent=2))
 
-    print(f"Saved {count} key pairs to {keys_dir}/")
+    total = time.monotonic() - gen_start
+    print(f"Saved {count} key pairs to {keys_dir}/ ({total:.0f}s total)")
 
 
 def download_keys(scheme: str) -> None:

--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -629,8 +629,7 @@ def _generate_single_keypair(
 
     elapsed = time.monotonic() - start
     print(
-        f"[key #{index}] attestation key done ({elapsed:.0f}s), "
-        f"generating proposal key...",
+        f"[key #{index}] attestation key done ({elapsed:.0f}s), generating proposal key...",
         flush=True,
     )
     prop_pk, prop_sk = scheme.key_gen(Slot(0), Uint64(num_slots))


### PR DESCRIPTION
## 🗒️ Description

Right now keygen can be very quiet throughout its hours of running. Adding in this PR some more verbose logging so progress is updated.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
