### PR TITLE
api, node: add runtime aggregator role toggle

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
@@ -14,6 +14,13 @@ from lean_spec.types import Bytes32, Uint64
 from ..genesis import generate_pre_state
 from .base import BaseConsensusFixture
 
+EndpointHandler = Callable[[Store, "ApiEndpointTest"], dict[str, Any]]
+"""Uniform signature for all endpoint response builders.
+
+Every handler receives both arguments even if it only needs one.
+This keeps the dispatch table simple: one signature, one call site.
+"""
+
 
 def _make_genesis_block(state: State) -> Block:
     """Build a slot-0 block anchored to the given genesis state."""
@@ -35,7 +42,7 @@ def _build_store(num_validators: int, genesis_time: int) -> Store:
     return Store.from_anchor(state, block, validator_id=None)
 
 
-def _health_response(_store: Store) -> dict[str, Any]:
+def _health_response(_store: Store, _fixture: "ApiEndpointTest") -> dict[str, Any]:
     """Static liveness check. Independent of consensus state."""
     return {
         "expected_status_code": 200,
@@ -44,7 +51,7 @@ def _health_response(_store: Store) -> dict[str, Any]:
     }
 
 
-def _justified_response(store: Store) -> dict[str, Any]:
+def _justified_response(store: Store, _fixture: "ApiEndpointTest") -> dict[str, Any]:
     """Latest justified checkpoint: slot + root. Root varies with validator count."""
     return {
         "expected_status_code": 200,
@@ -56,7 +63,7 @@ def _justified_response(store: Store) -> dict[str, Any]:
     }
 
 
-def _finalized_state_response(store: Store) -> dict[str, Any]:
+def _finalized_state_response(store: Store, _fixture: "ApiEndpointTest") -> dict[str, Any]:
     """Full SSZ-encoded finalized state as hex bytes."""
     state = store.states[store.latest_finalized.root]
     return {
@@ -66,7 +73,7 @@ def _finalized_state_response(store: Store) -> dict[str, Any]:
     }
 
 
-def _fork_choice_response(store: Store) -> dict[str, Any]:
+def _fork_choice_response(store: Store, _fixture: "ApiEndpointTest") -> dict[str, Any]:
     """Fork choice tree: blocks with weights, head, checkpoints, validator count."""
     weights = store.compute_block_weights()
 
@@ -105,13 +112,48 @@ def _fork_choice_response(store: Store) -> dict[str, Any]:
     }
 
 
-_ENDPOINT_HANDLERS: dict[str, Callable[[Store], dict[str, Any]]] = {
-    "/lean/v0/health": _health_response,
-    "/lean/v0/checkpoints/justified": _justified_response,
-    "/lean/v0/states/finalized": _finalized_state_response,
-    "/lean/v0/fork_choice": _fork_choice_response,
+def _aggregator_status_response(_store: Store, fixture: "ApiEndpointTest") -> dict[str, Any]:
+    """Current aggregator role as seeded by initial_is_aggregator."""
+    return {
+        "expected_status_code": 200,
+        "expected_content_type": "application/json",
+        "expected_body": {"is_aggregator": fixture.initial_is_aggregator},
+    }
+
+
+def _aggregator_toggle_response(_store: Store, fixture: "ApiEndpointTest") -> dict[str, Any]:
+    """Expected response after toggling the aggregator role.
+
+    The fixture models a single POST against a node whose starting state is
+    initial_is_aggregator. The response reflects the new value and the
+    previous value as an is_aggregator / previous dict.
+    """
+    body = fixture.request_body
+    if not isinstance(body, dict) or not isinstance(body.get("enabled"), bool):
+        raise ValueError(
+            "POST /lean/v0/admin/aggregator fixture requires request_body "
+            "with a boolean 'enabled' field"
+        )
+    new_value = body["enabled"]
+    return {
+        "expected_status_code": 200,
+        "expected_content_type": "application/json",
+        "expected_body": {
+            "is_aggregator": new_value,
+            "previous": fixture.initial_is_aggregator,
+        },
+    }
+
+
+_ENDPOINT_HANDLERS: dict[tuple[str, str], EndpointHandler] = {
+    ("GET", "/lean/v0/health"): _health_response,
+    ("GET", "/lean/v0/checkpoints/justified"): _justified_response,
+    ("GET", "/lean/v0/states/finalized"): _finalized_state_response,
+    ("GET", "/lean/v0/fork_choice"): _fork_choice_response,
+    ("GET", "/lean/v0/admin/aggregator"): _aggregator_status_response,
+    ("POST", "/lean/v0/admin/aggregator"): _aggregator_toggle_response,
 }
-"""Maps endpoint paths to response builders."""
+"""Maps (method, path) tuples to response builders."""
 
 
 class ApiEndpointTest(BaseConsensusFixture):
@@ -127,8 +169,26 @@ class ApiEndpointTest(BaseConsensusFixture):
     endpoint: str
     """API path under test, e.g. /lean/v0/health."""
 
+    method: str = "GET"
+    """HTTP method under test. Defaults to GET for read-only endpoints."""
+
     genesis_params: dict[str, int]
     """Genesis store inputs: numValidators and genesisTime."""
+
+    request_body: Any = None
+    """Optional request body for non-GET methods. JSON-serializable.
+
+    Consumed by admin endpoints (e.g. POST /lean/v0/admin/aggregator). Read-only
+    GET fixtures leave this as None.
+    """
+
+    initial_is_aggregator: bool = False
+    """Seeds the node's aggregator role before the request is sent.
+
+    Consumed by the admin aggregator endpoints. Clients must configure their
+    node with this value (e.g. via CLI or controller) before replaying the
+    fixture. Ignored by other endpoints.
+    """
 
     expected_status_code: int = 0
     """HTTP status code. Filled by make_fixture."""
@@ -141,12 +201,12 @@ class ApiEndpointTest(BaseConsensusFixture):
 
     def make_fixture(self) -> "ApiEndpointTest":
         """Build genesis store, compute expected response, populate output fields."""
-        handler = _ENDPOINT_HANDLERS.get(self.endpoint)
+        handler = _ENDPOINT_HANDLERS.get((self.method, self.endpoint))
         if handler is None:
-            raise ValueError(f"Unknown endpoint: {self.endpoint}")
+            raise ValueError(f"Unknown endpoint: {self.method} {self.endpoint}")
 
         store = _build_store(
             num_validators=self.genesis_params.get("numValidators", 4),
             genesis_time=self.genesis_params.get("genesisTime", 0),
         )
-        return self.model_copy(update=handler(store))
+        return self.model_copy(update=handler(store, self))

--- a/src/lean_spec/subspecs/api/__init__.py
+++ b/src/lean_spec/subspecs/api/__init__.py
@@ -1,8 +1,10 @@
 """API server module for various API endpoints."""
 
+from .aggregator_controller import AggregatorController
 from .server import ApiServer, ApiServerConfig
 
 __all__ = [
+    "AggregatorController",
     "ApiServer",
     "ApiServerConfig",
 ]

--- a/src/lean_spec/subspecs/api/aggregator_controller.py
+++ b/src/lean_spec/subspecs/api/aggregator_controller.py
@@ -1,0 +1,71 @@
+"""
+Runtime controller for the node's aggregator role.
+
+Exposes get/set operations over the shared is_aggregator flag so the admin
+API can rotate aggregator duties across nodes without restarting.
+
+Toggles are serialized under an asyncio lock so concurrent admin requests
+cannot leave the sync and network services disagreeing on the current role.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+
+from lean_spec.subspecs.networking import NetworkService
+from lean_spec.subspecs.sync import SyncService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class AggregatorController:
+    """
+    Runtime control over the node's aggregator role.
+
+    Operators toggle the flag to rotate aggregation duties across nodes when
+    an active aggregator becomes unhealthy, without restarting the node.
+
+    The spec-level semantics are unchanged: the sync service reads
+    is_aggregator on each gossip event and each tick, so flipping the flag
+    takes effect from the next event or tick onward.
+    """
+
+    sync_service: SyncService
+    """Sync service whose flag drives gossip-side aggregator behavior."""
+
+    network_service: NetworkService
+    """Network service whose flag mirrors the sync service for consistency."""
+
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
+    """Serializes concurrent toggles from API handlers."""
+
+    def is_enabled(self) -> bool:
+        """Return whether the node is currently acting as aggregator."""
+        return self.sync_service.is_aggregator
+
+    async def set_enabled(self, enabled: bool) -> bool:
+        """
+        Update the aggregator role and return the previous value.
+
+        The sync and network services are updated together under a lock so
+        both views remain consistent from any observer's perspective.
+
+        Args:
+            enabled: Desired aggregator state.
+
+        Returns:
+            Aggregator state prior to the update.
+        """
+        async with self._lock:
+            previous = self.sync_service.is_aggregator
+            self.sync_service.is_aggregator = enabled
+            self.network_service.is_aggregator = enabled
+            if previous != enabled:
+                logger.info(
+                    "Aggregator role %s via admin API",
+                    "activated" if enabled else "deactivated",
+                )
+            return previous

--- a/src/lean_spec/subspecs/api/endpoints/__init__.py
+++ b/src/lean_spec/subspecs/api/endpoints/__init__.py
@@ -1,8 +1,9 @@
 """API endpoint specifications."""
 
-from . import checkpoints, fork_choice, health, metrics, states
+from . import aggregator, checkpoints, fork_choice, health, metrics, states
 
 __all__ = [
+    "aggregator",
     "checkpoints",
     "fork_choice",
     "health",

--- a/src/lean_spec/subspecs/api/endpoints/aggregator.py
+++ b/src/lean_spec/subspecs/api/endpoints/aggregator.py
@@ -1,0 +1,78 @@
+"""Admin endpoints for toggling the aggregator role at runtime."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_status(request: web.Request) -> web.Response:
+    """
+    Handle aggregator status request.
+
+    Returns whether the node is currently acting as an aggregator.
+
+    Response: JSON object with fields:
+        - is_aggregator (bool): Whether the node is currently acting as aggregator.
+
+    Status Codes:
+        200 OK: Status returned successfully.
+        503 Service Unavailable: Aggregator controller not wired.
+    """
+    controller = request.app.get("aggregator_controller")
+    if controller is None:
+        raise web.HTTPServiceUnavailable(reason="Aggregator controller not available")
+
+    return web.Response(
+        body=json.dumps({"is_aggregator": controller.is_enabled()}),
+        content_type="application/json",
+    )
+
+
+async def handle_toggle(request: web.Request) -> web.Response:
+    """
+    Handle aggregator toggle request.
+
+    Activates or deactivates the aggregator role at runtime so operators can
+    rotate aggregator duties across nodes without restarting.
+
+    Request body: JSON object with fields:
+        - enabled (bool): Desired aggregator state.
+
+    Response: JSON object with fields:
+        - is_aggregator (bool): Aggregator state after the update.
+        - previous (bool): Aggregator state before the update.
+
+    Status Codes:
+        200 OK: Role updated successfully.
+        400 Bad Request: Body missing, malformed, or with wrong field types.
+        503 Service Unavailable: Aggregator controller not wired.
+    """
+    controller = request.app.get("aggregator_controller")
+    if controller is None:
+        raise web.HTTPServiceUnavailable(reason="Aggregator controller not available")
+
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError as exc:
+        raise web.HTTPBadRequest(reason="Invalid JSON body") from exc
+
+    if not isinstance(payload, dict) or "enabled" not in payload:
+        raise web.HTTPBadRequest(reason="Missing 'enabled' field in body")
+
+    enabled = payload["enabled"]
+    # Explicit bool check rejects ints like 0/1, which JSON does not distinguish
+    # from booleans in loose parsers but Python does.
+    if not isinstance(enabled, bool):
+        raise web.HTTPBadRequest(reason="'enabled' must be a boolean")
+
+    previous = await controller.set_enabled(enabled)
+
+    return web.Response(
+        body=json.dumps({"is_aggregator": enabled, "previous": previous}),
+        content_type="application/json",
+    )

--- a/src/lean_spec/subspecs/api/routes.py
+++ b/src/lean_spec/subspecs/api/routes.py
@@ -6,13 +6,22 @@ from collections.abc import Awaitable, Callable
 
 from aiohttp import web
 
-from .endpoints import checkpoints, fork_choice, health, metrics, states
+from .endpoints import aggregator, checkpoints, fork_choice, health, metrics, states
 
-ROUTES: dict[str, Callable[[web.Request], Awaitable[web.Response]]] = {
+Handler = Callable[[web.Request], Awaitable[web.Response]]
+"""Type alias for aiohttp request handlers."""
+
+ROUTES: dict[str, Handler] = {
     "/lean/v0/health": health.handle,
     "/lean/v0/states/finalized": states.handle_finalized,
     "/lean/v0/checkpoints/justified": checkpoints.handle_justified,
     "/lean/v0/fork_choice": fork_choice.handle,
     "/metrics": metrics.handle,
 }
-"""All API routes mapped to their handlers."""
+"""Read-only API routes registered as GET."""
+
+ADMIN_ROUTES: list[tuple[str, str, Handler]] = [
+    ("GET", "/lean/v0/admin/aggregator", aggregator.handle_status),
+    ("POST", "/lean/v0/admin/aggregator", aggregator.handle_toggle),
+]
+"""Admin routes as (method, path, handler) triples for non-GET verbs."""

--- a/src/lean_spec/subspecs/api/server.py
+++ b/src/lean_spec/subspecs/api/server.py
@@ -16,13 +16,15 @@ from aiohttp import web
 
 from lean_spec.subspecs.forkchoice import Store
 
-from .routes import ROUTES
+from .aggregator_controller import AggregatorController
+from .routes import ADMIN_ROUTES, ROUTES
 
 logger = logging.getLogger(__name__)
 
 
 _routes = [web.get(path, handler) for path, handler in ROUTES.items()]
-"""aiohttp route definitions generated from ROUTES."""
+_routes += [web.route(method, path, handler) for method, path, handler in ADMIN_ROUTES]
+"""aiohttp route definitions generated from ROUTES and ADMIN_ROUTES."""
 
 # The following classes are implementation details.
 # Other implementations may structure their code differently.
@@ -66,6 +68,14 @@ class ApiServer:
     store_getter: Callable[[], Store | None] | None = None
     """Callable that returns the current Store instance."""
 
+    aggregator_controller: AggregatorController | None = None
+    """
+    Optional controller for toggling the aggregator role at runtime.
+
+    When present, the admin aggregator endpoints can query and mutate the
+    node's aggregator flag. When absent, those endpoints return 503.
+    """
+
     _runner: web.AppRunner | None = field(default=None, init=False)
     """aiohttp application runner."""
 
@@ -87,6 +97,10 @@ class ApiServer:
 
         # Store the store_getter in app for handlers that need store access
         app["store_getter"] = self.store_getter
+
+        # Expose the aggregator controller to admin endpoints.
+        # Absence is fine; endpoints return 503 when unset.
+        app["aggregator_controller"] = self.aggregator_controller
 
         # Add all routes
         app.add_routes(_routes)

--- a/src/lean_spec/subspecs/node/node.py
+++ b/src/lean_spec/subspecs/node/node.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final
 
-from lean_spec.subspecs.api import ApiServer, ApiServerConfig
+from lean_spec.subspecs.api import AggregatorController, ApiServer, ApiServerConfig
 from lean_spec.subspecs.chain import SlotClock
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import ATTESTATION_COMMITTEE_COUNT
@@ -119,6 +119,11 @@ class NodeConfig:
 
     When False (default):
     - The node runs in standard validator or passive mode
+
+    Seeds the initial value of the live aggregator flag on SyncService and
+    NetworkService. The flag can be toggled at runtime via the admin API
+    (see AggregatorController). Runtime toggles do not persist across
+    restarts and do not update the local ENR or subnet subscriptions.
     """
 
     aggregate_subnet_ids: tuple[SubnetId, ...] = field(default_factory=tuple)
@@ -278,10 +283,17 @@ class Node:
         # Create API server if configured
         api_server: ApiServer | None = None
         if config.api_config is not None:
+            # Controller lets the admin API rotate the aggregator role at
+            # runtime when another aggregator becomes unhealthy.
+            aggregator_controller = AggregatorController(
+                sync_service=sync_service,
+                network_service=network_service,
+            )
             # Store getter captures sync_service to get the live store
             api_server = ApiServer(
                 config=config.api_config,
                 store_getter=lambda: sync_service.store,
+                aggregator_controller=aggregator_controller,
             )
 
         # Create validator service if registry provided.

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -3,16 +3,34 @@
 import asyncio
 import threading
 import time
+from dataclasses import dataclass, field
 from typing import Generator
 
 import httpx
 import pytest
 
-from lean_spec.subspecs.api import ApiServer, ApiServerConfig
+from lean_spec.subspecs.api import AggregatorController, ApiServer, ApiServerConfig
 from tests.lean_spec.helpers import make_store
 
 # Default port for auto-started local server
 DEFAULT_PORT = 15099
+
+
+@dataclass(slots=True)
+class _AggregatorStub:
+    """Minimal stub exposing only the is_aggregator flag."""
+
+    is_aggregator: bool = field(default=False)
+
+
+def _make_conformance_controller(initial: bool = False) -> AggregatorController:
+    """Build an AggregatorController backed by lightweight stubs."""
+    sync_stub = _AggregatorStub(is_aggregator=initial)
+    network_stub = _AggregatorStub(is_aggregator=initial)
+    return AggregatorController(
+        sync_service=sync_stub,  # type: ignore[arg-type]
+        network_service=network_stub,  # type: ignore[arg-type]
+    )
 
 
 class _ServerThread(threading.Thread):
@@ -46,11 +64,16 @@ class _ServerThread(threading.Thread):
                 self.loop.close()
 
     def _create_server(self) -> ApiServer:
-        """Create the API server with a test store."""
+        """Create the API server with a test store and aggregator controller."""
         store = make_store(num_validators=3, validator_id=None, genesis_time=int(time.time()))
 
+        controller = _make_conformance_controller(initial=False)
         config = ApiServerConfig(host="127.0.0.1", port=self.port)
-        return ApiServer(config=config, store_getter=lambda: store)
+        return ApiServer(
+            config=config,
+            store_getter=lambda: store,
+            aggregator_controller=controller,
+        )
 
     def stop(self) -> None:
         """Stop the server and event loop, awaiting cleanup so _async_stop is run."""

--- a/tests/api/endpoints/test_aggregator.py
+++ b/tests/api/endpoints/test_aggregator.py
@@ -1,0 +1,114 @@
+"""
+Tests for the admin aggregator endpoint.
+
+The conformance server is started with a controller seeded to disabled,
+so tests exercise both the happy path and error cases.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestAggregatorStatus:
+    """Tests for GET /lean/v0/admin/aggregator."""
+
+    def test_returns_200(self, server_url: str) -> None:
+        """GET returns 200 when the controller is wired."""
+        response = httpx.get(f"{server_url}/lean/v0/admin/aggregator")
+        assert response.status_code == 200
+
+    def test_content_type_is_json(self, server_url: str) -> None:
+        """GET returns JSON content type."""
+        response = httpx.get(f"{server_url}/lean/v0/admin/aggregator")
+        assert "application/json" in response.headers.get("content-type", "")
+
+    def test_response_has_is_aggregator_field(self, server_url: str) -> None:
+        """GET response contains the is_aggregator boolean field."""
+        response = httpx.get(f"{server_url}/lean/v0/admin/aggregator")
+        data = response.json()
+        assert "is_aggregator" in data
+        assert isinstance(data["is_aggregator"], bool)
+
+
+class TestAggregatorToggle:
+    """Tests for POST /lean/v0/admin/aggregator."""
+
+    def test_toggle_returns_200(self, server_url: str) -> None:
+        """POST with valid body returns 200."""
+        response = httpx.post(
+            f"{server_url}/lean/v0/admin/aggregator",
+            json={"enabled": True},
+        )
+        assert response.status_code == 200
+
+    def test_toggle_content_type_is_json(self, server_url: str) -> None:
+        """POST returns JSON content type."""
+        response = httpx.post(
+            f"{server_url}/lean/v0/admin/aggregator",
+            json={"enabled": True},
+        )
+        assert "application/json" in response.headers.get("content-type", "")
+
+    def test_toggle_response_structure(self, server_url: str) -> None:
+        """POST response contains is_aggregator and previous boolean fields."""
+        response = httpx.post(
+            f"{server_url}/lean/v0/admin/aggregator",
+            json={"enabled": True},
+        )
+        data = response.json()
+        assert "is_aggregator" in data
+        assert "previous" in data
+        assert isinstance(data["is_aggregator"], bool)
+        assert isinstance(data["previous"], bool)
+
+    def test_toggle_reflects_requested_value(self, server_url: str) -> None:
+        """POST response reflects the requested enabled value."""
+        response = httpx.post(
+            f"{server_url}/lean/v0/admin/aggregator",
+            json={"enabled": False},
+        )
+        assert response.json()["is_aggregator"] is False
+
+    def test_get_reflects_toggle(self, server_url: str) -> None:
+        """A follow-up GET reflects the state set by a preceding POST."""
+        httpx.post(
+            f"{server_url}/lean/v0/admin/aggregator",
+            json={"enabled": True},
+        )
+        response = httpx.get(f"{server_url}/lean/v0/admin/aggregator")
+        assert response.json()["is_aggregator"] is True
+
+
+class TestAggregatorErrors:
+    """Tests for error responses on /lean/v0/admin/aggregator."""
+
+    def test_unsupported_method_returns_405(self, server_url: str) -> None:
+        """DELETE against the admin aggregator route is not allowed."""
+        response = httpx.delete(f"{server_url}/lean/v0/admin/aggregator")
+        assert response.status_code == 405
+
+    def test_toggle_rejects_missing_body(self, server_url: str) -> None:
+        """POST with empty body returns 400."""
+        response = httpx.post(
+            f"{server_url}/lean/v0/admin/aggregator",
+            content=b"",
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 400
+
+    def test_toggle_rejects_missing_field(self, server_url: str) -> None:
+        """POST without enabled field returns 400."""
+        response = httpx.post(
+            f"{server_url}/lean/v0/admin/aggregator",
+            json={},
+        )
+        assert response.status_code == 400
+
+    def test_toggle_rejects_non_boolean(self, server_url: str) -> None:
+        """POST with non-boolean enabled returns 400."""
+        response = httpx.post(
+            f"{server_url}/lean/v0/admin/aggregator",
+            json={"enabled": "yes"},
+        )
+        assert response.status_code == 400

--- a/tests/consensus/devnet/api/test_api_endpoints.py
+++ b/tests/consensus/devnet/api/test_api_endpoints.py
@@ -45,3 +45,65 @@ def test_fork_choice_4v(api_endpoint: ApiEndpointTestFiller) -> None:
 def test_fork_choice_8v(api_endpoint: ApiEndpointTestFiller) -> None:
     """Fork choice tree at genesis with 8 validators. Same shape, higher count."""
     api_endpoint(endpoint="/lean/v0/fork_choice", genesis_params=GENESIS_8V)
+
+
+def test_aggregator_status_disabled(api_endpoint: ApiEndpointTestFiller) -> None:
+    """GET aggregator status on a node started with aggregator disabled."""
+    api_endpoint(
+        endpoint="/lean/v0/admin/aggregator",
+        genesis_params=GENESIS_4V,
+        initial_is_aggregator=False,
+    )
+
+
+def test_aggregator_status_enabled(api_endpoint: ApiEndpointTestFiller) -> None:
+    """GET aggregator status on a node started with aggregator enabled."""
+    api_endpoint(
+        endpoint="/lean/v0/admin/aggregator",
+        genesis_params=GENESIS_4V,
+        initial_is_aggregator=True,
+    )
+
+
+def test_aggregator_toggle_activate(api_endpoint: ApiEndpointTestFiller) -> None:
+    """POST enable=true flips the role from off to on."""
+    api_endpoint(
+        endpoint="/lean/v0/admin/aggregator",
+        method="POST",
+        genesis_params=GENESIS_4V,
+        initial_is_aggregator=False,
+        request_body={"enabled": True},
+    )
+
+
+def test_aggregator_toggle_deactivate(api_endpoint: ApiEndpointTestFiller) -> None:
+    """POST enable=false flips the role from on to off."""
+    api_endpoint(
+        endpoint="/lean/v0/admin/aggregator",
+        method="POST",
+        genesis_params=GENESIS_4V,
+        initial_is_aggregator=True,
+        request_body={"enabled": False},
+    )
+
+
+def test_aggregator_toggle_idempotent_enable(api_endpoint: ApiEndpointTestFiller) -> None:
+    """POST enable=true on an already-enabled node returns previous=true and is a no-op."""
+    api_endpoint(
+        endpoint="/lean/v0/admin/aggregator",
+        method="POST",
+        genesis_params=GENESIS_4V,
+        initial_is_aggregator=True,
+        request_body={"enabled": True},
+    )
+
+
+def test_aggregator_toggle_idempotent_disable(api_endpoint: ApiEndpointTestFiller) -> None:
+    """POST enable=false on an already-disabled node returns previous=false and is a no-op."""
+    api_endpoint(
+        endpoint="/lean/v0/admin/aggregator",
+        method="POST",
+        genesis_params=GENESIS_4V,
+        initial_is_aggregator=False,
+        request_body={"enabled": False},
+    )

--- a/tests/lean_spec/subspecs/api/test_aggregator_controller.py
+++ b/tests/lean_spec/subspecs/api/test_aggregator_controller.py
@@ -1,0 +1,98 @@
+"""Tests for the aggregator runtime controller."""
+
+from __future__ import annotations
+
+import asyncio
+
+from lean_spec.subspecs.api import AggregatorController
+from lean_spec.subspecs.networking import NetworkService, PeerId
+from lean_spec.subspecs.sync import SyncService
+from tests.lean_spec.helpers import MockEventSource, create_mock_sync_service
+
+FORK_DIGEST = "0x00000000"
+
+
+def _make_controller(
+    peer_id: PeerId,
+    *,
+    initial: bool = False,
+) -> tuple[AggregatorController, SyncService, NetworkService]:
+    """Build a controller wired to realistic sync/network services."""
+    sync_service = create_mock_sync_service(peer_id)
+    sync_service.is_aggregator = initial
+    network_service = NetworkService(
+        sync_service=sync_service,
+        event_source=MockEventSource(events=[]),
+        fork_digest=FORK_DIGEST,
+        is_aggregator=initial,
+    )
+    controller = AggregatorController(
+        sync_service=sync_service,
+        network_service=network_service,
+    )
+    return controller, sync_service, network_service
+
+
+class TestAggregatorControllerRead:
+    """Tests for the read path."""
+
+    def test_is_enabled_reflects_sync_service_flag(self, peer_id: PeerId) -> None:
+        """is_enabled reads the sync service flag as the source of truth."""
+        controller, sync_service, _ = _make_controller(peer_id, initial=False)
+        assert controller.is_enabled() is False
+
+        sync_service.is_aggregator = True
+        assert controller.is_enabled() is True
+
+
+class TestAggregatorControllerWrite:
+    """Tests for the write path."""
+
+    async def test_set_enabled_activates_role(self, peer_id: PeerId) -> None:
+        """set_enabled(True) flips the flag on both services."""
+        controller, sync_service, network_service = _make_controller(peer_id, initial=False)
+
+        previous = await controller.set_enabled(True)
+
+        assert previous is False
+        assert controller.is_enabled() is True
+        assert sync_service.is_aggregator is True
+        assert network_service.is_aggregator is True
+
+    async def test_set_enabled_deactivates_role(self, peer_id: PeerId) -> None:
+        """set_enabled(False) flips the flag off on both services."""
+        controller, sync_service, network_service = _make_controller(peer_id, initial=True)
+
+        previous = await controller.set_enabled(False)
+
+        assert previous is True
+        assert controller.is_enabled() is False
+        assert sync_service.is_aggregator is False
+        assert network_service.is_aggregator is False
+
+    async def test_set_enabled_idempotent(self, peer_id: PeerId) -> None:
+        """Setting the same value returns the current value and leaves state intact."""
+        controller, sync_service, network_service = _make_controller(peer_id, initial=True)
+
+        previous = await controller.set_enabled(True)
+
+        assert previous is True
+        assert sync_service.is_aggregator is True
+        assert network_service.is_aggregator is True
+
+    async def test_sequential_toggles_converge(self, peer_id: PeerId) -> None:
+        """Sequential toggles each see the prior state and converge to the last value."""
+        controller, sync_service, network_service = _make_controller(peer_id, initial=False)
+
+        results = await asyncio.gather(
+            controller.set_enabled(True),
+            controller.set_enabled(False),
+            controller.set_enabled(True),
+        )
+
+        # asyncio.gather on a single-threaded event loop preserves order.
+        # Each toggle sees the previous state correctly.
+        assert results == [False, True, False]
+        assert controller.is_enabled() is True
+        assert sync_service.is_aggregator is True
+        assert network_service.is_aggregator is True

--- a/tests/lean_spec/subspecs/api/test_server.py
+++ b/tests/lean_spec/subspecs/api/test_server.py
@@ -11,10 +11,34 @@ These tests cover leanSpec-specific implementation details:
 
 from __future__ import annotations
 
+import asyncio
+from dataclasses import dataclass, field
+
 import httpx
 
-from lean_spec.subspecs.api import ApiServer, ApiServerConfig
+from lean_spec.subspecs.api import AggregatorController, ApiServer, ApiServerConfig
 from lean_spec.subspecs.forkchoice import Store
+
+
+@dataclass(slots=True)
+class _AggregatorStub:
+    """Minimal aggregator role holder for wiring AggregatorController in tests."""
+
+    is_aggregator: bool = field(default=False)
+
+
+def _make_test_controller(initial: bool = False) -> AggregatorController:
+    """Build an AggregatorController backed by lightweight stubs.
+
+    Avoids pulling in the full SyncService / NetworkService dependency graph
+    for endpoint-level tests that only exercise the flag-toggle contract.
+    """
+    sync_stub = _AggregatorStub(is_aggregator=initial)
+    network_stub = _AggregatorStub(is_aggregator=initial)
+    return AggregatorController(
+        sync_service=sync_stub,  # type: ignore[arg-type]
+        network_service=network_stub,  # type: ignore[arg-type]
+    )
 
 
 class TestApiServerConfiguration:
@@ -162,6 +186,240 @@ class TestForkChoiceEndpoint:
                 assert node["root"] == head_root
                 assert node["slot"] == 0
                 assert node["weight"] == 0
+
+        finally:
+            await server.aclose()
+
+
+class TestAggregatorAdminEndpoint:
+    """Tests for the /lean/v0/admin/aggregator endpoint."""
+
+    async def test_status_returns_503_without_controller(self) -> None:
+        """GET returns 503 when no controller is wired."""
+        config = ApiServerConfig(port=15060)
+        server = ApiServer(config=config)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get("http://127.0.0.1:15060/lean/v0/admin/aggregator")
+
+                assert response.status_code == 503
+
+        finally:
+            await server.aclose()
+
+    async def test_status_returns_current_role(self) -> None:
+        """GET returns the current aggregator role from the controller."""
+        controller = _make_test_controller(initial=True)
+        config = ApiServerConfig(port=15061)
+        server = ApiServer(config=config, aggregator_controller=controller)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get("http://127.0.0.1:15061/lean/v0/admin/aggregator")
+
+                assert response.status_code == 200
+                assert response.headers["content-type"] == "application/json"
+                assert response.json() == {"is_aggregator": True}
+
+        finally:
+            await server.aclose()
+
+    async def test_toggle_activates_role(self) -> None:
+        """POST with enabled=true activates the aggregator role."""
+        controller = _make_test_controller(initial=False)
+        config = ApiServerConfig(port=15062)
+        server = ApiServer(config=config, aggregator_controller=controller)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "http://127.0.0.1:15062/lean/v0/admin/aggregator",
+                    json={"enabled": True},
+                )
+
+                assert response.status_code == 200
+                assert response.json() == {"is_aggregator": True, "previous": False}
+                assert controller.is_enabled() is True
+
+                # A follow-up GET sees the new value.
+                follow_up = await client.get("http://127.0.0.1:15062/lean/v0/admin/aggregator")
+                assert follow_up.json() == {"is_aggregator": True}
+
+        finally:
+            await server.aclose()
+
+    async def test_toggle_deactivates_role(self) -> None:
+        """POST with enabled=false deactivates the aggregator role."""
+        controller = _make_test_controller(initial=True)
+        config = ApiServerConfig(port=15063)
+        server = ApiServer(config=config, aggregator_controller=controller)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "http://127.0.0.1:15063/lean/v0/admin/aggregator",
+                    json={"enabled": False},
+                )
+
+                assert response.status_code == 200
+                assert response.json() == {"is_aggregator": False, "previous": True}
+                assert controller.is_enabled() is False
+
+        finally:
+            await server.aclose()
+
+    async def test_toggle_rejects_missing_body(self) -> None:
+        """POST with no body returns 400."""
+        controller = _make_test_controller()
+        config = ApiServerConfig(port=15064)
+        server = ApiServer(config=config, aggregator_controller=controller)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "http://127.0.0.1:15064/lean/v0/admin/aggregator",
+                    content=b"",
+                    headers={"Content-Type": "application/json"},
+                )
+
+                assert response.status_code == 400
+
+        finally:
+            await server.aclose()
+
+    async def test_toggle_rejects_missing_field(self) -> None:
+        """POST without 'enabled' field returns 400."""
+        controller = _make_test_controller()
+        config = ApiServerConfig(port=15065)
+        server = ApiServer(config=config, aggregator_controller=controller)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "http://127.0.0.1:15065/lean/v0/admin/aggregator",
+                    json={},
+                )
+
+                assert response.status_code == 400
+
+        finally:
+            await server.aclose()
+
+    async def test_toggle_rejects_non_boolean(self) -> None:
+        """POST with non-boolean 'enabled' returns 400 and does not change state."""
+        controller = _make_test_controller(initial=False)
+        config = ApiServerConfig(port=15066)
+        server = ApiServer(config=config, aggregator_controller=controller)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "http://127.0.0.1:15066/lean/v0/admin/aggregator",
+                    json={"enabled": "yes"},
+                )
+
+                assert response.status_code == 400
+                assert controller.is_enabled() is False
+
+        finally:
+            await server.aclose()
+
+    async def test_sequential_posts_converge(self) -> None:
+        """Multiple POSTs converge to the last-writer value."""
+        controller = _make_test_controller(initial=False)
+        config = ApiServerConfig(port=15067)
+        server = ApiServer(config=config, aggregator_controller=controller)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                url = "http://127.0.0.1:15067/lean/v0/admin/aggregator"
+                responses = await asyncio.gather(
+                    client.post(url, json={"enabled": True}),
+                    client.post(url, json={"enabled": False}),
+                    client.post(url, json={"enabled": True}),
+                )
+
+                assert all(r.status_code == 200 for r in responses)
+                assert controller.is_enabled() is True
+
+        finally:
+            await server.aclose()
+
+    async def test_toggle_rejects_null_body(self) -> None:
+        """POST with JSON null body returns 400."""
+        controller = _make_test_controller()
+        config = ApiServerConfig(port=15068)
+        server = ApiServer(config=config, aggregator_controller=controller)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "http://127.0.0.1:15068/lean/v0/admin/aggregator",
+                    content=b"null",
+                    headers={"Content-Type": "application/json"},
+                )
+
+                assert response.status_code == 400
+
+        finally:
+            await server.aclose()
+
+    async def test_toggle_rejects_array_body(self) -> None:
+        """POST with JSON array body returns 400."""
+        controller = _make_test_controller()
+        config = ApiServerConfig(port=15069)
+        server = ApiServer(config=config, aggregator_controller=controller)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "http://127.0.0.1:15069/lean/v0/admin/aggregator",
+                    json=[True],
+                )
+
+                assert response.status_code == 400
+
+        finally:
+            await server.aclose()
+
+    async def test_toggle_rejects_integer_enabled(self) -> None:
+        """POST with integer 1 as enabled returns 400 (must be boolean)."""
+        controller = _make_test_controller(initial=False)
+        config = ApiServerConfig(port=15070)
+        server = ApiServer(config=config, aggregator_controller=controller)
+
+        await server.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "http://127.0.0.1:15070/lean/v0/admin/aggregator",
+                    json={"enabled": 1},
+                )
+
+                assert response.status_code == 400
+                assert controller.is_enabled() is False
 
         finally:
             await server.aclose()


### PR DESCRIPTION
## Summary

Adds a new admin endpoint `/lean/v0/admin/aggregator` that allows operators to activate or deactivate a node's aggregator role at runtime. This enables rotating aggregation duties across nodes without restarting when an active aggregator becomes unhealthy / unrecoverable.

### Endpoints

- `GET /lean/v0/admin/aggregator` — returns `{"is_aggregator": bool}` reflecting the current role.
- `POST /lean/v0/admin/aggregator` with body `{"enabled": bool}` — toggles the role and returns `{"is_aggregator": <new>, "previous": <old>}`.

Both endpoints return `503 Service Unavailable` when no controller is wired (e.g. in tests that stand up a bare `ApiServer`). The POST handler returns `400 Bad Request` for missing body, missing `enabled` field, or non-boolean values.

### Implementation

- New `AggregatorController` (in `src/lean_spec/subspecs/api/aggregator_controller.py`) holds references to `SyncService` and `NetworkService` and serializes toggles under an `asyncio.Lock`. Both flags are flipped together so observers see a consistent view.
- Route registration in `routes.py` gains an `ADMIN_ROUTES` list for non-GET verbs. `server.py` registers both GET and admin routes via `web.route(method, path, handler)`.
- `ApiServer` grows an optional `aggregator_controller` field, mirroring the existing `store_getter` pattern.
- `Node.from_genesis` builds the controller from `sync_service` and `network_service` and passes it to the API server when the API is enabled.
- Docstring on `NodeConfig.is_aggregator` updated to remove the aspirational claim that the ENR advertises aggregator capability (no code path writes that key today) and to document the new runtime-toggle seeding semantics.

### Why this works at runtime

Both `SyncService.on_gossip_attestation` / `on_gossip_aggregated_attestation` and `Store.tick_interval` read the `is_aggregator` flag fresh on every event/tick, so toggling takes effect from the next tick — no restart, no gossip re-subscribe, no handshake churn.

## Scope and known limitations

This PR deliberately keeps the change small. It is explicitly **not**:

- **Persistent across restarts.** The CLI `--is-aggregator` flag seeds the initial value on each start. Runtime toggles are in-process only.
- **Reflected in gossip subnet subscriptions.** Subscriptions are decided once at startup in `run_node()` based on the CLI flag. Toggling on at runtime only imports gossip for subnets the node is already subscribed to.
  - Operational implication: standby aggregators should start with `--is-aggregator` (so subscriptions are in place) and be left OFF via this API until needed — hot-standby model.
- **Reflected in the local ENR.** The live node does not build or sign a local ENR today; `DiscoveryService` exists as a library but is not wired into the runtime node path. `ENR.is_aggregator` is currently read-only — no writer exists. Even if re-publication were added, no peer-side logic in `src/lean_spec` currently reads a remote peer's `is_aggregator` ENR bit to make decisions (peer selection, gossip routing, req/resp policy), so advertisement is decorative until a consumer is added. Tracked as a follow-up.
- **Authenticated.** Admin endpoints are currently unauthenticated, consistent with the rest of the HTTP API. If an auth layer is desired it should be applied uniformly, not just to this endpoint.

## Test plan

- [x] `uv run pytest --no-cov` — 3240 passed
- [x] `uvx tox -e all-checks` — ruff + ty + codespell + mdformat clean
- [x] New unit tests in `tests/lean_spec/subspecs/api/test_aggregator_controller.py` cover read, activate, deactivate, idempotence, and concurrent toggles.
- [x] New endpoint tests in `tests/lean_spec/subspecs/api/test_server.py` (`TestAggregatorAdminEndpoint`) exercise 503, GET status, POST activate/deactivate, bad-request paths, and concurrent POSTs.
- [x] New conformance tests in `tests/api/endpoints/test_aggregator.py` verify baseline 503 behavior and 405 for unsupported verbs against the default conformance server.
- [ ] Manual smoke test on a devnet node (to be done after PR review).

## Open questions for reviewers

- Route placement under `/lean/v0/admin/` (alternatives: `/lean/v0/validator/aggregator`, `/lean/v0/node/aggregator`).
- Whether `aggregate_subnet_ids` should also be mutable at runtime (requires gossip subscribe/unsubscribe plumbing — scoped out here).
- Whether to open a follow-up issue to build a real ENR lifecycle (signed local ENR, `ENR.mutate`/re-sign helper, handshake refresh hook, and a peer-side consumer of the `is_aggregator` bit) so advertisement would actually influence peer behavior.