### PR TITLE
test(networking): reject malformed snappy frames

### DIFF
--- a/tests/consensus/devnet/networking/test_snappy_frame_rejections.py
+++ b/tests/consensus/devnet/networking/test_snappy_frame_rejections.py
@@ -1,0 +1,60 @@
+"""Snappy framing decoder: malformed-input rejection vectors."""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+from lean_spec.snappy.decompress import SnappyDecompressionError
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_snappy_frame_decode_rejects_empty_input(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Empty input is not a valid snappy frame and must be rejected.
+
+    Every framed snappy stream begins with a ten-byte stream identifier.
+    Zero bytes cannot satisfy that minimum so the decoder aborts early
+    with SnappyDecompressionError.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "snappy_frame", "bytes": "0x"},
+        expect_exception=SnappyDecompressionError,
+    )
+
+
+def test_snappy_frame_decode_rejects_wrong_stream_identifier(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """A stream whose opening bytes do not spell the snappy magic is rejected.
+
+    A valid framed snappy stream starts with the ten-byte sequence
+    ``ff 06 00 00 73 4e 61 50 70 59`` ("sNaPpY"). Ten zero bytes satisfy
+    the length check but carry the wrong magic, so the decoder rejects
+    the stream at the identifier check.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "snappy_frame", "bytes": "0x" + "00" * 10},
+        expect_exception=SnappyDecompressionError,
+    )
+
+
+def test_snappy_frame_decode_rejects_unknown_unskippable_chunk(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """A chunk of an unassigned unskippable type is rejected.
+
+    The byte sequence begins with a valid stream identifier followed by a
+    chunk whose type byte is ``0x03`` with a zero-length payload. Type
+    ``0x03`` sits in the reserved-unskippable range, so any unrecognised
+    occurrence must force the decoder to abort.
+    """
+    stream_identifier = "ff060000734e61507059"
+    unknown_chunk = "03000000"
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "snappy_frame", "bytes": "0x" + stream_identifier + unknown_chunk},
+        expect_exception=SnappyDecompressionError,
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds three rejection vectors for the snappy framing decoder, covering the user-reachable \`SnappyDecompressionError\` paths that fire before any payload processing:

- **Empty input** below the ten-byte stream-identifier minimum → \`"Input too short for framed snappy"\`.
- **Wrong stream identifier** — ten bytes of zeros satisfy the length check but carry the wrong magic → \`"Invalid stream identifier"\`.
- **Unknown unskippable chunk type** — type byte \`0x03\` sits in the reserved-unskippable range, so any occurrence forces the decoder to abort → \`"Unknown unskippable chunk type"\`.

Uses the \`decode_failure\` dispatcher added in #647. Fills the gap between \`test_snappy_codec.py\`'s roundtrip vectors and the framing-error paths in the spec.

## 🔗 Related Issues or PRs

Follows #643, #644, #645, #646, #647, #648, #649, #650.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)