### PR TITLE
refactor(forkchoice): extract AttestationPool from Store

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -449,7 +449,7 @@ class BlockSpec(CamelModel):
             proposer_index=proposer_index,
             parent_root=parent_root,
             known_block_roots=set(store.blocks.keys()),
-            aggregated_payloads=merged_store.latest_known_aggregated_payloads,
+            aggregated_payloads=merged_store.attestation_pool.known_proofs,
         )
 
         # Append forced attestations that bypass the builder's MAX cap.

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -391,10 +391,10 @@ class StoreChecks(CamelModel):
             assert self.attestation_checks is not None
             for check in self.attestation_checks:
                 if check.location == "new":
-                    payloads = store.latest_new_aggregated_payloads
+                    payloads = store.attestation_pool.new_proofs
                     label = "in latest_new"
                 else:
-                    payloads = store.latest_known_aggregated_payloads
+                    payloads = store.attestation_pool.known_proofs
                     label = "in latest_known"
 
                 extracted = store.extract_attestations_from_aggregated_payloads(payloads)
@@ -407,19 +407,19 @@ class StoreChecks(CamelModel):
 
         if "attestation_signature_target_slots" in fields:
             assert self.attestation_signature_target_slots is not None
-            actual = sorted({data.target.slot for data in store.attestation_signatures})
+            actual = sorted({data.target.slot for data in store.attestation_pool.signatures})
             expected = sorted(self.attestation_signature_target_slots)
             _check("attestation_signatures.target_slots", actual, expected)
 
         if "latest_new_aggregated_target_slots" in fields:
             assert self.latest_new_aggregated_target_slots is not None
-            actual = sorted({data.target.slot for data in store.latest_new_aggregated_payloads})
+            actual = sorted({data.target.slot for data in store.attestation_pool.new_proofs})
             expected = sorted(self.latest_new_aggregated_target_slots)
             _check("latest_new_aggregated_payloads.target_slots", actual, expected)
 
         if "latest_known_aggregated_target_slots" in fields:
             assert self.latest_known_aggregated_target_slots is not None
-            actual = sorted({data.target.slot for data in store.latest_known_aggregated_payloads})
+            actual = sorted({data.target.slot for data in store.attestation_pool.known_proofs})
             expected = sorted(self.latest_known_aggregated_target_slots)
             _check("latest_known_aggregated_payloads.target_slots", actual, expected)
 
@@ -562,7 +562,7 @@ class StoreChecks(CamelModel):
             slot = block.slot
 
             known_attestations = store.extract_attestations_from_aggregated_payloads(
-                store.latest_known_aggregated_payloads
+                store.attestation_pool.known_proofs
             )
             weight = 0
             for attestation in known_attestations.values():

--- a/src/lean_spec/subspecs/forkchoice/__init__.py
+++ b/src/lean_spec/subspecs/forkchoice/__init__.py
@@ -5,9 +5,11 @@ This module implements the LMD GHOST forkchoice algorithm for Ethereum,
 providing the core functionality for determining the canonical chain head.
 """
 
-from .store import AttestationSignatureEntry, Store
+from .attestation_pool import AttestationPool, AttestationSignatureEntry
+from .store import Store
 
 __all__ = [
+    "AttestationPool",
     "AttestationSignatureEntry",
     "Store",
 ]

--- a/src/lean_spec/subspecs/forkchoice/attestation_pool.py
+++ b/src/lean_spec/subspecs/forkchoice/attestation_pool.py
@@ -1,0 +1,217 @@
+"""In-memory three-stage attestation pool used by the forkchoice store."""
+
+from typing import NamedTuple
+
+from lean_spec.subspecs.containers.attestation.attestation import AttestationData
+from lean_spec.subspecs.containers.slot import Slot
+from lean_spec.subspecs.containers.validator import ValidatorIndex
+from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
+from lean_spec.subspecs.xmss.containers import Signature
+from lean_spec.types.base import StrictBaseModel
+
+
+class AttestationSignatureEntry(NamedTuple):
+    """One validator's gossip signature paired with its index."""
+
+    validator_id: ValidatorIndex
+    signature: Signature
+
+
+class AttestationPool(StrictBaseModel):
+    """Three-stage attestation evidence shared across the slot's interval cycle.
+
+    Stages and their roles:
+
+    - signatures: aggregator inbox of raw single-validator gossip signatures.
+      Drained when aggregation runs.
+    - new_proofs: aggregated proofs produced this round. Used as a current-slot
+      availability signal for safe-target selection. Promoted at slot rollover.
+    - known_proofs: aggregated proofs eligible to weigh head selection and
+      reusable as building blocks for deeper aggregation.
+
+    Block-included attestations bypass the new pool and land directly in known
+    so they can influence fork choice without waiting for a stage migration.
+
+    The pool is kept in memory only and never serialized to the wire, hence
+    the plain strict-model base instead of an SSZ container.
+    """
+
+    signatures: dict[AttestationData, set[AttestationSignatureEntry]] = {}
+    """Pending raw gossip signatures, grouped by attestation data."""
+
+    new_proofs: dict[AttestationData, set[AggregatedSignatureProof]] = {}
+    """Aggregated proofs from the current round, not yet weighted by fork choice."""
+
+    known_proofs: dict[AttestationData, set[AggregatedSignatureProof]] = {}
+    """Aggregated proofs already eligible to influence head selection."""
+
+    def prune_finalized(self, finalized_slot: Slot) -> "AttestationPool":
+        """Drop every entry whose target slot is not strictly above the finalized slot.
+
+        An attestation whose target sits inside the finalized prefix can no
+        longer change chain selection, so it is safe to forget.
+
+        Args:
+            finalized_slot: The current finalized slot. Used as a strict lower bound.
+
+        Returns:
+            A new pool with stale entries filtered out.
+        """
+        # Strict-greater predicate: an entry survives only if its target slot
+        # sits strictly past the finalized boundary.
+        #
+        # Why strict: a target equal to the finalized slot is already absorbed
+        # into the finalized prefix and cannot move the head.
+        #
+        # Inner sets are not mutated here, so the same set objects can be
+        # reused in the new dicts without copying.
+        return self.model_copy(
+            update={
+                "signatures": {
+                    data: sigs
+                    for data, sigs in self.signatures.items()
+                    if data.target.slot > finalized_slot
+                },
+                "new_proofs": {
+                    data: proofs
+                    for data, proofs in self.new_proofs.items()
+                    if data.target.slot > finalized_slot
+                },
+                "known_proofs": {
+                    data: proofs
+                    for data, proofs in self.known_proofs.items()
+                    if data.target.slot > finalized_slot
+                },
+            }
+        )
+
+    def add_signature(
+        self, data: AttestationData, entry: AttestationSignatureEntry
+    ) -> "AttestationPool":
+        """Record one validator's gossip signature into the aggregator inbox.
+
+        Args:
+            data: Attestation data the signature attests to.
+            entry: Validator index plus its raw signature.
+
+        Returns:
+            A new pool with the signature added under the matching data key.
+        """
+        # Shallow-copy the outer dict and clone each inner set.
+        #
+        # Why: the previous pool must remain untouched for callers holding it.
+        signatures = {k: set(v) for k, v in self.signatures.items()}
+
+        # Append to the bucket for this attestation data, creating it if absent.
+        signatures.setdefault(data, set()).add(entry)
+
+        return self.model_copy(update={"signatures": signatures})
+
+    def add_new_proof(
+        self, data: AttestationData, proof: AggregatedSignatureProof
+    ) -> "AttestationPool":
+        """Record a freshly aggregated proof under the given attestation data.
+
+        Args:
+            data: Attestation data the proof covers.
+            proof: Aggregated proof produced this round.
+
+        Returns:
+            A new pool with the proof added to the new-proofs stage.
+        """
+        # Same copy-on-write discipline as the signature path: the prior pool
+        # is left intact for any caller still holding a reference.
+        new_proofs = {k: set(v) for k, v in self.new_proofs.items()}
+
+        # Place the proof into the bucket for this attestation data.
+        new_proofs.setdefault(data, set()).add(proof)
+
+        return self.model_copy(update={"new_proofs": new_proofs})
+
+    def add_block_proofs(
+        self,
+        proofs_by_data: dict[AttestationData, set[AggregatedSignatureProof]],
+    ) -> "AttestationPool":
+        """Merge a batch of block-included proofs straight into the known pool.
+
+        Block-included proofs skip the new stage on purpose: they have already
+        been validated as part of the block and can immediately weigh head
+        selection without waiting for a slot rollover.
+
+        Args:
+            proofs_by_data: Aggregated proofs grouped by attestation data.
+
+        Returns:
+            A new pool with the block proofs unioned into the known stage.
+        """
+        # Clone outer dict and inner sets up front.
+        #
+        # Why: the union step below mutates inner sets in place.
+        known_proofs = {k: set(v) for k, v in self.known_proofs.items()}
+
+        # Union each incoming bucket into the matching known bucket.
+        for data, proofs in proofs_by_data.items():
+            known_proofs.setdefault(data, set()).update(proofs)
+
+        return self.model_copy(update={"known_proofs": known_proofs})
+
+    def migrate_new_to_known(self) -> "AttestationPool":
+        """Promote every new-stage proof into the known stage and clear the new stage.
+
+        Called at the slot boundary that makes current-round aggregates
+        eligible for fork-choice weighting.
+
+        Returns:
+            A new pool with an empty new stage and all proofs unioned into known.
+        """
+        # Clone the known stage as the merge target.
+        #
+        # Why a clone: the union below mutates the dict's inner sets.
+        merged = {k: set(v) for k, v in self.known_proofs.items()}
+
+        # Fold each new-stage bucket into the matching known bucket.
+        for data, proofs in self.new_proofs.items():
+            merged.setdefault(data, set()).update(proofs)
+
+        # Reset the new stage; everything has been promoted.
+        return self.model_copy(update={"known_proofs": merged, "new_proofs": {}})
+
+    def replace_after_aggregation(
+        self,
+        new_proofs: dict[AttestationData, set[AggregatedSignatureProof]],
+    ) -> "AttestationPool":
+        """Swap in this round's aggregated proofs and drop the consumed signatures.
+
+        The new stage is replaced wholesale rather than merged.
+
+        Why a replace, not a merge:
+
+        - Aggregation may early-exit on a lone child without producing a fresh
+          proof for an attestation data that was present last round.
+        - Re-emitting that stale aggregate would misrepresent the current
+          round's evidence.
+        - Any pre-existing entry that did not produce a fresh proof this round
+          is therefore deliberately discarded.
+
+        Gossip signatures whose attestation data appears in the supplied
+        new-stage map are considered consumed and dropped. Signatures keyed
+        on other attestation data survive so they can feed the next round.
+
+        Args:
+            new_proofs: The freshly produced aggregated proofs for this round.
+
+        Returns:
+            A new pool with the new stage replaced and consumed signatures removed.
+        """
+        # Keep only signatures that were not folded into a fresh proof.
+        #
+        # Why filter on data only: every signature under a consumed data
+        # bucket has been absorbed into the new aggregate, so the entire
+        # bucket is redundant.
+        #
+        # Inner sets stay intact; the filter is purely on the dict keys.
+        signatures = {
+            data: sigs for data, sigs in self.signatures.items() if data not in new_proofs
+        }
+
+        return self.model_copy(update={"new_proofs": new_proofs, "signatures": signatures})

--- a/src/lean_spec/subspecs/forkchoice/store.py
+++ b/src/lean_spec/subspecs/forkchoice/store.py
@@ -4,10 +4,9 @@ Forkchoice store for tracking chain state and attestations.
 The Store tracks all information required for the LMD GHOST forkchoice algorithm.
 """
 
-__all__ = ["AttestationSignatureEntry", "Store"]
+__all__ = ["Store"]
 
 from collections import defaultdict
-from typing import NamedTuple
 
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import (
@@ -35,7 +34,6 @@ from lean_spec.subspecs.xmss.aggregation import (
     AggregatedSignatureProof,
     AggregationError,
 )
-from lean_spec.subspecs.xmss.containers import Signature
 from lean_spec.subspecs.xmss.interface import TARGET_SIGNATURE_SCHEME, GeneralizedXmssScheme
 from lean_spec.types import (
     ZERO_HASH,
@@ -45,17 +43,7 @@ from lean_spec.types import (
 )
 from lean_spec.types.base import StrictBaseModel
 
-
-class AttestationSignatureEntry(NamedTuple):
-    """
-    Single validator's XMSS signature for an attestation.
-
-    Used as an element in the attestation_signatures map: one entry per validator
-    that attested to the same AttestationData.
-    """
-
-    validator_id: ValidatorIndex
-    signature: Signature
+from .attestation_pool import AttestationPool, AttestationSignatureEntry
 
 
 class Store(StrictBaseModel):
@@ -137,28 +125,12 @@ class Store(StrictBaseModel):
     validator_id: ValidatorIndex | None
     """Index of the validator running this store instance."""
 
-    attestation_signatures: dict[AttestationData, set[AttestationSignatureEntry]] = {}
-    """
-    Per-validator XMSS signatures learned from committee attesters.
+    attestation_pool: AttestationPool = AttestationPool()
+    """Three-stage attestation evidence: gossip signatures, new proofs, known proofs.
 
-    Keyed by AttestationData.
-    """
-
-    latest_new_aggregated_payloads: dict[AttestationData, set[AggregatedSignatureProof]] = {}
-    """
-    Aggregated signature proofs pending processing.
-
-    These payloads are "new" and do not yet contribute to fork choice.
-    They migrate to known payloads via interval ticks.
-    Populated from blocks or gossip aggregated attestations.
-    """
-
-    latest_known_aggregated_payloads: dict[AttestationData, set[AggregatedSignatureProof]] = {}
-    """
-    Aggregated signature proofs that have been processed.
-
-    These payloads are "known" and contribute to fork choice weights.
-    Used for recursive signature aggregation when building blocks.
+    See AttestationPool for the per-stage lifecycle and the order in which
+    gossip arrivals, aggregation, block inclusion, and migration touch each
+    stage during a slot's interval cycle.
     """
 
     @classmethod
@@ -247,28 +219,11 @@ class Store(StrictBaseModel):
         Returns:
             New Store with stale attestation data removed.
         """
-        # Filter out stale entries from all attestation-related mappings.
-        #
-        # Each mapping is keyed by attestation data, so we check membership by slot
-        # against the finalized slot.
-
         return self.model_copy(
             update={
-                "attestation_signatures": {
-                    attestation_data: sigs
-                    for attestation_data, sigs in self.attestation_signatures.items()
-                    if attestation_data.target.slot > self.latest_finalized.slot
-                },
-                "latest_new_aggregated_payloads": {
-                    attestation_data: proofs
-                    for attestation_data, proofs in self.latest_new_aggregated_payloads.items()
-                    if attestation_data.target.slot > self.latest_finalized.slot
-                },
-                "latest_known_aggregated_payloads": {
-                    attestation_data: proofs
-                    for attestation_data, proofs in self.latest_known_aggregated_payloads.items()
-                    if attestation_data.target.slot > self.latest_finalized.slot
-                },
+                "attestation_pool": self.attestation_pool.prune_finalized(
+                    self.latest_finalized.slot
+                ),
             }
         )
 
@@ -375,23 +330,19 @@ class Store(StrictBaseModel):
                 public_key, attestation_data.slot, hash_tree_root(attestation_data), signature
             ), "Signature verification failed"
 
-            # Store signature and attestation data for later aggregation.
-            # Copy the inner sets so we can add to them without mutating the previous store.
-            new_committee_sigs = {k: set(v) for k, v in self.attestation_signatures.items()}
-
             # Aggregators store all received gossip signatures.
             # The p2p layer only delivers attestations from subscribed subnets,
             # so subnet filtering happens at subscription time, not here.
             # Non-aggregator nodes validate and drop — they never store gossip signatures.
-            if is_aggregator:
-                new_committee_sigs.setdefault(attestation_data, set()).add(
-                    AttestationSignatureEntry(validator_id, signature)
-                )
+            if not is_aggregator:
+                return self
 
-            # Return store with updated signature map and attestation data
             return self.model_copy(
                 update={
-                    "attestation_signatures": new_committee_sigs,
+                    "attestation_pool": self.attestation_pool.add_signature(
+                        attestation_data,
+                        AttestationSignatureEntry(validator_id, signature),
+                    ),
                 }
             )
 
@@ -452,16 +403,9 @@ class Store(StrictBaseModel):
                 f"Committee aggregation signature verification failed: {exc}"
             ) from exc
 
-        # Shallow-copy the dict and its inner sets to preserve immutability.
-        new_aggregated_payloads = {
-            k: set(v) for k, v in self.latest_new_aggregated_payloads.items()
-        }
-        new_aggregated_payloads.setdefault(data, set()).add(proof)
-
-        # Return store with updated aggregated payloads and attestation data
         return self.model_copy(
             update={
-                "latest_new_aggregated_payloads": new_aggregated_payloads,
+                "attestation_pool": self.attestation_pool.add_new_proof(data, proof),
             }
         )
 
@@ -553,19 +497,19 @@ class Store(StrictBaseModel):
                 f"maximum is {MAX_ATTESTATIONS_DATA}"
             )
 
-            # Copy the aggregated proof map for updates
-            # Shallow-copy the dict and its inner sets to preserve immutability
-            # Block attestations go directly to "known" payloads
-            # (like is_from_block=True in the spec)
-            block_proofs: dict[AttestationData, set[AggregatedSignatureProof]] = {
-                k: set(v) for k, v in store.latest_known_aggregated_payloads.items()
-            }
-
+            # Block attestations go straight to "known" (is_from_block=True in the spec).
+            # Group them by data so the pool merges per-key in one pass.
+            block_proofs_by_data: dict[AttestationData, set[AggregatedSignatureProof]] = {}
             for att, proof in zip(aggregated_attestations, attestation_signatures, strict=True):
-                block_proofs.setdefault(att.data, set()).add(proof)
+                block_proofs_by_data.setdefault(att.data, set()).add(proof)
 
-            # Update store with new aggregated proofs and attestation data
-            store = store.model_copy(update={"latest_known_aggregated_payloads": block_proofs})
+            store = store.model_copy(
+                update={
+                    "attestation_pool": store.attestation_pool.add_block_proofs(
+                        block_proofs_by_data
+                    ),
+                }
+            )
 
             # Update forkchoice head based on new block and attestations
             store = store.update_head()
@@ -612,7 +556,7 @@ class Store(StrictBaseModel):
             Mapping from block root to accumulated attestation weight.
         """
         attestations = self.extract_attestations_from_aggregated_payloads(
-            self.latest_known_aggregated_payloads
+            self.attestation_pool.known_proofs
         )
 
         start_slot = self.latest_finalized.slot
@@ -734,7 +678,7 @@ class Store(StrictBaseModel):
         """
         # Extract attestations from known aggregated payloads
         attestations = self.extract_attestations_from_aggregated_payloads(
-            self.latest_known_aggregated_payloads
+            self.attestation_pool.known_proofs
         )
 
         # Run LMD-GHOST fork choice algorithm.
@@ -757,9 +701,9 @@ class Store(StrictBaseModel):
         """
         Process pending aggregated payloads and update forkchoice head.
 
-        Moves aggregated payloads from latest_new_aggregated_payloads to
-        latest_known_aggregated_payloads, making them eligible to contribute to
-        fork choice weights. This migration happens at specific interval ticks.
+        Moves aggregated payloads from the new pool to the known pool,
+        making them eligible to contribute to fork choice weights.
+        This migration happens at specific interval ticks.
 
         The Interval Tick System
         -------------------------
@@ -776,20 +720,9 @@ class Store(StrictBaseModel):
         Returns:
             New Store with migrated aggregated payloads and updated head.
         """
-        # Merge new aggregated payloads into known aggregated payloads
-        merged_aggregated_payloads = {
-            attestation_data: set(proofs)
-            for attestation_data, proofs in self.latest_known_aggregated_payloads.items()
-        }
-        for attestation_data, proofs in self.latest_new_aggregated_payloads.items():
-            merged_aggregated_payloads.setdefault(attestation_data, set()).update(proofs)
-
-        # Create store with migrated aggregated payloads
+        # Migrate new -> known and clear the new pool in one shot.
         store = self.model_copy(
-            update={
-                "latest_known_aggregated_payloads": merged_aggregated_payloads,
-                "latest_new_aggregated_payloads": {},
-            }
+            update={"attestation_pool": self.attestation_pool.migrate_new_to_known()}
         )
 
         # Update head with newly accepted aggregated payloads
@@ -854,7 +787,7 @@ class Store(StrictBaseModel):
         # the availability rationale tied to the interval-3/interval-4
         # ordering.
         attestations = self.extract_attestations_from_aggregated_payloads(
-            self.latest_new_aggregated_payloads,
+            self.attestation_pool.new_proofs,
         )
 
         # Run LMD GHOST with the supermajority threshold.
@@ -911,9 +844,9 @@ class Store(StrictBaseModel):
             Updated store and the list of freshly produced signed attestations.
         """
         validators = self.states[self.head].validators
-        gossip_sigs = self.attestation_signatures
-        new = self.latest_new_aggregated_payloads
-        known = self.latest_known_aggregated_payloads
+        gossip_sigs = self.attestation_pool.signatures
+        new = self.attestation_pool.new_proofs
+        known = self.attestation_pool.known_proofs
 
         new_aggregates: list[SignedAggregatedAttestation] = []
 
@@ -995,7 +928,7 @@ class Store(StrictBaseModel):
             )
             new_aggregates.append(SignedAggregatedAttestation(data=data, proof=proof))
 
-        # ── Store bookkeeping ────────────────────────────────────────
+        # Store bookkeeping.
         #
         # Record freshly produced proofs so future rounds can reuse them.
         # Remove gossip signatures that were consumed by this aggregation.
@@ -1003,16 +936,11 @@ class Store(StrictBaseModel):
         for signed_att in new_aggregates:
             new_aggregated_payloads.setdefault(signed_att.data, set()).add(signed_att.proof)
 
-        remaining_attestation_signatures = {
-            data: sigs
-            for data, sigs in self.attestation_signatures.items()
-            if data not in new_aggregated_payloads
-        }
-
         return self.model_copy(
             update={
-                "latest_new_aggregated_payloads": new_aggregated_payloads,
-                "attestation_signatures": remaining_attestation_signatures,
+                "attestation_pool": self.attestation_pool.replace_after_aggregation(
+                    new_aggregated_payloads
+                ),
             }
         ), new_aggregates
 
@@ -1301,7 +1229,7 @@ class Store(StrictBaseModel):
             proposer_index=validator_index,
             parent_root=head_root,
             known_block_roots=set(store.blocks.keys()),
-            aggregated_payloads=store.latest_known_aggregated_payloads,
+            aggregated_payloads=store.attestation_pool.known_proofs,
         )
 
         # Invariant: the produced block must close any justified divergence.

--- a/tests/interop/helpers/node_runner.py
+++ b/tests/interop/helpers/node_runner.py
@@ -109,9 +109,9 @@ class TestNode:
             safe_target_slot=int(safe_block.slot) if safe_block else 0,
             finalized_slot=self.finalized_slot,
             justified_slot=self.justified_slot,
-            attestation_signatures_count=len(store.attestation_signatures),
-            new_aggregated_count=len(store.latest_new_aggregated_payloads),
-            known_aggregated_count=len(store.latest_known_aggregated_payloads),
+            attestation_signatures_count=len(store.attestation_pool.signatures),
+            new_aggregated_count=len(store.attestation_pool.new_proofs),
+            known_aggregated_count=len(store.attestation_pool.known_proofs),
             block_count=len(store.blocks),
         )
 

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -31,7 +31,7 @@ from lean_spec.subspecs.containers.block.types import AggregatedAttestations, At
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.state import Validators
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
-from lean_spec.subspecs.forkchoice import AttestationSignatureEntry, Store
+from lean_spec.subspecs.forkchoice import AttestationPool, AttestationSignatureEntry, Store
 from lean_spec.subspecs.koalabear import Fp
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.networking.peer import PeerInfo
@@ -377,17 +377,13 @@ def make_store_with_attestation_signatures(
         validator_id,
         attestation_slot,
     )
-    attestation_signatures = {
+    signatures = {
         attestation_data: {
             AttestationSignatureEntry(vid, key_manager.sign_attestation_data(vid, attestation_data))
             for vid in attesting_validators
         },
     }
-    store = store.model_copy(
-        update={
-            "attestation_signatures": attestation_signatures,
-        }
-    )
+    store = store.model_copy(update={"attestation_pool": AttestationPool(signatures=signatures)})
     return store, attestation_data
 
 

--- a/tests/lean_spec/subspecs/containers/test_state_aggregation.py
+++ b/tests/lean_spec/subspecs/containers/test_state_aggregation.py
@@ -10,7 +10,7 @@ from lean_spec.subspecs.containers.block.types import AggregatedAttestations
 from lean_spec.subspecs.containers.checkpoint import Checkpoint
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
-from lean_spec.subspecs.forkchoice import AttestationSignatureEntry
+from lean_spec.subspecs.forkchoice import AttestationPool, AttestationSignatureEntry
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.types import Bytes32
 from tests.lean_spec.helpers import (
@@ -41,7 +41,9 @@ def test_aggregated_signatures_prefers_full_gossip_payload(
         }
     }
 
-    store = store.model_copy(update={"attestation_signatures": attestation_signatures})
+    store = store.model_copy(
+        update={"attestation_pool": AttestationPool(signatures=attestation_signatures)}
+    )
     _, results = store.aggregate()
 
     assert len(results) == 1
@@ -176,7 +178,9 @@ def test_aggregated_signatures_with_multiple_data_groups(
         },
     }
 
-    store = store.model_copy(update={"attestation_signatures": attestation_signatures})
+    store = store.model_copy(
+        update={"attestation_pool": AttestationPool(signatures=attestation_signatures)}
+    )
     _, results = store.aggregate()
 
     assert len(results) == 2

--- a/tests/lean_spec/subspecs/forkchoice/test_attestation_pool.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_attestation_pool.py
@@ -1,0 +1,254 @@
+"""Unit tests for the AttestationPool value object."""
+
+from __future__ import annotations
+
+from lean_spec.subspecs.containers.slot import Slot
+from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.subspecs.forkchoice import AttestationPool, AttestationSignatureEntry
+from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
+from lean_spec.types import ByteListMiB, Bytes32
+from tests.lean_spec.helpers import make_attestation_data, make_bytes32, make_mock_signature
+
+
+def _proof(participants: list[int]) -> AggregatedSignatureProof:
+    """Build a placeholder aggregated proof for the given validator indices."""
+    return AggregatedSignatureProof(
+        participants=ValidatorIndices(
+            data=[ValidatorIndex(p) for p in participants]
+        ).to_aggregation_bits(),
+        proof_data=ByteListMiB(data=b""),
+    )
+
+
+def _data_at(slot_value: int, root_seed: int = 1) -> "make_attestation_data":  # type: ignore[name-defined]
+    """Attestation data with target slot equal to the input slot."""
+    return make_attestation_data(
+        slot=Slot(slot_value),
+        target_slot=Slot(slot_value),
+        target_root=make_bytes32(root_seed),
+        source_slot=Slot(0),
+        source_root=Bytes32.zero(),
+    )
+
+
+def test_default_pool_is_empty() -> None:
+    """Default-constructed pool has all three stages empty."""
+    pool = AttestationPool()
+    assert pool.signatures == {}
+    assert pool.new_proofs == {}
+    assert pool.known_proofs == {}
+
+
+def test_prune_drops_target_at_finalized_slot() -> None:
+    """Prune removes entries whose target slot equals the finalized slot."""
+    data = _data_at(5)
+    sig = AttestationSignatureEntry(ValidatorIndex(0), make_mock_signature())
+    pool = AttestationPool(signatures={data: {sig}})
+
+    pruned = pool.prune_finalized(Slot(5))
+
+    assert pruned.signatures == {}
+
+
+def test_prune_drops_target_before_finalized_slot() -> None:
+    """Prune removes entries whose target slot is below the finalized slot."""
+    data = _data_at(3)
+    sig = AttestationSignatureEntry(ValidatorIndex(0), make_mock_signature())
+    pool = AttestationPool(signatures={data: {sig}})
+
+    pruned = pool.prune_finalized(Slot(5))
+
+    assert pruned.signatures == {}
+
+
+def test_prune_keeps_target_after_finalized_slot() -> None:
+    """Prune retains entries whose target slot is above the finalized slot."""
+    data = _data_at(10)
+    sig = AttestationSignatureEntry(ValidatorIndex(0), make_mock_signature())
+    pool = AttestationPool(signatures={data: {sig}})
+
+    pruned = pool.prune_finalized(Slot(5))
+
+    assert pruned.signatures == {data: {sig}}
+
+
+def test_prune_filters_all_three_stages_atomically() -> None:
+    """One prune call applies the same predicate to signatures, new and known proofs."""
+    stale = _data_at(3, root_seed=1)
+    fresh = _data_at(10, root_seed=2)
+    sig_stale = AttestationSignatureEntry(ValidatorIndex(0), make_mock_signature())
+    sig_fresh = AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+    proof = _proof([0])
+
+    pool = AttestationPool(
+        signatures={stale: {sig_stale}, fresh: {sig_fresh}},
+        new_proofs={stale: {proof}, fresh: {proof}},
+        known_proofs={stale: {proof}, fresh: {proof}},
+    )
+
+    pruned = pool.prune_finalized(Slot(5))
+
+    assert pruned == AttestationPool(
+        signatures={fresh: {sig_fresh}},
+        new_proofs={fresh: {proof}},
+        known_proofs={fresh: {proof}},
+    )
+
+
+def test_add_signature_creates_first_entry() -> None:
+    """First signature for a key initializes the inner set."""
+    data = _data_at(1)
+    sig = AttestationSignatureEntry(ValidatorIndex(0), make_mock_signature())
+
+    pool = AttestationPool().add_signature(data, sig)
+
+    assert pool.signatures == {data: {sig}}
+
+
+def test_add_signature_appends_to_existing_entry() -> None:
+    """Subsequent signatures for the same key union into the existing set."""
+    data = _data_at(1)
+    sig0 = AttestationSignatureEntry(ValidatorIndex(0), make_mock_signature())
+    sig1 = AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+
+    pool = AttestationPool().add_signature(data, sig0).add_signature(data, sig1)
+
+    assert pool.signatures == {data: {sig0, sig1}}
+
+
+def test_add_signature_does_not_mutate_previous_pool() -> None:
+    """Returned pool owns a fresh dict and inner set; the prior pool is untouched."""
+    data = _data_at(1)
+    sig0 = AttestationSignatureEntry(ValidatorIndex(0), make_mock_signature())
+    sig1 = AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+
+    pool0 = AttestationPool().add_signature(data, sig0)
+    pool1 = pool0.add_signature(data, sig1)
+
+    # Mutating either resulting set must not bleed into the other.
+    assert pool0.signatures == {data: {sig0}}
+    assert pool1.signatures == {data: {sig0, sig1}}
+    assert pool0.signatures[data] is not pool1.signatures[data]
+
+
+def test_add_new_proof_creates_first_entry() -> None:
+    """First proof for a key initializes the inner set in new_proofs."""
+    data = _data_at(2)
+    proof = _proof([0])
+
+    pool = AttestationPool().add_new_proof(data, proof)
+
+    assert pool.new_proofs == {data: {proof}}
+
+
+def test_add_new_proof_does_not_touch_other_stages() -> None:
+    """add_new_proof leaves signatures and known_proofs untouched."""
+    data = _data_at(2)
+    proof = _proof([0])
+
+    pool = AttestationPool().add_new_proof(data, proof)
+
+    assert pool.signatures == {}
+    assert pool.known_proofs == {}
+
+
+def test_add_block_proofs_targets_known_pool() -> None:
+    """Block-included proofs land in known_proofs, bypassing new_proofs."""
+    data = _data_at(2)
+    proof = _proof([0])
+
+    pool = AttestationPool().add_block_proofs({data: {proof}})
+
+    assert pool.known_proofs == {data: {proof}}
+    assert pool.new_proofs == {}
+
+
+def test_add_block_proofs_unions_with_existing_known() -> None:
+    """Repeated block batches union into the same data key in known_proofs."""
+    data = _data_at(2)
+    proof_a = _proof([0])
+    proof_b = _proof([1])
+
+    pool = AttestationPool(known_proofs={data: {proof_a}}).add_block_proofs({data: {proof_b}})
+
+    assert pool.known_proofs == {data: {proof_a, proof_b}}
+
+
+def test_migrate_new_to_known_unions_and_clears() -> None:
+    """Migration unions new_proofs into known_proofs and empties new_proofs."""
+    data = _data_at(3)
+    proof_known = _proof([0])
+    proof_new = _proof([1])
+    pool = AttestationPool(
+        new_proofs={data: {proof_new}},
+        known_proofs={data: {proof_known}},
+    )
+
+    migrated = pool.migrate_new_to_known()
+
+    assert migrated == AttestationPool(known_proofs={data: {proof_known, proof_new}})
+
+
+def test_migrate_with_disjoint_keys_preserves_both() -> None:
+    """Migration leaves keys that exist only in known_proofs untouched."""
+    new_data = _data_at(3, root_seed=1)
+    known_data = _data_at(4, root_seed=2)
+    proof_new = _proof([0])
+    proof_known = _proof([1])
+    pool = AttestationPool(
+        new_proofs={new_data: {proof_new}},
+        known_proofs={known_data: {proof_known}},
+    )
+
+    migrated = pool.migrate_new_to_known()
+
+    assert migrated == AttestationPool(
+        known_proofs={known_data: {proof_known}, new_data: {proof_new}}
+    )
+
+
+def test_replace_after_aggregation_overwrites_new_pool() -> None:
+    """Replacement is wholesale: pre-existing new_proofs entries are dropped.
+
+    This pins the documented aggregate behavior: any data that did not
+    produce a fresh proof this round disappears from new_proofs, even if
+    it had a stale entry.
+    """
+    stale_data = _data_at(2, root_seed=1)
+    fresh_data = _data_at(3, root_seed=2)
+    stale_proof = _proof([0])
+    fresh_proof = _proof([1])
+    pool = AttestationPool(new_proofs={stale_data: {stale_proof}})
+
+    aggregated = pool.replace_after_aggregation({fresh_data: {fresh_proof}})
+
+    assert aggregated.new_proofs == {fresh_data: {fresh_proof}}
+
+
+def test_replace_after_aggregation_keeps_unconsumed_signatures() -> None:
+    """Gossip signatures whose data did not produce a fresh proof survive."""
+    data_consumed = _data_at(2, root_seed=1)
+    data_kept = _data_at(3, root_seed=2)
+    sig_consumed = AttestationSignatureEntry(ValidatorIndex(0), make_mock_signature())
+    sig_kept = AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+    proof = _proof([0])
+
+    pool = AttestationPool(
+        signatures={data_consumed: {sig_consumed}, data_kept: {sig_kept}},
+    )
+
+    aggregated = pool.replace_after_aggregation({data_consumed: {proof}})
+
+    assert aggregated.signatures == {data_kept: {sig_kept}}
+
+
+def test_replace_after_aggregation_leaves_known_pool_untouched() -> None:
+    """Aggregation does not touch known_proofs."""
+    data = _data_at(2)
+    known_proof = _proof([0])
+    new_proof = _proof([1])
+    pool = AttestationPool(known_proofs={data: {known_proof}})
+
+    aggregated = pool.replace_after_aggregation({data: {new_proof}})
+
+    assert aggregated.known_proofs == {data: {known_proof}}

--- a/tests/lean_spec/subspecs/forkchoice/test_compute_block_weights.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_compute_block_weights.py
@@ -6,7 +6,7 @@ from lean_spec.subspecs.containers.attestation import AttestationData
 from lean_spec.subspecs.containers.checkpoint import Checkpoint
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
-from lean_spec.subspecs.forkchoice import Store
+from lean_spec.subspecs.forkchoice import AttestationPool, Store
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.types.byte_arrays import ByteListMiB
@@ -71,7 +71,7 @@ def test_linear_chain_weight_accumulates_upward(base_store: Store) -> None:
             "blocks": new_blocks,
             "states": new_states,
             "head": block2_root,
-            "latest_known_aggregated_payloads": aggregated_payloads,
+            "attestation_pool": AttestationPool(known_proofs=aggregated_payloads),
         }
     )
 
@@ -118,7 +118,7 @@ def test_multiple_attestations_accumulate(base_store: Store) -> None:
             "blocks": new_blocks,
             "states": new_states,
             "head": block1_root,
-            "latest_known_aggregated_payloads": aggregated_payloads,
+            "attestation_pool": AttestationPool(known_proofs=aggregated_payloads),
         }
     )
 

--- a/tests/lean_spec/subspecs/forkchoice/test_store_attestations.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_store_attestations.py
@@ -14,7 +14,7 @@ from lean_spec.subspecs.containers.attestation import (
 from lean_spec.subspecs.containers.checkpoint import Checkpoint
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
-from lean_spec.subspecs.forkchoice import AttestationSignatureEntry
+from lean_spec.subspecs.forkchoice import AttestationPool, AttestationSignatureEntry
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.types import ByteListMiB, Bytes32, Uint64
@@ -43,9 +43,7 @@ def test_on_block_processes_multi_validator_aggregations(key_manager: XmssKeyMan
     aggregated_payloads = {attestation_data: {proof}}
 
     producer_store = base_store.model_copy(
-        update={
-            "latest_known_aggregated_payloads": aggregated_payloads,
-        }
+        update={"attestation_pool": AttestationPool(known_proofs=aggregated_payloads)}
     )
 
     proposer_index = ValidatorIndex(1)
@@ -57,7 +55,7 @@ def test_on_block_processes_multi_validator_aggregations(key_manager: XmssKeyMan
 
     # Verify attestations can be extracted from aggregated payloads
     extracted_attestations = updated_store.extract_attestations_from_aggregated_payloads(
-        updated_store.latest_known_aggregated_payloads
+        updated_store.attestation_pool.known_proofs
     )
     assert ValidatorIndex(1) in extracted_attestations
     assert ValidatorIndex(2) in extracted_attestations
@@ -87,9 +85,7 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
     }
 
     producer_store_1 = base_store.model_copy(
-        update={
-            "attestation_signatures": gossip_sigs_1,
-        }
+        update={"attestation_pool": AttestationPool(signatures=gossip_sigs_1)}
     )
 
     consumer_store_1, signed_block_1 = make_signed_block_from_store(
@@ -111,9 +107,7 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
     }
 
     producer_store_2 = store_after_block_1.model_copy(
-        update={
-            "attestation_signatures": gossip_sigs_2,
-        }
+        update={"attestation_pool": AttestationPool(signatures=gossip_sigs_2)}
     )
 
     store_before_block_2, signed_block_2 = make_signed_block_from_store(
@@ -122,7 +116,7 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
 
     # Capture the original list lengths for keys that already exist
     original_sig_lengths = {
-        k: len(v) for k, v in store_before_block_2.latest_new_aggregated_payloads.items()
+        k: len(v) for k, v in store_before_block_2.attestation_pool.new_proofs.items()
     }
 
     # Process the second block
@@ -130,7 +124,7 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
 
     # Verify immutability: the list lengths in store_before_block_2 should not have changed
     for key, original_length in original_sig_lengths.items():
-        current_length = len(store_before_block_2.latest_new_aggregated_payloads[key])
+        current_length = len(store_before_block_2.attestation_pool.new_proofs[key])
         assert current_length == original_length, (
             f"Immutability violated: list for key {key} grew from {original_length} to "
             f"{current_length}"
@@ -138,8 +132,8 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
 
     # Verify that the updated store has new keys (different attestation data in block 2)
     # The key point is that store_before_block_2 wasn't mutated
-    assert len(store_after_block_2.latest_new_aggregated_payloads) >= len(
-        store_before_block_2.latest_new_aggregated_payloads
+    assert len(store_after_block_2.attestation_pool.new_proofs) >= len(
+        store_before_block_2.attestation_pool.new_proofs
     )
 
 
@@ -168,13 +162,13 @@ class TestOnGossipAttestationImportGating:
             signature=key_manager.sign_attestation_data(attester_validator, attestation_data),
         )
 
-        assert attestation_data not in store.attestation_signatures, (
+        assert attestation_data not in store.attestation_pool.signatures, (
             "Precondition: no signatures before processing"
         )
 
         updated_store = store.on_gossip_attestation(signed_attestation, is_aggregator=True)
 
-        sigs = updated_store.attestation_signatures.get(attestation_data, set())
+        sigs = updated_store.attestation_pool.signatures.get(attestation_data, set())
         assert attester_validator in {entry.validator_id for entry in sigs}, (
             "Aggregator should store any attestation it receives"
         )
@@ -201,7 +195,7 @@ class TestOnGossipAttestationImportGating:
 
         stored_ids = {
             entry.validator_id
-            for entry in updated.attestation_signatures.get(attestation_data, set())
+            for entry in updated.attestation_pool.signatures.get(attestation_data, set())
         }
         assert stored_ids == set(attesters), (
             "Aggregator should store attestations from all received validators"
@@ -224,7 +218,7 @@ class TestOnGossipAttestationImportGating:
 
         updated_store = store.on_gossip_attestation(signed_attestation, is_aggregator=False)
 
-        sigs = updated_store.attestation_signatures.get(attestation_data, set())
+        sigs = updated_store.attestation_pool.signatures.get(attestation_data, set())
         assert attester_validator not in {entry.validator_id for entry in sigs}, (
             "Non-aggregator should never store gossip signatures"
         )
@@ -248,7 +242,7 @@ class TestOnGossipAttestationImportGating:
 
         updated_store = store.on_gossip_attestation(signed_attestation, is_aggregator=False)
 
-        assert attestation_data not in updated_store.attestation_signatures, (
+        assert attestation_data not in updated_store.attestation_pool.signatures, (
             "Non-aggregator should not create any attestation_signatures entry"
         )
 
@@ -300,10 +294,10 @@ class TestOnGossipAggregatedAttestation:
         updated_store = store.on_gossip_aggregated_attestation(signed_aggregated)
 
         # Verify proof is stored keyed by attestation data
-        assert attestation_data in updated_store.latest_new_aggregated_payloads, (
+        assert attestation_data in updated_store.attestation_pool.new_proofs, (
             "Proof should be stored for this attestation data"
         )
-        proofs = updated_store.latest_new_aggregated_payloads[attestation_data]
+        proofs = updated_store.attestation_pool.new_proofs[attestation_data]
         assert len(proofs) == 1
         assert proof in proofs
 
@@ -344,8 +338,8 @@ class TestOnGossipAggregatedAttestation:
 
         updated_store = store.on_gossip_aggregated_attestation(signed_aggregated)
 
-        assert attestation_data in updated_store.latest_new_aggregated_payloads
-        assert proof in updated_store.latest_new_aggregated_payloads[attestation_data]
+        assert attestation_data in updated_store.attestation_pool.new_proofs
+        assert proof in updated_store.attestation_pool.new_proofs[attestation_data]
 
     def test_invalid_proof_rejected(self, key_manager: XmssKeyManager) -> None:
         """
@@ -457,7 +451,7 @@ class TestOnGossipAggregatedAttestation:
         )
 
         # Both proofs should be stored under the same attestation data
-        stored_proofs = store.latest_new_aggregated_payloads[attestation_data]
+        stored_proofs = store.attestation_pool.new_proofs[attestation_data]
         assert len(stored_proofs) == 2
         assert proof_1 in stored_proofs, "First proof should be stored"
         assert proof_2 in stored_proofs, "Second proof should be stored"
@@ -495,10 +489,10 @@ class TestAggregateCommitteeSignatures:
         updated_store, _ = store.aggregate()
 
         # Verify proofs were created and stored keyed by attestation data
-        assert attestation_data in updated_store.latest_new_aggregated_payloads, (
+        assert attestation_data in updated_store.attestation_pool.new_proofs, (
             "Aggregated proof should be stored for this attestation data"
         )
-        proofs = updated_store.latest_new_aggregated_payloads[attestation_data]
+        proofs = updated_store.attestation_pool.new_proofs[attestation_data]
         assert len(proofs) >= 1, "At least one proof should exist"
 
     def test_aggregated_proof_is_valid(self, key_manager: XmssKeyManager) -> None:
@@ -519,7 +513,7 @@ class TestAggregateCommitteeSignatures:
 
         updated_store, _ = store.aggregate()
 
-        proofs = updated_store.latest_new_aggregated_payloads[attestation_data]
+        proofs = updated_store.attestation_pool.new_proofs[attestation_data]
         proof = next(iter(proofs))
 
         # Extract participants from the proof
@@ -551,7 +545,7 @@ class TestAggregateCommitteeSignatures:
         updated_store, _ = store.aggregate()
 
         # Verify no proofs were created
-        assert len(updated_store.latest_new_aggregated_payloads) == 0
+        assert len(updated_store.attestation_pool.new_proofs) == 0
 
     def test_multiple_attestation_data_grouped_separately(
         self, key_manager: XmssKeyManager
@@ -584,16 +578,14 @@ class TestAggregateCommitteeSignatures:
         }
 
         store = base_store.model_copy(
-            update={
-                "attestation_signatures": attestation_signatures,
-            }
+            update={"attestation_pool": AttestationPool(signatures=attestation_signatures)}
         )
 
         updated_store, _ = store.aggregate()
 
         # Verify both attestation data have separate proofs
-        assert att_data_1 in updated_store.latest_new_aggregated_payloads
-        assert att_data_2 in updated_store.latest_new_aggregated_payloads
+        assert att_data_1 in updated_store.attestation_pool.new_proofs
+        assert att_data_2 in updated_store.attestation_pool.new_proofs
 
 
 class TestTickIntervalAggregation:
@@ -631,7 +623,7 @@ class TestTickIntervalAggregation:
         updated_store, _ = store.tick_interval(has_proposal=False, is_aggregator=True)
 
         # Verify aggregation was performed
-        assert attestation_data in updated_store.latest_new_aggregated_payloads, (
+        assert attestation_data in updated_store.attestation_pool.new_proofs, (
             "Aggregation should occur at interval 2 for aggregators"
         )
 
@@ -659,7 +651,7 @@ class TestTickIntervalAggregation:
         updated_store, _ = store.tick_interval(has_proposal=False, is_aggregator=False)
 
         # Verify aggregation was NOT performed
-        assert attestation_data not in updated_store.latest_new_aggregated_payloads, (
+        assert attestation_data not in updated_store.attestation_pool.new_proofs, (
             "Aggregation should NOT occur for non-aggregators"
         )
 
@@ -691,7 +683,7 @@ class TestTickIntervalAggregation:
 
             updated_store, _ = test_store.tick_interval(has_proposal=False, is_aggregator=True)
 
-            assert attestation_data not in updated_store.latest_new_aggregated_payloads, (
+            assert attestation_data not in updated_store.attestation_pool.new_proofs, (
                 f"Aggregation should NOT occur at interval {target_interval}"
             )
 
@@ -764,7 +756,7 @@ class TestEndToEndAggregationFlow:
             )
 
         # Verify signatures were stored
-        sigs = store.attestation_signatures.get(attestation_data, set())
+        sigs = store.attestation_pool.signatures.get(attestation_data, set())
         stored_validators = {entry.validator_id for entry in sigs}
         for vid in attesting_validators:
             assert vid in stored_validators, f"Signature for {vid} should be stored"
@@ -774,12 +766,12 @@ class TestEndToEndAggregationFlow:
         store, _ = store.tick_interval(has_proposal=False, is_aggregator=True)
 
         # Step 3: Verify aggregated proofs were created
-        assert attestation_data in store.latest_new_aggregated_payloads, (
+        assert attestation_data in store.attestation_pool.new_proofs, (
             "Aggregated proofs should exist after interval 2"
         )
 
         # Step 4: Verify the proof is valid
-        proof = next(iter(store.latest_new_aggregated_payloads[attestation_data]))
+        proof = next(iter(store.attestation_pool.new_proofs[attestation_data]))
         participants = proof.participants.to_validator_indices()
         public_keys = [key_manager[vid].attestation_public for vid in participants]
 

--- a/tests/lean_spec/subspecs/forkchoice/test_store_pruning.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_store_pruning.py
@@ -2,7 +2,7 @@
 
 from lean_spec.subspecs.containers.slot import Slot
 from lean_spec.subspecs.containers.validator import ValidatorIndex, ValidatorIndices
-from lean_spec.subspecs.forkchoice import AttestationSignatureEntry, Store
+from lean_spec.subspecs.forkchoice import AttestationPool, AttestationSignatureEntry, Store
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.types import ByteListMiB, Bytes32
 from tests.lean_spec.helpers import (
@@ -29,22 +29,24 @@ def test_prunes_entries_with_target_at_finalized(pruning_store: Store) -> None:
     # Set up store with attestation data and finalized slot at 5
     store = store.model_copy(
         update={
-            "attestation_signatures": {
-                attestation_data: {
-                    AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+            "attestation_pool": AttestationPool(
+                signatures={
+                    attestation_data: {
+                        AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+                    },
                 },
-            },
+            ),
             "latest_finalized": make_checkpoint(root_seed=255, slot=5),
         }
     )
 
     # Verify data exists before pruning
-    assert attestation_data in store.attestation_signatures
+    assert attestation_data in store.attestation_pool.signatures
 
     # Prune should remove entries where target.slot <= finalized.slot
     pruned_store = store.prune_stale_attestation_data()
 
-    assert attestation_data not in pruned_store.attestation_signatures
+    assert attestation_data not in pruned_store.attestation_pool.signatures
 
 
 def test_prunes_entries_with_target_before_finalized(pruning_store: Store) -> None:
@@ -63,22 +65,24 @@ def test_prunes_entries_with_target_before_finalized(pruning_store: Store) -> No
     # Set up store with finalized slot at 5 (greater than target.slot)
     store = store.model_copy(
         update={
-            "attestation_signatures": {
-                attestation_data: {
-                    AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+            "attestation_pool": AttestationPool(
+                signatures={
+                    attestation_data: {
+                        AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+                    },
                 },
-            },
+            ),
             "latest_finalized": make_checkpoint(root_seed=255, slot=5),
         }
     )
 
     # Verify data exists before pruning
-    assert attestation_data in store.attestation_signatures
+    assert attestation_data in store.attestation_pool.signatures
 
     # Prune should remove entries where target.slot <= finalized.slot
     pruned_store = store.prune_stale_attestation_data()
 
-    assert attestation_data not in pruned_store.attestation_signatures
+    assert attestation_data not in pruned_store.attestation_pool.signatures
 
 
 def test_keeps_entries_with_target_after_finalized(pruning_store: Store) -> None:
@@ -97,22 +101,24 @@ def test_keeps_entries_with_target_after_finalized(pruning_store: Store) -> None
     # Set up store with finalized slot at 5 (less than target.slot)
     store = store.model_copy(
         update={
-            "attestation_signatures": {
-                attestation_data: {
-                    AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+            "attestation_pool": AttestationPool(
+                signatures={
+                    attestation_data: {
+                        AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+                    },
                 },
-            },
+            ),
             "latest_finalized": make_checkpoint(root_seed=255, slot=5),
         }
     )
 
     # Verify data exists before pruning
-    assert attestation_data in store.attestation_signatures
+    assert attestation_data in store.attestation_pool.signatures
 
     # Prune should keep entries where target.slot > finalized.slot
     pruned_store = store.prune_stale_attestation_data()
 
-    assert attestation_data in pruned_store.attestation_signatures
+    assert attestation_data in pruned_store.attestation_pool.signatures
 
 
 def test_prunes_related_structures_together(pruning_store: Store) -> None:
@@ -146,45 +152,47 @@ def test_prunes_related_structures_together(pruning_store: Store) -> None:
     # Set up store with both stale and fresh entries in all structures
     store = store.model_copy(
         update={
-            "attestation_signatures": {
-                stale_attestation: {
-                    AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+            "attestation_pool": AttestationPool(
+                signatures={
+                    stale_attestation: {
+                        AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+                    },
+                    fresh_attestation: {
+                        AttestationSignatureEntry(ValidatorIndex(2), make_mock_signature())
+                    },
                 },
-                fresh_attestation: {
-                    AttestationSignatureEntry(ValidatorIndex(2), make_mock_signature())
+                new_proofs={
+                    stale_attestation: {mock_proof},
+                    fresh_attestation: {mock_proof},
                 },
-            },
-            "latest_new_aggregated_payloads": {
-                stale_attestation: {mock_proof},
-                fresh_attestation: {mock_proof},
-            },
-            "latest_known_aggregated_payloads": {
-                stale_attestation: {mock_proof},
-                fresh_attestation: {mock_proof},
-            },
+                known_proofs={
+                    stale_attestation: {mock_proof},
+                    fresh_attestation: {mock_proof},
+                },
+            ),
             "latest_finalized": make_checkpoint(root_seed=255, slot=5),
         }
     )
 
     # Verify all data exists before pruning
-    assert stale_attestation in store.attestation_signatures
-    assert stale_attestation in store.latest_new_aggregated_payloads
-    assert stale_attestation in store.latest_known_aggregated_payloads
-    assert fresh_attestation in store.attestation_signatures
-    assert fresh_attestation in store.latest_new_aggregated_payloads
-    assert fresh_attestation in store.latest_known_aggregated_payloads
+    assert stale_attestation in store.attestation_pool.signatures
+    assert stale_attestation in store.attestation_pool.new_proofs
+    assert stale_attestation in store.attestation_pool.known_proofs
+    assert fresh_attestation in store.attestation_pool.signatures
+    assert fresh_attestation in store.attestation_pool.new_proofs
+    assert fresh_attestation in store.attestation_pool.known_proofs
 
     pruned_store = store.prune_stale_attestation_data()
 
     # Stale entries should be removed from all structures
-    assert stale_attestation not in pruned_store.attestation_signatures
-    assert stale_attestation not in pruned_store.latest_new_aggregated_payloads
-    assert stale_attestation not in pruned_store.latest_known_aggregated_payloads
+    assert stale_attestation not in pruned_store.attestation_pool.signatures
+    assert stale_attestation not in pruned_store.attestation_pool.new_proofs
+    assert stale_attestation not in pruned_store.attestation_pool.known_proofs
 
     # Fresh entries should be preserved in all structures
-    assert fresh_attestation in pruned_store.attestation_signatures
-    assert fresh_attestation in pruned_store.latest_new_aggregated_payloads
-    assert fresh_attestation in pruned_store.latest_known_aggregated_payloads
+    assert fresh_attestation in pruned_store.attestation_pool.signatures
+    assert fresh_attestation in pruned_store.attestation_pool.new_proofs
+    assert fresh_attestation in pruned_store.attestation_pool.known_proofs
 
 
 def test_handles_empty_attestation_signatures(pruning_store: Store) -> None:
@@ -192,12 +200,12 @@ def test_handles_empty_attestation_signatures(pruning_store: Store) -> None:
     store = pruning_store
 
     # Ensure store has empty gossip signatures
-    assert len(store.attestation_signatures) == 0
+    assert len(store.attestation_pool.signatures) == 0
 
     # Pruning should not fail
     pruned_store = store.prune_stale_attestation_data()
 
-    assert len(pruned_store.attestation_signatures) == 0
+    assert len(pruned_store.attestation_pool.signatures) == 0
 
 
 def test_prunes_multiple_validators_same_attestation_data(pruning_store: Store) -> None:
@@ -216,24 +224,26 @@ def test_prunes_multiple_validators_same_attestation_data(pruning_store: Store) 
     # Multiple validators signed the same attestation data
     store = store.model_copy(
         update={
-            "attestation_signatures": {
-                stale_attestation: {
-                    AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature()),
-                    AttestationSignatureEntry(ValidatorIndex(2), make_mock_signature()),
+            "attestation_pool": AttestationPool(
+                signatures={
+                    stale_attestation: {
+                        AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature()),
+                        AttestationSignatureEntry(ValidatorIndex(2), make_mock_signature()),
+                    },
                 },
-            },
+            ),
             "latest_finalized": make_checkpoint(root_seed=255, slot=5),
         }
     )
 
     # Verify data exists before pruning
-    assert stale_attestation in store.attestation_signatures
-    assert len(store.attestation_signatures[stale_attestation]) == 2
+    assert stale_attestation in store.attestation_pool.signatures
+    assert len(store.attestation_pool.signatures[stale_attestation]) == 2
 
     pruned_store = store.prune_stale_attestation_data()
 
     # All validators' signatures should be removed (whole entry pruned)
-    assert stale_attestation not in pruned_store.attestation_signatures
+    assert stale_attestation not in pruned_store.attestation_pool.signatures
 
 
 def test_mixed_stale_and_fresh_entries(pruning_store: Store) -> None:
@@ -260,21 +270,21 @@ def test_mixed_stale_and_fresh_entries(pruning_store: Store) -> None:
     # Finalized at slot 5 means slots 1-5 are stale, 6-10 are fresh
     store = store.model_copy(
         update={
-            "attestation_signatures": gossip_sigs,
+            "attestation_pool": AttestationPool(signatures=gossip_sigs),
             "latest_finalized": make_checkpoint(root_seed=255, slot=5),
         }
     )
 
     # Verify all data exists before pruning
     for att in attestations:
-        assert att in store.attestation_signatures
+        assert att in store.attestation_pool.signatures
 
     pruned_store = store.prune_stale_attestation_data()
 
     # Entries with target.slot <= 5 should be pruned (slots 1-5)
     for att in attestations[:5]:
-        assert att not in pruned_store.attestation_signatures
+        assert att not in pruned_store.attestation_pool.signatures
 
     # Entries with target.slot > 5 should be kept (slots 6-10)
     for att in attestations[5:]:
-        assert att in pruned_store.attestation_signatures
+        assert att in pruned_store.attestation_pool.signatures

--- a/tests/lean_spec/subspecs/forkchoice/test_time_management.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_time_management.py
@@ -153,14 +153,14 @@ class TestAttestationProcessingTiming:
         """Test basic new attestation processing moves aggregated payloads."""
         # The method now processes aggregated payloads, not attestations directly
         # Just verify the method runs without error
-        initial_known_payloads = len(sample_store.latest_known_aggregated_payloads)
+        initial_known_payloads = len(sample_store.attestation_pool.known_proofs)
 
         # Accept new attestations (which processes aggregated payloads)
         sample_store = sample_store.accept_new_attestations()
 
         # New payloads should move to known payloads
-        assert len(sample_store.latest_new_aggregated_payloads) == 0
-        assert len(sample_store.latest_known_aggregated_payloads) >= initial_known_payloads
+        assert len(sample_store.attestation_pool.new_proofs) == 0
+        assert len(sample_store.attestation_pool.known_proofs) >= initial_known_payloads
 
     def test_accept_new_attestations_multiple(self, sample_store: Store) -> None:
         """Test accepting multiple new aggregated payloads."""
@@ -169,18 +169,18 @@ class TestAttestationProcessingTiming:
         sample_store = sample_store.accept_new_attestations()
 
         # All new payloads should move to known payloads
-        assert len(sample_store.latest_new_aggregated_payloads) == 0
+        assert len(sample_store.attestation_pool.new_proofs) == 0
 
     def test_accept_new_attestations_empty(self, sample_store: Store) -> None:
         """Test accepting new attestations when there are none."""
-        initial_known_payloads = len(sample_store.latest_known_aggregated_payloads)
+        initial_known_payloads = len(sample_store.attestation_pool.known_proofs)
 
         # Accept attestations when there are no new payloads
         sample_store = sample_store.accept_new_attestations()
 
         # Should be no-op
-        assert len(sample_store.latest_new_aggregated_payloads) == 0
-        assert len(sample_store.latest_known_aggregated_payloads) == initial_known_payloads
+        assert len(sample_store.attestation_pool.new_proofs) == 0
+        assert len(sample_store.attestation_pool.known_proofs) == initial_known_payloads
 
 
 class TestProposalHeadTiming:
@@ -229,7 +229,7 @@ class TestProposalHeadTiming:
 
         # get_proposal_head should have called accept_new_attestations
         # which migrates new payloads to known payloads
-        assert len(store.latest_new_aggregated_payloads) == 0
+        assert len(store.attestation_pool.new_proofs) == 0
 
 
 class TestTimeConstants:

--- a/tests/lean_spec/subspecs/forkchoice/test_validator.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_validator.py
@@ -15,7 +15,7 @@ from lean_spec.subspecs.containers import (
     ValidatorIndex,
 )
 from lean_spec.subspecs.containers.slot import Slot
-from lean_spec.subspecs.forkchoice import AttestationSignatureEntry, Store
+from lean_spec.subspecs.forkchoice import AttestationPool, AttestationSignatureEntry, Store
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.types import Bytes32, Uint64
@@ -101,8 +101,10 @@ class TestBlockProduction:
 
         sample_store = sample_store.model_copy(
             update={
-                "latest_known_aggregated_payloads": known_payloads,
-                "attestation_signatures": gossip_sigs,
+                "attestation_pool": AttestationPool(
+                    signatures=gossip_sigs,
+                    known_proofs=known_payloads,
+                ),
             }
         )
 
@@ -178,11 +180,7 @@ class TestBlockProduction:
         validator_idx = ValidatorIndex(3)
 
         # Ensure no attestations in store (clear aggregated payloads)
-        sample_store = sample_store.model_copy(
-            update={
-                "latest_known_aggregated_payloads": {},
-            }
-        )
+        sample_store = sample_store.model_copy(update={"attestation_pool": AttestationPool()})
 
         store, block, _signatures = sample_store.produce_block_with_signatures(
             slot,
@@ -221,12 +219,14 @@ class TestBlockProduction:
 
         sample_store = sample_store.model_copy(
             update={
-                "latest_known_aggregated_payloads": {signed_7.data: {proof_7}},
-                "attestation_signatures": {
-                    signed_7.data: {
-                        AttestationSignatureEntry(ValidatorIndex(7), signed_7.signature)
+                "attestation_pool": AttestationPool(
+                    signatures={
+                        signed_7.data: {
+                            AttestationSignatureEntry(ValidatorIndex(7), signed_7.signature)
+                        },
                     },
-                },
+                    known_proofs={signed_7.data: {proof_7}},
+                ),
             }
         )
 

--- a/tests/lean_spec/subspecs/validator/test_service.py
+++ b/tests/lean_spec/subspecs/validator/test_service.py
@@ -18,7 +18,7 @@ from lean_spec.subspecs.containers import (
     ValidatorIndices,
 )
 from lean_spec.subspecs.containers.slot import Slot
-from lean_spec.subspecs.forkchoice import Store
+from lean_spec.subspecs.forkchoice import AttestationPool, Store
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.sync.block_cache import BlockCache
 from lean_spec.subspecs.sync.peer_manager import PeerManager
@@ -1130,7 +1130,9 @@ class TestValidatorServiceIntegration:
         )
 
         updated_store = store.model_copy(
-            update={"latest_known_aggregated_payloads": {attestation_data: {proof}}}
+            update={
+                "attestation_pool": AttestationPool(known_proofs={attestation_data: {proof}}),
+            }
         )
         real_sync_service.store = updated_store
 


### PR DESCRIPTION
## Summary

Three parallel dict fields lived directly on `Store`:

```python
attestation_signatures: dict[AttestationData, set[AttestationSignatureEntry]]
latest_new_aggregated_payloads: dict[AttestationData, set[AggregatedSignatureProof]]
latest_known_aggregated_payloads: dict[AttestationData, set[AggregatedSignatureProof]]
```

Each was deep-copied with `{k: set(v) for k, v in d.items()}` in five different `Store` methods. This PR collapses all three into a single immutable `AttestationPool` value object that owns the gossip → new → known lifecycle, and rewrites those five methods to delegate to pool methods.

**Net diff:** `store.py` shrinks by ~80 lines; one new module (`attestation_pool.py`); one new test file with 17 cases covering each pool method, including the edge cases flagged as test gaps during research (lone-child early-exit drop, gossip retention by data key).

## Pool API

| Method | Replaces | Why a method |
| --- | --- | --- |
| `prune_finalized(slot)` | `prune_stale_attestation_data` body | Encapsulates atomic three-stage prune at finalization advances |
| `add_signature(data, entry)` | `on_gossip_attestation` deep-copy block | Aggregator inbox arrival |
| `add_new_proof(data, proof)` | `on_gossip_aggregated_attestation` deep-copy block | Direct-to-new gossip arrival |
| `add_block_proofs(by_data)` | `on_block` body-attestation merge | Block-included proofs bypass the new stage |
| `migrate_new_to_known()` | `accept_new_attestations` merge step | Slot-rollover stage promotion |
| `replace_after_aggregation(new)` | `aggregate` end-of-method bookkeeping | Wholesale new-stage swap + consumed-signature drop |

Read paths stay direct: `aggregate`, `compute_block_weights`, `update_head`, `update_safe_target`, and `produce_block_with_signatures` access `pool.signatures`, `pool.new_proofs`, `pool.known_proofs` as plain attributes — every read site already knows which stage it cares about and the docstrings explain why (see e.g. the safe-target rationale).

## Field renames on the pool

- `attestation_signatures` → `signatures`
- `latest_new_aggregated_payloads` → `new_proofs`
- `latest_known_aggregated_payloads` → `known_proofs`

The `AttestationPool` prefix already conveys "attestation"; the `latest_` prefix was misleading (the maps don't store latest-vote-per-validator). No back-compat aliases — every call site is updated in this PR.

## Behavior preserved exactly

The design phase ran through both consensus-correctness and Pythonic-API reviews before any code was written. Specifically:

- **Pruning predicate** stays strict-greater (`target.slot > finalized_slot`); test boundaries verified.
- **Aggregation** still replaces the new pool wholesale (not a merge): pre-existing entries that did not produce a fresh proof this round still disappear (lone-child early-exit). Gossip retention predicate is keyed on data, not produced-proofs.
- **`on_block` ordering** preserved: persist + advance checkpoints → process body attestations → `update_head` → prune. Pruning runs on the post-update store as before.
- **`AttestationSignatureEntry`** stays a `NamedTuple` (must be hashable for sets) and moves to `attestation_pool.py` since it has no consumer outside the pool.

## Tests

- 17 new unit tests in `tests/lean_spec/subspecs/forkchoice/test_attestation_pool.py` covering each pool method, including the two edges flagged as gaps in the existing test suite during research:
  - `test_replace_after_aggregation_overwrites_new_pool` (lone-child entries drop)
  - `test_replace_after_aggregation_keeps_unconsumed_signatures` (gossip retention)
- Existing `tests/lean_spec/subspecs/forkchoice/` and `tests/consensus/devnet/fc/` test suites all still pass.
- 3178 total unit tests pass.

## Test plan

- [x] `uvx tox -e all-checks` (ruff, format, ty, codespell, mdformat)
- [x] `uv run pytest tests/lean_spec/subspecs/forkchoice/ tests/lean_spec/subspecs/containers/test_state_aggregation.py tests/lean_spec/subspecs/validator/test_service.py` — 150 passed
- [x] Full `uv run pytest tests/lean_spec --no-cov` — 3178 passed
- [ ] Reviewer to spot-check `replace_after_aggregation` semantics against the existing aggregator behavior
- [ ] Reviewer to spot-check that no test pierces the renamed fields with stale references

🤖 Generated with [Claude Code](https://claude.com/claude-code)