### PR TITLE
test(fc): store from anchor rejects mismatched state root

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Self
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.containers.block import (
@@ -88,6 +88,30 @@ class ForkChoiceTest(BaseConsensusFixture):
     Each step can validate Store state via checks.
     """
 
+    anchor_valid: bool = Field(default=True, exclude=True)
+    """
+    Whether Store.from_anchor is expected to succeed.
+
+    Default True covers every normal test.
+    Set False to assert that store initialization itself must fail,
+    e.g. when the anchor block and state are inconsistent.
+
+    Excluded from JSON output: configures the test runner, not the test
+    vector that clients consume.
+    """
+
+    expected_anchor_error: str | None = Field(default=None, exclude=True)
+    """
+    Substring required in the raised exception when anchor_valid is False.
+
+    Ignored when anchor_valid is True.
+    Used to pin the failure to a specific precondition rather than any crash.
+    When None, any AssertionError from Store.from_anchor is accepted.
+
+    Excluded from JSON output: configures the test runner, not the test
+    vector that clients consume.
+    """
+
     max_slot: Slot | None = None
     """
     Maximum slot for XMSS key validity.
@@ -164,6 +188,36 @@ class ForkChoiceTest(BaseConsensusFixture):
         assert self.anchor_state is not None, "anchor state must be set before making fixture"
         assert self.anchor_block is not None, "anchor block must be set before making fixture"
         assert self.max_slot is not None, "max slot must be set before making fixture"
+
+        # Expected anchor-init failure path.
+        #
+        # When anchor_valid is False, the test asserts that Store.from_anchor
+        # rejects the given (state, block) pair. The pubkey sync that normally
+        # fixes up the anchor block's state root is skipped, since that would
+        # mask the very inconsistency under test.
+        if not self.anchor_valid:
+            assert self.steps == [], (
+                "steps must be empty when anchor_valid is False: "
+                "Store.from_anchor is expected to fail before any step can run"
+            )
+            try:
+                Store.from_anchor(
+                    self.anchor_state,
+                    self.anchor_block,
+                    validator_id=ValidatorIndex(0),
+                )
+            except AssertionError as e:
+                if self.expected_anchor_error is not None and self.expected_anchor_error not in str(
+                    e
+                ):
+                    raise AssertionError(
+                        "Store.from_anchor failed with wrong error.\n"
+                        f"  Expected error containing: {self.expected_anchor_error!r}\n"
+                        f"  Actual error: {e!r}"
+                    ) from e
+                return self
+
+            raise AssertionError("Store.from_anchor was expected to fail but succeeded")
 
         # Key manager setup
         #

--- a/tests/consensus/devnet/fc/test_checkpoint_sync.py
+++ b/tests/consensus/devnet/fc/test_checkpoint_sync.py
@@ -15,7 +15,7 @@ from lean_spec.subspecs.chain.config import INTERVALS_PER_SLOT, SECONDS_PER_SLOT
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Uint64
+from lean_spec.types import Bytes32, Uint64
 
 pytestmark = pytest.mark.valid_until("Devnet")
 
@@ -322,4 +322,52 @@ def test_non_genesis_anchor_is_internally_consistent(
                 checks=StoreChecks(head_root_label="genesis"),
             ),
         ],
+    )
+
+
+def test_store_from_anchor_rejects_mismatched_state_root(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """Store.from_anchor aborts when the anchor block's state_root disagrees
+    with the hash of the anchor state.
+
+    Scenario
+    --------
+    Build a valid mid-chain anchor, then replace the anchor block's state_root
+    with an unrelated value. The block and state no longer agree on the post
+    state, so the store must refuse the pair.
+
+    Key Assertions
+    --------------
+
+    - The fixture is marked anchor_valid=False and carries no steps: init
+      aborts before any step could run.
+    - Store.from_anchor raises an AssertionError whose message contains the
+      exact precondition text from the spec, pinning the failure to the
+      state-root check rather than any later crash.
+    - No Store is returned to the caller; initialization fails cleanly.
+
+    Why This Matters
+    ----------------
+    A block and state that disagree on the state root are structurally
+    inconsistent. Seeding a store from that pair would corrupt every future
+    lookup that resolves a block root to its post state. Clients must refuse
+    the anchor at init time, not silently repair or ignore it.
+    """
+    anchor_state, anchor_block = build_anchor(
+        num_validators=NUM_VALIDATORS, anchor_slot=ANCHOR_SLOT
+    )
+
+    # Sanity: the helper-built pair is consistent to begin with. Makes the
+    # mismatch below the only difference between this test and the happy path.
+    assert anchor_block.state_root == hash_tree_root(anchor_state)
+
+    bad_anchor_block = anchor_block.model_copy(update={"state_root": Bytes32(b"\xff" * 32)})
+
+    fork_choice_test(
+        anchor_state=anchor_state,
+        anchor_block=bad_anchor_block,
+        anchor_valid=False,
+        expected_anchor_error="Anchor block state root must match anchor state hash",
+        steps=[],
     )


### PR DESCRIPTION
## 🗒️ Description

Adds a fork choice filler asserting that `Store.from_anchor` aborts when the anchor block's `state_root` disagrees with `hash_tree_root(anchor_state)`. This is a safety precondition every client must enforce: an anchor pair where the block and state disagree on the post state would corrupt every subsequent block-root-to-state lookup.

### Test

`tests/consensus/devnet/fc/test_checkpoint_sync.py::test_store_from_anchor_rejects_mismatched_state_root`

Builds a valid mid-chain anchor via `build_anchor`, overrides the anchor block's `state_root` with an unrelated value, and feeds the pair to the filler. The fixture verifies `Store.from_anchor` raises `AssertionError` whose message contains the exact precondition text (`"Anchor block state root must match anchor state hash"`), pinning the failure to the state-root check rather than any later crash.

### Framework extension

`Store.from_anchor` runs **before** any step, so the existing per-step `valid=False` / `expected_error` mechanism cannot express an expected failure at initialization. Two optional fields are added to `ForkChoiceTest` to fill this gap:

- `anchor_valid: bool = True`
- `expected_anchor_error: str | None = None`

When `anchor_valid=False`, the fixture:

1. Asserts `steps == []` (no step can run if init aborts).
2. Skips the validator pubkey sync that would otherwise silently overwrite the anchor block's `state_root` to match the state.
3. Wraps `Store.from_anchor` in `try/except` and verifies the raised exception's message contains `expected_anchor_error`.

Defaults preserve existing behaviour: all 545 consensus fixtures regenerate byte-identical.

Serialised as `anchorValid` / `expectedAnchorError` via `CamelModel`. Clients consuming fixtures branch on `anchorValid=false` and verify their equivalent `Store.from_anchor` rejects the input.

## 🔗 Related Issues or PRs

Closes #570

## ✅ Checklist

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox -e all-checks
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.