### PR TITLE
test(networking): reqresp error-response payload roundtrip vectors

### DIFF
--- a/tests/consensus/devnet/networking/test_reqresp_error_utf8.py
+++ b/tests/consensus/devnet/networking/test_reqresp_error_utf8.py
@@ -1,0 +1,63 @@
+"""Req/resp error-response payload roundtrip at size and UTF-8 boundaries."""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_reqresp_error_at_max_error_message_size(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Error response carrying a payload at the maximum error-message size roundtrips.
+
+    The handler truncates server-side error strings to 256 bytes before
+    encoding. A payload at that boundary exercises the exact wire shape
+    clients may receive and must be able to decode back to the same
+    bytes without loss.
+    """
+    payload = b"e" * 256
+    networking_codec(
+        codec_name="reqresp_response",
+        input={
+            "responseCode": 1,
+            "sszData": "0x" + payload.hex(),
+        },
+    )
+
+
+def test_reqresp_error_with_multi_byte_utf8(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Error response carrying multi-byte UTF-8 text roundtrips byte-for-byte.
+
+    The codec treats the payload as opaque bytes. A multi-byte UTF-8
+    payload verifies that compression, length framing, and decode
+    preserve the original bytes even when they are not ASCII-only.
+    """
+    payload = "errür😀fail".encode()
+    networking_codec(
+        codec_name="reqresp_response",
+        input={
+            "responseCode": 2,
+            "sszData": "0x" + payload.hex(),
+        },
+    )
+
+
+def test_reqresp_error_resource_unavailable_with_informational_text(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Error code 3 response carrying a short descriptive message roundtrips.
+
+    Pins the wire shape for the common peer-observed case of an
+    informational error string alongside the RESOURCE_UNAVAILABLE code.
+    """
+    payload = b"block not found"
+    networking_codec(
+        codec_name="reqresp_response",
+        input={
+            "responseCode": 3,
+            "sszData": "0x" + payload.hex(),
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description

Three vectors pinning the wire shape of error responses at the error-message-size boundary and at non-ASCII payloads:

- **Error code 1** with payload exactly at \`MAX_ERROR_MESSAGE_SIZE\` (256 bytes).
- **Error code 2** with multi-byte UTF-8 characters (umlaut, emoji).
- **Error code 3** with a short descriptive ASCII message.

Existing \`test_reqresp_codec.py\` has short 1-2-byte error payloads only. These close the gap at the max-size boundary and at non-ASCII UTF-8, two common divergence surfaces between client error handlers.

Uses the existing \`reqresp_response\` codec — pure content extension, no framework change.

## 🔗 Related Issues or PRs

Follows the post-#666 round-2 audit.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)