### PR TITLE
framework: add decode-failure mode to ssz and networking_codec formats

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -113,9 +113,78 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 output = self._make_xor_distance()
             case "log2_distance":
                 output = self._make_log2_distance()
+            case "decode_failure":
+                output = self._make_decode_failure()
             case _:
                 raise ValueError(f"Unknown codec: {self.codec_name}")
         return self.model_copy(update={"output": output})
+
+    def _make_decode_failure(self) -> dict[str, Any]:
+        """Assert that decoding ``input.bytes`` with ``input.decoder`` raises.
+
+        Dispatches to one of the wire-format decoders and confirms that the
+        expected exception (on :attr:`expect_exception`) is raised. Used to
+        generate negative-path test vectors for client decoders.
+
+        The input record carries two fields:
+
+        - ``decoder``: name of the target decoder (``varint``, ``snappy_frame``,
+          ``gossipsub_rpc``, ``reqresp_request``, ``reqresp_response``,
+          ``discv5_message``, ``enr``).
+        - ``bytes``: hex-encoded malformed input.
+
+        Returns:
+            A dict echoing the decoder name along with the error type and
+            message for reproducibility.
+
+        Raises:
+            AssertionError: If the decoder succeeds or raises a mismatched
+                exception type.
+            ValueError: If ``expect_exception`` is unset or the decoder is
+                unknown.
+        """
+        if self.expect_exception is None:
+            raise ValueError("decode_failure codec requires expect_exception to be set")
+
+        decoder_name = self.input["decoder"]
+        raw = _from_hex(self.input["bytes"])
+
+        decoders: dict[str, Any] = {
+            "varint": decode_varint,
+            "snappy_frame": frame_decompress,
+            "snappy_block": decompress,
+            "gossipsub_rpc": RPC.decode,
+            "reqresp_request": decode_request,
+            "reqresp_response": ResponseCode.decode,
+            "discv5_message": decode_message,
+            "enr": ENR.from_rlp,
+        }
+        if decoder_name not in decoders:
+            raise ValueError(f"Unknown decoder for decode_failure: {decoder_name!r}")
+
+        decoder = decoders[decoder_name]
+        exception_raised: Exception | None = None
+        try:
+            decoder(raw)
+        except Exception as exc:
+            exception_raised = exc
+
+        if exception_raised is None:
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} from "
+                f"{decoder_name!r} decode, but decode succeeded"
+            )
+        if not isinstance(exception_raised, self.expect_exception):
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} but got "
+                f"{type(exception_raised).__name__}: {exception_raised}"
+            )
+
+        return {
+            "decoder": decoder_name,
+            "errorType": type(exception_raised).__name__,
+            "errorMessage": str(exception_raised),
+        }
 
     def _make_varint(self) -> dict[str, Any]:
         """Encode a value as LEB128, decode it back, assert roundtrip."""

--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -16,9 +16,14 @@ from .base import BaseConsensusFixture
 class SSZTest(BaseConsensusFixture):
     """Fixture for SSZ conformance testing.
 
-    Verifies roundtrip serialization and Merkleization for any SSZ type.
+    Supports two modes:
 
-    JSON output: typeName, value, serialized, root.
+    - Roundtrip mode (default): encode ``value``, decode back, verify equality
+      and compute ``hash_tree_root``. JSON output: typeName, value, serialized, root.
+    - Decode-failure mode: when ``expect_exception`` is set, ``raw_bytes`` holds
+      the malformed input. The fixture decodes the input as ``type(value)`` and
+      asserts the expected exception is raised. JSON output keeps the same
+      shape; ``serialized`` holds the malformed bytes and ``root`` is empty.
     """
 
     format_name: ClassVar[str] = "ssz"
@@ -28,13 +33,27 @@ class SSZTest(BaseConsensusFixture):
     """SSZ type class name."""
 
     value: SSZType
-    """The SSZ value under test."""
+    """
+    The SSZ value under test.
+
+    Roundtrip mode: the value to encode and round-trip.
+    Decode-failure mode: acts as a type tag; its class is used as the decoder.
+    Supply any instance of the target type (often a default-constructed one).
+    """
+
+    raw_bytes: str | None = None
+    """
+    Hex-encoded malformed input for decode-failure mode.
+
+    Only consulted when ``expect_exception`` is set. The fixture decodes these
+    bytes using ``type(value).decode_bytes`` and asserts the decoder raises.
+    """
 
     serialized: str = ""
     """Hex SSZ bytes. Empty until fixture generation fills it."""
 
     root: str = ""
-    """Hex hash_tree_root. Empty until fixture generation fills it."""
+    """Hex hash_tree_root. Empty in decode-failure mode."""
 
     @field_serializer("value", when_used="json")
     def serialize_value(self, value: SSZType) -> Any:
@@ -53,14 +72,20 @@ class SSZTest(BaseConsensusFixture):
         return str(value)
 
     def make_fixture(self) -> "SSZTest":
-        """Verify SSZ roundtrip and produce the reference encoding and root.
+        """Verify SSZ roundtrip or decode-failure and produce the reference output.
 
         Returns:
-            A copy of this fixture with serialized and root populated.
+            A copy of this fixture with ``serialized`` and ``root`` populated.
 
         Raises:
-            AssertionError: If decode(encode(value)) != value.
+            AssertionError:
+                - In roundtrip mode, if ``decode(encode(value)) != value``.
+                - In decode-failure mode, if the decoder does not raise the
+                  expected exception type.
         """
+        if self.expect_exception is not None:
+            return self._make_decode_failure()
+
         ssz_bytes = self.value.encode_bytes()
         decoded = self.value.decode_bytes(ssz_bytes)
 
@@ -77,5 +102,45 @@ class SSZTest(BaseConsensusFixture):
             update={
                 "serialized": "0x" + ssz_bytes.hex(),
                 "root": "0x" + root.hex(),
+            }
+        )
+
+    def _make_decode_failure(self) -> "SSZTest":
+        """Run the decode-failure path: assert decoding ``raw_bytes`` raises.
+
+        The class of ``value`` is used as the decoder. ``serialized`` carries
+        the malformed bytes verbatim so consumers can reproduce the input.
+
+        Raises:
+            AssertionError: If the decoder succeeds or raises a different type.
+            ValueError: If ``raw_bytes`` is missing.
+        """
+        assert self.expect_exception is not None
+        if self.raw_bytes is None:
+            raise ValueError("raw_bytes is required when expect_exception is set")
+
+        raw = bytes.fromhex(self.raw_bytes.removeprefix("0x"))
+        decoder = type(self.value)
+        exception_raised: Exception | None = None
+        try:
+            decoder.decode_bytes(raw)
+        except Exception as exc:
+            exception_raised = exc
+
+        if exception_raised is None:
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} from "
+                f"{decoder.__name__}.decode_bytes, but decode succeeded"
+            )
+        if not isinstance(exception_raised, self.expect_exception):
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} but got "
+                f"{type(exception_raised).__name__}: {exception_raised}"
+            )
+
+        return self.model_copy(
+            update={
+                "serialized": "0x" + raw.hex(),
+                "root": "",
             }
         )

--- a/tests/consensus/devnet/networking/test_decode_failure_smoke.py
+++ b/tests/consensus/devnet/networking/test_decode_failure_smoke.py
@@ -1,0 +1,23 @@
+"""Smoke test for the networking_codec fixture's decode_failure dispatcher.
+
+Exercises the new ``decode_failure`` codec so the framework change is covered
+independently of later negative-path content PRs.
+"""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_decode_failure_varint_truncated(networking_codec: NetworkingCodecTestFiller) -> None:
+    """A truncated varint (continuation bit set on the final byte) must fail to decode.
+
+    Pins the new ``decode_failure`` codec dispatch path on the
+    networking_codec fixture.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "varint", "bytes": "0x80"},
+        expect_exception=Exception,
+    )

--- a/tests/consensus/devnet/ssz/test_decode_failure_smoke.py
+++ b/tests/consensus/devnet/ssz/test_decode_failure_smoke.py
@@ -1,0 +1,35 @@
+"""Smoke test for the ssz fixture's decode-failure mode.
+
+Exercises the new ``raw_bytes`` + ``expect_exception`` path so the framework
+change is covered independently of later negative-path content PRs.
+"""
+
+from typing import ClassVar
+
+import pytest
+from consensus_testing import SSZTestFiller
+
+from lean_spec.types import BaseBitlist, Boolean
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+class SmokeBitlist8(BaseBitlist):
+    """Small bitlist with an 8-bit limit, used only by the decode-failure smoke test."""
+
+    LIMIT: ClassVar[int] = 8
+
+
+def test_ssz_decode_failure_bitlist_exceeds_limit(ssz: SSZTestFiller) -> None:
+    """Decoding a bitlist whose contents imply a length above its LIMIT raises.
+
+    The payload ``0x0010`` encodes 16 bits before the sentinel. The ``LIMIT``
+    on the decoder type is 8, so SSZ decode must reject. This pins the new
+    ``raw_bytes`` + ``expect_exception`` path on the ssz fixture.
+    """
+    ssz(
+        type_name="SmokeBitlist8",
+        value=SmokeBitlist8(data=[Boolean(False)]),
+        raw_bytes="0x0010",
+        expect_exception=Exception,
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds a **negative-path execution mode** to the two existing wire-format fixtures so test vectors can pin the rejection behaviour of SSZ and networking decoders, not just the happy-path roundtrips.

### \`ssz\` format

- Accepts an optional \`raw_bytes\` field (hex).
- When \`expect_exception\` is set, the fixture decodes \`raw_bytes\` via \`type(value).decode_bytes\` and asserts the expected exception is raised.
- Roundtrip mode is unchanged.

### \`networking_codec\` format

- Adds a \`decode_failure\` codec dispatcher.
- Its input record names a target decoder (\`varint\`, \`snappy_frame\`, \`snappy_block\`, \`gossipsub_rpc\`, \`reqresp_request\`, \`reqresp_response\`, \`discv5_message\`, \`enr\`) plus malformed hex bytes.
- On a matching exception, the output captures \`errorType\` and \`errorMessage\` for downstream reproducibility.

### Smoke tests

Each format ships with one smoke test exercising the new path so the framework change is covered independently of downstream content PRs. All 276 existing ssz + networking fixtures continue to pass.

### Why

Several upcoming content PRs require this capability: SSZ malformed-input rejection vectors, varint rejection vectors, snappy-frame rejection vectors, gossipsub-RPC malformed-protobuf rejection vectors, and req/resp wire-level rejection vectors. Landing the infrastructure in one small PR keeps each downstream PR to a single clean theme.

## 🔗 Related Issues or PRs

Follows #643, #644, #645, #646. Unblocks the SSZ decode-rejection and networking-codec rejection vectors in the test-vector plan.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes — smoke tests in each format cover the new path.
- [x] N/A for docs — framework-internal mode is surfaced only through fixture-field docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)