### PR TITLE
framework: add field_arithmetic fixture format with KoalaBear KATs

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -8,6 +8,7 @@ from .test_fixtures import (
     ApiEndpointTest,
     BaseConsensusFixture,
     DiscoveryCryptoTest,
+    FieldArithmeticTest,
     ForkChoiceTest,
     GossipsubHandlerTest,
     JustifiabilityTest,
@@ -44,6 +45,7 @@ ApiEndpointTestFiller = Type[ApiEndpointTest]
 SlotClockTestFiller = Type[SlotClockTest]
 DiscoveryCryptoTestFiller = Type[DiscoveryCryptoTest]
 JustifiabilityTestFiller = Type[JustifiabilityTest]
+FieldArithmeticTestFiller = Type[FieldArithmeticTest]
 
 __all__ = [
     # Public API
@@ -67,6 +69,7 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "FieldArithmeticTest",
     # Test types
     "BaseForkChoiceStep",
     "TickStep",
@@ -89,4 +92,5 @@ __all__ = [
     "SlotClockTestFiller",
     "DiscoveryCryptoTestFiller",
     "JustifiabilityTestFiller",
+    "FieldArithmeticTestFiller",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -3,6 +3,7 @@
 from .api_endpoint import ApiEndpointTest
 from .base import BaseConsensusFixture
 from .discovery_crypto import DiscoveryCryptoTest
+from .field_arithmetic import FieldArithmeticTest
 from .fork_choice import ForkChoiceTest
 from .gossipsub_handler import GossipsubHandlerTest
 from .justifiability import JustifiabilityTest
@@ -24,4 +25,5 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "FieldArithmeticTest",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/field_arithmetic.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/field_arithmetic.py
@@ -1,0 +1,148 @@
+"""KoalaBear field arithmetic test fixture.
+
+Generates JSON test vectors for add, sub, mul, pow, inverse, negate, and
+serialization roundtrip on the KoalaBear prime field. Clients must
+reproduce identical outputs bit-for-bit.
+"""
+
+from typing import Any, ClassVar
+
+from lean_spec.subspecs.koalabear.field import Fp
+
+from .base import BaseConsensusFixture
+
+
+def _decimal(value: int) -> str:
+    """Format an integer as a decimal string (avoids JSON precision loss)."""
+    return str(value)
+
+
+def _to_hex(data: bytes) -> str:
+    """Format raw bytes as a 0x-prefixed hex string."""
+    return "0x" + data.hex()
+
+
+def _from_hex(hex_str: str) -> bytes:
+    """Parse a 0x-prefixed hex string into raw bytes."""
+    return bytes.fromhex(hex_str.removeprefix("0x"))
+
+
+class FieldArithmeticTest(BaseConsensusFixture):
+    """Fixture for KoalaBear field arithmetic conformance.
+
+    Each vector names an operation, supplies decimal operands, and
+    reports the computed result. Serialization vectors additionally
+    report the 4-byte little-endian byte encoding.
+
+    JSON output: operation, input, output.
+    """
+
+    format_name: ClassVar[str] = "field_arithmetic"
+    description: ClassVar[str] = "Tests KoalaBear prime-field arithmetic operations"
+
+    operation: str
+    """Field operation: add, sub, mul, pow, inverse, negate, or serialize."""
+
+    input: dict[str, Any]
+    """Operation-specific input parameters. See per-handler docstrings."""
+
+    output: dict[str, Any] = {}
+    """Computed output. Filled by make_fixture."""
+
+    def make_fixture(self) -> "FieldArithmeticTest":
+        """Dispatch to the operation handler and produce the computed output.
+
+        Returns:
+            A copy of this fixture with output populated.
+
+        Raises:
+            AssertionError: If the decode-failure path is triggered and the
+                expected exception does not match.
+            ValueError: If the operation name is unknown.
+        """
+        match self.operation:
+            case "add":
+                output = self._binary_op("+")
+            case "sub":
+                output = self._binary_op("-")
+            case "mul":
+                output = self._binary_op("*")
+            case "pow":
+                output = self._make_pow()
+            case "inverse":
+                output = self._make_inverse()
+            case "negate":
+                output = self._make_negate()
+            case "serialize":
+                output = self._make_serialize()
+            case _:
+                raise ValueError(f"Unknown operation: {self.operation}")
+        return self.model_copy(update={"output": output})
+
+    def _binary_op(self, op: str) -> dict[str, Any]:
+        """Evaluate one of the binary field operations on the supplied operands.
+
+        Input keys ``a`` and ``b`` are decimal strings representing field
+        elements. The computed result is emitted as a decimal string.
+        """
+        a = Fp(int(self.input["a"]))
+        b = Fp(int(self.input["b"]))
+        if op == "+":
+            result = a + b
+        elif op == "-":
+            result = a - b
+        elif op == "*":
+            result = a * b
+        else:
+            raise ValueError(f"Unknown binary operation: {op}")
+        return {"result": _decimal(result.value)}
+
+    def _make_pow(self) -> dict[str, Any]:
+        """Exponentiate a field element by a non-negative integer exponent.
+
+        Input keys ``base`` (decimal) and ``exponent`` (integer).
+        """
+        base = Fp(int(self.input["base"]))
+        exponent = int(self.input["exponent"])
+        result = base**exponent
+        return {"result": _decimal(result.value)}
+
+    def _make_inverse(self) -> dict[str, Any]:
+        """Compute the multiplicative inverse.
+
+        Supports the decode-failure path: when ``expect_exception`` is set
+        the fixture asserts the inversion raises rather than returning.
+        """
+        a = Fp(int(self.input["a"]))
+        if self.expect_exception is not None:
+            raised: Exception | None = None
+            try:
+                a.inverse()
+            except Exception as exc:
+                raised = exc
+            if raised is None:
+                raise AssertionError(
+                    f"Expected {self.expect_exception.__name__} from inverse of {a.value}"
+                )
+            if not isinstance(raised, self.expect_exception):
+                raise AssertionError(
+                    f"Expected {self.expect_exception.__name__} but got "
+                    f"{type(raised).__name__}: {raised}"
+                )
+            return {"errorType": type(raised).__name__, "errorMessage": str(raised)}
+        result = a.inverse()
+        return {"result": _decimal(result.value)}
+
+    def _make_negate(self) -> dict[str, Any]:
+        """Compute the additive inverse."""
+        a = Fp(int(self.input["a"]))
+        result = -a
+        return {"result": _decimal(result.value)}
+
+    def _make_serialize(self) -> dict[str, Any]:
+        """Emit the 4-byte little-endian encoding and roundtrip-decode back to the value."""
+        a = Fp(int(self.input["value"]))
+        encoded = a.encode_bytes()
+        decoded = Fp.decode_bytes(encoded)
+        assert decoded.value == a.value, "Fp encode roundtrip produced different value"
+        return {"encoded": _to_hex(encoded), "byteLength": len(encoded)}

--- a/tests/consensus/devnet/koalabear/test_field.py
+++ b/tests/consensus/devnet/koalabear/test_field.py
@@ -1,0 +1,112 @@
+"""KoalaBear field arithmetic: known-answer test vectors.
+
+The prime modulus is P = 2^31 - 2^24 + 1 = 2130706433. Every field
+element lives in [0, P). Vectors pin add, sub, mul, pow, negate,
+inverse, and the 4-byte little-endian serialization so clients can
+cross-check bit-for-bit.
+"""
+
+import pytest
+from consensus_testing import FieldArithmeticTestFiller
+
+from lean_spec.subspecs.koalabear.field import P
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_add_zero_plus_zero(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """0 + 0 in the field."""
+    field_arithmetic(operation="add", input={"a": "0", "b": "0"})
+
+
+def test_add_one_plus_one(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """1 + 1 in the field."""
+    field_arithmetic(operation="add", input={"a": "1", "b": "1"})
+
+
+def test_add_p_minus_one_plus_one_wraps(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """(P - 1) + 1 wraps to zero under modular addition."""
+    field_arithmetic(operation="add", input={"a": str(P - 1), "b": "1"})
+
+
+def test_add_p_minus_one_plus_p_minus_one(
+    field_arithmetic: FieldArithmeticTestFiller,
+) -> None:
+    """(P - 1) + (P - 1) sits just under 2P, reducing to P - 2."""
+    field_arithmetic(operation="add", input={"a": str(P - 1), "b": str(P - 1)})
+
+
+def test_sub_zero_minus_one_wraps(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """0 - 1 wraps to P - 1 under modular subtraction."""
+    field_arithmetic(operation="sub", input={"a": "0", "b": "1"})
+
+
+def test_mul_two_times_p_minus_one(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """2 * (P - 1) lies just below 2P and reduces to P - 2."""
+    field_arithmetic(operation="mul", input={"a": "2", "b": str(P - 1)})
+
+
+def test_mul_p_minus_one_squared(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """(P - 1)^2 exercises the widest intermediate before modular reduction."""
+    field_arithmetic(operation="mul", input={"a": str(P - 1), "b": str(P - 1)})
+
+
+def test_negate_zero_is_zero(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """Negation of zero returns zero."""
+    field_arithmetic(operation="negate", input={"a": "0"})
+
+
+def test_negate_one_is_p_minus_one(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """Negation of one returns P - 1."""
+    field_arithmetic(operation="negate", input={"a": "1"})
+
+
+def test_pow_base_zero_exponent_zero(
+    field_arithmetic: FieldArithmeticTestFiller,
+) -> None:
+    """0^0 conventionally evaluates to 1 under the field's pow implementation."""
+    field_arithmetic(operation="pow", input={"base": "0", "exponent": 0})
+
+
+def test_pow_two_cubed(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """2^3 returns 8 and fits well within the field."""
+    field_arithmetic(operation="pow", input={"base": "2", "exponent": 3})
+
+
+def test_pow_p_minus_one_to_two(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """(P - 1)^2 via pow matches (P - 1) * (P - 1) via mul."""
+    field_arithmetic(operation="pow", input={"base": str(P - 1), "exponent": 2})
+
+
+def test_inverse_of_one_is_one(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """The multiplicative inverse of 1 is 1."""
+    field_arithmetic(operation="inverse", input={"a": "1"})
+
+
+def test_inverse_of_p_minus_one(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """(P - 1) is its own inverse since (P - 1) * (P - 1) = 1 mod P."""
+    field_arithmetic(operation="inverse", input={"a": str(P - 1)})
+
+
+def test_inverse_of_zero_is_rejected(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """Inverting zero must raise ZeroDivisionError rather than return a value."""
+    field_arithmetic(
+        operation="inverse",
+        input={"a": "0"},
+        expect_exception=ZeroDivisionError,
+    )
+
+
+def test_serialize_zero(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """Zero encodes as four zero bytes in little-endian order."""
+    field_arithmetic(operation="serialize", input={"value": "0"})
+
+
+def test_serialize_one(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """One encodes as 0x01 0x00 0x00 0x00."""
+    field_arithmetic(operation="serialize", input={"value": "1"})
+
+
+def test_serialize_p_minus_one(field_arithmetic: FieldArithmeticTestFiller) -> None:
+    """P - 1 encodes with the widest representable little-endian payload."""
+    field_arithmetic(operation="serialize", input={"value": str(P - 1)})


### PR DESCRIPTION
## 🗒️ Description

Introduces a new consensus fixture format for KoalaBear prime-field arithmetic and lands the first batch of known-answer vectors.

### field_arithmetic format

- Operation dispatcher: \`add\`, \`sub\`, \`mul\`, \`pow\`, \`inverse\`, \`negate\`, \`serialize\`.
- Decimal operand strings avoid JSON precision loss.
- \`serialize\` emits the 4-byte little-endian byte encoding and exercises the decode roundtrip.
- \`inverse\` honours \`expect_exception\` so clients can pin the rejection of \`inv(0)\` with \`ZeroDivisionError\`; the output captures \`errorType\` and \`errorMessage\`.

### Initial vectors (18 KATs)

Covering add / sub / mul / pow / negate / inverse / serialize at the field boundaries (0, 1, P − 1) plus one rejection (inverse of zero). The prime modulus \`P = 2^31 − 2^24 + 1 = 2130706433\`.

Closes the gap between the spec's Fp arithmetic and client-consumable vectors that can be diffed bit-for-bit.

## 🔗 Related Issues or PRs

Follows #643–#654. Starts Tranche B of the test-vector plan (new greenfield formats for crypto primitives).

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector and fixture-format-only PR; the new format is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)