### PR TITLE
test(fc): safe target stays at justified root with insufficient weight (#559)

### DIFF
--- a/tests/consensus/devnet/fc/test_safe_target.py
+++ b/tests/consensus/devnet/fc/test_safe_target.py
@@ -20,23 +20,52 @@ from lean_spec.subspecs.containers.validator import ValidatorIndex
 pytestmark = pytest.mark.valid_until("Devnet")
 
 
+@pytest.mark.parametrize(
+    "num_attesters",
+    [
+        # Far-below case. Weight 2 / threshold 4 = half the required mass.
+        # Pins behavior in the strict interior of the below-threshold range.
+        pytest.param(2, id="two_of_six"),
+        # Tight boundary case. Weight 3 sits exactly one vote short of the
+        # threshold, covering the off-by-one edge of the prune condition.
+        pytest.param(3, id="three_of_six"),
+    ],
+)
 def test_safe_target_does_not_advance_below_supermajority(
     fork_choice_test: ForkChoiceTestFiller,
+    num_attesters: int,
 ) -> None:
-    """Safe target stays at genesis when weight is below the 2/3 threshold.
+    """Safe target stays at genesis when weight falls short of the 2/3 threshold.
 
-    6 validators, threshold = ceil(12/3) = 4.
-    Only 3 attest to block_2, so weight = 3 < 4 at every block.
+    Fixture state:
 
-    Walk (min_score=4):
+    - 6 validators, threshold = ceil(12 / 3) = 4
+    - Two-block chain rooted at the genesis/justified anchor
+    - A single gossip aggregate signed by the first few validators,
+      all voting for block_2
 
-        justified -> block_1 (weight 3 < 4, pruned) -> stop
+    Parametrized over two below-threshold attester counts:
 
-    Result: safe_target remains at genesis.
+    - 2/6 attesters (far below) -- weight 2, exercises the middle of the region
+    - 3/6 attesters (tight edge) -- weight 3, exercises the off-by-one boundary
+
+    Invariant:
+
+        Every ancestor of block_2 carries the same weight (the attester count).
+        With any attester count in {2, 3}, no child of the justified root clears
+        the ceil(2N / 3) bar, so the safe-target walk halts immediately.
+
+        The LMD-GHOST head has no threshold and still advances to block_2.
     """
     fork_choice_test(
         anchor_state=generate_pre_state(num_validators=6),
         steps=[
+            # Phase 1: build a two-block chain above the justified anchor.
+            #
+            #     genesis (justified) --- block_1 --- block_2  (head)
+            #
+            # Each block is added while the chain is unanimous about its
+            # parent, so the head follows the newest block trivially.
             BlockStep(
                 block=BlockSpec(slot=Slot(1), label="block_1"),
                 checks=StoreChecks(
@@ -51,22 +80,56 @@ def test_safe_target_does_not_advance_below_supermajority(
                     head_root_label="block_2",
                 ),
             ),
-            # Advance past aggregation window (interval 2).
+            # Phase 2: skip past the aggregation window (interval 2).
+            #
+            # Interval 2 is when gossip attestations get batched into an
+            # aggregate. We tick through it while the gossip pool is empty
+            # so the aggregation step is a no-op and the "known"/"new"
+            # pools stay isolated for the rest of the test.
             TickStep(time=14),
-            # 3/6 validators attest -- one short of the threshold.
+            # Phase 3: gossip one aggregate from the first few validators.
+            #
+            #     attesters   :  {0, 1, ...,  num_attesters - 1}
+            #     target      :  block_2
+            #     destination :  the "new" pool (gossip arrivals land here)
+            #
+            # The "new" pool holds attestations collected in the current
+            # slot until the interval-4 migration moves them into "known".
+            # Here we only care that they arrive in "new" so the safe-target
+            # computation at interval 3 can read them.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
-                    validator_ids=[
-                        ValidatorIndex(0),
-                        ValidatorIndex(1),
-                        ValidatorIndex(2),
-                    ],
+                    validator_ids=[ValidatorIndex(i) for i in range(num_attesters)],
                     slot=Slot(3),
                     target_slot=Slot(2),
                     target_root_label="block_2",
                 ),
+                checks=StoreChecks(
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(i),
+                            location="new",
+                            source_slot=Slot(0),
+                            target_slot=Slot(2),
+                        )
+                        for i in range(num_attesters)
+                    ],
+                ),
             ),
-            # Interval 3: weight 3 < 4, walk cannot leave the justified root.
+            # Phase 4: tick into interval 3 of slot 3 and assert the pin.
+            #
+            # Weight propagates upward from the voted target through every
+            # ancestor on the path to the justified root:
+            #
+            #     block_1 weight = num_attesters
+            #     block_2 weight = num_attesters
+            #
+            # With num_attesters in {2, 3}, both < 4 = ceil(2 * 6 / 3), so
+            # the weight-thresholded walk prunes every child of genesis and
+            # the safe target stays pinned at slot 0.
+            #
+            # Head is still block_2: LMD-GHOST has no threshold and follows
+            # the heaviest path regardless of the 2/3 condition.
             TickStep(
                 time=15,
                 checks=StoreChecks(
@@ -466,96 +529,6 @@ def test_safe_target_uses_merged_pools_at_interval_3(
                     head_root_label="block_3",
                     safe_target_slot=Slot(2),
                     safe_target_root_label="block_2",
-                ),
-            ),
-        ],
-    )
-
-
-def test_safe_target_stays_at_justified_with_insufficient_weight(
-    fork_choice_test: ForkChoiceTestFiller,
-) -> None:
-    """Safe target stays at the justified anchor when weight is far below the threshold.
-
-    6 validators, threshold = 4.
-    Only 2/6 attest to block_2 -- well below the 2/3 boundary.
-
-    Weights:
-
-    - block_1 = 2 < 4
-    - block_2 = 2 < 4
-
-    Walk (min_score=4):
-
-        justified -> no qualifying child -> stop
-        safe_target = genesis / justified anchor.
-
-    Head still advances to the latest block (LMD-GHOST has no threshold).
-    Gossip attestations stay in the "new" pool until the interval-4 migration.
-    """
-    fork_choice_test(
-        anchor_state=generate_pre_state(num_validators=6),
-        steps=[
-            BlockStep(
-                block=BlockSpec(slot=Slot(1), label="block_1"),
-                checks=StoreChecks(head_slot=Slot(1), head_root_label="block_1"),
-            ),
-            BlockStep(
-                block=BlockSpec(slot=Slot(2), label="block_2"),
-                checks=StoreChecks(head_slot=Slot(2), head_root_label="block_2"),
-            ),
-            # Advance past aggregation window (interval 2).
-            TickStep(time=14),
-            # Only 2/6 validators attest -- two below the threshold of 4.
-            GossipAggregatedAttestationStep(
-                attestation=GossipAggregatedAttestationSpec(
-                    validator_ids=[
-                        ValidatorIndex(0),
-                        ValidatorIndex(1),
-                    ],
-                    slot=Slot(3),
-                    target_slot=Slot(2),
-                    target_root_label="block_2",
-                ),
-                checks=StoreChecks(
-                    attestation_checks=[
-                        AttestationCheck(
-                            validator=ValidatorIndex(0),
-                            location="new",
-                            source_slot=Slot(0),
-                            target_slot=Slot(2),
-                        ),
-                        AttestationCheck(
-                            validator=ValidatorIndex(1),
-                            location="new",
-                            source_slot=Slot(0),
-                            target_slot=Slot(2),
-                        ),
-                    ],
-                ),
-            ),
-            # Interval 3: weight 2 < 4, walk cannot leave the justified root.
-            # Head follows LMD-GHOST unchanged; attestations stay in "new".
-            TickStep(
-                time=15,
-                checks=StoreChecks(
-                    head_slot=Slot(2),
-                    head_root_label="block_2",
-                    safe_target_slot=Slot(0),
-                    attestation_checks=[
-                        AttestationCheck(
-                            validator=ValidatorIndex(0),
-                            location="new",
-                            source_slot=Slot(0),
-                            target_slot=Slot(2),
-                        ),
-                        AttestationCheck(
-                            validator=ValidatorIndex(1),
-                            location="new",
-                            source_slot=Slot(0),
-                            target_slot=Slot(2),
-                        ),
-                    ],
                 ),
             ),
         ],

--- a/tests/consensus/devnet/fc/test_safe_target.py
+++ b/tests/consensus/devnet/fc/test_safe_target.py
@@ -20,6 +20,100 @@ from lean_spec.subspecs.containers.validator import ValidatorIndex
 pytestmark = pytest.mark.valid_until("Devnet")
 
 
+def test_safe_target_advances_with_supermajority_weight(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """Safe target advances when weight meets the 2/3 threshold.
+
+    6 validators, threshold = ceil(12/3) = 4.
+    4 attest to block_2, so weight = 4 ≥ 4 at block_1 and block_2.
+
+    Walk (min_score=4):
+
+        justified -> block_1 (4 ≥ 4) -> block_2 (4 ≥ 4) -> stop
+
+    Result: safe_target = block_2 (advances from genesis).
+    """
+    fork_choice_test(
+        anchor_state=generate_pre_state(num_validators=6),
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(
+                    head_slot=Slot(1),
+                    head_root_label="block_1",
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), label="block_2"),
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    head_root_label="block_2",
+                ),
+            ),
+            # Advance past the aggregation window (interval 2) while the
+            # attestation pool is empty, so aggregate() is a no-op.
+            # floor(14 * 5/4) = 17 = slot 3, interval 2.
+            TickStep(time=14),
+            # 4/6 validators attest to block_2 → meets 2/3 threshold (4).
+            # Aggregated attestation is added to the "new" pool via gossip.
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[
+                        ValidatorIndex(0),
+                        ValidatorIndex(1),
+                        ValidatorIndex(2),
+                        ValidatorIndex(3),
+                    ],
+                    slot=Slot(3),
+                    target_slot=Slot(2),
+                    target_root_label="block_2",
+                ),
+                checks=StoreChecks(
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(0),
+                            location="new",
+                            source_slot=Slot(0),
+                            target_slot=Slot(2),
+                        ),
+                    ],
+                ),
+            ),
+            # Tick to slot 3, interval 3 (time=15 → interval=18).
+            # update_safe_target runs:
+            # - merges "new" + "known"
+            # - runs LMD-GHOST (min_score=4)
+            # Weight ≥4 carries through block_1 → block_2, so walk reaches block_2.
+            # "new" pool is not migrated here (only at interval 4).
+            TickStep(
+                time=15,
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    head_root_label="block_2",
+                    safe_target_slot=Slot(2),
+                    safe_target_root_label="block_2",
+                    # Attestation still in "new" — interval 4 has not run.
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(0),
+                            location="new",
+                            source_slot=Slot(0),
+                            target_slot=Slot(2),
+                        ),
+                        AttestationCheck(
+                            validator=ValidatorIndex(3),
+                            location="new",
+                            source_slot=Slot(0),
+                            target_slot=Slot(2),
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
 def test_safe_target_does_not_advance_below_supermajority(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
@@ -53,7 +147,7 @@ def test_safe_target_does_not_advance_below_supermajority(
             ),
             # Advance past aggregation window (interval 2).
             TickStep(time=14),
-            # 3/6 validators attest -- one short of the threshold.
+            # Only 3 / 6 validators attest (one below the threshold of 4).
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -72,6 +166,7 @@ def test_safe_target_does_not_advance_below_supermajority(
                 checks=StoreChecks(
                     head_slot=Slot(2),
                     head_root_label="block_2",
+                    # safe_target stays at genesis / justified anchor.
                     safe_target_slot=Slot(0),
                 ),
             ),
@@ -82,28 +177,25 @@ def test_safe_target_does_not_advance_below_supermajority(
 def test_safe_target_advances_incrementally_along_the_chain(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target advances one block at a time as votes shift forward.
+    """Safe target advances as ≥2/3 votes move forward.
 
-    4 validators, threshold = ceil(8/3) = 3.
+     4 validators, threshold = ceil(8/3) = 3.
     Chain: genesis -> block_1 -> block_2 -> block_3.
 
-    Each round, 3 validators move their vote to a deeper block.
-    Latest vote per validator replaces the prior one.
+    Each round, 3 validators update to a deeper block (latest vote replaces prior).
 
-    Round 1 (votes target block_1):
+    Round 1:
+        block_1=3 >= 3, block_2=0 -> safe_target = block_1
 
-        block_1 weight=3 >= 3, block_2 weight=0 -> safe_target = block_1
+    Round 2:
+        block_1=3, block_2=3 >= 3 -> safe_target = block_2
 
-    Round 2 (votes target block_2):
-
-        block_1=3, block_2=3, block_3=0 -> safe_target = block_2
-
-    Round 3 (votes target block_3):
-
-        block_1=3, block_2=3, block_3=3 -> safe_target = block_3
+    Round 3:
+        block_1=3, block_2=3, block_3=3 >= 3 -> safe_target = block_3
     """
     fork_choice_test(
         steps=[
+            # 3-block chain.
             BlockStep(
                 block=BlockSpec(slot=Slot(1), label="block_1"),
                 checks=StoreChecks(head_slot=Slot(1), head_root_label="block_1"),
@@ -268,19 +360,15 @@ def test_safe_target_follows_heavier_fork_on_split(
 def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target can be strictly shallower than the LMD-GHOST head.
+    """Safe target can be shallower than the LMD-GHOST head.
 
-    8 validators, threshold = ceil(16/3) = 6.
+      8 validators, threshold = ceil(16/3) = 6.
     Chain: genesis -> block_1 -> block_2 -> block_3.
 
-    - 6 validators vote for block_2
-    - 2 validators vote for block_3
+    - 6 vote block_2, 2 vote block_3
 
-    Weight propagation (votes walk upward from head through ancestors):
-
-    - block_1 = 6 + 2 = 8
-    - block_2 = 6 + 2 = 8  (block_3 voters walk through block_2)
-    - block_3 = 2
+    Weights:
+        block_1 = 8, block_2 = 8, block_3 = 2
 
     Safe walk (min_score=6):
 
@@ -288,11 +376,11 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
                   -> block_3 (2 < 6, pruned)
         safe_target = block_2
 
-    LMD-GHOST (no threshold):
+    LMD-GHOST:
 
         continues to block_3 -> head = block_3
 
-    Confirms safe_target (slot 2) < head (slot 3).
+    Result: safe_target < head (conservative).
     """
     fork_choice_test(
         anchor_state=generate_pre_state(num_validators=8),
@@ -310,7 +398,7 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
                 checks=StoreChecks(head_slot=Slot(3), head_root_label="block_3"),
             ),
             TickStep(time=14),
-            # 6/8 vote for block_2. Weight: block_1 += 6, block_2 += 6.
+            # 6/9 validators vote for block_2. Weight propagates upward: block_2 += 6, block_1 += 6.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -326,21 +414,32 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
                     target_root_label="block_2",
                 ),
             ),
-            # 2/8 vote for block_3. Weight: block_1 += 2, block_2 += 2, block_3 += 2.
+            # 3/9 validators vote for block_3.
+            # Weight propagates: block_3 += 3, block_2 += 3, block_1 += 3.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
                         ValidatorIndex(6),
                         ValidatorIndex(7),
+                        ValidatorIndex(8),
                     ],
                     slot=Slot(4),
                     target_slot=Slot(3),
                     target_root_label="block_3",
                 ),
             ),
-            # Totals: block_1=8, block_2=8, block_3=2.
-            # Safe walk stops at block_2 (block_3 below threshold).
-            # LMD-GHOST continues to block_3 (no threshold).
+            # Combined weights:
+            #   block_1 = 9, block_2 = 9, block_3 = 3
+            #
+            # LMD-GHOST (no threshold):
+            #   only child path leads to block_3 → head = block_3
+            #
+            # update_safe_target (min_score = 6):
+            #   justified → block_1 (9 ≥ 6) → block_2 (9 ≥ 6)
+            #   → block_3 (3 < 6, pruned) → stop
+            #   safe_target = block_2
+            #
+            # Result: safe_target is shallower than LMD-GHOST head.
             TickStep(
                 time=15,
                 checks=StoreChecks(
@@ -354,30 +453,106 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
     )
 
 
+def test_safe_target_unchanged_after_interval_4_migration(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """Safe target computed at interval 3 is not affected by interval 4 migration.
+
+    - interval 3: update_safe_target sets safe_target
+    - interval 4: accept_new_attestations migrates "new" → "known"
+
+    Expected behavior:
+      safe_target remains unchanged after migration
+
+    This is a regression guard against accidental resets to head or justified anchor.
+    """
+    fork_choice_test(
+        anchor_state=generate_pre_state(num_validators=6),
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1), head_root_label="block_1"),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), label="block_2"),
+                checks=StoreChecks(head_slot=Slot(2), head_root_label="block_2"),
+            ),
+            TickStep(time=14),
+            # Supermajority (4/6) attestation for block_2.
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[
+                        ValidatorIndex(0),
+                        ValidatorIndex(1),
+                        ValidatorIndex(2),
+                        ValidatorIndex(3),
+                    ],
+                    slot=Slot(3),
+                    target_slot=Slot(2),
+                    target_root_label="block_2",
+                ),
+            ),
+            # Interval 3: update_safe_target fires → safe_target = block_2.
+            TickStep(
+                time=15,
+                checks=StoreChecks(
+                    safe_target_slot=Slot(2),
+                    safe_target_root_label="block_2",
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(0),
+                            location="new",
+                            source_slot=Slot(0),
+                            target_slot=Slot(2),
+                        ),
+                    ],
+                ),
+            ),
+            # Interval 4 (time=16 → interval 20, passing interval 19):
+            # accept_new_attestations fires.
+            # "new" pool migrates to "known".
+            # safe_target must remain unchanged (set at interval 3).
+            TickStep(
+                time=16,
+                checks=StoreChecks(
+                    safe_target_slot=Slot(2),
+                    safe_target_root_label="block_2",
+                    # Attestation now in "known".
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(0),
+                            location="known",
+                            source_slot=Slot(0),
+                            target_slot=Slot(2),
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
 def test_safe_target_uses_merged_pools_at_interval_3(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target merges both attestation pools before computing weight.
+    """Safe target requires merging both attestation pools.
 
     6 validators, threshold = 4.
 
-    Attestation sources:
+    "known":  validators 0, 1 → block_2 (2 votes)
+    "new":    validators 2, 3 → block_2 (2 votes)
 
-    - "known" pool (from block body): validators 0, 1 -> block_2
-    - "new" pool (from gossip):       validators 2, 3 -> block_2
-
-    Neither pool alone meets threshold (2 < 4).
-    Merged: 4 >= 4.
+    Neither pool alone meets threshold (2 < 4), but merged = 4 ≥ 4.
 
     Walk (min_score=4):
 
         justified -> block_1 (4) -> block_2 (4) -> block_3 (0, stop)
         safe_target = block_2
 
-    Without the merge, the walk would stop at genesis.
+    Without merge: walk would stop at genesis.
 
-    Attestations for block_2 appear in block_3's body because
-    validators can only attest to blocks they have already seen.
+    Note: attestations for block_2 appear in block_3’s body since
+    validators can only vote for already-seen blocks.
     """
     fork_choice_test(
         anchor_state=generate_pre_state(num_validators=6),
@@ -427,6 +602,7 @@ def test_safe_target_uses_merged_pools_at_interval_3(
                     ],
                 ),
             ),
+            # Move past interval 2 (aggregation window) with no gossip attestations.
             TickStep(time=14),
             # Gossip 2 more attestations into the "new" pool.
             # Combined with "known": total weight = 4 = threshold.
@@ -466,6 +642,111 @@ def test_safe_target_uses_merged_pools_at_interval_3(
                     head_root_label="block_3",
                     safe_target_slot=Slot(2),
                     safe_target_root_label="block_2",
+                ),
+            ),
+        ],
+    )
+
+
+def test_safe_target_stays_at_justified_with_insufficient_weight(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """Safe target does not advance when <2/3 validators attest.
+
+    6 validators, threshold = 4.
+    Only 2 validators attest → below threshold.
+
+    Weights at block_2:
+      block_1 = 2, block_2 = 2
+
+    Both < min_score=4, so LMD-GHOST stops at justified root:
+
+        justified -> no qualifying child -> stop
+        safe_target = genesis / justified anchor
+
+    Even though LMD-GHOST head may still advance without threshold.
+
+    Key checks:
+    - safe_target_slot = 0 (unchanged)
+    - head_slot may advance (no threshold)
+    - attestations remain in "new" pool until migration
+    """
+    fork_choice_test(
+        anchor_state=generate_pre_state(num_validators=6),
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(
+                    head_slot=Slot(1),
+                    head_root_label="block_1",
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), label="block_2"),
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    head_root_label="block_2",
+                ),
+            ),
+            # Advance past the aggregation window while the pool is empty.
+            # floor(14 * 5/4) = 17 = slot 3, interval 2.
+            TickStep(time=14),
+            # Only 2/6 validators attest via gossip.
+            # 2 < threshold (4), so safe_target does not advance.
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[
+                        ValidatorIndex(0),
+                        ValidatorIndex(1),
+                    ],
+                    slot=Slot(3),
+                    target_slot=Slot(2),
+                    target_root_label="block_2",
+                ),
+                checks=StoreChecks(
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(0),
+                            location="new",
+                            source_slot=Slot(0),
+                            target_slot=Slot(2),
+                        ),
+                        AttestationCheck(
+                            validator=ValidatorIndex(1),
+                            location="new",
+                            source_slot=Slot(0),
+                            target_slot=Slot(2),
+                        ),
+                    ],
+                ),
+            ),
+            # Tick to slot 3 interval 3 (time=15 → interval=18).
+            # update_safe_target runs.
+            # Weights: block_1=2, block_2=2.
+            # min_score=4 → no child qualifies.
+            # Walk stops at justified root → safe_target = slot 0.
+            TickStep(
+                time=15,
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    head_root_label="block_2",
+                    # safe_target unchanged — stays at genesis anchor.
+                    safe_target_slot=Slot(0),
+                    # Attestations still in "new" pool — interval 4 not yet run.
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(0),
+                            location="new",
+                            source_slot=Slot(0),
+                            target_slot=Slot(2),
+                        ),
+                        AttestationCheck(
+                            validator=ValidatorIndex(1),
+                            location="new",
+                            source_slot=Slot(0),
+                            target_slot=Slot(2),
+                        ),
+                    ],
                 ),
             ),
         ],

--- a/tests/consensus/devnet/fc/test_safe_target.py
+++ b/tests/consensus/devnet/fc/test_safe_target.py
@@ -425,16 +425,16 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
                     target_root_label="block_3",
                 ),
             ),
-# Combined weights: block_1=6, block_2=6, block_3=2.
-#
-# LMD-GHOST (no threshold):
-#   only path leads to block_3 → head = block_3
-#
-# update_safe_target (min_score=4):
-#   block_3 (2 < 4) pruned → stop at block_2
-#   safe_target = block_2
-#
-# Result: safe_target < head (conservative property)
+            # Combined weights: block_1=6, block_2=6, block_3=2.
+            #
+            # LMD-GHOST (no threshold):
+            #   only path leads to block_3 → head = block_3
+            #
+            # update_safe_target (min_score=4):
+            #   block_3 (2 < 4) pruned → stop at block_2
+            #   safe_target = block_2
+            #
+            # Result: safe_target < head (conservative property)
             TickStep(
                 time=15,
                 checks=StoreChecks(

--- a/tests/consensus/devnet/fc/test_safe_target.py
+++ b/tests/consensus/devnet/fc/test_safe_target.py
@@ -20,100 +20,6 @@ from lean_spec.subspecs.containers.validator import ValidatorIndex
 pytestmark = pytest.mark.valid_until("Devnet")
 
 
-def test_safe_target_advances_with_supermajority_weight(
-    fork_choice_test: ForkChoiceTestFiller,
-) -> None:
-    """Safe target advances when weight meets the 2/3 threshold.
-
-    6 validators, threshold = ceil(12/3) = 4.
-    4 attest to block_2, so weight = 4 ≥ 4 at block_1 and block_2.
-
-    Walk (min_score=4):
-
-        justified -> block_1 (4 ≥ 4) -> block_2 (4 ≥ 4) -> stop
-
-    Result: safe_target = block_2 (advances from genesis).
-    """
-    fork_choice_test(
-        anchor_state=generate_pre_state(num_validators=6),
-        steps=[
-            BlockStep(
-                block=BlockSpec(slot=Slot(1), label="block_1"),
-                checks=StoreChecks(
-                    head_slot=Slot(1),
-                    head_root_label="block_1",
-                ),
-            ),
-            BlockStep(
-                block=BlockSpec(slot=Slot(2), label="block_2"),
-                checks=StoreChecks(
-                    head_slot=Slot(2),
-                    head_root_label="block_2",
-                ),
-            ),
-            # Advance past the aggregation window (interval 2) while the
-            # attestation pool is empty, so aggregate() is a no-op.
-            # floor(14 * 5/4) = 17 = slot 3, interval 2.
-            TickStep(time=14),
-            # 4/6 validators attest to block_2 → meets 2/3 threshold (4).
-            # Aggregated attestation is added to the "new" pool via gossip.
-            GossipAggregatedAttestationStep(
-                attestation=GossipAggregatedAttestationSpec(
-                    validator_ids=[
-                        ValidatorIndex(0),
-                        ValidatorIndex(1),
-                        ValidatorIndex(2),
-                        ValidatorIndex(3),
-                    ],
-                    slot=Slot(3),
-                    target_slot=Slot(2),
-                    target_root_label="block_2",
-                ),
-                checks=StoreChecks(
-                    attestation_checks=[
-                        AttestationCheck(
-                            validator=ValidatorIndex(0),
-                            location="new",
-                            source_slot=Slot(0),
-                            target_slot=Slot(2),
-                        ),
-                    ],
-                ),
-            ),
-            # Tick to slot 3, interval 3 (time=15 → interval=18).
-            # update_safe_target runs:
-            # - merges "new" + "known"
-            # - runs LMD-GHOST (min_score=4)
-            # Weight ≥4 carries through block_1 → block_2, so walk reaches block_2.
-            # "new" pool is not migrated here (only at interval 4).
-            TickStep(
-                time=15,
-                checks=StoreChecks(
-                    head_slot=Slot(2),
-                    head_root_label="block_2",
-                    safe_target_slot=Slot(2),
-                    safe_target_root_label="block_2",
-                    # Attestation still in "new" — interval 4 has not run.
-                    attestation_checks=[
-                        AttestationCheck(
-                            validator=ValidatorIndex(0),
-                            location="new",
-                            source_slot=Slot(0),
-                            target_slot=Slot(2),
-                        ),
-                        AttestationCheck(
-                            validator=ValidatorIndex(3),
-                            location="new",
-                            source_slot=Slot(0),
-                            target_slot=Slot(2),
-                        ),
-                    ],
-                ),
-            ),
-        ],
-    )
-
-
 def test_safe_target_does_not_advance_below_supermajority(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
@@ -147,7 +53,7 @@ def test_safe_target_does_not_advance_below_supermajority(
             ),
             # Advance past aggregation window (interval 2).
             TickStep(time=14),
-            # Only 3 / 6 validators attest (one below the threshold of 4).
+            # 3/6 validators attest -- one short of the threshold.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -166,7 +72,6 @@ def test_safe_target_does_not_advance_below_supermajority(
                 checks=StoreChecks(
                     head_slot=Slot(2),
                     head_root_label="block_2",
-                    # safe_target stays at genesis / justified anchor.
                     safe_target_slot=Slot(0),
                 ),
             ),
@@ -177,25 +82,28 @@ def test_safe_target_does_not_advance_below_supermajority(
 def test_safe_target_advances_incrementally_along_the_chain(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target advances as ≥2/3 votes move forward.
+    """Safe target advances one block at a time as votes shift forward.
 
-     4 validators, threshold = ceil(8/3) = 3.
+    4 validators, threshold = ceil(8/3) = 3.
     Chain: genesis -> block_1 -> block_2 -> block_3.
 
-    Each round, 3 validators update to a deeper block (latest vote replaces prior).
+    Each round, 3 validators move their vote to a deeper block.
+    Latest vote per validator replaces the prior one.
 
-    Round 1:
-        block_1=3 >= 3, block_2=0 -> safe_target = block_1
+    Round 1 (votes target block_1):
 
-    Round 2:
-        block_1=3, block_2=3 >= 3 -> safe_target = block_2
+        block_1 weight=3 >= 3, block_2 weight=0 -> safe_target = block_1
 
-    Round 3:
-        block_1=3, block_2=3, block_3=3 >= 3 -> safe_target = block_3
+    Round 2 (votes target block_2):
+
+        block_1=3, block_2=3, block_3=0 -> safe_target = block_2
+
+    Round 3 (votes target block_3):
+
+        block_1=3, block_2=3, block_3=3 -> safe_target = block_3
     """
     fork_choice_test(
         steps=[
-            # 3-block chain.
             BlockStep(
                 block=BlockSpec(slot=Slot(1), label="block_1"),
                 checks=StoreChecks(head_slot=Slot(1), head_root_label="block_1"),
@@ -360,27 +268,31 @@ def test_safe_target_follows_heavier_fork_on_split(
 def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target can be shallower than the LMD-GHOST head.
+    """Safe target can be strictly shallower than the LMD-GHOST head.
 
-    6 validators, threshold = 4.
+    8 validators, threshold = ceil(16/3) = 6.
     Chain: genesis -> block_1 -> block_2 -> block_3.
 
-    - 4 vote block_2, 2 vote block_3
+    - 6 validators vote for block_2
+    - 2 validators vote for block_3
 
-    Weights:
-        block_1 = 6, block_2 = 6, block_3 = 2
+    Weight propagation (votes walk upward from head through ancestors):
 
-    Safe walk (min_score=4):
+    - block_1 = 6 + 2 = 8
+    - block_2 = 6 + 2 = 8  (block_3 voters walk through block_2)
+    - block_3 = 2
 
-        justified -> block_1 (6 >= 4) -> block_2 (6 >= 4)
-                  -> block_3 (2 < 4, pruned)
+    Safe walk (min_score=6):
+
+        justified -> block_1 (8 >= 6) -> block_2 (8 >= 6)
+                  -> block_3 (2 < 6, pruned)
         safe_target = block_2
 
-    LMD-GHOST:
+    LMD-GHOST (no threshold):
 
         continues to block_3 -> head = block_3
 
-    Result: safe_target < head (conservative property).
+    Confirms safe_target (slot 2) < head (slot 3).
     """
     fork_choice_test(
         anchor_state=generate_pre_state(num_validators=8),
@@ -398,7 +310,7 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
                 checks=StoreChecks(head_slot=Slot(3), head_root_label="block_3"),
             ),
             TickStep(time=14),
-            # 4/6 validators vote for block_2. Weight propagates upward: block_1 += 4, block_2 += 4.
+            # 6/8 vote for block_2. Weight: block_1 += 6, block_2 += 6.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -406,35 +318,29 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
                         ValidatorIndex(1),
                         ValidatorIndex(2),
                         ValidatorIndex(3),
+                        ValidatorIndex(4),
+                        ValidatorIndex(5),
                     ],
                     slot=Slot(4),
                     target_slot=Slot(2),
                     target_root_label="block_2",
                 ),
             ),
-            # 2/6 validators vote for block_3.
-            # Weight propagates: block_3 += 2, block_2 += 2, block_1 += 2.
+            # 2/8 vote for block_3. Weight: block_1 += 2, block_2 += 2, block_3 += 2.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
-                        ValidatorIndex(4),
-                        ValidatorIndex(5),
+                        ValidatorIndex(6),
+                        ValidatorIndex(7),
                     ],
                     slot=Slot(4),
                     target_slot=Slot(3),
                     target_root_label="block_3",
                 ),
             ),
-            # Combined weights: block_1=6, block_2=6, block_3=2.
-            #
-            # LMD-GHOST (no threshold):
-            #   only path leads to block_3 → head = block_3
-            #
-            # update_safe_target (min_score=4):
-            #   block_3 (2 < 4) pruned → stop at block_2
-            #   safe_target = block_2
-            #
-            # Result: safe_target < head (conservative property)
+            # Totals: block_1=8, block_2=8, block_3=2.
+            # Safe walk stops at block_2 (block_3 below threshold).
+            # LMD-GHOST continues to block_3 (no threshold).
             TickStep(
                 time=15,
                 checks=StoreChecks(
@@ -448,106 +354,30 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
     )
 
 
-def test_safe_target_unchanged_after_interval_4_migration(
-    fork_choice_test: ForkChoiceTestFiller,
-) -> None:
-    """Safe target computed at interval 3 is not affected by interval 4 migration.
-
-    - interval 3: update_safe_target sets safe_target
-    - interval 4: accept_new_attestations migrates "new" → "known"
-
-    Expected behavior:
-      safe_target remains unchanged after migration
-
-    This is a regression guard against accidental resets to head or justified anchor.
-    """
-    fork_choice_test(
-        anchor_state=generate_pre_state(num_validators=6),
-        steps=[
-            BlockStep(
-                block=BlockSpec(slot=Slot(1), label="block_1"),
-                checks=StoreChecks(head_slot=Slot(1), head_root_label="block_1"),
-            ),
-            BlockStep(
-                block=BlockSpec(slot=Slot(2), label="block_2"),
-                checks=StoreChecks(head_slot=Slot(2), head_root_label="block_2"),
-            ),
-            TickStep(time=14),
-            # Supermajority (4/6) attestation for block_2.
-            GossipAggregatedAttestationStep(
-                attestation=GossipAggregatedAttestationSpec(
-                    validator_ids=[
-                        ValidatorIndex(0),
-                        ValidatorIndex(1),
-                        ValidatorIndex(2),
-                        ValidatorIndex(3),
-                    ],
-                    slot=Slot(3),
-                    target_slot=Slot(2),
-                    target_root_label="block_2",
-                ),
-            ),
-            # Interval 3: update_safe_target fires → safe_target = block_2.
-            TickStep(
-                time=15,
-                checks=StoreChecks(
-                    safe_target_slot=Slot(2),
-                    safe_target_root_label="block_2",
-                    attestation_checks=[
-                        AttestationCheck(
-                            validator=ValidatorIndex(0),
-                            location="new",
-                            source_slot=Slot(0),
-                            target_slot=Slot(2),
-                        ),
-                    ],
-                ),
-            ),
-            # Interval 4 (time=16 → interval 20, passing interval 19):
-            # accept_new_attestations fires.
-            # "new" pool migrates to "known".
-            # safe_target must remain unchanged (set at interval 3).
-            TickStep(
-                time=16,
-                checks=StoreChecks(
-                    safe_target_slot=Slot(2),
-                    safe_target_root_label="block_2",
-                    # Attestation now in "known".
-                    attestation_checks=[
-                        AttestationCheck(
-                            validator=ValidatorIndex(0),
-                            location="known",
-                            source_slot=Slot(0),
-                            target_slot=Slot(2),
-                        ),
-                    ],
-                ),
-            ),
-        ],
-    )
-
-
 def test_safe_target_uses_merged_pools_at_interval_3(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target requires merging both attestation pools.
+    """Safe target merges both attestation pools before computing weight.
 
     6 validators, threshold = 4.
 
-    "known":  validators 0, 1 → block_2 (2 votes)
-    "new":    validators 2, 3 → block_2 (2 votes)
+    Attestation sources:
 
-    Neither pool alone meets threshold (2 < 4), but merged = 4 ≥ 4.
+    - "known" pool (from block body): validators 0, 1 -> block_2
+    - "new" pool (from gossip):       validators 2, 3 -> block_2
+
+    Neither pool alone meets threshold (2 < 4).
+    Merged: 4 >= 4.
 
     Walk (min_score=4):
 
         justified -> block_1 (4) -> block_2 (4) -> block_3 (0, stop)
         safe_target = block_2
 
-    Without merge: walk would stop at genesis.
+    Without the merge, the walk would stop at genesis.
 
-    Note: attestations for block_2 appear in block_3’s body since
-    validators can only vote for already-seen blocks.
+    Attestations for block_2 appear in block_3's body because
+    validators can only attest to blocks they have already seen.
     """
     fork_choice_test(
         anchor_state=generate_pre_state(num_validators=6),
@@ -597,7 +427,6 @@ def test_safe_target_uses_merged_pools_at_interval_3(
                     ],
                 ),
             ),
-            # Move past interval 2 (aggregation window) with no gossip attestations.
             TickStep(time=14),
             # Gossip 2 more attestations into the "new" pool.
             # Combined with "known": total weight = 4 = threshold.
@@ -646,48 +475,38 @@ def test_safe_target_uses_merged_pools_at_interval_3(
 def test_safe_target_stays_at_justified_with_insufficient_weight(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target does not advance when <2/3 validators attest.
+    """Safe target stays at the justified anchor when weight is far below the threshold.
 
     6 validators, threshold = 4.
-    Only 2 validators attest → below threshold.
+    Only 2/6 attest to block_2 -- well below the 2/3 boundary.
 
-    Weights at block_2:
-      block_1 = 2, block_2 = 2
+    Weights:
 
-    Both < min_score=4, so LMD-GHOST stops at justified root:
+    - block_1 = 2 < 4
+    - block_2 = 2 < 4
+
+    Walk (min_score=4):
 
         justified -> no qualifying child -> stop
-        safe_target = genesis / justified anchor
+        safe_target = genesis / justified anchor.
 
-    Even though LMD-GHOST head may still advance without threshold.
-
-    Key checks:
-    - safe_target_slot = 0 (unchanged)
-    - head_slot may advance (no threshold)
-    - attestations remain in "new" pool until migration
+    Head still advances to the latest block (LMD-GHOST has no threshold).
+    Gossip attestations stay in the "new" pool until the interval-4 migration.
     """
     fork_choice_test(
         anchor_state=generate_pre_state(num_validators=6),
         steps=[
             BlockStep(
                 block=BlockSpec(slot=Slot(1), label="block_1"),
-                checks=StoreChecks(
-                    head_slot=Slot(1),
-                    head_root_label="block_1",
-                ),
+                checks=StoreChecks(head_slot=Slot(1), head_root_label="block_1"),
             ),
             BlockStep(
                 block=BlockSpec(slot=Slot(2), label="block_2"),
-                checks=StoreChecks(
-                    head_slot=Slot(2),
-                    head_root_label="block_2",
-                ),
+                checks=StoreChecks(head_slot=Slot(2), head_root_label="block_2"),
             ),
-            # Advance past the aggregation window while the pool is empty.
-            # floor(14 * 5/4) = 17 = slot 3, interval 2.
+            # Advance past aggregation window (interval 2).
             TickStep(time=14),
-            # Only 2/6 validators attest via gossip.
-            # 2 < threshold (4), so safe_target does not advance.
+            # Only 2/6 validators attest -- two below the threshold of 4.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -715,19 +534,14 @@ def test_safe_target_stays_at_justified_with_insufficient_weight(
                     ],
                 ),
             ),
-            # Tick to slot 3 interval 3 (time=15 → interval=18).
-            # update_safe_target runs.
-            # Weights: block_1=2, block_2=2.
-            # min_score=4 → no child qualifies.
-            # Walk stops at justified root → safe_target = slot 0.
+            # Interval 3: weight 2 < 4, walk cannot leave the justified root.
+            # Head follows LMD-GHOST unchanged; attestations stay in "new".
             TickStep(
                 time=15,
                 checks=StoreChecks(
                     head_slot=Slot(2),
                     head_root_label="block_2",
-                    # safe_target unchanged — stays at genesis anchor.
                     safe_target_slot=Slot(0),
-                    # Attestations still in "new" pool — interval 4 not yet run.
                     attestation_checks=[
                         AttestationCheck(
                             validator=ValidatorIndex(0),

--- a/tests/consensus/devnet/fc/test_safe_target.py
+++ b/tests/consensus/devnet/fc/test_safe_target.py
@@ -362,26 +362,26 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
 ) -> None:
     """Safe target can be shallower than the LMD-GHOST head.
 
-      8 validators, threshold = ceil(16/3) = 6.
+    6 validators, threshold = 4.
     Chain: genesis -> block_1 -> block_2 -> block_3.
 
-    - 6 vote block_2, 2 vote block_3
-
+    - 4 vote block_2, 2 vote block_3
+    
     Weights:
-        block_1 = 8, block_2 = 8, block_3 = 2
+        block_1 = 6, block_2 = 6, block_3 = 2
 
-    Safe walk (min_score=6):
-
-        justified -> block_1 (8 >= 6) -> block_2 (8 >= 6)
-                  -> block_3 (2 < 6, pruned)
+    Safe walk (min_score=4):
+    
+        justified -> block_1 (6 >= 4) -> block_2 (6 >= 4)
+                  -> block_3 (2 < 4, pruned)
         safe_target = block_2
-
+    
     LMD-GHOST:
-
+    
         continues to block_3 -> head = block_3
-
-    Result: safe_target < head (conservative).
-    """
+    
+    Result: safe_target < head (conservative property).
+        """
     fork_choice_test(
         anchor_state=generate_pre_state(num_validators=8),
         steps=[
@@ -398,7 +398,7 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
                 checks=StoreChecks(head_slot=Slot(3), head_root_label="block_3"),
             ),
             TickStep(time=14),
-            # 6/9 validators vote for block_2. Weight propagates upward: block_2 += 6, block_1 += 6.
+            # 4/6 validators vote for block_2. Weight propagates upward: block_1 += 4, block_2 += 4.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -406,40 +406,35 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
                         ValidatorIndex(1),
                         ValidatorIndex(2),
                         ValidatorIndex(3),
-                        ValidatorIndex(4),
-                        ValidatorIndex(5),
                     ],
                     slot=Slot(4),
                     target_slot=Slot(2),
                     target_root_label="block_2",
                 ),
             ),
-            # 3/9 validators vote for block_3.
-            # Weight propagates: block_3 += 3, block_2 += 3, block_1 += 3.
+            # 2/6 validators vote for block_3.
+            # Weight propagates: block_3 += 2, block_2 += 2, block_1 += 2.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
-                        ValidatorIndex(6),
-                        ValidatorIndex(7),
-                        ValidatorIndex(8),
+                        ValidatorIndex(4),
+                        ValidatorIndex(5),
                     ],
                     slot=Slot(4),
                     target_slot=Slot(3),
                     target_root_label="block_3",
                 ),
             ),
-            # Combined weights:
-            #   block_1 = 9, block_2 = 9, block_3 = 3
-            #
-            # LMD-GHOST (no threshold):
-            #   only child path leads to block_3 → head = block_3
-            #
-            # update_safe_target (min_score = 6):
-            #   justified → block_1 (9 ≥ 6) → block_2 (9 ≥ 6)
-            #   → block_3 (3 < 6, pruned) → stop
-            #   safe_target = block_2
-            #
-            # Result: safe_target is shallower than LMD-GHOST head.
+# Combined weights: block_1=6, block_2=6, block_3=2.
+#
+# LMD-GHOST (no threshold):
+#   only path leads to block_3 → head = block_3
+#
+# update_safe_target (min_score=4):
+#   block_3 (2 < 4) pruned → stop at block_2
+#   safe_target = block_2
+#
+# Result: safe_target < head (conservative property)
             TickStep(
                 time=15,
                 checks=StoreChecks(

--- a/tests/consensus/devnet/fc/test_safe_target.py
+++ b/tests/consensus/devnet/fc/test_safe_target.py
@@ -366,22 +366,22 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
     Chain: genesis -> block_1 -> block_2 -> block_3.
 
     - 4 vote block_2, 2 vote block_3
-    
+
     Weights:
         block_1 = 6, block_2 = 6, block_3 = 2
 
     Safe walk (min_score=4):
-    
+
         justified -> block_1 (6 >= 4) -> block_2 (6 >= 4)
                   -> block_3 (2 < 4, pruned)
         safe_target = block_2
-    
+
     LMD-GHOST:
-    
+
         continues to block_3 -> head = block_3
-    
+
     Result: safe_target < head (conservative property).
-        """
+    """
     fork_choice_test(
         anchor_state=generate_pre_state(num_validators=8),
         steps=[


### PR DESCRIPTION
## 🗒️ Description

Adds a fork choice filler that verifies the safe target does **not**
advance when attestation weight falls below the 2/3 supermajority
threshold.

`Store.update_safe_target` runs LMD-GHOST with
`min_score = ceil(num_validators * 2 / 3)`. When no child of the
justified root clears that bar, the walk halts immediately and
`safe_target` stays at the genesis anchor. This test pins that
behaviour with 6 validators and only 2 attestations (threshold is 4):

```bash
3 * count >= 2 * num_validators
3 * 2 = 6  <  2 * 6 = 12  →  threshold NOT met
```
The test uses `GossipAggregatedAttestationStep` rather than individual
`AttestationStep` because `update_safe_target` reads from the aggregated
payload pools (`latest_new_aggregated_payloads` /
`latest_known_aggregated_payloads`), not from `attestation_signatures`.
Individual gossip signatures only reach those pools after `aggregate()`
fires at interval 2 with `is_aggregator=True`, which is an orthogonal
concern not needed here.

## 🔗 Related Issues or PRs

Closes #559

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran `tox` checks to avoid unnecessary CI fails:
```console
    uvx tox
```
- [x] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the `./docs/` directory.