### PR TITLE
test(networking): reject malformed ENR RLP

### DIFF
--- a/tests/consensus/devnet/networking/test_enr_rejections.py
+++ b/tests/consensus/devnet/networking/test_enr_rejections.py
@@ -1,0 +1,39 @@
+"""ENR RLP decoder: malformed-input rejection vectors."""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_enr_decode_rejects_oversize_payload(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """An ENR RLP payload above the 300-byte cap is rejected.
+
+    EIP-778 caps the encoded ENR at 300 bytes so records can travel
+    comfortably through DNS TXT records. A 301-byte input must be
+    rejected before any RLP parsing runs.
+    """
+    oversize = "0x" + "ff" * 301
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "enr", "bytes": oversize},
+        expect_exception=ValueError,
+    )
+
+
+def test_enr_decode_rejects_malformed_rlp(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """An input that cannot be parsed as an RLP list is rejected.
+
+    The byte 0x00 is valid RLP for the single byte value 0x00, not for a
+    list structure. The ENR decoder requires a list header, so the parse
+    fails and the error surfaces as a ValueError on the ENR API.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "enr", "bytes": "0x00"},
+        expect_exception=ValueError,
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds two rejection vectors for the ENR RLP decoder:

- **Oversize payload** — 301-byte input exceeds the EIP-778 300-byte cap and must be rejected before any RLP parsing runs.
- **Malformed RLP** — the byte \`0x00\` is valid RLP for a single byte but not for a list structure; the ENR decoder requires a list header.

Uses the \`decode_failure\` dispatcher added in #647. Fills the gap between \`test_enr_and_peer_id.py\`'s happy-path decode vectors and the size-limit and RLP-shape rejection paths in the spec.

## 🔗 Related Issues or PRs

Follows #643–#652.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)