### PR TITLE
framework: add discv5_packet codec dispatcher + packet-framing KATs

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -8,15 +8,28 @@ from lean_spec.subspecs.networking.discovery.codec import decode_message, encode
 from lean_spec.subspecs.networking.discovery.messages import (
     Distance,
     FindNode,
+    IdNonce,
     IPv4,
     IPv6,
     Nodes,
+    Nonce,
+    PacketFlag,
     Ping,
     Pong,
     Port,
     RequestId,
     TalkReq,
     TalkResp,
+)
+from lean_spec.subspecs.networking.discovery.packet import (
+    decode_handshake_authdata,
+    decode_message_authdata,
+    decode_packet_header,
+    decode_whoareyou_authdata,
+    encode_handshake_authdata,
+    encode_message_authdata,
+    encode_packet,
+    encode_whoareyou_authdata,
 )
 from lean_spec.subspecs.networking.discovery.routing import log2_distance, xor_distance
 from lean_spec.subspecs.networking.enr.enr import ENR
@@ -43,6 +56,7 @@ from lean_spec.subspecs.networking.reqresp.codec import (
 from lean_spec.subspecs.networking.transport.peer_id import KeyType, PeerId, PublicKeyProto
 from lean_spec.subspecs.networking.types import NodeId, SeqNumber
 from lean_spec.subspecs.networking.varint import decode_varint, encode_varint
+from lean_spec.types import Bytes16, Bytes33, Bytes64
 
 from .base import BaseConsensusFixture
 
@@ -105,6 +119,8 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 output = self._make_peer_id()
             case "discv5_message":
                 output = self._make_discv5_message()
+            case "discv5_packet":
+                output = self._make_discv5_packet()
             case "snappy_block":
                 output = self._make_snappy_block()
             case "snappy_frame":
@@ -157,6 +173,10 @@ class NetworkingCodecTest(BaseConsensusFixture):
             "reqresp_request": decode_request,
             "reqresp_response": ResponseCode.decode,
             "discv5_message": decode_message,
+            "discv5_packet": lambda raw: decode_packet_header(
+                NodeId(_from_hex(self.input.get("localNodeId", "0x" + "00" * 32))),
+                raw,
+            ),
             "enr": ENR.from_rlp,
         }
         if decoder_name not in decoders:
@@ -390,6 +410,95 @@ class NetworkingCodecTest(BaseConsensusFixture):
         assert encoded == re_encoded, "Discv5 message roundtrip produced different bytes"
 
         return {"encoded": _to_hex(encoded)}
+
+    def _make_discv5_packet(self) -> dict[str, Any]:
+        """Encode a Discovery v5 packet and roundtrip-decode the header.
+
+        Input keys (all hex unless noted):
+
+        - ``packetType``: "message", "whoareyou", or "handshake".
+        - ``destNodeId``: 32-byte destination node ID. Masking key
+          derives from its first 16 bytes; clients also use this as the
+          local node id when decoding.
+        - ``nonce``: 12-byte message nonce.
+        - ``maskingIv``: 16-byte header-masking IV, supplied explicitly
+          so the produced bytes are deterministic.
+        - ``message``: message payload (empty for WHOAREYOU, otherwise
+          the already-encrypted ciphertext bytes).
+        - ``encryptionKey``: 16-byte AES-GCM key for non-WHOAREYOU.
+
+        Packet-type-specific input keys:
+
+        - message: ``srcId``.
+        - whoareyou: ``idNonce``, ``enrSeq`` (uint64 integer).
+        - handshake: ``srcId``, ``idSignature``, ``ephPubkey``, optional
+          ``record`` (RLP-encoded ENR).
+
+        Output:
+
+        - ``encoded``: full packet hex.
+        - ``flag``: numeric flag (0/1/2) recovered via decode.
+        - ``authdataSize``: size of authdata in bytes.
+        """
+        packet_type = self.input["packetType"]
+        dest_node_id = NodeId(_from_hex(self.input["destNodeId"]))
+        nonce = Nonce(_from_hex(self.input["nonce"]))
+        masking_iv = Bytes16(_from_hex(self.input["maskingIv"]))
+        message_bytes = _from_hex(self.input.get("message", "0x"))
+
+        if packet_type == "message":
+            flag = PacketFlag.MESSAGE
+            authdata = encode_message_authdata(NodeId(_from_hex(self.input["srcId"])))
+            encryption_key: Bytes16 | None = Bytes16(_from_hex(self.input["encryptionKey"]))
+        elif packet_type == "whoareyou":
+            flag = PacketFlag.WHOAREYOU
+            authdata = encode_whoareyou_authdata(
+                IdNonce(_from_hex(self.input["idNonce"])),
+                SeqNumber(int(self.input["enrSeq"])),
+            )
+            encryption_key = None
+        elif packet_type == "handshake":
+            flag = PacketFlag.HANDSHAKE
+            record = _from_hex(self.input["record"]) if self.input.get("record") else None
+            authdata = encode_handshake_authdata(
+                NodeId(_from_hex(self.input["srcId"])),
+                Bytes64(_from_hex(self.input["idSignature"])),
+                Bytes33(_from_hex(self.input["ephPubkey"])),
+                record=record,
+            )
+            encryption_key = Bytes16(_from_hex(self.input["encryptionKey"]))
+        else:
+            raise ValueError(f"Unknown discv5 packet type: {packet_type!r}")
+
+        encoded = encode_packet(
+            dest_node_id=dest_node_id,
+            flag=flag,
+            nonce=nonce,
+            authdata=authdata,
+            message=message_bytes,
+            encryption_key=encryption_key,
+            masking_iv=masking_iv,
+        )
+
+        # Roundtrip: decode header and assert shape matches.
+        header, _msg, _ad = decode_packet_header(dest_node_id, encoded)
+        assert header.flag == flag, "Packet flag roundtrip mismatch"
+        assert header.nonce == nonce, "Packet nonce roundtrip mismatch"
+        assert header.authdata == authdata, "Packet authdata roundtrip mismatch"
+
+        # Exercise per-type authdata decode for extra shape coverage.
+        if flag == PacketFlag.MESSAGE:
+            decode_message_authdata(header.authdata)
+        elif flag == PacketFlag.WHOAREYOU:
+            decode_whoareyou_authdata(header.authdata)
+        elif flag == PacketFlag.HANDSHAKE:
+            decode_handshake_authdata(header.authdata)
+
+        return {
+            "encoded": _to_hex(encoded),
+            "flag": int(flag),
+            "authdataSize": len(authdata),
+        }
 
 
 def _build_discv5_message(

--- a/tests/consensus/devnet/networking/test_discv5_packet.py
+++ b/tests/consensus/devnet/networking/test_discv5_packet.py
@@ -1,0 +1,151 @@
+"""Discovery v5 packet framing: known-answer and rejection vectors.
+
+Pins the exact wire-level encoding produced by the spec for each packet
+type clients must emit. Uses deterministic masking IVs so the resulting
+bytes are stable, and roundtrip-decodes the header to assert shape
+preservation. Rejection vectors cover the public size and protocol-id
+checks.
+"""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+DEST_NODE_ID = "0x" + "11" * 32
+"""Fixed destination node ID. Its first 16 bytes act as the masking key."""
+
+NONCE = "0x" + "22" * 12
+"""Fixed 12-byte message nonce."""
+
+MASKING_IV = "0x" + "33" * 16
+"""Fixed 16-byte header-masking IV for deterministic packet bytes."""
+
+ENCRYPTION_KEY = "0x" + "44" * 16
+"""Fixed 16-byte AES-GCM encryption key for non-WHOAREYOU packets."""
+
+SRC_NODE_ID = "0x" + "55" * 32
+"""Fixed source node ID used inside MESSAGE and HANDSHAKE authdata."""
+
+ID_NONCE = "0x" + "66" * 16
+"""Fixed 16-byte ID nonce used inside WHOAREYOU authdata."""
+
+ID_SIGNATURE = "0x" + "77" * 64
+"""Fixed 64-byte ID-nonce signature used inside HANDSHAKE authdata."""
+
+EPH_PUBKEY = "0x02" + "88" * 32
+"""Fixed 33-byte compressed ephemeral public key (prefix byte then 32 bytes)."""
+
+# An encrypted message payload the AES-GCM layer will accept; exact
+# ciphertext bytes do not matter for packet-shape assertions.
+MESSAGE_PAYLOAD = "0x" + "ab" * 16
+
+
+def test_discv5_packet_message(networking_codec: NetworkingCodecTestFiller) -> None:
+    """MESSAGE packet (flag=0) with known inputs pins the full wire bytes.
+
+    Encodes a MESSAGE packet with a fixed destination node id, nonce,
+    masking IV, encryption key, and source id. The fixture asserts
+    the encoded packet round-trips through decode_packet_header with
+    flag, nonce, and authdata preserved.
+    """
+    networking_codec(
+        codec_name="discv5_packet",
+        input={
+            "packetType": "message",
+            "destNodeId": DEST_NODE_ID,
+            "nonce": NONCE,
+            "maskingIv": MASKING_IV,
+            "encryptionKey": ENCRYPTION_KEY,
+            "srcId": SRC_NODE_ID,
+            "message": MESSAGE_PAYLOAD,
+        },
+    )
+
+
+def test_discv5_packet_whoareyou(networking_codec: NetworkingCodecTestFiller) -> None:
+    """WHOAREYOU packet (flag=1) with known inputs pins the full wire bytes.
+
+    WHOAREYOU carries no encrypted payload. The authdata is the 16-byte
+    ID nonce concatenated with the 8-byte ENR sequence number.
+    """
+    networking_codec(
+        codec_name="discv5_packet",
+        input={
+            "packetType": "whoareyou",
+            "destNodeId": DEST_NODE_ID,
+            "nonce": NONCE,
+            "maskingIv": MASKING_IV,
+            "idNonce": ID_NONCE,
+            "enrSeq": 42,
+        },
+    )
+
+
+def test_discv5_packet_handshake_without_record(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """HANDSHAKE packet (flag=2) without an embedded ENR record.
+
+    Exercises the fixed-size authdata path where the record field is
+    absent. Pins the encoded length and the roundtrip decode that reads
+    sig-size / eph-key-size from the authdata header.
+    """
+    networking_codec(
+        codec_name="discv5_packet",
+        input={
+            "packetType": "handshake",
+            "destNodeId": DEST_NODE_ID,
+            "nonce": NONCE,
+            "maskingIv": MASKING_IV,
+            "encryptionKey": ENCRYPTION_KEY,
+            "srcId": SRC_NODE_ID,
+            "idSignature": ID_SIGNATURE,
+            "ephPubkey": EPH_PUBKEY,
+            "message": MESSAGE_PAYLOAD,
+        },
+    )
+
+
+def test_discv5_packet_decode_rejects_too_small(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Decoding a packet below MIN_PACKET_SIZE must raise ValueError.
+
+    MIN_PACKET_SIZE is 63 bytes. A 10-byte blob cannot carry even the
+    masking IV plus a static header, so the decoder must reject before
+    any unmask work runs.
+    """
+    networking_codec(
+        codec_name="decode_failure",
+        input={
+            "decoder": "discv5_packet",
+            "localNodeId": DEST_NODE_ID,
+            "bytes": "0x" + "00" * 10,
+        },
+        expect_exception=ValueError,
+    )
+
+
+def test_discv5_packet_decode_rejects_wrong_protocol_id(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Decoding with the wrong local node id (unmask key) surfaces the protocol-id check.
+
+    The masking key is derived from the local node id. Decoding with a
+    different node id than the packet was encoded for produces garbage
+    for the static header; the decoder rejects because the protocol id
+    bytes no longer read as 'discv5'.
+    """
+    # 63 bytes all zero; after unmask with any key, the first 6 bytes
+    # produce pseudo-random output that will not spell "discv5".
+    networking_codec(
+        codec_name="decode_failure",
+        input={
+            "decoder": "discv5_packet",
+            "localNodeId": DEST_NODE_ID,
+            "bytes": "0x" + "00" * 63,
+        },
+        expect_exception=ValueError,
+    )


### PR DESCRIPTION
## 🗒️ Description

Extends \`networking_codec\` with a \`discv5_packet\` dispatcher that exercises the full Discovery v5 packet-framing path: static header, masked header via AES-CTR, per-type authdata, and optional AES-GCM encrypted message payload.

### Framework

- New \`discv5_packet\` dispatch accepts an explicit \`maskingIv\` so the produced packet bytes are deterministic across clients.
- Roundtrip-decodes the header with \`decode_packet_header\` and re-runs the per-type authdata decoder so any drift in size computation, field ordering, or masking-key derivation surfaces in the emitted output.
- \`decode_failure\` dispatch grows a \`discv5_packet\` entry.

### Vectors (5)

- **MESSAGE** packet with fixed source id.
- **WHOAREYOU** packet with id-nonce and ENR seq.
- **HANDSHAKE** packet without an embedded ENR record.
- Reject packet below \`MIN_PACKET_SIZE\` (63 bytes).
- Reject packet whose unmask fails the protocol-id check.

### Why client-relevant

\`packet.py\` is a pure encoder/decoder used for every Discovery v5 peer interaction. The round-2 audit flagged zero test-vector coverage on this path despite clients needing to produce byte-identical packets for AES-CTR masking and static-header composition to interoperate.

## 🔗 Related Issues or PRs

Closes round-2 audit gap NW-1.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector and fixture-extension PR; the new codec is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)