### PR TITLE
framework: add xmss_prf fixture format with PRF KATs

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -16,6 +16,7 @@ from .test_fixtures import (
     SSZTest,
     StateTransitionTest,
     VerifySignaturesTest,
+    XmssPrfTest,
 )
 from .test_types import (
     AggregatedAttestationCheck,
@@ -44,6 +45,7 @@ ApiEndpointTestFiller = Type[ApiEndpointTest]
 SlotClockTestFiller = Type[SlotClockTest]
 DiscoveryCryptoTestFiller = Type[DiscoveryCryptoTest]
 JustifiabilityTestFiller = Type[JustifiabilityTest]
+XmssPrfTestFiller = Type[XmssPrfTest]
 
 __all__ = [
     # Public API
@@ -67,6 +69,7 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "XmssPrfTest",
     # Test types
     "BaseForkChoiceStep",
     "TickStep",
@@ -89,4 +92,5 @@ __all__ = [
     "SlotClockTestFiller",
     "DiscoveryCryptoTestFiller",
     "JustifiabilityTestFiller",
+    "XmssPrfTestFiller",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -11,6 +11,7 @@ from .slot_clock import SlotClockTest
 from .ssz import SSZTest
 from .state_transition import StateTransitionTest
 from .verify_signatures import VerifySignaturesTest
+from .xmss_prf import XmssPrfTest
 
 __all__ = [
     "BaseConsensusFixture",
@@ -24,4 +25,5 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "XmssPrfTest",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/xmss_prf.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/xmss_prf.py
@@ -1,0 +1,78 @@
+"""XMSS PRF test fixture.
+
+Generates JSON test vectors for the SHAKE128-based PRF that XMSS uses
+to derive hash-chain starting digests and signing randomness from a
+master secret. Pins both PRF modes so clients align on the deterministic
+key schedule.
+"""
+
+from typing import Any, ClassVar
+
+from lean_spec.subspecs.xmss.constants import PROD_CONFIG, TEST_CONFIG
+from lean_spec.subspecs.xmss.prf import Prf
+from lean_spec.subspecs.xmss.types import PRFKey
+from lean_spec.types import Bytes32, Uint64
+
+from .base import BaseConsensusFixture
+
+
+class XmssPrfTest(BaseConsensusFixture):
+    """Fixture for XMSS PRF conformance.
+
+    Each vector names the XMSS mode and the PRF role (chain start or
+    randomness). The fixture runs the spec's PRF and emits the output
+    as decimal field-element strings.
+
+    JSON output: mode, role, input, output.
+    """
+
+    format_name: ClassVar[str] = "xmss_prf"
+    description: ClassVar[str] = "Tests XMSS SHAKE128-based PRF outputs"
+
+    mode: str
+    """XMSS mode: test or prod."""
+
+    role: str
+    """PRF role: chain_start or randomness."""
+
+    input: dict[str, Any]
+    """PRF input; keys depend on role."""
+
+    output: dict[str, Any] = {}
+    """Computed PRF output as a list of decimal Fp strings."""
+
+    def make_fixture(self) -> "XmssPrfTest":
+        """Run the spec's PRF and produce the derived output.
+
+        Returns:
+            A copy of this fixture with output populated.
+
+        Raises:
+            ValueError: If mode or role is unknown.
+        """
+        if self.mode == "test":
+            prf = Prf(config=TEST_CONFIG)
+        elif self.mode == "prod":
+            prf = Prf(config=PROD_CONFIG)
+        else:
+            raise ValueError(f"Unknown XMSS mode: {self.mode}")
+
+        key_bytes = bytes.fromhex(self.input["key"].removeprefix("0x"))
+        key = PRFKey(key_bytes)
+
+        if self.role == "chain_start":
+            epoch = Uint64(int(self.input["epoch"]))
+            chain_index = Uint64(int(self.input["chainIndex"]))
+            digest = prf.apply(key, epoch, chain_index)
+            output = {"fieldElements": [str(fp.value) for fp in digest.data]}
+        elif self.role == "randomness":
+            epoch = Uint64(int(self.input["epoch"]))
+            message_bytes = bytes.fromhex(self.input["message"].removeprefix("0x"))
+            message = Bytes32(message_bytes)
+            counter = Uint64(int(self.input["counter"]))
+            randomness = prf.get_randomness(key, epoch, message, counter)
+            output = {"fieldElements": [str(fp.value) for fp in randomness.data]}
+        else:
+            raise ValueError(f"Unknown PRF role: {self.role}")
+
+        return self.model_copy(update={"output": output})

--- a/tests/consensus/devnet/xmss/test_prf.py
+++ b/tests/consensus/devnet/xmss/test_prf.py
@@ -1,0 +1,113 @@
+"""XMSS PRF: deterministic key-schedule known-answer vectors.
+
+Pins the SHAKE128-based PRF outputs for the two roles used by the XMSS
+signature scheme: deriving hash-chain starting digests and deriving
+signing randomness. Clients must reproduce these outputs bit-for-bit
+so the deterministic key schedule agrees across implementations.
+"""
+
+import pytest
+from consensus_testing import XmssPrfTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+KEY_ZEROS = "0x" + "00" * 32
+"""32-byte PRF key of all zeros."""
+
+KEY_INCREMENT = "0x" + "".join(f"{i:02x}" for i in range(32))
+"""32-byte PRF key with byte i at position i."""
+
+MESSAGE_ZERO = "0x" + "00" * 32
+"""All-zero 32-byte message for randomness derivation."""
+
+MESSAGE_INCREMENT = "0x" + "".join(f"{i:02x}" for i in range(32))
+"""Incremental 32-byte message."""
+
+
+def test_prf_chain_start_zero_key_epoch_zero(
+    xmss_prf: XmssPrfTestFiller,
+) -> None:
+    """Chain-start PRF at the minimal input: zero key, epoch 0, chain index 0.
+
+    Pins the smallest point in the chain-start PRF input space so any
+    drift in domain separator bytes or SHAKE128 output shifts every
+    downstream hash-chain seed.
+    """
+    xmss_prf(
+        mode="test",
+        role="chain_start",
+        input={"key": KEY_ZEROS, "epoch": "0", "chainIndex": "0"},
+    )
+
+
+def test_prf_chain_start_distinct_epoch_and_chain(
+    xmss_prf: XmssPrfTestFiller,
+) -> None:
+    """Chain-start PRF with a non-zero incremental key, epoch, and chain index.
+
+    Distinct bytes in every input component check that the PRF packs
+    key, epoch, and chain index without silently dropping any field.
+    """
+    xmss_prf(
+        mode="test",
+        role="chain_start",
+        input={"key": KEY_INCREMENT, "epoch": "7", "chainIndex": "3"},
+    )
+
+
+def test_prf_chain_start_changing_chain_index_changes_output(
+    xmss_prf: XmssPrfTestFiller,
+) -> None:
+    """Same key and epoch, different chain index must produce a different digest.
+
+    Pins independence of sibling hash chains under the PRF so client
+    implementations do not accidentally reuse a chain-start seed across
+    two different chain indices.
+    """
+    xmss_prf(
+        mode="test",
+        role="chain_start",
+        input={"key": KEY_ZEROS, "epoch": "0", "chainIndex": "1"},
+    )
+
+
+def test_prf_randomness_zero_inputs(
+    xmss_prf: XmssPrfTestFiller,
+) -> None:
+    """Randomness PRF at zero key, epoch, message, counter.
+
+    Pins the randomness role's smallest input point to guard the
+    domain-separator byte (0x01) and the message-length slot.
+    """
+    xmss_prf(
+        mode="test",
+        role="randomness",
+        input={
+            "key": KEY_ZEROS,
+            "epoch": "0",
+            "message": MESSAGE_ZERO,
+            "counter": "0",
+        },
+    )
+
+
+def test_prf_randomness_non_zero_counter(
+    xmss_prf: XmssPrfTestFiller,
+) -> None:
+    """Randomness PRF with an incremental key and message, and counter = 1.
+
+    Exercises the retry path in message encoding: a non-zero counter
+    must yield a different randomness vector than counter zero under
+    otherwise identical inputs.
+    """
+    xmss_prf(
+        mode="test",
+        role="randomness",
+        input={
+            "key": KEY_INCREMENT,
+            "epoch": "3",
+            "message": MESSAGE_INCREMENT,
+            "counter": "1",
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description

Introduces a new consensus fixture format for the XMSS SHAKE128-based PRF and lands the first batch of known-answer vectors covering both roles the PRF serves.

### \`xmss_prf\` format

- Dispatch by XMSS mode (\`test\` or \`prod\`) to the spec's \`Prf\`.
- Role \`chain_start\` runs \`prf.apply\` and emits the hash-chain starting digest as decimal Fp strings.
- Role \`randomness\` runs \`prf.get_randomness\` and emits the signing randomness as decimal Fp strings.

### Initial vectors (5 KATs)

Under \`tests/consensus/devnet/xmss/\`:

- **Chain start at minimum inputs** (zero key, epoch 0, chain 0).
- **Chain start with distinct non-zero** key, epoch, chain index.
- **Chain start where only the chain index changes** — pins per-chain independence.
- **Randomness at zero inputs**.
- **Randomness with non-zero counter** — exercises the retry path.

## 🔗 Related Issues or PRs

Follows #660 (xmss_chain), #659 (message_hash), #658 (tweak_hash). Continues Tranche B.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector and fixture-format-only PR; the new format is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)