### PR TITLE
framework: advance api_endpoint store past genesis + post-genesis vectors

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
@@ -11,7 +11,7 @@ from lean_spec.subspecs.forkchoice.store import Store
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.types import Bytes32, Uint64
 
-from ..genesis import generate_pre_state
+from ..genesis import build_anchor, generate_pre_state
 from .base import BaseConsensusFixture
 
 EndpointHandler = Callable[[Store, "ApiEndpointTest"], dict[str, Any]]
@@ -34,11 +34,31 @@ def _make_genesis_block(state: State) -> Block:
     )
 
 
-def _build_store(num_validators: int, genesis_time: int) -> Store:
-    """Build a deterministic genesis-only store. Same params always produce same roots."""
-    state = generate_pre_state(genesis_time=Uint64(genesis_time), num_validators=num_validators)
-    block = _make_genesis_block(state)
-    # No validator identity — fixture only reads store data, never signs.
+def _build_store(num_validators: int, genesis_time: int, anchor_slot: int = 0) -> Store:
+    """Build a deterministic store rooted at genesis or at an advanced anchor.
+
+    At anchor_slot 0 the store is genesis-only. At higher slots the store
+    is seeded with a real (state, block) pair produced by advancing an
+    empty chain through anchor_slot; the store then carries non-empty
+    historical block hashes but leaves justification and finalization at
+    genesis (no attestations are injected). This is enough to exercise
+    endpoint responses whose shape depends on post-genesis slot numbers,
+    historical roots, and multi-node fork-choice trees.
+    """
+    if anchor_slot == 0:
+        state = generate_pre_state(genesis_time=Uint64(genesis_time), num_validators=num_validators)
+        block = _make_genesis_block(state)
+        # No validator identity — fixture only reads store data, never signs.
+        return Store.from_anchor(state, block, validator_id=None)
+
+    # Walk the chain from genesis through anchor_slot using empty blocks.
+    # The returned pair (state, block) is internally consistent with the
+    # historical chain the fixture wants to present to the endpoint.
+    state, block = build_anchor(
+        num_validators=num_validators,
+        anchor_slot=Slot(anchor_slot),
+        genesis_time=Uint64(genesis_time),
+    )
     return Store.from_anchor(state, block, validator_id=None)
 
 
@@ -173,7 +193,13 @@ class ApiEndpointTest(BaseConsensusFixture):
     """HTTP method under test. Defaults to GET for read-only endpoints."""
 
     genesis_params: dict[str, int]
-    """Genesis store inputs: numValidators and genesisTime."""
+    """Genesis store inputs.
+
+    - numValidators: validator-set size (defaults to 4 when absent).
+    - genesisTime: unix genesis timestamp (defaults to 0 when absent).
+    - anchorSlot: optional post-genesis slot to advance the chain to
+      before building the store. Defaults to 0 (genesis-only).
+    """
 
     request_body: Any = None
     """Optional request body for non-GET methods. JSON-serializable.
@@ -208,5 +234,6 @@ class ApiEndpointTest(BaseConsensusFixture):
         store = _build_store(
             num_validators=self.genesis_params.get("numValidators", 4),
             genesis_time=self.genesis_params.get("genesisTime", 0),
+            anchor_slot=self.genesis_params.get("anchorSlot", 0),
         )
         return self.model_copy(update=handler(store, self))

--- a/tests/consensus/devnet/api/test_api_post_genesis.py
+++ b/tests/consensus/devnet/api/test_api_post_genesis.py
@@ -1,0 +1,50 @@
+"""API endpoint conformance vectors after the chain has advanced past genesis.
+
+Existing API fixtures pin responses against a genesis-only store. This
+file pins the same endpoints after an empty-block chain has advanced,
+so clients' response shapes at non-zero slots are also captured.
+"""
+
+import pytest
+from consensus_testing import ApiEndpointTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+GENESIS_4V_AT_SLOT_3 = {"numValidators": 4, "genesisTime": 0, "anchorSlot": 3}
+"""4-validator store advanced through three empty blocks past genesis."""
+
+
+def test_fork_choice_tree_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
+    """Fork-choice response carries a multi-node tree once the chain advances.
+
+    With the chain at slot 3 the store holds four blocks (genesis plus
+    slots 1 through 3). The response's nodes list, head root, and
+    parent-root linkage are pinned so clients diverge only when their
+    tree traversal or SSZ root computation differs.
+    """
+    api_endpoint(endpoint="/lean/v0/fork_choice", genesis_params=GENESIS_4V_AT_SLOT_3)
+
+
+def test_finalized_state_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
+    """Finalized-state response returns the SSZ-encoded anchor state after chain advance.
+
+    Finalization has not yet moved past genesis (no attestations have
+    been injected), but the served state now carries non-empty
+    historical_block_hashes because the chain has processed three empty
+    blocks. Pins the exact SSZ bytes at that configuration.
+    """
+    api_endpoint(endpoint="/lean/v0/states/finalized", genesis_params=GENESIS_4V_AT_SLOT_3)
+
+
+def test_justified_checkpoint_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
+    """Justified-checkpoint response at a non-genesis slot pins the slot=0 root.
+
+    Without attestations, justification remains at genesis even after
+    the chain advances. This vector pins that the response still
+    reports the genesis checkpoint, not a synthesised advance.
+    """
+    api_endpoint(
+        endpoint="/lean/v0/checkpoints/justified",
+        genesis_params=GENESIS_4V_AT_SLOT_3,
+    )


### PR DESCRIPTION
## 🗒️ Description

Extends the \`api_endpoint\` fixture so tests can exercise endpoint responses after the chain has advanced past genesis:

- \`_build_store\` accepts an optional \`anchor_slot\`. When > 0, the helper uses \`build_anchor\` to walk an empty-block chain up to that slot and seeds the store with the consistent \`(state, block)\` pair.
- \`genesis_params\` grows an optional \`anchorSlot\` key; existing callers keep genesis-only behaviour by omitting it.

### Vectors landed (3 at anchor_slot 3)

- **\`/lean/v0/fork_choice\`** — pins a multi-node tree (genesis plus three empty blocks) with head root, parent linkage, and weights.
- **\`/lean/v0/states/finalized\`** — returns the SSZ-encoded state with non-empty \`historical_block_hashes\`.
- **\`/lean/v0/checkpoints/justified\`** — still reports the genesis checkpoint (no attestations injected), pinning the non-advance.

### Why client-relevant

The round-2 audit flagged API-2 / API-3 / API-4 as the most divergence-prone endpoints because every existing fixture uses a genesis-only store. Clients' tree traversal, SSZ root computation, and historical-hash formatting only get exercised by non-genesis responses.

## 🔗 Related Issues or PRs

Closes round-2 audit gaps API-2, API-3, API-4.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector and fixture-extension PR; the new parameter is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)