### PR TITLE
test(api): pin /metrics endpoint scrape contract

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
@@ -121,6 +121,46 @@ def _aggregator_status_response(_store: Store, fixture: "ApiEndpointTest") -> di
     }
 
 
+def _metrics_response(_store: Store, _fixture: "ApiEndpointTest") -> dict[str, Any]:
+    """Prometheus-format metrics scrape.
+
+    The body of /metrics is dynamic (counters accumulate, timestamps shift)
+    so the fixture pins only the stable contract: status, content-type,
+    and the full list of metric names clients must expose.
+    """
+    from lean_spec.subspecs.metrics.registry import registry as metrics_registry
+
+    # Names enumerated from the leanMetrics spec. Any change to this list
+    # is a cross-client-visible metrics surface change and should be
+    # reflected in the spec first.
+    required_metric_names = [
+        "lean_node_info",
+        "lean_node_start_time_seconds",
+        "lean_head_slot",
+        "lean_current_slot",
+        "lean_safe_target_slot",
+        "lean_fork_choice_block_processing_time_seconds",
+        "lean_attestations_valid_total",
+        "lean_attestations_invalid_total",
+        "lean_attestation_validation_time_seconds",
+        "lean_fork_choice_reorgs_total",
+        "lean_fork_choice_reorg_depth",
+        "lean_latest_justified_slot",
+        "lean_latest_finalized_slot",
+        "lean_state_transition_time_seconds",
+        "lean_validators_count",
+        "lean_connected_peers",
+    ]
+    # Touch the module import so spec refactors that remove the registry
+    # trip the fixture instead of failing silently.
+    assert metrics_registry is not None
+    return {
+        "expected_status_code": 200,
+        "expected_content_type": "text/plain; version=0.0.4; charset=utf-8",
+        "expected_body": {"required_metric_names": required_metric_names},
+    }
+
+
 def _aggregator_toggle_response(_store: Store, fixture: "ApiEndpointTest") -> dict[str, Any]:
     """Expected response after toggling the aggregator role.
 
@@ -152,6 +192,7 @@ _ENDPOINT_HANDLERS: dict[tuple[str, str], EndpointHandler] = {
     ("GET", "/lean/v0/fork_choice"): _fork_choice_response,
     ("GET", "/lean/v0/admin/aggregator"): _aggregator_status_response,
     ("POST", "/lean/v0/admin/aggregator"): _aggregator_toggle_response,
+    ("GET", "/metrics"): _metrics_response,
 }
 """Maps (method, path) tuples to response builders."""
 

--- a/tests/consensus/devnet/api/test_metrics_endpoint.py
+++ b/tests/consensus/devnet/api/test_metrics_endpoint.py
@@ -1,0 +1,24 @@
+"""API endpoint: /metrics scrape contract vector."""
+
+import pytest
+from consensus_testing import ApiEndpointTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_metrics_endpoint_scrape_contract(
+    api_endpoint: ApiEndpointTestFiller,
+) -> None:
+    """GET /metrics returns the Prometheus-format scrape with the required metric names.
+
+    The endpoint body is dynamic (counters accumulate, timestamps shift),
+    so the vector pins only the stable contract: status 200, the
+    Prometheus text-exposition content type, and the full list of
+    metric names a compliant node must expose. Clients replay the
+    fixture and confirm every listed metric appears in their scrape.
+    """
+    api_endpoint(
+        endpoint="/metrics",
+        method="GET",
+        genesis_params={"numValidators": 4, "genesisTime": 0},
+    )


### PR DESCRIPTION
## 🗒️ Description

The \`/metrics\` endpoint exposes Prometheus text-exposition metrics. The body is dynamic (counters accumulate, timestamps shift) so the vector pins only the stable contract a client must honour:

- Status 200
- Content-Type \`text/plain; version=0.0.4; charset=utf-8\`
- Full list of required metric names from the leanMetrics spec

Extends \`api_endpoint\` with a \`/metrics\` handler that emits the stable contract and enumerates every required metric name. Clients replay the fixture and confirm every listed metric appears in their own scrape output.

### Metrics enumerated (16)

\`lean_node_info\`, \`lean_node_start_time_seconds\`, \`lean_head_slot\`, \`lean_current_slot\`, \`lean_safe_target_slot\`, \`lean_fork_choice_block_processing_time_seconds\`, \`lean_attestations_valid_total\`, \`lean_attestations_invalid_total\`, \`lean_attestation_validation_time_seconds\`, \`lean_fork_choice_reorgs_total\`, \`lean_fork_choice_reorg_depth\`, \`lean_latest_justified_slot\`, \`lean_latest_finalized_slot\`, \`lean_state_transition_time_seconds\`, \`lean_validators_count\`, \`lean_connected_peers\`.

## 🔗 Related Issues or PRs

Closes the round-2 audit gap API-1 (registered in \`routes.py\`, zero fixture coverage).

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)