### PR TITLE
framework: gossip_topic fork-digest validation + accept/reject vectors

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -199,7 +199,13 @@ class NetworkingCodecTest(BaseConsensusFixture):
         return {"encoded": _to_hex(encoded), "byteLength": byte_length}
 
     def _make_gossip_topic(self) -> dict[str, Any]:
-        """Build a topic string from components, parse it back, assert roundtrip."""
+        """Build a topic string from components, parse it back, assert roundtrip.
+
+        When the input carries ``expectedForkDigest``, also run validate_fork
+        against the parsed topic and report whether the fork digest matched.
+        This pins the accept / reject branches clients must agree on when
+        deciding which mesh to admit a topic into.
+        """
         kind = TopicKind(self.input["kind"])
         fork_digest = self.input["forkDigest"]
         raw_subnet = self.input.get("subnetId")
@@ -212,7 +218,17 @@ class NetworkingCodecTest(BaseConsensusFixture):
         parsed = GossipTopic.from_string(topic_string)
         assert parsed == topic, f"Topic roundtrip: {topic} -> {topic_string!r} -> {parsed}"
 
-        return {"topicString": topic_string}
+        output: dict[str, Any] = {"topicString": topic_string}
+
+        expected_fork_digest = self.input.get("expectedForkDigest")
+        if expected_fork_digest is not None:
+            try:
+                parsed.validate_fork(expected_fork_digest)
+                output["forkValid"] = True
+            except ValueError:
+                output["forkValid"] = False
+
+        return output
 
     def _make_gossip_message_id(self) -> dict[str, Any]:
         """Compute a 20-byte gossipsub message ID from topic, data, and domain."""

--- a/tests/consensus/devnet/networking/test_gossip_topic_fork.py
+++ b/tests/consensus/devnet/networking/test_gossip_topic_fork.py
@@ -1,0 +1,70 @@
+"""Gossipsub topic fork-digest validation vectors.
+
+Validates that a parsed topic carries the fork digest a client
+expects. A mismatch is the only mechanism preventing cross-fork mesh
+admission; pinning both branches stops clients from silently admitting
+wrong-fork messages into their subscriptions.
+"""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_gossip_topic_fork_digest_matches(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Block topic whose fork digest matches the expected value validates cleanly.
+
+    Pins the accept branch of validate_fork: a topic built with a fork
+    digest equal to the expected one must pass the check.
+    """
+    networking_codec(
+        codec_name="gossip_topic",
+        input={
+            "kind": "block",
+            "forkDigest": "0x12345678",
+            "expectedForkDigest": "0x12345678",
+        },
+    )
+
+
+def test_gossip_topic_fork_digest_mismatch(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Block topic with a fork digest different from the expected one is rejected.
+
+    Pins the reject branch of validate_fork: a topic built for one fork
+    must not pass when validated against a different fork digest. The
+    output reports forkValid=false so clients align on the rejection
+    verdict.
+    """
+    networking_codec(
+        codec_name="gossip_topic",
+        input={
+            "kind": "block",
+            "forkDigest": "0x12345678",
+            "expectedForkDigest": "0xdeadbeef",
+        },
+    )
+
+
+def test_gossip_topic_fork_digest_match_on_attestation_subnet(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Attestation-subnet topic carries the subnet id and still validates its fork.
+
+    Mixes a non-default kind and subnet id with fork validation to
+    confirm the validator reads fork_digest independent of other topic
+    components.
+    """
+    networking_codec(
+        codec_name="gossip_topic",
+        input={
+            "kind": "attestation",
+            "forkDigest": "0xabcdef01",
+            "subnetId": 7,
+            "expectedForkDigest": "0xabcdef01",
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds \`validate_fork\` verdict reporting to the \`gossip_topic\` codec.

### Framework

When the input carries \`expectedForkDigest\`, the fixture runs \`GossipTopic.validate_fork\` against the parsed topic and reports whether the check passed as a \`forkValid\` boolean in the output. This pins the accept / reject branches clients must agree on when deciding which mesh to admit a topic into.

### Vectors (3)

- Block topic whose fork digest matches the expected value → accepted.
- Block topic whose fork digest does not match → rejected.
- Attestation-subnet topic with matching fork digest → fork validation is independent of other topic components.

### Why client-relevant

\`validate_fork\` is the sole mechanism preventing cross-fork message admission into a node's gossipsub meshes. Pinning both branches stops clients from silently admitting wrong-fork messages during a fork transition.

## 🔗 Related Issues or PRs

Closes round-2 audit gap NW-5.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector and fixture-extension PR; the new sub-op is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)