### PR TITLE
test(verify_signatures): reject out-of-range attestation validator index

### DIFF
--- a/tests/consensus/devnet/verify_signatures/test_index_out_of_range.py
+++ b/tests/consensus/devnet/verify_signatures/test_index_out_of_range.py
@@ -1,0 +1,60 @@
+"""Signature Verification: Out-of-Range Attestation Validator Index."""
+
+import pytest
+from consensus_testing import (
+    AggregatedAttestationSpec,
+    BlockSpec,
+    VerifySignaturesTestFiller,
+    generate_pre_state,
+)
+
+from lean_spec.subspecs.containers.slot import Slot
+from lean_spec.subspecs.containers.validator import ValidatorIndex
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_attestation_validator_index_out_of_range_rejected(
+    verify_signatures_test: VerifySignaturesTestFiller,
+) -> None:
+    """
+    An attestation whose participants include an index beyond the registry is rejected.
+
+    Scenario
+    --------
+    - Anchor state has 4 validators.
+    - Block at slot 2 carries one aggregated attestation whose participants
+      bitfield includes validator index 99.
+    - The attestation is marked valid_signature=False so the fixture path
+      builds an invalid proof directly, without attempting XMSS signing for
+      the out-of-range index.
+
+    Expected Behavior
+    -----------------
+    Signature verification fails with AssertionError: "Validator index out of range"
+
+    Why This Matters
+    ----------------
+    Enforces the validator-registry bound during attestation verification:
+
+    - A malformed bitfield that references indices past the registry would
+      otherwise cause undefined behaviour in public-key lookup.
+    - The bound-check runs before attestation aggregate-signature verification
+      so the failure reason is unambiguous across clients.
+    """
+    verify_signatures_test(
+        anchor_state=generate_pre_state(),
+        block=BlockSpec(
+            slot=Slot(2),
+            attestations=[
+                AggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(99)],
+                    slot=Slot(1),
+                    target_slot=Slot(0),
+                    target_root_label="genesis",
+                    valid_signature=False,
+                ),
+            ],
+        ),
+        expect_exception=AssertionError,
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds the untested rejection vector for \`block.py:255\`: an aggregated attestation whose participants bitfield includes an index beyond the validator registry triggers

\`\`\`
"Validator index out of range"
\`\`\`

The bound-check runs inside \`verify_signatures\` before aggregate-signature verification, so the rejection reason is unambiguous across clients.

### Scope note — proposer-index variant deferred

The analogous \`block.py:277\` assertion for \`proposer_index\` out-of-range is effectively unreachable in the current test framework: \`state.build_block\` runs \`process_block_header\` internally, which catches any out-of-range index via the round-robin proposer check (\`"Incorrect block proposer"\`) before \`verify_signatures\` ever sees the block. Shipping a faithful test vector for that assertion requires framework support to construct a \`SignedBlock\` bypassing \`state_transition\`. Tracked as follow-up.

This is the third PR in a planned series of small, single-theme test-vector PRs.

## 🔗 Related Issues or PRs

Follows #643, #644.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)