### PR TITLE
framework: add xmss_chain fixture format with WOTS KATs

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -16,6 +16,7 @@ from .test_fixtures import (
     SSZTest,
     StateTransitionTest,
     VerifySignaturesTest,
+    XmssChainTest,
 )
 from .test_types import (
     AggregatedAttestationCheck,
@@ -44,6 +45,7 @@ ApiEndpointTestFiller = Type[ApiEndpointTest]
 SlotClockTestFiller = Type[SlotClockTest]
 DiscoveryCryptoTestFiller = Type[DiscoveryCryptoTest]
 JustifiabilityTestFiller = Type[JustifiabilityTest]
+XmssChainTestFiller = Type[XmssChainTest]
 
 __all__ = [
     # Public API
@@ -67,6 +69,7 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "XmssChainTest",
     # Test types
     "BaseForkChoiceStep",
     "TickStep",
@@ -89,4 +92,5 @@ __all__ = [
     "SlotClockTestFiller",
     "DiscoveryCryptoTestFiller",
     "JustifiabilityTestFiller",
+    "XmssChainTestFiller",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -11,6 +11,7 @@ from .slot_clock import SlotClockTest
 from .ssz import SSZTest
 from .state_transition import StateTransitionTest
 from .verify_signatures import VerifySignaturesTest
+from .xmss_chain import XmssChainTest
 
 __all__ = [
     "BaseConsensusFixture",
@@ -24,4 +25,5 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "XmssChainTest",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/xmss_chain.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/xmss_chain.py
@@ -1,0 +1,77 @@
+"""XMSS hash chain test fixture.
+
+Generates JSON test vectors for the WOTS+ iterated hashing primitive
+underlying XMSS. Each step applies the tweakable hash once, so pinning
+start/intermediate/end digests lets clients verify chain traversal
+without reconstructing the full signature.
+"""
+
+from typing import Any, ClassVar
+
+from lean_spec.subspecs.koalabear.field import Fp
+from lean_spec.subspecs.xmss.constants import PROD_CONFIG, TEST_CONFIG
+from lean_spec.subspecs.xmss.poseidon import PROD_POSEIDON, TEST_POSEIDON
+from lean_spec.subspecs.xmss.tweak_hash import TweakHasher
+from lean_spec.subspecs.xmss.types import HashDigestVector, Parameter
+from lean_spec.types import Uint64
+
+from .base import BaseConsensusFixture
+
+
+class XmssChainTest(BaseConsensusFixture):
+    """Fixture for XMSS hash-chain conformance.
+
+    Each vector names the XMSS mode, fixes the chain position, and
+    supplies the starting digest. The fixture runs the spec's
+    TweakHasher.hash_chain and emits the resulting digest.
+
+    JSON output: mode, input, output.
+    """
+
+    format_name: ClassVar[str] = "xmss_chain"
+    description: ClassVar[str] = "Tests XMSS WOTS+ hash chain intermediate digests"
+
+    mode: str
+    """XMSS mode: test or prod."""
+
+    input: dict[str, Any]
+    """Chain parameters: parameter, epoch, chainIndex, startStep, numSteps, startDigest."""
+
+    output: dict[str, Any] = {}
+    """Computed digest after the requested number of chain steps."""
+
+    def make_fixture(self) -> "XmssChainTest":
+        """Run the spec's hash_chain and produce the end-of-chain digest.
+
+        Returns:
+            A copy of this fixture with output populated.
+
+        Raises:
+            ValueError: If the mode is unknown.
+        """
+        if self.mode == "test":
+            hasher = TweakHasher(config=TEST_CONFIG, poseidon=TEST_POSEIDON)
+        elif self.mode == "prod":
+            hasher = TweakHasher(config=PROD_CONFIG, poseidon=PROD_POSEIDON)
+        else:
+            raise ValueError(f"Unknown XMSS mode: {self.mode}")
+
+        parameter = Parameter(data=[Fp(int(v)) for v in self.input["parameter"]])
+        start_digest = HashDigestVector(data=[Fp(int(v)) for v in self.input["startDigest"]])
+        epoch = Uint64(int(self.input["epoch"]))
+        chain_index = int(self.input["chainIndex"])
+        start_step = int(self.input["startStep"])
+        num_steps = int(self.input["numSteps"])
+
+        end_digest = hasher.hash_chain(
+            parameter=parameter,
+            epoch=epoch,
+            chain_index=chain_index,
+            start_step=start_step,
+            num_steps=num_steps,
+            start_digest=start_digest,
+        )
+
+        return self.model_copy(
+            update={"output": {"endDigest": [str(fp.value) for fp in end_digest.data]}}
+        )

--- a/tests/consensus/devnet/xmss/test_chain.py
+++ b/tests/consensus/devnet/xmss/test_chain.py
@@ -1,0 +1,110 @@
+"""XMSS WOTS+ hash chain: known-answer vectors.
+
+Pins the digest produced by iterating the tweakable hash from a given
+starting digest across a sequence of chain steps. Clients must
+reproduce the same intermediate and end-of-chain digests so chain
+traversal agrees across implementations.
+"""
+
+import pytest
+from consensus_testing import XmssChainTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+PARAMETER_ZEROS = ["0", "0", "0", "0", "0"]
+"""Zero parameter (length PARAMETER_LEN = 5)."""
+
+DIGEST_ZEROS = ["0"] * 8
+"""Zero starting digest (length HASH_LEN_FE = 8)."""
+
+DIGEST_INCREMENT = ["1", "2", "3", "4", "5", "6", "7", "8"]
+"""Incremental starting digest exposing per-slot chain arithmetic."""
+
+
+def test_chain_zero_steps_is_identity(
+    xmss_chain: XmssChainTestFiller,
+) -> None:
+    """Zero steps must return the start digest unchanged.
+
+    The hash_chain helper loops num_steps times and returns the current
+    digest. With num_steps = 0 the loop body never runs, so the output
+    must equal the input. Pins the identity boundary of the iteration.
+    """
+    xmss_chain(
+        mode="test",
+        input={
+            "parameter": PARAMETER_ZEROS,
+            "epoch": "0",
+            "chainIndex": 0,
+            "startStep": 0,
+            "numSteps": 0,
+            "startDigest": DIGEST_ZEROS,
+        },
+    )
+
+
+def test_chain_single_step_from_zero(
+    xmss_chain: XmssChainTestFiller,
+) -> None:
+    """One chain step from the zero digest at epoch 0, chain 0, start step 0.
+
+    Corresponds to applying the tweakable hash once with ChainTweak
+    (epoch=0, chain_index=0, step=1). Pins the first step of the simplest
+    chain.
+    """
+    xmss_chain(
+        mode="test",
+        input={
+            "parameter": PARAMETER_ZEROS,
+            "epoch": "0",
+            "chainIndex": 0,
+            "startStep": 0,
+            "numSteps": 1,
+            "startDigest": DIGEST_ZEROS,
+        },
+    )
+
+
+def test_chain_full_traversal_test_base_minus_one(
+    xmss_chain: XmssChainTestFiller,
+) -> None:
+    """Traverse BASE - 1 steps at test-mode base (7) from the incremental digest.
+
+    A full chain covers every non-zero digit in base-BASE. For test mode
+    (BASE = 8) that is seven steps. The resulting digest pins the
+    end-of-chain value clients must agree on.
+    """
+    xmss_chain(
+        mode="test",
+        input={
+            "parameter": PARAMETER_ZEROS,
+            "epoch": "0",
+            "chainIndex": 0,
+            "startStep": 0,
+            "numSteps": 7,
+            "startDigest": DIGEST_INCREMENT,
+        },
+    )
+
+
+def test_chain_mid_range_step_and_index(
+    xmss_chain: XmssChainTestFiller,
+) -> None:
+    """Start at mid-chain with a non-zero chain index and a small positive epoch.
+
+    Pins the interaction between start_step and chain_index in the
+    ChainTweak. A mistake in the step offset or chain-index packing
+    shifts the resulting digest.
+    """
+    xmss_chain(
+        mode="test",
+        input={
+            "parameter": PARAMETER_ZEROS,
+            "epoch": "3",
+            "chainIndex": 2,
+            "startStep": 2,
+            "numSteps": 3,
+            "startDigest": DIGEST_INCREMENT,
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description

Introduces a new consensus fixture format for the XMSS WOTS+ hash-chain traversal and lands the first batch of known-answer vectors.

### \`xmss_chain\` format

- Dispatch by XMSS mode (\`test\` or \`prod\`) to the spec's \`TweakHasher\`.
- Inputs: \`parameter\`, \`epoch\`, \`chainIndex\`, \`startStep\`, \`numSteps\`, and the starting digest as decimal Fp strings.
- Output: end-of-chain digest after \`numSteps\` applications of the tweakable hash.

### Initial vectors (4 KATs)

Under \`tests/consensus/devnet/xmss/\`:

- **Zero steps** — identity boundary; output equals input.
- **Single step** from the zero digest at epoch 0, chain 0.
- **Full traversal** (BASE − 1 = 7 steps in test mode) from an incremental digest.
- **Mid-range start_step and chain_index** with a positive epoch.

## 🔗 Related Issues or PRs

Follows #659 (message_hash) and #658 (tweak_hash). Continues Tranche B.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector and fixture-format-only PR; the new format is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)