### PR TITLE
test(ssz): reject malformed decoder inputs

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -113,9 +113,78 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 output = self._make_xor_distance()
             case "log2_distance":
                 output = self._make_log2_distance()
+            case "decode_failure":
+                output = self._make_decode_failure()
             case _:
                 raise ValueError(f"Unknown codec: {self.codec_name}")
         return self.model_copy(update={"output": output})
+
+    def _make_decode_failure(self) -> dict[str, Any]:
+        """Assert that decoding ``input.bytes`` with ``input.decoder`` raises.
+
+        Dispatches to one of the wire-format decoders and confirms that the
+        expected exception (on :attr:`expect_exception`) is raised. Used to
+        generate negative-path test vectors for client decoders.
+
+        The input record carries two fields:
+
+        - ``decoder``: name of the target decoder (``varint``, ``snappy_frame``,
+          ``gossipsub_rpc``, ``reqresp_request``, ``reqresp_response``,
+          ``discv5_message``, ``enr``).
+        - ``bytes``: hex-encoded malformed input.
+
+        Returns:
+            A dict echoing the decoder name along with the error type and
+            message for reproducibility.
+
+        Raises:
+            AssertionError: If the decoder succeeds or raises a mismatched
+                exception type.
+            ValueError: If ``expect_exception`` is unset or the decoder is
+                unknown.
+        """
+        if self.expect_exception is None:
+            raise ValueError("decode_failure codec requires expect_exception to be set")
+
+        decoder_name = self.input["decoder"]
+        raw = _from_hex(self.input["bytes"])
+
+        decoders: dict[str, Any] = {
+            "varint": decode_varint,
+            "snappy_frame": frame_decompress,
+            "snappy_block": decompress,
+            "gossipsub_rpc": RPC.decode,
+            "reqresp_request": decode_request,
+            "reqresp_response": ResponseCode.decode,
+            "discv5_message": decode_message,
+            "enr": ENR.from_rlp,
+        }
+        if decoder_name not in decoders:
+            raise ValueError(f"Unknown decoder for decode_failure: {decoder_name!r}")
+
+        decoder = decoders[decoder_name]
+        exception_raised: Exception | None = None
+        try:
+            decoder(raw)
+        except Exception as exc:
+            exception_raised = exc
+
+        if exception_raised is None:
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} from "
+                f"{decoder_name!r} decode, but decode succeeded"
+            )
+        if not isinstance(exception_raised, self.expect_exception):
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} but got "
+                f"{type(exception_raised).__name__}: {exception_raised}"
+            )
+
+        return {
+            "decoder": decoder_name,
+            "errorType": type(exception_raised).__name__,
+            "errorMessage": str(exception_raised),
+        }
 
     def _make_varint(self) -> dict[str, Any]:
         """Encode a value as LEB128, decode it back, assert roundtrip."""

--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -16,9 +16,14 @@ from .base import BaseConsensusFixture
 class SSZTest(BaseConsensusFixture):
     """Fixture for SSZ conformance testing.
 
-    Verifies roundtrip serialization and Merkleization for any SSZ type.
+    Supports two modes:
 
-    JSON output: typeName, value, serialized, root.
+    - Roundtrip mode (default): encode ``value``, decode back, verify equality
+      and compute ``hash_tree_root``. JSON output: typeName, value, serialized, root.
+    - Decode-failure mode: when ``expect_exception`` is set, ``raw_bytes`` holds
+      the malformed input. The fixture decodes the input as ``type(value)`` and
+      asserts the expected exception is raised. JSON output keeps the same
+      shape; ``serialized`` holds the malformed bytes and ``root`` is empty.
     """
 
     format_name: ClassVar[str] = "ssz"
@@ -28,13 +33,27 @@ class SSZTest(BaseConsensusFixture):
     """SSZ type class name."""
 
     value: SSZType
-    """The SSZ value under test."""
+    """
+    The SSZ value under test.
+
+    Roundtrip mode: the value to encode and round-trip.
+    Decode-failure mode: acts as a type tag; its class is used as the decoder.
+    Supply any instance of the target type (often a default-constructed one).
+    """
+
+    raw_bytes: str | None = None
+    """
+    Hex-encoded malformed input for decode-failure mode.
+
+    Only consulted when ``expect_exception`` is set. The fixture decodes these
+    bytes using ``type(value).decode_bytes`` and asserts the decoder raises.
+    """
 
     serialized: str = ""
     """Hex SSZ bytes. Empty until fixture generation fills it."""
 
     root: str = ""
-    """Hex hash_tree_root. Empty until fixture generation fills it."""
+    """Hex hash_tree_root. Empty in decode-failure mode."""
 
     @field_serializer("value", when_used="json")
     def serialize_value(self, value: SSZType) -> Any:
@@ -53,14 +72,20 @@ class SSZTest(BaseConsensusFixture):
         return str(value)
 
     def make_fixture(self) -> "SSZTest":
-        """Verify SSZ roundtrip and produce the reference encoding and root.
+        """Verify SSZ roundtrip or decode-failure and produce the reference output.
 
         Returns:
-            A copy of this fixture with serialized and root populated.
+            A copy of this fixture with ``serialized`` and ``root`` populated.
 
         Raises:
-            AssertionError: If decode(encode(value)) != value.
+            AssertionError:
+                - In roundtrip mode, if ``decode(encode(value)) != value``.
+                - In decode-failure mode, if the decoder does not raise the
+                  expected exception type.
         """
+        if self.expect_exception is not None:
+            return self._make_decode_failure()
+
         ssz_bytes = self.value.encode_bytes()
         decoded = self.value.decode_bytes(ssz_bytes)
 
@@ -77,5 +102,45 @@ class SSZTest(BaseConsensusFixture):
             update={
                 "serialized": "0x" + ssz_bytes.hex(),
                 "root": "0x" + root.hex(),
+            }
+        )
+
+    def _make_decode_failure(self) -> "SSZTest":
+        """Run the decode-failure path: assert decoding ``raw_bytes`` raises.
+
+        The class of ``value`` is used as the decoder. ``serialized`` carries
+        the malformed bytes verbatim so consumers can reproduce the input.
+
+        Raises:
+            AssertionError: If the decoder succeeds or raises a different type.
+            ValueError: If ``raw_bytes`` is missing.
+        """
+        assert self.expect_exception is not None
+        if self.raw_bytes is None:
+            raise ValueError("raw_bytes is required when expect_exception is set")
+
+        raw = bytes.fromhex(self.raw_bytes.removeprefix("0x"))
+        decoder = type(self.value)
+        exception_raised: Exception | None = None
+        try:
+            decoder.decode_bytes(raw)
+        except Exception as exc:
+            exception_raised = exc
+
+        if exception_raised is None:
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} from "
+                f"{decoder.__name__}.decode_bytes, but decode succeeded"
+            )
+        if not isinstance(exception_raised, self.expect_exception):
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} but got "
+                f"{type(exception_raised).__name__}: {exception_raised}"
+            )
+
+        return self.model_copy(
+            update={
+                "serialized": "0x" + raw.hex(),
+                "root": "",
             }
         )

--- a/tests/consensus/devnet/networking/test_decode_failure_smoke.py
+++ b/tests/consensus/devnet/networking/test_decode_failure_smoke.py
@@ -1,0 +1,23 @@
+"""Smoke test for the networking_codec fixture's decode_failure dispatcher.
+
+Exercises the new ``decode_failure`` codec so the framework change is covered
+independently of later negative-path content PRs.
+"""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_decode_failure_varint_truncated(networking_codec: NetworkingCodecTestFiller) -> None:
+    """A truncated varint (continuation bit set on the final byte) must fail to decode.
+
+    Pins the new ``decode_failure`` codec dispatch path on the
+    networking_codec fixture.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "varint", "bytes": "0x80"},
+        expect_exception=Exception,
+    )

--- a/tests/consensus/devnet/ssz/test_decode_failure_smoke.py
+++ b/tests/consensus/devnet/ssz/test_decode_failure_smoke.py
@@ -1,0 +1,35 @@
+"""Smoke test for the ssz fixture's decode-failure mode.
+
+Exercises the new ``raw_bytes`` + ``expect_exception`` path so the framework
+change is covered independently of later negative-path content PRs.
+"""
+
+from typing import ClassVar
+
+import pytest
+from consensus_testing import SSZTestFiller
+
+from lean_spec.types import BaseBitlist, Boolean
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+class SmokeBitlist8(BaseBitlist):
+    """Small bitlist with an 8-bit limit, used only by the decode-failure smoke test."""
+
+    LIMIT: ClassVar[int] = 8
+
+
+def test_ssz_decode_failure_bitlist_exceeds_limit(ssz: SSZTestFiller) -> None:
+    """Decoding a bitlist whose contents imply a length above its LIMIT raises.
+
+    The payload ``0x0010`` encodes 16 bits before the sentinel. The ``LIMIT``
+    on the decoder type is 8, so SSZ decode must reject. This pins the new
+    ``raw_bytes`` + ``expect_exception`` path on the ssz fixture.
+    """
+    ssz(
+        type_name="SmokeBitlist8",
+        value=SmokeBitlist8(data=[Boolean(False)]),
+        raw_bytes="0x0010",
+        expect_exception=Exception,
+    )

--- a/tests/consensus/devnet/ssz/test_decode_rejections.py
+++ b/tests/consensus/devnet/ssz/test_decode_rejections.py
@@ -1,0 +1,125 @@
+"""SSZ: decode-failure vectors for malformed inputs.
+
+Exercises the SSZ decoder's user-triggerable rejection paths through the
+decode-failure fixture. Each vector captures the expected exception class
+so client implementations can align on the rejection contract, not only
+the roundtrip contract covered by the basic-types vectors.
+"""
+
+from typing import ClassVar
+
+import pytest
+from consensus_testing import SSZTestFiller
+
+from lean_spec.types import (
+    BaseBitlist,
+    BaseBitvector,
+    Boolean,
+    Bytes4,
+    Uint32,
+)
+from lean_spec.types.exceptions import SSZSerializationError, SSZValueError
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+class DecodeBitlist8(BaseBitlist):
+    """Bitlist with an 8-bit limit, used to exercise bitlist-decode rejections."""
+
+    LIMIT: ClassVar[int] = 8
+
+
+class DecodeBitvector16(BaseBitvector):
+    """Fixed-width 16-bit bitvector, used to exercise fixed-width length checks."""
+
+    LENGTH: ClassVar[int] = 16
+
+
+def test_bitlist_decode_rejects_empty_input(ssz: SSZTestFiller) -> None:
+    """Bitlist decoding of zero bytes has no delimiter bit and must be rejected.
+
+    Every SSZ bitlist encoding ends in a sentinel set bit that signals the
+    bit-length. Empty input carries no such sentinel, so the decoder cannot
+    determine how many bits the value was supposed to hold.
+    """
+    ssz(
+        type_name="DecodeBitlist8",
+        value=DecodeBitlist8(data=[Boolean(False)]),
+        raw_bytes="0x",
+        expect_exception=SSZSerializationError,
+    )
+
+
+def test_bitlist_decode_rejects_missing_delimiter(ssz: SSZTestFiller) -> None:
+    """Bitlist bytes with no set bits carry no sentinel and must be rejected.
+
+    A single 0x00 byte encodes eight clear bits with nothing marking the
+    end of the logical bitlist. The decoder needs the sentinel to know
+    where the payload stops.
+    """
+    ssz(
+        type_name="DecodeBitlist8",
+        value=DecodeBitlist8(data=[Boolean(False)]),
+        raw_bytes="0x00",
+        expect_exception=SSZSerializationError,
+    )
+
+
+def test_bitlist_decode_rejects_length_above_limit(ssz: SSZTestFiller) -> None:
+    """Bitlist whose sentinel implies a bit-length beyond the type limit must be rejected.
+
+    The payload 0x0002 places the sentinel at bit index nine, implying a
+    nine-bit bitlist. The type caps at eight bits, so the decoder must
+    refuse to widen past its own limit.
+    """
+    ssz(
+        type_name="DecodeBitlist8",
+        value=DecodeBitlist8(data=[Boolean(False)]),
+        raw_bytes="0x0002",
+        expect_exception=SSZValueError,
+    )
+
+
+def test_bitvector_decode_rejects_wrong_byte_length(ssz: SSZTestFiller) -> None:
+    """Fixed-width bitvector decoding rejects inputs whose byte count does not match LENGTH.
+
+    The fixed-width bitvector here occupies exactly two bytes. A single-byte
+    input underfills the vector. The fixed-size decode path requires an
+    exact byte match, so the decoder must reject.
+    """
+    ssz(
+        type_name="DecodeBitvector16",
+        value=DecodeBitvector16(data=[Boolean(False)] * 16),
+        raw_bytes="0x00",
+        expect_exception=SSZValueError,
+    )
+
+
+def test_bytes4_decode_rejects_extra_trailing_bytes(ssz: SSZTestFiller) -> None:
+    """Fixed-size byte arrays reject inputs longer than their declared LENGTH.
+
+    A four-byte fixed array cannot consume five input bytes. The extra
+    trailing byte has no slot in the type, so the decoder must raise
+    rather than silently ignore the overflow.
+    """
+    ssz(
+        type_name="Bytes4",
+        value=Bytes4(b"\x00\x00\x00\x00"),
+        raw_bytes="0x0102030405",
+        expect_exception=SSZValueError,
+    )
+
+
+def test_uint32_decode_rejects_wrong_byte_length(ssz: SSZTestFiller) -> None:
+    """Fixed-size uint types reject input whose byte length does not match the type.
+
+    A uint32 is always four bytes. A three-byte input underfills the slot
+    and cannot be safely widened. The decoder raises rather than guessing
+    a padding convention.
+    """
+    ssz(
+        type_name="Uint32",
+        value=Uint32(0),
+        raw_bytes="0x010203",
+        expect_exception=SSZSerializationError,
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds six rejection vectors for the SSZ decoder, covering the primary user-reachable failure paths:

- Bitlist decode with zero input (no sentinel).
- Bitlist decode with all-zero bytes (no sentinel).
- Bitlist whose sentinel implies a length above its \`LIMIT\`.
- Fixed-width bitvector with too few input bytes.
- Fixed-size byte array with extra trailing bytes.
- Fixed-size uint with a byte length that does not match the type.

Fills the gap between the roundtrip-only basic-types suite and the rejection contract each client must implement identically. Uses the decode-failure mode on the ssz fixture added in #647.

### ⚠️ Depends on #647

Stacked on \`framework/decode-failure-mode\`. Please review and merge #647 first; after that lands I'll rebase this on \`main\` and the diff will shrink to just the test file.

## 🔗 Related Issues or PRs

Stacked on #647. Follows #643, #644, #645, #646, #648.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)