### PR TITLE
test(verify_signatures): reject out-of-range proposer_index via tamper

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -58,6 +58,10 @@ class VerifySignaturesTest(BaseConsensusFixture):
       from the block's attestation_signatures list. Produces a signed
       block whose signature-group count is one less than its
       attestation count.
+    - ``{"operation": "set_proposer_index", "value": int}``: Rewrite
+      the block's proposer_index field. Use this to exercise the
+      validator-bounds check that the builder skips because its round-
+      robin selection stays within range by construction.
 
     Tampered blocks bypass the builder's structural invariants. The
     resulting fixture pins the exact rejection a client must raise when
@@ -148,5 +152,16 @@ class VerifySignaturesTest(BaseConsensusFixture):
                 update={"attestation_signatures": truncated}
             )
             return signed_block.model_copy(update={"signature": tampered_signatures})
+
+        if operation == "set_proposer_index":
+            from lean_spec.subspecs.containers.validator import ValidatorIndex
+
+            value = self.tamper.get("value")
+            if value is None:
+                raise ValueError("set_proposer_index requires a value")
+            tampered_block = signed_block.block.model_copy(
+                update={"proposer_index": ValidatorIndex(int(value))}
+            )
+            return signed_block.model_copy(update={"block": tampered_block})
 
         raise ValueError(f"Unknown tamper operation: {operation!r}")

--- a/tests/consensus/devnet/verify_signatures/test_proposer_index_bounds.py
+++ b/tests/consensus/devnet/verify_signatures/test_proposer_index_bounds.py
@@ -1,0 +1,49 @@
+"""Signature verification: proposer-index bounds rejection vector."""
+
+import pytest
+from consensus_testing import (
+    BlockSpec,
+    VerifySignaturesTestFiller,
+    generate_pre_state,
+)
+
+from lean_spec.subspecs.containers.slot import Slot
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_proposer_index_out_of_range_rejected(
+    verify_signatures_test: VerifySignaturesTestFiller,
+) -> None:
+    """A signed block whose proposer_index exceeds the validator registry is rejected.
+
+    Scenario
+    --------
+    - Anchor state has 4 validators.
+    - Block at slot 1 is built normally by the round-robin-selected
+      in-range proposer.
+    - The tamper hook then rewrites proposer_index to 99.
+
+    Expected Behavior
+    -----------------
+    Signature verification fails with AssertionError: "Proposer index out of range"
+
+    Why This Matters
+    ----------------
+    The builder's round-robin proposer selection never produces an
+    out-of-range index, so the block.py bounds check only fires for
+    blocks received from a malicious peer. This vector pins the
+    rejection clients must raise in that case.
+
+    Distinct from the round-robin check "Incorrect block proposer",
+    which catches wrong-but-in-range proposers during state transition.
+    """
+    verify_signatures_test(
+        anchor_state=generate_pre_state(num_validators=4),
+        block=BlockSpec(
+            slot=Slot(1),
+            attestations=[],
+        ),
+        tamper={"operation": "set_proposer_index", "value": 99},
+        expect_exception=AssertionError,
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds the rejection vector for \`block.py:277\` *Proposer index out of range*. The builder's round-robin proposer selection never produces an out-of-range index, so this rejection only fires for blocks received from a malicious peer.

Uses the \`verify_signatures\` tamper hook to set \`proposer_index\` to 99 on a block built normally against a 4-validator state. The fixture pins the \`AssertionError\` clients must raise.

### Tamper extension

Extends the dispatcher in #663 with a \`set_proposer_index\` operation. Preserves the same contract: tamper runs after the valid build, before verification.

### ⚠️ Depends on #663

Stacked on \`framework/verify-signatures-tamper\`. Please review and merge #663 first; after that lands I'll rebase this on \`main\` and the diff will shrink to just the new operation + test.

## 🔗 Related Issues or PRs

Stacked on #663.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)