### PR TITLE
framework: add message_hash fixture format with XMSS KATs

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -11,6 +11,7 @@ from .test_fixtures import (
     ForkChoiceTest,
     GossipsubHandlerTest,
     JustifiabilityTest,
+    MessageHashTest,
     NetworkingCodecTest,
     SlotClockTest,
     SSZTest,
@@ -44,6 +45,7 @@ ApiEndpointTestFiller = Type[ApiEndpointTest]
 SlotClockTestFiller = Type[SlotClockTest]
 DiscoveryCryptoTestFiller = Type[DiscoveryCryptoTest]
 JustifiabilityTestFiller = Type[JustifiabilityTest]
+MessageHashTestFiller = Type[MessageHashTest]
 
 __all__ = [
     # Public API
@@ -67,6 +69,7 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "MessageHashTest",
     # Test types
     "BaseForkChoiceStep",
     "TickStep",
@@ -89,4 +92,5 @@ __all__ = [
     "SlotClockTestFiller",
     "DiscoveryCryptoTestFiller",
     "JustifiabilityTestFiller",
+    "MessageHashTestFiller",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -6,6 +6,7 @@ from .discovery_crypto import DiscoveryCryptoTest
 from .fork_choice import ForkChoiceTest
 from .gossipsub_handler import GossipsubHandlerTest
 from .justifiability import JustifiabilityTest
+from .message_hash import MessageHashTest
 from .networking_codec import NetworkingCodecTest
 from .slot_clock import SlotClockTest
 from .ssz import SSZTest
@@ -24,4 +25,5 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "MessageHashTest",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/message_hash.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/message_hash.py
@@ -1,0 +1,76 @@
+"""XMSS message hash test fixture.
+
+Generates JSON test vectors for the aborting hypercube encoding that
+maps an XMSS message plus epoch randomness to a codeword (or None on
+abort). Clients must reproduce the same codeword digits or the same
+abort decision bit-for-bit.
+"""
+
+from typing import Any, ClassVar
+
+from lean_spec.subspecs.koalabear.field import Fp
+from lean_spec.subspecs.xmss.constants import PROD_CONFIG, TEST_CONFIG
+from lean_spec.subspecs.xmss.message_hash import MessageHasher
+from lean_spec.subspecs.xmss.poseidon import PROD_POSEIDON, TEST_POSEIDON
+from lean_spec.subspecs.xmss.types import Parameter, Randomness
+from lean_spec.types import Bytes32, Uint64
+
+from .base import BaseConsensusFixture
+
+
+class MessageHashTest(BaseConsensusFixture):
+    """Fixture for XMSS message hash conformance.
+
+    Each vector names the XMSS mode, provides the parameter, epoch,
+    randomness, and message, and reports the resulting codeword. When
+    the aborting decode rejects, the codeword field is null and an
+    aborted flag signals the outcome.
+
+    JSON output: mode, input, output.
+    """
+
+    format_name: ClassVar[str] = "message_hash"
+    description: ClassVar[str] = "Tests XMSS aborting hypercube message-hash encoding"
+
+    mode: str
+    """XMSS mode: test or prod."""
+
+    input: dict[str, Any]
+    """Hasher input with keys parameter, epoch, rho, and message."""
+
+    output: dict[str, Any] = {}
+    """Computed codeword (or null when the aborting decode rejects)."""
+
+    def make_fixture(self) -> "MessageHashTest":
+        """Run the spec's MessageHasher and produce the codeword or abort signal.
+
+        Returns:
+            A copy of this fixture with output populated.
+
+        Raises:
+            ValueError: If the mode is unknown.
+        """
+        if self.mode == "test":
+            hasher = MessageHasher(config=TEST_CONFIG, poseidon=TEST_POSEIDON)
+        elif self.mode == "prod":
+            hasher = MessageHasher(config=PROD_CONFIG, poseidon=PROD_POSEIDON)
+        else:
+            raise ValueError(f"Unknown XMSS mode: {self.mode}")
+
+        parameter = Parameter(data=[Fp(int(v)) for v in self.input["parameter"]])
+        rho = Randomness(data=[Fp(int(v)) for v in self.input["rho"]])
+        epoch = Uint64(int(self.input["epoch"]))
+        message_bytes = bytes.fromhex(self.input["message"].removeprefix("0x"))
+        if len(message_bytes) != 32:
+            raise ValueError(f"Message must be 32 bytes, got {len(message_bytes)}")
+        message = Bytes32(message_bytes)
+
+        codeword = hasher.apply(parameter, epoch, rho, message)
+
+        output: dict[str, Any]
+        if codeword is None:
+            output = {"codeword": None, "aborted": True}
+        else:
+            output = {"codeword": codeword, "aborted": False}
+
+        return self.model_copy(update={"output": output})

--- a/tests/consensus/devnet/xmss/test_message_hash.py
+++ b/tests/consensus/devnet/xmss/test_message_hash.py
@@ -1,0 +1,110 @@
+"""XMSS message hash: aborting hypercube encoding known-answer vectors.
+
+Pins the codeword that XMSS derives from a 32-byte message under a
+given parameter, epoch, and randomness. Clients must reproduce
+identical digit sequences or the same abort decision.
+"""
+
+import pytest
+from consensus_testing import MessageHashTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+PARAMETER_ZEROS = ["0", "0", "0", "0", "0"]
+"""Zero parameter (length PARAMETER_LEN = 5)."""
+
+RHO_ZEROS = ["0"] * 7
+"""Zero randomness (length RAND_LEN_FE = 7 in both test and prod configs)."""
+
+RHO_INCREMENT = ["1", "2", "3", "4", "5", "6", "7"]
+"""Incremental randomness exercising per-slot placement."""
+
+MESSAGE_ZERO = "0x" + "00" * 32
+"""All-zero 32-byte message."""
+
+MESSAGE_INCREMENT = "0x" + "".join(f"{i:02x}" for i in range(32))
+"""Message with byte i at position i."""
+
+MESSAGE_HIGH = "0x" + "ff" * 32
+"""All-ones 32-byte message."""
+
+
+def test_message_hash_zero_message_zero_parameter_zero_rho(
+    message_hash: MessageHashTestFiller,
+) -> None:
+    """Minimal input: zero parameter, zero randomness, zero message, epoch zero.
+
+    Pins the simplest point in the encoding's input space. Any drift in
+    field-element packing, epoch encoding, or Poseidon dispatch shifts
+    the output codeword.
+    """
+    message_hash(
+        mode="test",
+        input={
+            "parameter": PARAMETER_ZEROS,
+            "epoch": "0",
+            "rho": RHO_ZEROS,
+            "message": MESSAGE_ZERO,
+        },
+    )
+
+
+def test_message_hash_incremental_message_with_zero_context(
+    message_hash: MessageHashTestFiller,
+) -> None:
+    """32-byte message with byte i at position i, under zero context.
+
+    A message with distinct bytes per position exposes any off-by-one in
+    the little-endian packing used to encode the message into field
+    elements.
+    """
+    message_hash(
+        mode="test",
+        input={
+            "parameter": PARAMETER_ZEROS,
+            "epoch": "0",
+            "rho": RHO_ZEROS,
+            "message": MESSAGE_INCREMENT,
+        },
+    )
+
+
+def test_message_hash_high_message_incremental_rho(
+    message_hash: MessageHashTestFiller,
+) -> None:
+    """All-ones message, incremental randomness, non-zero epoch.
+
+    Stresses the widest representable message integer against a varied
+    randomness vector. Pins the interaction between message decomposition
+    and randomness packing in the Poseidon call.
+    """
+    message_hash(
+        mode="test",
+        input={
+            "parameter": PARAMETER_ZEROS,
+            "epoch": "42",
+            "rho": RHO_INCREMENT,
+            "message": MESSAGE_HIGH,
+        },
+    )
+
+
+def test_message_hash_incremental_parameter_and_rho(
+    message_hash: MessageHashTestFiller,
+) -> None:
+    """Distinct parameter entries combined with distinct randomness entries.
+
+    Every slot of parameter and rho differs from its neighbours. Pins
+    that no slot is silently ignored or duplicated during the Poseidon
+    input assembly.
+    """
+    message_hash(
+        mode="test",
+        input={
+            "parameter": ["1", "2", "3", "4", "5"],
+            "epoch": "1",
+            "rho": RHO_INCREMENT,
+            "message": MESSAGE_ZERO,
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description

Introduces a new consensus fixture format for the XMSS aborting hypercube encoding and lands the first batch of known-answer vectors.

### \`message_hash\` format

- Dispatch by XMSS mode (\`test\` or \`prod\`) to the spec's \`MessageHasher\`.
- Inputs: parameter (decimal Fp strings), epoch, randomness (decimal Fp strings), and a 32-byte hex message.
- Output: codeword as a list of base-BASE digits, or \`null\` with the \`aborted\` flag set when the aborting decode rejects.

### Initial vectors (4 KATs)

Under \`tests/consensus/devnet/xmss/\`, covering structurally distinct points of the encoding input space:

- Zero parameter, zero rho, zero message, epoch zero.
- Incremental-byte message with zero context.
- All-ones message with incremental rho and non-zero epoch.
- Distinct parameter and rho slots with zero message.

## 🔗 Related Issues or PRs

Follows #658 (tweak_hash). Continues Tranche B of the test-vector plan.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector and fixture-format-only PR; the new format is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)