### PR TITLE
framework: add xmss_target_sum fixture format with KATs

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -16,6 +16,7 @@ from .test_fixtures import (
     SSZTest,
     StateTransitionTest,
     VerifySignaturesTest,
+    XmssTargetSumTest,
 )
 from .test_types import (
     AggregatedAttestationCheck,
@@ -44,6 +45,7 @@ ApiEndpointTestFiller = Type[ApiEndpointTest]
 SlotClockTestFiller = Type[SlotClockTest]
 DiscoveryCryptoTestFiller = Type[DiscoveryCryptoTest]
 JustifiabilityTestFiller = Type[JustifiabilityTest]
+XmssTargetSumTestFiller = Type[XmssTargetSumTest]
 
 __all__ = [
     # Public API
@@ -67,6 +69,7 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "XmssTargetSumTest",
     # Test types
     "BaseForkChoiceStep",
     "TickStep",
@@ -89,4 +92,5 @@ __all__ = [
     "SlotClockTestFiller",
     "DiscoveryCryptoTestFiller",
     "JustifiabilityTestFiller",
+    "XmssTargetSumTestFiller",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -11,6 +11,7 @@ from .slot_clock import SlotClockTest
 from .ssz import SSZTest
 from .state_transition import StateTransitionTest
 from .verify_signatures import VerifySignaturesTest
+from .xmss_target_sum import XmssTargetSumTest
 
 __all__ = [
     "BaseConsensusFixture",
@@ -24,4 +25,5 @@ __all__ = [
     "SlotClockTest",
     "DiscoveryCryptoTest",
     "JustifiabilityTest",
+    "XmssTargetSumTest",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/xmss_target_sum.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/xmss_target_sum.py
@@ -1,0 +1,93 @@
+"""XMSS target-sum encoder test fixture.
+
+Generates JSON test vectors for the Winternitz target-sum encoding
+check. Each vector pins whether a given (parameter, epoch, rho,
+message) combination produces a codeword that lies on the required
+hypercube layer.
+"""
+
+from typing import Any, ClassVar
+
+from lean_spec.subspecs.koalabear.field import Fp
+from lean_spec.subspecs.xmss.constants import PROD_CONFIG, TEST_CONFIG
+from lean_spec.subspecs.xmss.message_hash import PROD_MESSAGE_HASHER, TEST_MESSAGE_HASHER
+from lean_spec.subspecs.xmss.target_sum import TargetSumEncoder
+from lean_spec.subspecs.xmss.types import Parameter, Randomness
+from lean_spec.types import Bytes32, Uint64
+
+from .base import BaseConsensusFixture
+
+
+class XmssTargetSumTest(BaseConsensusFixture):
+    """Fixture for XMSS target-sum encoding conformance.
+
+    Each vector names the XMSS mode and supplies the encoder inputs.
+    The fixture reports whether the candidate codeword matches the
+    target sum (acceptance), along with the codeword digits and their
+    sum for diagnostic cross-check.
+
+    JSON output: mode, input, output.
+    """
+
+    format_name: ClassVar[str] = "xmss_target_sum"
+    description: ClassVar[str] = "Tests XMSS Winternitz target-sum acceptance"
+
+    mode: str
+    """XMSS mode: test or prod."""
+
+    input: dict[str, Any]
+    """Encoder input with keys parameter, epoch, rho, and message."""
+
+    output: dict[str, Any] = {}
+    """Encoder verdict: acceptance flag, digits, digit sum, and target sum."""
+
+    def make_fixture(self) -> "XmssTargetSumTest":
+        """Run the spec's target-sum encoder and produce its verdict.
+
+        Returns:
+            A copy of this fixture with output populated.
+
+        Raises:
+            ValueError: If the mode is unknown.
+        """
+        if self.mode == "test":
+            encoder = TargetSumEncoder(config=TEST_CONFIG, message_hasher=TEST_MESSAGE_HASHER)
+        elif self.mode == "prod":
+            encoder = TargetSumEncoder(config=PROD_CONFIG, message_hasher=PROD_MESSAGE_HASHER)
+        else:
+            raise ValueError(f"Unknown XMSS mode: {self.mode}")
+
+        parameter = Parameter(data=[Fp(int(v)) for v in self.input["parameter"]])
+        rho = Randomness(data=[Fp(int(v)) for v in self.input["rho"]])
+        epoch = Uint64(int(self.input["epoch"]))
+        message_bytes = bytes.fromhex(self.input["message"].removeprefix("0x"))
+        if len(message_bytes) != 32:
+            raise ValueError(f"Message must be 32 bytes, got {len(message_bytes)}")
+        message = Bytes32(message_bytes)
+
+        # Run the candidate-codeword hash so the diagnostic output carries the
+        # digits and their sum regardless of whether the target-sum check passes.
+        candidate = encoder.message_hasher.apply(parameter, epoch, rho, message)
+        verdict = encoder.encode(parameter, message, rho, epoch)
+        target = int(encoder.config.TARGET_SUM)
+
+        output: dict[str, Any]
+        if candidate is None:
+            output = {
+                "accepted": False,
+                "aborted": True,
+                "digits": None,
+                "digitSum": None,
+                "targetSum": target,
+            }
+        else:
+            digit_sum = int(sum(candidate))
+            output = {
+                "accepted": verdict is not None,
+                "aborted": False,
+                "digits": candidate,
+                "digitSum": digit_sum,
+                "targetSum": target,
+            }
+
+        return self.model_copy(update={"output": output})

--- a/tests/consensus/devnet/xmss/test_target_sum.py
+++ b/tests/consensus/devnet/xmss/test_target_sum.py
@@ -1,0 +1,107 @@
+"""XMSS target-sum encoder: acceptance and digit-sum vectors.
+
+Pins the outcome of the Winternitz target-sum check for a small set of
+(parameter, epoch, rho, message) inputs. Clients must agree both on
+whether a given input produces an acceptable codeword and on the
+digits themselves.
+"""
+
+import pytest
+from consensus_testing import XmssTargetSumTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+PARAMETER_ZEROS = ["0", "0", "0", "0", "0"]
+"""Zero parameter (length PARAMETER_LEN = 5)."""
+
+RHO_ZEROS = ["0"] * 7
+"""Zero randomness (length RAND_LEN_FE = 7)."""
+
+RHO_INCREMENT = ["1", "2", "3", "4", "5", "6", "7"]
+"""Incremental randomness exercising per-slot placement."""
+
+MESSAGE_ZERO = "0x" + "00" * 32
+"""All-zero 32-byte message."""
+
+MESSAGE_INCREMENT = "0x" + "".join(f"{i:02x}" for i in range(32))
+"""Message with byte i at position i."""
+
+
+def test_target_sum_zero_inputs(
+    xmss_target_sum: XmssTargetSumTestFiller,
+) -> None:
+    """Target-sum check at zero parameter, zero rho, zero message, epoch zero.
+
+    Pins the simplest point in the encoder input space, along with the
+    digit sum and its comparison to TARGET_SUM, so clients see the exact
+    acceptance contract at a known baseline.
+    """
+    xmss_target_sum(
+        mode="test",
+        input={
+            "parameter": PARAMETER_ZEROS,
+            "epoch": "0",
+            "rho": RHO_ZEROS,
+            "message": MESSAGE_ZERO,
+        },
+    )
+
+
+def test_target_sum_incremental_rho_with_zero_message(
+    xmss_target_sum: XmssTargetSumTestFiller,
+) -> None:
+    """Incremental rho under a zero message and epoch.
+
+    Exercises a second point in the encoder space where rho varies
+    per-slot but message and parameter stay zero. Pins the response to
+    rho alone.
+    """
+    xmss_target_sum(
+        mode="test",
+        input={
+            "parameter": PARAMETER_ZEROS,
+            "epoch": "0",
+            "rho": RHO_INCREMENT,
+            "message": MESSAGE_ZERO,
+        },
+    )
+
+
+def test_target_sum_incremental_message_with_zero_rho(
+    xmss_target_sum: XmssTargetSumTestFiller,
+) -> None:
+    """Incremental-byte message under zero rho and non-zero epoch.
+
+    Pins the per-message acceptance outcome with a distinct-byte message
+    so any little-endian packing drift surfaces through the verdict.
+    """
+    xmss_target_sum(
+        mode="test",
+        input={
+            "parameter": PARAMETER_ZEROS,
+            "epoch": "2",
+            "rho": RHO_ZEROS,
+            "message": MESSAGE_INCREMENT,
+        },
+    )
+
+
+def test_target_sum_distinct_parameter_rho_and_message(
+    xmss_target_sum: XmssTargetSumTestFiller,
+) -> None:
+    """All encoder inputs carry distinct per-slot or per-byte content.
+
+    Combines distinct parameter entries, incremental rho, non-zero
+    epoch, and incremental message. Pins the acceptance outcome under a
+    fully varied input.
+    """
+    xmss_target_sum(
+        mode="test",
+        input={
+            "parameter": ["1", "2", "3", "4", "5"],
+            "epoch": "3",
+            "rho": RHO_INCREMENT,
+            "message": MESSAGE_INCREMENT,
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description

Introduces a new consensus fixture format for the XMSS Winternitz target-sum encoding check and lands the first batch of known-answer vectors.

### \`xmss_target_sum\` format

- Dispatch by XMSS mode (\`test\` or \`prod\`) to the spec's \`TargetSumEncoder\`.
- Inputs: \`parameter\`, \`epoch\`, \`rho\`, and a 32-byte hex \`message\`.
- Output: \`accepted\` flag, codeword \`digits\`, \`digitSum\`, and \`targetSum\` for diagnostic cross-check. When the underlying message hash aborts, \`digits\` and \`digitSum\` are null and \`aborted\` is true.

### Initial vectors (4 KATs)

Under \`tests/consensus/devnet/xmss/\`:

- **Zero parameter, zero rho, zero message, epoch zero** — baseline.
- **Incremental rho** under a zero message.
- **Incremental message** under a zero rho at a non-zero epoch.
- **Distinct parameter, rho, and message** — fully varied input.

## 🔗 Related Issues or PRs

Follows #661 (xmss_prf), #660 (xmss_chain), #659 (message_hash), #658 (tweak_hash). Continues Tranche B.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector and fixture-format-only PR; the new format is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)