### PR TITLE
test(poseidon1): width-24 permutation known-answer vectors

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -12,6 +12,7 @@ from .test_fixtures import (
     GossipsubHandlerTest,
     JustifiabilityTest,
     NetworkingCodecTest,
+    PoseidonPermutationTest,
     SlotClockTest,
     SSZTest,
     StateTransitionTest,
@@ -44,6 +45,7 @@ ApiEndpointTestFiller = Type[ApiEndpointTest]
 SlotClockTestFiller = Type[SlotClockTest]
 DiscoveryCryptoTestFiller = Type[DiscoveryCryptoTest]
 JustifiabilityTestFiller = Type[JustifiabilityTest]
+PoseidonPermutationTestFiller = Type[PoseidonPermutationTest]
 
 __all__ = [
     # Public API
@@ -67,6 +69,7 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "PoseidonPermutationTest",
     # Test types
     "BaseForkChoiceStep",
     "TickStep",
@@ -89,4 +92,5 @@ __all__ = [
     "SlotClockTestFiller",
     "DiscoveryCryptoTestFiller",
     "JustifiabilityTestFiller",
+    "PoseidonPermutationTestFiller",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -7,6 +7,7 @@ from .fork_choice import ForkChoiceTest
 from .gossipsub_handler import GossipsubHandlerTest
 from .justifiability import JustifiabilityTest
 from .networking_codec import NetworkingCodecTest
+from .poseidon_permutation import PoseidonPermutationTest
 from .slot_clock import SlotClockTest
 from .ssz import SSZTest
 from .state_transition import StateTransitionTest
@@ -24,4 +25,5 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "PoseidonPermutationTest",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
@@ -1,0 +1,65 @@
+"""Poseidon1 permutation test fixture.
+
+Generates JSON test vectors for the Poseidon1 permutation over the
+KoalaBear field at widths 16 and 24. Clients must produce identical
+output states bit-for-bit for every input state.
+"""
+
+from typing import Any, ClassVar
+
+from lean_spec.subspecs.koalabear.field import Fp
+from lean_spec.subspecs.poseidon1 import PARAMS_16, PARAMS_24, Poseidon1
+
+from .base import BaseConsensusFixture
+
+
+class PoseidonPermutationTest(BaseConsensusFixture):
+    """Fixture for Poseidon1 permutation conformance.
+
+    Each vector names the permutation width and supplies an input state
+    as decimal strings. The fixture runs the spec's permutation engine
+    and emits the output state as decimal strings.
+
+    JSON output: width, input, output.
+    """
+
+    format_name: ClassVar[str] = "poseidon_permutation"
+    description: ClassVar[str] = "Tests Poseidon1 permutation at widths 16 and 24"
+
+    width: int
+    """State width. Must be 16 or 24."""
+
+    input: dict[str, Any]
+    """Input state. Key inputState holds a list of decimal element strings."""
+
+    output: dict[str, Any] = {}
+    """Computed output state. Filled by make_fixture."""
+
+    def make_fixture(self) -> "PoseidonPermutationTest":
+        """Run the Poseidon1 permutation and produce the output state.
+
+        Returns:
+            A copy of this fixture with output populated.
+
+        Raises:
+            ValueError: If the width is unsupported.
+        """
+        if self.width == 16:
+            engine = Poseidon1(PARAMS_16)
+        elif self.width == 24:
+            engine = Poseidon1(PARAMS_24)
+        else:
+            raise ValueError(f"Unsupported Poseidon1 width: {self.width}")
+
+        state_ints = [int(x) for x in self.input["inputState"]]
+        if len(state_ints) != self.width:
+            raise ValueError(
+                f"Input state length {len(state_ints)} does not match width {self.width}"
+            )
+
+        input_state = [Fp(v) for v in state_ints]
+        output_state = engine.permute(input_state)
+
+        return self.model_copy(
+            update={"output": {"outputState": [str(fp.value) for fp in output_state]}}
+        )

--- a/tests/consensus/devnet/poseidon1/test_permutation_width16.py
+++ b/tests/consensus/devnet/poseidon1/test_permutation_width16.py
@@ -1,0 +1,77 @@
+"""Poseidon1 permutation: width-16 known-answer vectors.
+
+Pins the output state of the Poseidon1 permutation over the KoalaBear
+field at state width 16 for four structural input patterns. Clients
+must produce identical output states bit-for-bit.
+"""
+
+import pytest
+from consensus_testing import PoseidonPermutationTestFiller
+
+from lean_spec.subspecs.koalabear.field import P
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+WIDTH: int = 16
+
+
+def test_permutation_width16_all_zero(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Input state of all zeros pins the round-constant-only output.
+
+    With a zero state, the only contribution to every S-box input is the
+    round-constants stream. The output state therefore depends purely on
+    the round constants and the MDS matrix, making this vector a
+    sensitive diff for tables-of-constants drift.
+    """
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": ["0"] * WIDTH},
+    )
+
+
+def test_permutation_width16_all_one(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Input state of all ones exercises uniform non-zero entries.
+
+    Every element begins at the smallest non-zero field value. The MDS
+    multiplications see a state vector whose entries all carry the same
+    contribution, pinning the first-row linearity of the permutation.
+    """
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": ["1"] * WIDTH},
+    )
+
+
+def test_permutation_width16_incremental_index(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Input state filled with 0, 1, 2, ..., WIDTH - 1.
+
+    Distinct entries per slot expose per-position behaviour: any
+    off-by-one in MDS row indexing or round-constant slicing perturbs
+    the output noticeably.
+    """
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": [str(i) for i in range(WIDTH)]},
+    )
+
+
+def test_permutation_width16_p_minus_one_and_near_zero(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Mix of field-boundary values P - 1 and small values across the state.
+
+    Half the slots sit at the maximum representable field element, the
+    other half at small positives. This pattern stresses the reduction
+    path for the widest intermediates generated inside the S-box.
+    """
+    state = [str(P - 1) if i % 2 == 0 else str(i) for i in range(WIDTH)]
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": state},
+    )

--- a/tests/consensus/devnet/poseidon1/test_permutation_width24.py
+++ b/tests/consensus/devnet/poseidon1/test_permutation_width24.py
@@ -1,0 +1,62 @@
+"""Poseidon1 permutation: width-24 known-answer vectors.
+
+Pins the output state of the Poseidon1 permutation over the KoalaBear
+field at state width 24 for four structural input patterns. Mirrors
+the width-16 coverage on the larger parameter set.
+"""
+
+import pytest
+from consensus_testing import PoseidonPermutationTestFiller
+
+from lean_spec.subspecs.koalabear.field import P
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+WIDTH: int = 24
+
+
+def test_permutation_width24_all_zero(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Input state of all zeros pins the round-constant-only output at width 24.
+
+    With a zero state the only contribution to every S-box input is the
+    round-constants stream. The output state depends purely on the
+    round constants and MDS matrix, making this vector sensitive to
+    tables-of-constants drift at the larger width.
+    """
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": ["0"] * WIDTH},
+    )
+
+
+def test_permutation_width24_all_one(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Input state of all ones exercises uniform non-zero entries at width 24."""
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": ["1"] * WIDTH},
+    )
+
+
+def test_permutation_width24_incremental_index(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Input state filled with 0, 1, 2, ..., 23 pins per-slot MDS behaviour."""
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": [str(i) for i in range(WIDTH)]},
+    )
+
+
+def test_permutation_width24_p_minus_one_and_near_zero(
+    poseidon_permutation: PoseidonPermutationTestFiller,
+) -> None:
+    """Alternating P - 1 and small positives stress reduction at width 24."""
+    state = [str(P - 1) if i % 2 == 0 else str(i) for i in range(WIDTH)]
+    poseidon_permutation(
+        width=WIDTH,
+        input={"inputState": state},
+    )


### PR DESCRIPTION
## 🗒️ Description

Mirrors the four width-16 input patterns on the larger width-24 parameter set:

- **All-zero state** — pins round-constants-and-MDS-only output.
- **All-one state** — pins MDS first-row linearity.
- **Incremental 0..23** — pins per-slot behaviour.
- **Alternating P − 1 and small positives** — stresses reduction at the widest intermediate.

Reuses the \`poseidon_permutation\` fixture format introduced alongside the width-16 batch.

### ⚠️ Depends on #656

Stacked on \`framework/poseidon-permutation-format\`. Please review and merge #656 first; after that lands I'll rebase this on \`main\` and the diff will shrink to just the new test file.

## 🔗 Related Issues or PRs

Stacked on #656. Follows #655.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)