### PR TITLE
test(networking): reject malformed req/resp framing

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -113,9 +113,78 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 output = self._make_xor_distance()
             case "log2_distance":
                 output = self._make_log2_distance()
+            case "decode_failure":
+                output = self._make_decode_failure()
             case _:
                 raise ValueError(f"Unknown codec: {self.codec_name}")
         return self.model_copy(update={"output": output})
+
+    def _make_decode_failure(self) -> dict[str, Any]:
+        """Assert that decoding ``input.bytes`` with ``input.decoder`` raises.
+
+        Dispatches to one of the wire-format decoders and confirms that the
+        expected exception (on :attr:`expect_exception`) is raised. Used to
+        generate negative-path test vectors for client decoders.
+
+        The input record carries two fields:
+
+        - ``decoder``: name of the target decoder (``varint``, ``snappy_frame``,
+          ``gossipsub_rpc``, ``reqresp_request``, ``reqresp_response``,
+          ``discv5_message``, ``enr``).
+        - ``bytes``: hex-encoded malformed input.
+
+        Returns:
+            A dict echoing the decoder name along with the error type and
+            message for reproducibility.
+
+        Raises:
+            AssertionError: If the decoder succeeds or raises a mismatched
+                exception type.
+            ValueError: If ``expect_exception`` is unset or the decoder is
+                unknown.
+        """
+        if self.expect_exception is None:
+            raise ValueError("decode_failure codec requires expect_exception to be set")
+
+        decoder_name = self.input["decoder"]
+        raw = _from_hex(self.input["bytes"])
+
+        decoders: dict[str, Any] = {
+            "varint": decode_varint,
+            "snappy_frame": frame_decompress,
+            "snappy_block": decompress,
+            "gossipsub_rpc": RPC.decode,
+            "reqresp_request": decode_request,
+            "reqresp_response": ResponseCode.decode,
+            "discv5_message": decode_message,
+            "enr": ENR.from_rlp,
+        }
+        if decoder_name not in decoders:
+            raise ValueError(f"Unknown decoder for decode_failure: {decoder_name!r}")
+
+        decoder = decoders[decoder_name]
+        exception_raised: Exception | None = None
+        try:
+            decoder(raw)
+        except Exception as exc:
+            exception_raised = exc
+
+        if exception_raised is None:
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} from "
+                f"{decoder_name!r} decode, but decode succeeded"
+            )
+        if not isinstance(exception_raised, self.expect_exception):
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} but got "
+                f"{type(exception_raised).__name__}: {exception_raised}"
+            )
+
+        return {
+            "decoder": decoder_name,
+            "errorType": type(exception_raised).__name__,
+            "errorMessage": str(exception_raised),
+        }
 
     def _make_varint(self) -> dict[str, Any]:
         """Encode a value as LEB128, decode it back, assert roundtrip."""

--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -16,9 +16,14 @@ from .base import BaseConsensusFixture
 class SSZTest(BaseConsensusFixture):
     """Fixture for SSZ conformance testing.
 
-    Verifies roundtrip serialization and Merkleization for any SSZ type.
+    Supports two modes:
 
-    JSON output: typeName, value, serialized, root.
+    - Roundtrip mode (default): encode ``value``, decode back, verify equality
+      and compute ``hash_tree_root``. JSON output: typeName, value, serialized, root.
+    - Decode-failure mode: when ``expect_exception`` is set, ``raw_bytes`` holds
+      the malformed input. The fixture decodes the input as ``type(value)`` and
+      asserts the expected exception is raised. JSON output keeps the same
+      shape; ``serialized`` holds the malformed bytes and ``root`` is empty.
     """
 
     format_name: ClassVar[str] = "ssz"
@@ -28,13 +33,27 @@ class SSZTest(BaseConsensusFixture):
     """SSZ type class name."""
 
     value: SSZType
-    """The SSZ value under test."""
+    """
+    The SSZ value under test.
+
+    Roundtrip mode: the value to encode and round-trip.
+    Decode-failure mode: acts as a type tag; its class is used as the decoder.
+    Supply any instance of the target type (often a default-constructed one).
+    """
+
+    raw_bytes: str | None = None
+    """
+    Hex-encoded malformed input for decode-failure mode.
+
+    Only consulted when ``expect_exception`` is set. The fixture decodes these
+    bytes using ``type(value).decode_bytes`` and asserts the decoder raises.
+    """
 
     serialized: str = ""
     """Hex SSZ bytes. Empty until fixture generation fills it."""
 
     root: str = ""
-    """Hex hash_tree_root. Empty until fixture generation fills it."""
+    """Hex hash_tree_root. Empty in decode-failure mode."""
 
     @field_serializer("value", when_used="json")
     def serialize_value(self, value: SSZType) -> Any:
@@ -53,14 +72,20 @@ class SSZTest(BaseConsensusFixture):
         return str(value)
 
     def make_fixture(self) -> "SSZTest":
-        """Verify SSZ roundtrip and produce the reference encoding and root.
+        """Verify SSZ roundtrip or decode-failure and produce the reference output.
 
         Returns:
-            A copy of this fixture with serialized and root populated.
+            A copy of this fixture with ``serialized`` and ``root`` populated.
 
         Raises:
-            AssertionError: If decode(encode(value)) != value.
+            AssertionError:
+                - In roundtrip mode, if ``decode(encode(value)) != value``.
+                - In decode-failure mode, if the decoder does not raise the
+                  expected exception type.
         """
+        if self.expect_exception is not None:
+            return self._make_decode_failure()
+
         ssz_bytes = self.value.encode_bytes()
         decoded = self.value.decode_bytes(ssz_bytes)
 
@@ -77,5 +102,45 @@ class SSZTest(BaseConsensusFixture):
             update={
                 "serialized": "0x" + ssz_bytes.hex(),
                 "root": "0x" + root.hex(),
+            }
+        )
+
+    def _make_decode_failure(self) -> "SSZTest":
+        """Run the decode-failure path: assert decoding ``raw_bytes`` raises.
+
+        The class of ``value`` is used as the decoder. ``serialized`` carries
+        the malformed bytes verbatim so consumers can reproduce the input.
+
+        Raises:
+            AssertionError: If the decoder succeeds or raises a different type.
+            ValueError: If ``raw_bytes`` is missing.
+        """
+        assert self.expect_exception is not None
+        if self.raw_bytes is None:
+            raise ValueError("raw_bytes is required when expect_exception is set")
+
+        raw = bytes.fromhex(self.raw_bytes.removeprefix("0x"))
+        decoder = type(self.value)
+        exception_raised: Exception | None = None
+        try:
+            decoder.decode_bytes(raw)
+        except Exception as exc:
+            exception_raised = exc
+
+        if exception_raised is None:
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} from "
+                f"{decoder.__name__}.decode_bytes, but decode succeeded"
+            )
+        if not isinstance(exception_raised, self.expect_exception):
+            raise AssertionError(
+                f"Expected {self.expect_exception.__name__} but got "
+                f"{type(exception_raised).__name__}: {exception_raised}"
+            )
+
+        return self.model_copy(
+            update={
+                "serialized": "0x" + raw.hex(),
+                "root": "",
             }
         )

--- a/tests/consensus/devnet/networking/test_decode_failure_smoke.py
+++ b/tests/consensus/devnet/networking/test_decode_failure_smoke.py
@@ -1,0 +1,23 @@
+"""Smoke test for the networking_codec fixture's decode_failure dispatcher.
+
+Exercises the new ``decode_failure`` codec so the framework change is covered
+independently of later negative-path content PRs.
+"""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_decode_failure_varint_truncated(networking_codec: NetworkingCodecTestFiller) -> None:
+    """A truncated varint (continuation bit set on the final byte) must fail to decode.
+
+    Pins the new ``decode_failure`` codec dispatch path on the
+    networking_codec fixture.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "varint", "bytes": "0x80"},
+        expect_exception=Exception,
+    )

--- a/tests/consensus/devnet/networking/test_reqresp_rejections.py
+++ b/tests/consensus/devnet/networking/test_reqresp_rejections.py
@@ -1,0 +1,61 @@
+"""Req/resp codec: wire-level rejection vectors.
+
+Exercises the user-reachable CodecError paths in the req/resp decoder.
+Each vector pins the exact exception class a client must raise when a
+peer sends malformed framing.
+"""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+from lean_spec.subspecs.networking.reqresp.codec import CodecError
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_reqresp_decode_rejects_empty_request(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Decoding an empty request is rejected with CodecError.
+
+    The req/resp framing demands a length-prefix varint followed by a
+    compressed payload. Zero input carries neither, so the decoder must
+    refuse before any downstream parsing.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "reqresp_request", "bytes": "0x"},
+        expect_exception=CodecError,
+    )
+
+
+def test_reqresp_decode_rejects_invalid_varint_prefix(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """A request whose length prefix is a malformed varint is rejected with CodecError.
+
+    Two continuation bytes with no terminator make the varint parse raise.
+    The decoder wraps the underlying varint error in CodecError so clients
+    can uniformly treat wire-level framing errors as a single class.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "reqresp_request", "bytes": "0x8080"},
+        expect_exception=CodecError,
+    )
+
+
+def test_reqresp_decode_rejects_declared_length_above_max(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """A request whose declared length exceeds the ten-mebibyte cap is rejected.
+
+    The varint 0x81 0x80 0x80 0x05 declares 10,485,761 bytes, one over the
+    ten-mebibyte protocol cap. Refusing before decompression prevents a
+    sender from forcing resource allocation proportional to a claimed size.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "reqresp_request", "bytes": "0x81808005"},
+        expect_exception=CodecError,
+    )

--- a/tests/consensus/devnet/ssz/test_decode_failure_smoke.py
+++ b/tests/consensus/devnet/ssz/test_decode_failure_smoke.py
@@ -1,0 +1,35 @@
+"""Smoke test for the ssz fixture's decode-failure mode.
+
+Exercises the new ``raw_bytes`` + ``expect_exception`` path so the framework
+change is covered independently of later negative-path content PRs.
+"""
+
+from typing import ClassVar
+
+import pytest
+from consensus_testing import SSZTestFiller
+
+from lean_spec.types import BaseBitlist, Boolean
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+class SmokeBitlist8(BaseBitlist):
+    """Small bitlist with an 8-bit limit, used only by the decode-failure smoke test."""
+
+    LIMIT: ClassVar[int] = 8
+
+
+def test_ssz_decode_failure_bitlist_exceeds_limit(ssz: SSZTestFiller) -> None:
+    """Decoding a bitlist whose contents imply a length above its LIMIT raises.
+
+    The payload ``0x0010`` encodes 16 bits before the sentinel. The ``LIMIT``
+    on the decoder type is 8, so SSZ decode must reject. This pins the new
+    ``raw_bytes`` + ``expect_exception`` path on the ssz fixture.
+    """
+    ssz(
+        type_name="SmokeBitlist8",
+        value=SmokeBitlist8(data=[Boolean(False)]),
+        raw_bytes="0x0010",
+        expect_exception=Exception,
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds three wire-level rejection vectors for the req/resp decoder, covering the user-reachable \`CodecError\` paths in \`reqresp/codec.py\`:

1. **Empty request input** is rejected with \`CodecError("Empty request")\`.
2. **Request with malformed varint length prefix** is rejected with \`CodecError("Invalid request length: …")\` — the underlying \`VarintError\` is wrapped for uniform treatment.
3. **Request whose declared length exceeds the ten-mebibyte cap** is rejected with \`CodecError("Declared length too large: …")\` before decompression runs.

Uses the \`decode_failure\` dispatcher added in #647. Fills the gap between \`test_reqresp_codec.py\`'s roundtrip vectors and the framing-error paths in the spec.

The two remaining paths (decompression failure, length mismatch) will ship as a follow-up since they require crafting specific malformed Snappy frames.

### ⚠️ Depends on #647

Stacked on \`framework/decode-failure-mode\`. Please review and merge #647 first; after that lands I'll rebase this on \`main\` and the diff will shrink to just the test file.

## 🔗 Related Issues or PRs

Stacked on #647. Follows #643, #644, #645, #646, #648, #649.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)