### PR TITLE
test(fc): reject block body with duplicate AttestationData

### DIFF
--- a/tests/consensus/devnet/fc/test_duplicate_attestation_data.py
+++ b/tests/consensus/devnet/fc/test_duplicate_attestation_data.py
@@ -1,0 +1,78 @@
+"""Fork Choice: Duplicate AttestationData Rejection."""
+
+import pytest
+from consensus_testing import (
+    AggregatedAttestationSpec,
+    BlockSpec,
+    BlockStep,
+    ForkChoiceTestFiller,
+    StoreChecks,
+)
+
+from lean_spec.subspecs.containers.slot import Slot
+from lean_spec.subspecs.containers.validator import ValidatorIndex
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_block_with_duplicate_aggregated_attestation_data_rejected(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Blocks containing two aggregated attestations with identical data are rejected.
+
+    Scenario
+    --------
+    - Slot 1: common ancestor block accepted by the store.
+    - Slot 2: proposer builds a block whose body contains two aggregated
+      attestations that reference identical data:
+        - same slot
+        - same target
+        - same source
+        - same validator set
+      The two entries are appended via forced attestations so the builder's
+      merge-by-data pass does not collapse them.
+
+    Expected Behavior
+    -----------------
+    Fork-choice store rejects the block with AssertionError containing:
+    "Block contains duplicate AttestationData"
+
+    Why This Matters
+    ----------------
+    Each unique AttestationData must appear at most once per block:
+
+    - Prevents inflating attestation weight by repeating the same vote.
+    - Keeps signature-aggregation accounting one-to-one with data.
+    - Without this check, a proposer could double-count votes from a single
+      validator set just by repeating the entry.
+    """
+    duplicated_spec = AggregatedAttestationSpec(
+        validator_ids=[ValidatorIndex(0)],
+        slot=Slot(1),
+        target_slot=Slot(1),
+        target_root_label="block_1",
+    )
+
+    fork_choice_test(
+        steps=[
+            # Common ancestor at slot 1
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(
+                    head_slot=Slot(1),
+                    head_root_label="block_1",
+                ),
+            ),
+            # Slot 2 block carrying two byte-identical aggregated attestations
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(2),
+                    parent_label="block_1",
+                    forced_attestations=[duplicated_spec, duplicated_spec],
+                ),
+                valid=False,
+                expected_error="Block contains duplicate AttestationData",
+            ),
+        ],
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds the untested store-level rejection vector for block bodies containing two aggregated attestations with byte-identical \`AttestationData\`.

The existing suite covers the \`MAX_ATTESTATIONS_DATA\` cap (\`test_block_exceeding_maximum_attestations_is_rejected\`) but not the duplicate-data cardinality check at \`store.py:554\`:

\`\`\`
Block contains duplicate AttestationData entries;
each AttestationData must appear at most once
\`\`\`

Duplicates are injected via \`forced_attestations\` so the builder's merge-by-data aggregation pass does not collapse the two entries back into one before they reach \`Store.on_block\`.

This is the second PR in a planned series of small, single-theme PRs covering untested rejection/KAT/behavioral vectors. Follow-up PRs will address the remaining FC block-body structural rejections (\`Attestation signature groups must align\` and \`Aggregated attestation must reference at least one validator\`) which require test-framework extensions to construct.

## 🔗 Related Issues or PRs

Follows #643.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)