### PR TITLE
test(networking): reject malformed discv5 messages

### DIFF
--- a/tests/consensus/devnet/networking/test_discv5_message_rejections.py
+++ b/tests/consensus/devnet/networking/test_discv5_message_rejections.py
@@ -1,0 +1,56 @@
+"""Discv5 message decoder: malformed-input rejection vectors."""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+from lean_spec.subspecs.networking.discovery.codec import MessageDecodingError
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_discv5_message_decode_rejects_empty_input(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Zero bytes is too short to carry a discv5 message type byte.
+
+    Every discv5 message begins with a single type byte followed by an
+    RLP-encoded payload. Empty input cannot satisfy even the type byte
+    so the decoder must abort immediately.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "discv5_message", "bytes": "0x"},
+        expect_exception=MessageDecodingError,
+    )
+
+
+def test_discv5_message_decode_rejects_unknown_type_byte(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """A type byte outside the assigned set is rejected.
+
+    Only 0x01 through 0x06 are valid discv5 message types. A byte of 0xff
+    followed by an empty RLP list carries no meaningful message and must
+    be rejected rather than silently ignored.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "discv5_message", "bytes": "0xffc0"},
+        expect_exception=MessageDecodingError,
+    )
+
+
+def test_discv5_ping_decode_rejects_wrong_element_count(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """A PING payload with the wrong number of RLP elements is rejected.
+
+    PING requires exactly two fields: request_id and enr_seq. The payload
+    0x01 (ping type) followed by 0xc0 (empty RLP list) carries zero
+    elements, so the decoder must refuse to build a PING record.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={"decoder": "discv5_message", "bytes": "0x01c0"},
+        expect_exception=MessageDecodingError,
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds three rejection vectors for the discv5 message decoder:

- **Empty input** cannot carry the one-byte message type → \`MessageDecodingError("Message too short")\`.
- **Unknown type byte** — 0xff is outside the assigned 0x01–0x06 set → \`MessageDecodingError("Unknown message type: 0xff")\`.
- **Wrong PING element count** — 0x01 0xc0 produces a PING with zero elements instead of the required two → \`MessageDecodingError("PING requires 2 elements")\`.

Uses the \`decode_failure\` dispatcher added in #647. Fills the gap between \`test_discv5_messages.py\`'s roundtrip vectors and the user-reachable \`MessageDecodingError\` paths.

## 🔗 Related Issues or PRs

Follows #643–#653.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)