### PR TITLE
framework: add poseidon_permutation fixture format with width-16 KATs

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -12,6 +12,7 @@ from .test_fixtures import (
     GossipsubHandlerTest,
     JustifiabilityTest,
     NetworkingCodecTest,
+    PoseidonPermutationTest,
     SlotClockTest,
     SSZTest,
     StateTransitionTest,
@@ -44,6 +45,7 @@ ApiEndpointTestFiller = Type[ApiEndpointTest]
 SlotClockTestFiller = Type[SlotClockTest]
 DiscoveryCryptoTestFiller = Type[DiscoveryCryptoTest]
 JustifiabilityTestFiller = Type[JustifiabilityTest]
+PoseidonPermutationTestFiller = Type[PoseidonPermutationTest]
 
 __all__ = [
     # Public API
@@ -67,6 +69,7 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "PoseidonPermutationTest",
     # Test types
     "BaseForkChoiceStep",
     "TickStep",
@@ -89,4 +92,5 @@ __all__ = [
     "SlotClockTestFiller",
     "DiscoveryCryptoTestFiller",
     "JustifiabilityTestFiller",
+    "PoseidonPermutationTestFiller",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -7,6 +7,7 @@ from .fork_choice import ForkChoiceTest
 from .gossipsub_handler import GossipsubHandlerTest
 from .justifiability import JustifiabilityTest
 from .networking_codec import NetworkingCodecTest
+from .poseidon_permutation import PoseidonPermutationTest
 from .slot_clock import SlotClockTest
 from .ssz import SSZTest
 from .state_transition import StateTransitionTest
@@ -24,4 +25,5 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "PoseidonPermutationTest",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
@@ -1,0 +1,65 @@
+"""Poseidon1 permutation test fixture.
+
+Generates JSON test vectors for the Poseidon1 permutation over the
+KoalaBear field at widths 16 and 24. Clients must produce identical
+output states bit-for-bit for every input state.
+"""
+
+from typing import Any, ClassVar
+
+from lean_spec.subspecs.koalabear.field import Fp
+from lean_spec.subspecs.poseidon1 import PARAMS_16, PARAMS_24, Poseidon1
+
+from .base import BaseConsensusFixture
+
+
+class PoseidonPermutationTest(BaseConsensusFixture):
+    """Fixture for Poseidon1 permutation conformance.
+
+    Each vector names the permutation width and supplies an input state
+    as decimal strings. The fixture runs the spec's permutation engine
+    and emits the output state as decimal strings.
+
+    JSON output: width, input, output.
+    """
+
+    format_name: ClassVar[str] = "poseidon_permutation"
+    description: ClassVar[str] = "Tests Poseidon1 permutation at widths 16 and 24"
+
+    width: int
+    """State width. Must be 16 or 24."""
+
+    input: dict[str, Any]
+    """Input state. Key inputState holds a list of decimal element strings."""
+
+    output: dict[str, Any] = {}
+    """Computed output state. Filled by make_fixture."""
+
+    def make_fixture(self) -> "PoseidonPermutationTest":
+        """Run the Poseidon1 permutation and produce the output state.
+
+        Returns:
+            A copy of this fixture with output populated.
+
+        Raises:
+            ValueError: If the width is unsupported.
+        """
+        if self.width == 16:
+            engine = Poseidon1(PARAMS_16)
+        elif self.width == 24:
+            engine = Poseidon1(PARAMS_24)
+        else:
+            raise ValueError(f"Unsupported Poseidon1 width: {self.width}")
+
+        state_ints = [int(x) for x in self.input["inputState"]]
+        if len(state_ints) != self.width:
+            raise ValueError(
+                f"Input state length {len(state_ints)} does not match width {self.width}"
+            )
+
+        input_state = [Fp(v) for v in state_ints]
+        output_state = engine.permute(input_state)
+
+        return self.model_copy(
+            update={"output": {"outputState": [str(fp.value) for fp in output_state]}}
+        )

--- a/tests/consensus/devnet/poseidon1/test_permutation_width16.py
+++ b/tests/consensus/devnet/poseidon1/test_permutation_width16.py
@@ -1,0 +1,77 @@
+"""Poseidon1 permutation: width-16 known-answer vectors.
+
+Pins the output state of the Poseidon1 permutation over the KoalaBear
+field at state width 16 for four structural input patterns. Clients
+must produce identical output states bit-for-bit.
+"""
+
+import pytest
+from consensus_testing import PoseidonPermutationTestFiller
+
+from lean_spec.subspecs.koalabear.field import P
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+WIDTH: int = 16
+
+
+def test_permutation_width16_all_zero(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Input state of all zeros pins the round-constant-only output.
+
+    With a zero state, the only contribution to every S-box input is the
+    round-constants stream. The output state therefore depends purely on
+    the round constants and the MDS matrix, making this vector a
+    sensitive diff for tables-of-constants drift.
+    """
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": ["0"] * WIDTH},
+    )
+
+
+def test_permutation_width16_all_one(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Input state of all ones exercises uniform non-zero entries.
+
+    Every element begins at the smallest non-zero field value. The MDS
+    multiplications see a state vector whose entries all carry the same
+    contribution, pinning the first-row linearity of the permutation.
+    """
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": ["1"] * WIDTH},
+    )
+
+
+def test_permutation_width16_incremental_index(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Input state filled with 0, 1, 2, ..., WIDTH - 1.
+
+    Distinct entries per slot expose per-position behaviour: any
+    off-by-one in MDS row indexing or round-constant slicing perturbs
+    the output noticeably.
+    """
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": [str(i) for i in range(WIDTH)]},
+    )
+
+
+def test_permutation_width16_p_minus_one_and_near_zero(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Mix of field-boundary values P - 1 and small values across the state.
+
+    Half the slots sit at the maximum representable field element, the
+    other half at small positives. This pattern stresses the reduction
+    path for the widest intermediates generated inside the S-box.
+    """
+    state = [str(P - 1) if i % 2 == 0 else str(i) for i in range(WIDTH)]
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": state},
+    )


### PR DESCRIPTION
## 🗒️ Description

Introduces a new consensus fixture format for the Poseidon1 permutation over the KoalaBear field and lands the first batch of width-16 vectors.

### \`poseidon_permutation\` format

- Dispatch by state \`width\` (16 or 24) to the spec's Poseidon1 engine.
- Input state is a list of decimal KoalaBear element strings.
- Output state is emitted as decimal strings.

### Width-16 initial vectors (4 KATs)

Four known-answer vectors pinning the permutation output for structurally distinct input patterns that catch common drift modes:

- **All-zero state** — output depends purely on round constants and MDS.
- **All-one state** — uniform non-zero entries pin MDS first-row linearity.
- **Incremental 0..WIDTH-1** — distinct per-slot entries expose position bugs.
- **Mixed P − 1 and small positives** — stresses the widest S-box intermediate.

A width-24 follow-up will reuse the same format in a separate PR.

## 🔗 Related Issues or PRs

Follows #655 (field_arithmetic format). Continues Tranche B of the test-vector plan.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector and fixture-format-only PR; the new format is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)