### PR TITLE
test(st): genesis with maximum validators

### DIFF
--- a/tests/consensus/devnet/state_transition/test_genesis.py
+++ b/tests/consensus/devnet/state_transition/test_genesis.py
@@ -264,3 +264,70 @@ def test_first_post_genesis_block_sets_checkpoint_anchor_roots(
             justified_slots=JustifiedSlots(data=[]),
         ),
     )
+
+def test_genesis_maximum_validators(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """Genesis with VALIDATOR_REGISTRY_LIMIT (4096) validators."""
+    pre = generate_pre_state(num_validators=4096, genesis_time=Uint64(0))
+    # The anchor root is the root of the genesis block header with its state root filled.
+    # This header is materialized when transitioning to the first post-genesis block.
+    anchor_root = hash_tree_root(pre.process_slots(Slot(1)).latest_block_header)
+
+    state_transition_test(
+        pre=pre,
+        blocks=[
+            BlockSpec(slot=Slot(1), proposer_index=ValidatorIndex(1)),
+        ],
+        post=StateExpectation(
+            slot=Slot(1),
+            validator_count=4096,
+            latest_justified_slot=Slot(0),
+            latest_justified_root=anchor_root,
+            latest_finalized_slot=Slot(0),
+            latest_finalized_root=anchor_root,
+            latest_block_header_slot=Slot(1),
+            latest_block_header_proposer_index=1,
+            latest_block_header_parent_root=anchor_root,
+        ),
+    )
+
+
+def test_genesis_maximum_validators_justification(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Justification with VALIDATOR_REGISTRY_LIMIT (4096) validators.
+
+    Threshold: ceil(2/3 * 4096) = 2731 validators needed.
+    """
+    pre = generate_pre_state(num_validators=4096, genesis_time=Uint64(0))
+    # Anchor root for checkpoints
+    anchor_root = hash_tree_root(pre.process_slots(Slot(1)).latest_block_header)
+
+    state_transition_test(
+        pre=pre,
+        blocks=[
+            # Block 1: creates the attestation target
+            BlockSpec(slot=Slot(1), label="block_1"),
+            # Block 2: 2731 validators attest to slot 1
+            # Threshold: 3*2731=8193 >= 2*4096=8192 -> justifies slot 1.
+            BlockSpec(
+                slot=Slot(2),
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[ValidatorIndex(i) for i in range(2731)],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(2),
+            validator_count=4096,
+            latest_justified_slot=Slot(1),
+            latest_justified_root_label="block_1",
+        ),
+    )

--- a/tests/consensus/devnet/state_transition/test_genesis.py
+++ b/tests/consensus/devnet/state_transition/test_genesis.py
@@ -321,7 +321,6 @@ def test_genesis_maximum_validators_justification(
     2. Produce a block at slot 1.
     3. Produce a block at slot 2 containing attestations from 2731 validators
        targeting slot 1.
-    
     Threshold Calculation:
     - supermajority_threshold = ceil(2/3 * 4096) = 2731 validators.
     - Total weight: 2731 * 3 = 8193.
@@ -334,9 +333,6 @@ def test_genesis_maximum_validators_justification(
     """
     # Generate pre-state with max validators
     pre = generate_pre_state(num_validators=4096, genesis_time=Uint64(0))
-
-    # Anchor root for checkpoints (genesis block header processed to slot 1)
-    anchor_root = hash_tree_root(pre.process_slots(Slot(1)).latest_block_header)
 
     state_transition_test(
         pre=pre,

--- a/tests/consensus/devnet/state_transition/test_genesis.py
+++ b/tests/consensus/devnet/state_transition/test_genesis.py
@@ -265,6 +265,7 @@ def test_first_post_genesis_block_sets_checkpoint_anchor_roots(
         ),
     )
 
+
 def test_genesis_maximum_validators(
     state_transition_test: StateTransitionTestFiller,
 ) -> None:

--- a/tests/consensus/devnet/state_transition/test_genesis.py
+++ b/tests/consensus/devnet/state_transition/test_genesis.py
@@ -268,10 +268,26 @@ def test_first_post_genesis_block_sets_checkpoint_anchor_roots(
 def test_genesis_maximum_validators(
     state_transition_test: StateTransitionTestFiller,
 ) -> None:
-    """Genesis with VALIDATOR_REGISTRY_LIMIT (4096) validators."""
+    """
+    Test genesis state generation with VALIDATOR_REGISTRY_LIMIT (4096).
+
+    Scenario
+    --------
+    Generate a genesis state with the maximum allowed number of validators (4096).
+    The test then transitions to slot 1 to verify proposer rotation.
+
+    Expected Behavior
+    -----------------
+    - Genesis state should contain exactly 4096 validators.
+    - Proposer for slot 1 should be validator index 1 (standard proposer rotation).
+    - All state roots and headers should be correctly materialized.
+    """
+    # Generate large pre-state with 4096 validators
     pre = generate_pre_state(num_validators=4096, genesis_time=Uint64(0))
+
     # The anchor root is the root of the genesis block header with its state root filled.
     # This header is materialized when transitioning to the first post-genesis block.
+    # We process slots up to slot 1 to get the expected header for comparison.
     anchor_root = hash_tree_root(pre.process_slots(Slot(1)).latest_block_header)
 
     state_transition_test(
@@ -297,12 +313,29 @@ def test_genesis_maximum_validators_justification(
     state_transition_test: StateTransitionTestFiller,
 ) -> None:
     """
-    Justification with VALIDATOR_REGISTRY_LIMIT (4096) validators.
+    Test supermajority justification with 4096 validators.
 
-    Threshold: ceil(2/3 * 4096) = 2731 validators needed.
+    Scenario
+    --------
+    1. Generate genesis with 4096 validators.
+    2. Produce a block at slot 1.
+    3. Produce a block at slot 2 containing attestations from 2731 validators
+       targeting slot 1.
+    
+    Threshold Calculation:
+    - supermajority_threshold = ceil(2/3 * 4096) = 2731 validators.
+    - Total weight: 2731 * 3 = 8193.
+    - Threshold weight: 2 * 4096 = 8192.
+    - Result: 8193 >= 8192 -> Slot 1 becomes justified.
+
+    Expected Behavior
+    -----------------
+    Slot 1 should be justified in the state after processing the block at slot 2.
     """
+    # Generate pre-state with max validators
     pre = generate_pre_state(num_validators=4096, genesis_time=Uint64(0))
-    # Anchor root for checkpoints
+
+    # Anchor root for checkpoints (genesis block header processed to slot 1)
     anchor_root = hash_tree_root(pre.process_slots(Slot(1)).latest_block_header)
 
     state_transition_test(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
This PR introduces comprehensive stress tests for the consensus layer when configured with the maximum allowed validator set (VALIDATOR_REGISTRY_LIMIT = 4096).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->
Fixes #580 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [X] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [X] Considered adding appropriate tests for the changes.
- [X] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
