### PR TITLE
framework: reqresp_response_stream codec + multi-chunk stream vectors

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -99,6 +99,8 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 output = self._make_reqresp_request()
             case "reqresp_response":
                 output = self._make_reqresp_response()
+            case "reqresp_response_stream":
+                output = self._make_reqresp_response_stream()
             case "enr":
                 output = self._make_enr()
             case "peer_id":
@@ -259,6 +261,38 @@ class NetworkingCodecTest(BaseConsensusFixture):
         assert decoded_data == ssz_data, "Response roundtrip produced different bytes"
 
         return {"encoded": _to_hex(encoded)}
+
+    def _make_reqresp_response_stream(self) -> dict[str, Any]:
+        """Encode a sequence of response chunks as a concatenated stream.
+
+        Multi-chunk responses (for example BlocksByRoot returning N blocks)
+        send their chunks back-to-back on a single libp2p stream: each
+        chunk is its own [code][varint][snappy_frame] triple, and the
+        receiver reads them in order until EOF.
+
+        Input keys:
+
+        - ``chunks``: ordered list of ``{"responseCode": int, "sszData": hex}``.
+          Each entry is encoded independently with ResponseCode.encode
+          and the resulting bytes are concatenated.
+
+        Output:
+
+        - ``encoded``: concatenated stream hex. Clients reproduce the
+          same bytes and their multi-chunk reader must yield the same
+          sequence of (code, ssz_data) records.
+        - ``chunkCount``: number of chunks in the stream.
+        """
+        raw_chunks = self.input["chunks"]
+        buffer = bytearray()
+        for entry in raw_chunks:
+            code = ResponseCode(entry["responseCode"])
+            ssz_data = _from_hex(entry["sszData"])
+            buffer.extend(code.encode(ssz_data))
+        return {
+            "encoded": _to_hex(bytes(buffer)),
+            "chunkCount": len(raw_chunks),
+        }
 
     def _make_snappy_block(self) -> dict[str, Any]:
         """Compress with raw Snappy block format, decompress, assert roundtrip."""

--- a/tests/consensus/devnet/networking/test_reqresp_response_stream.py
+++ b/tests/consensus/devnet/networking/test_reqresp_response_stream.py
@@ -1,0 +1,73 @@
+"""Req/resp multi-chunk response stream vectors.
+
+Pins the concatenated byte layout of a libp2p request/response stream
+carrying multiple chunks. Each chunk is its own [code][varint][snappy]
+triple; clients must read them back-to-back until the stream closes
+and produce the same ordered list of (code, sszData) records.
+"""
+
+import pytest
+from consensus_testing import NetworkingCodecTestFiller
+
+pytestmark = pytest.mark.valid_until("Devnet")
+
+
+def test_stream_two_success_chunks(networking_codec: NetworkingCodecTestFiller) -> None:
+    """Stream with two SUCCESS chunks carrying distinct payload bytes.
+
+    Pins the concatenation of two independent response frames. Clients
+    must read both records before signalling EOF, so a receiver that
+    stops after the first chunk drops half the response.
+    """
+    networking_codec(
+        codec_name="reqresp_response_stream",
+        input={
+            "chunks": [
+                {"responseCode": 0, "sszData": "0xdeadbeef"},
+                {"responseCode": 0, "sszData": "0xcafebabe"},
+            ],
+        },
+    )
+
+
+def test_stream_success_then_resource_unavailable(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """A SUCCESS chunk followed by a RESOURCE_UNAVAILABLE terminator.
+
+    Real servers end a multi-chunk response early when the peer asked
+    for more items than the server holds. The vector pins the exact
+    concatenation so clients surface both the delivered payload and
+    the error terminator.
+    """
+    networking_codec(
+        codec_name="reqresp_response_stream",
+        input={
+            "chunks": [
+                {"responseCode": 0, "sszData": "0x" + "11" * 16},
+                {"responseCode": 3, "sszData": "0x" + b"not found".hex()},
+            ],
+        },
+    )
+
+
+def test_stream_three_success_chunks_with_compressible_payloads(
+    networking_codec: NetworkingCodecTestFiller,
+) -> None:
+    """Three SUCCESS chunks whose payloads compress well.
+
+    Exercises the N>2 case and highlights that each chunk carries its
+    own snappy stream-identifier preamble inside the concatenated bytes;
+    stream-level parsers that reset snappy state between chunks must
+    produce identical output to stateful parsers.
+    """
+    networking_codec(
+        codec_name="reqresp_response_stream",
+        input={
+            "chunks": [
+                {"responseCode": 0, "sszData": "0x" + "00" * 64},
+                {"responseCode": 0, "sszData": "0x" + "ff" * 64},
+                {"responseCode": 0, "sszData": "0x" + "aa" * 64},
+            ],
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description

Multi-chunk responses (for example \`BlocksByRoot\` returning N blocks) send their chunks back-to-back on a single libp2p stream: each chunk is its own \`[code][varint][snappy_frame]\` triple, and the receiver reads them in order until EOF.

### Framework

New \`reqresp_response_stream\` codec dispatcher accepts an ordered list of \`{responseCode, sszData}\` entries, encodes each with \`ResponseCode.encode\`, and emits the concatenated bytes plus chunk count.

### Vectors (3)

- Stream with **two SUCCESS chunks** carrying distinct payload bytes.
- **SUCCESS followed by RESOURCE_UNAVAILABLE** terminator — early-end case when the peer asked for more items than the server holds.
- **Three SUCCESS chunks** with compressible payloads — stateful vs stateless snappy parsers must produce identical output.

### Why client-relevant

A receiver that stops reading after the first chunk drops the rest of a valid response. Pinning the exact concatenated layout plus the expected chunk count forces clients to agree on the EOF-framed stream contract.

## 🔗 Related Issues or PRs

Closes round-2 audit gap NW-2.

## ✅ Checklist

- [x] Ran \`tox\` checks to avoid unnecessary CI fails:
    \`\`\`console
    uvx tox -e all-checks
    \`\`\`
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs — test-vector and fixture-extension PR; the new codec is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)