### PR TITLE
test: add fork choice and block production test vectors for non-zero finality and equivocation

### DIFF
--- a/tests/consensus/devnet/fc/test_attestation_target_selection.py
+++ b/tests/consensus/devnet/fc/test_attestation_target_selection.py
@@ -526,3 +526,143 @@ def test_attestation_target_walkback_bounded_by_lookback(
         for s in range(1, head + 1)
     ]
     fork_choice_test(steps=steps)
+
+
+def test_attestation_target_selection_after_finality_has_moved(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Attestation target selection respects a non-zero finalized boundary.
+
+    Scenario
+    --------
+    1. Justify block_1 in block_3
+    2. Process block_8 so slots 2 and 7 become justified and slot 1 becomes finalized
+    3. Extend the empty chain through block_11
+
+    Expected Behavior
+    -----------------
+    1. latest_justified_slot remains 7
+    2. latest_finalized_slot remains 1
+    3. safe_target settles on block_7
+    4. The attestation target also resolves to block_7
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), parent_label="block_1", label="block_2"),
+                checks=StoreChecks(head_slot=Slot(2)),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(3),
+                    parent_label="block_2",
+                    label="block_3",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[
+                                ValidatorIndex(0),
+                                ValidatorIndex(1),
+                                ValidatorIndex(2),
+                            ],
+                            slot=Slot(3),
+                            target_slot=Slot(1),
+                            target_root_label="block_1",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(3),
+                    latest_justified_slot=Slot(1),
+                    latest_finalized_slot=Slot(0),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(4), parent_label="block_3", label="block_4"),
+                checks=StoreChecks(head_slot=Slot(4)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(5), parent_label="block_4", label="block_5"),
+                checks=StoreChecks(head_slot=Slot(5)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(6), parent_label="block_5", label="block_6"),
+                checks=StoreChecks(head_slot=Slot(6)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(7), parent_label="block_6", label="block_7"),
+                checks=StoreChecks(head_slot=Slot(7)),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(8),
+                    parent_label="block_7",
+                    label="block_8",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[
+                                ValidatorIndex(0),
+                                ValidatorIndex(1),
+                                ValidatorIndex(2),
+                            ],
+                            slot=Slot(8),
+                            target_slot=Slot(2),
+                            target_root_label="block_2",
+                        ),
+                        AggregatedAttestationSpec(
+                            validator_ids=[
+                                ValidatorIndex(0),
+                                ValidatorIndex(1),
+                                ValidatorIndex(2),
+                            ],
+                            slot=Slot(8),
+                            target_slot=Slot(7),
+                            target_root_label="block_7",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(8),
+                    latest_justified_slot=Slot(7),
+                    latest_finalized_slot=Slot(1),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(9), parent_label="block_8", label="block_9"),
+                checks=StoreChecks(
+                    head_slot=Slot(9),
+                    latest_justified_slot=Slot(7),
+                    latest_finalized_slot=Slot(1),
+                    safe_target_slot=Slot(7),
+                    safe_target_root_label="block_7",
+                    attestation_target_slot=Slot(7),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(10), parent_label="block_9", label="block_10"),
+                checks=StoreChecks(
+                    head_slot=Slot(10),
+                    latest_justified_slot=Slot(7),
+                    latest_finalized_slot=Slot(1),
+                    safe_target_slot=Slot(7),
+                    safe_target_root_label="block_7",
+                    attestation_target_slot=Slot(7),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(11), parent_label="block_10", label="block_11"),
+                checks=StoreChecks(
+                    head_slot=Slot(11),
+                    latest_justified_slot=Slot(7),
+                    latest_finalized_slot=Slot(1),
+                    safe_target_slot=Slot(7),
+                    safe_target_root_label="block_7",
+                    attestation_target_slot=Slot(7),
+                ),
+            ),
+        ],
+    )

--- a/tests/consensus/devnet/fc/test_block_production.py
+++ b/tests/consensus/devnet/fc/test_block_production.py
@@ -417,3 +417,199 @@ def test_produce_block_includes_pending_attestations(
             ),
         ],
     )
+
+
+def test_block_builder_recovers_finality_after_non_zero_boundary_stall(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Block production recovers finality after the finalized slot has already moved.
+
+    Scenario
+    --------
+    1. Justify block_1 in block_3
+    2. Process block_8 so slots 2 and 7 become justified and slot 1 becomes finalized
+    3. Extend the chain through block_11
+    4. Gossip two aggregated attestations for slot 11:
+       one from block_7 to block_10, then one from block_10 to block_11
+    5. Produce block_12 without explicit attestation specs
+
+    Expected Behavior
+    -----------------
+    1. The builder first includes the block_7 to block_10 attestation
+    2. That attestation justifies slot 10 and finalizes slot 7
+    3. The re-iteration then includes the block_10 to block_11 attestation
+    4. The post-store head is block_12 at slot 12
+    5. latest_justified_slot is 11
+    6. latest_finalized_slot is 10
+    7. The block body contains exactly both aggregated attestations
+    """
+    aggregate_interval = 11 * int(INTERVALS_PER_SLOT) + 2
+    aggregate_time = math.ceil(aggregate_interval * int(MILLISECONDS_PER_INTERVAL) / 1000)
+    block_time = 12 * int(SECONDS_PER_SLOT)
+
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), parent_label="block_1", label="block_2"),
+                checks=StoreChecks(head_slot=Slot(2)),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(3),
+                    parent_label="block_2",
+                    label="block_3",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[
+                                ValidatorIndex(0),
+                                ValidatorIndex(1),
+                                ValidatorIndex(2),
+                            ],
+                            slot=Slot(3),
+                            target_slot=Slot(1),
+                            target_root_label="block_1",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(3),
+                    latest_justified_slot=Slot(1),
+                    latest_finalized_slot=Slot(0),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(4), parent_label="block_3", label="block_4"),
+                checks=StoreChecks(head_slot=Slot(4)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(5), parent_label="block_4", label="block_5"),
+                checks=StoreChecks(head_slot=Slot(5)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(6), parent_label="block_5", label="block_6"),
+                checks=StoreChecks(head_slot=Slot(6)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(7), parent_label="block_6", label="block_7"),
+                checks=StoreChecks(head_slot=Slot(7)),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(8),
+                    parent_label="block_7",
+                    label="block_8",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_ids=[
+                                ValidatorIndex(0),
+                                ValidatorIndex(1),
+                                ValidatorIndex(2),
+                            ],
+                            slot=Slot(8),
+                            target_slot=Slot(2),
+                            target_root_label="block_2",
+                        ),
+                        AggregatedAttestationSpec(
+                            validator_ids=[
+                                ValidatorIndex(0),
+                                ValidatorIndex(1),
+                                ValidatorIndex(2),
+                            ],
+                            slot=Slot(8),
+                            target_slot=Slot(7),
+                            target_root_label="block_7",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(8),
+                    latest_justified_slot=Slot(7),
+                    latest_justified_root_label="block_7",
+                    latest_finalized_slot=Slot(1),
+                    latest_finalized_root_label="block_1",
+                ),
+            ),
+            *[
+                BlockStep(
+                    block=BlockSpec(
+                        slot=Slot(n),
+                        parent_label=f"block_{n - 1}",
+                        label=f"block_{n}",
+                    ),
+                    checks=(StoreChecks(head_slot=Slot(n)) if n == 9 or n == 11 else None),
+                )
+                for n in range(9, 12)
+            ],
+            TickStep(time=aggregate_time),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[
+                        ValidatorIndex(0),
+                        ValidatorIndex(1),
+                        ValidatorIndex(2),
+                    ],
+                    slot=Slot(11),
+                    target_slot=Slot(10),
+                    target_root_label="block_10",
+                    source_root_label="block_7",
+                    source_slot=Slot(7),
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[
+                        ValidatorIndex(1),
+                        ValidatorIndex(2),
+                        ValidatorIndex(3),
+                    ],
+                    slot=Slot(11),
+                    target_slot=Slot(11),
+                    target_root_label="block_11",
+                    source_root_label="block_10",
+                    source_slot=Slot(10),
+                ),
+            ),
+            TickStep(
+                time=block_time,
+                checks=StoreChecks(
+                    latest_justified_slot=Slot(7),
+                    latest_finalized_slot=Slot(1),
+                    latest_known_aggregated_target_slots=[
+                        Slot(2),
+                        Slot(7),
+                        Slot(10),
+                        Slot(11),
+                    ],
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(12), parent_label="block_11", label="block_12"),
+                checks=StoreChecks(
+                    head_slot=Slot(12),
+                    head_root_label="block_12",
+                    latest_justified_slot=Slot(11),
+                    latest_justified_root_label="block_11",
+                    latest_finalized_slot=Slot(10),
+                    latest_finalized_root_label="block_10",
+                    block_attestation_count=2,
+                    block_attestations=[
+                        AggregatedAttestationCheck(
+                            participants={0, 1, 2},
+                            attestation_slot=Slot(11),
+                            target_slot=Slot(10),
+                        ),
+                        AggregatedAttestationCheck(
+                            participants={1, 2, 3},
+                            attestation_slot=Slot(11),
+                            target_slot=Slot(11),
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )

--- a/tests/consensus/devnet/fc/test_equivocation.py
+++ b/tests/consensus/devnet/fc/test_equivocation.py
@@ -7,6 +7,8 @@ from consensus_testing import (
     BlockSpec,
     BlockStep,
     ForkChoiceTestFiller,
+    GossipAggregatedAttestationSpec,
+    GossipAggregatedAttestationStep,
     GossipAttestationSpec,
     StoreChecks,
     TickStep,
@@ -246,6 +248,85 @@ def test_equivocating_proposer_with_split_attestations(
                 checks=StoreChecks(
                     head_slot=Slot(2),
                     head_root_label="fork_b",
+                ),
+            ),
+        ],
+    )
+
+
+def test_same_slot_equivocating_attesters_count_once(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Same-slot conflicting attestations from the same validators count once.
+
+    Scenario
+    --------
+    Eight validators. Two forks diverge from a common ancestor:
+
+    - fork_a receives slot-3 votes from validators 0, 1, and 2
+    - fork_b receives slot-3 votes from validators 0, 1, 3, and 4
+
+    Validators 0 and 1 equivocate by signing both fork votes at the same
+    attestation slot. Their later conflicting vote must not add weight to
+    fork_b while still counting for fork_a.
+
+    Expected Behavior
+    -----------------
+    1. fork_a has effective weight 3
+    2. fork_b has effective weight 2
+    3. Head stays on fork_a
+    4. No checkpoint is justified by the below-threshold votes
+    """
+    fork_choice_test(
+        anchor_state=generate_pre_state(num_validators=8),
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="common"),
+                checks=StoreChecks(head_slot=Slot(1), head_root_label="common"),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), parent_label="common", label="fork_a"),
+                checks=StoreChecks(head_slot=Slot(2), head_root_label="fork_a"),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(3), parent_label="common", label="fork_b"),
+                checks=StoreChecks(lexicographic_head_among=["fork_a", "fork_b"]),
+            ),
+            TickStep(interval=18),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[
+                        ValidatorIndex(0),
+                        ValidatorIndex(1),
+                        ValidatorIndex(2),
+                    ],
+                    slot=Slot(3),
+                    target_slot=Slot(2),
+                    target_root_label="fork_a",
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=GossipAggregatedAttestationSpec(
+                    validator_ids=[
+                        ValidatorIndex(0),
+                        ValidatorIndex(1),
+                        ValidatorIndex(3),
+                        ValidatorIndex(4),
+                    ],
+                    slot=Slot(3),
+                    target_slot=Slot(3),
+                    target_root_label="fork_b",
+                ),
+            ),
+            TickStep(
+                time=16,
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    head_root_label="fork_a",
+                    latest_justified_slot=Slot(0),
+                    latest_finalized_slot=Slot(0),
+                    latest_known_aggregated_target_slots=[Slot(2), Slot(3)],
                 ),
             ),
         ],


### PR DESCRIPTION
## 🗒️ Description

Add 3 new test vectors covering attestation target selection, block production, and equivocation handling. All tests use the `ForkChoiceTestFiller` pattern, generating JSON fixtures for client implementations.

**New tests**

| Test | Description |
|---|---|
| [`test_attestation_target_selection_after_finality_has_moved`](tests/consensus/devnet/fc/test_attestation_target_selection.py) | Verifies that attestation target selection uses the current finalized slot.<br><br>Once slot 1 is finalized and slot 7 is the latest justified block, the store should return block 7 as the attestation target at slots 9, 10, and 11.<br><br>If the walkback used genesis instead of the current finalized slot, the returned target could fall behind the latest justified block, and any vote using that target would be silently rejected during state transition. |
| [`test_block_builder_recovers_finality_after_non_zero_boundary_stall`](tests/consensus/devnet/fc/test_block_production.py) | Verifies that the block builder repeats its inclusion check after each accepted attestation, allowing finality to advance multiple steps within a single block.<br><br>Two supermajority aggregates arrive for slot 11, the first with `source = block 7` and `target = block 10`, the second with `source = block 10` and `target = block 11`. The second is only valid after the first is included, since block 10 becomes justified only once the first is processed.<br><br>Without this loop, only the first aggregate is included and finality stalls at slot 7 instead of advancing to slot 10. |
| [`test_same_slot_equivocating_attesters_count_once`](tests/consensus/devnet/fc/test_equivocation.py) | Verifies that equivocating validators are counted only once in fork choice.<br><br>Validators 0 and 1 sign attestations at slot 3 for both `fork_a` and `fork_b`. The store keeps only the first vote per validator when two attestations share a slot, so `fork_a` holds 3 votes and `fork_b` holds 2; the head stays on `fork_a`.<br><br>If this rule were relaxed and the later vote overwrote the first, `fork_b` would jump to 4 votes and become the head. Without it, equivocators could change their effective vote after observing the network's response, manipulating fork choice via gossip timing. |

**Spec lines covered per test:**

- `test_attestation_target_selection_after_finality_has_moved`: [forkchoice/store.py#L1184-L1204](src/lean_spec/subspecs/forkchoice/store.py#L1184-L1204), [containers/slot.py#L30-L75](src/lean_spec/subspecs/containers/slot.py#L30-L75)
- `test_block_builder_recovers_finality_after_non_zero_boundary_stall`: [state/state.py#L676-L727](src/lean_spec/subspecs/containers/state/state.py#L676-L727), [state/state.py#L425-L430](src/lean_spec/subspecs/containers/state/state.py#L425-L430), [state/state.py#L514-L523](src/lean_spec/subspecs/containers/state/state.py#L514-L523), [state/state.py#L539-L545](src/lean_spec/subspecs/containers/state/state.py#L539-L545), [forkchoice/store.py#L1299-L1347](src/lean_spec/subspecs/forkchoice/store.py#L1299-L1347)
- `test_same_slot_equivocating_attesters_count_once`: [forkchoice/store.py#L601-L609](src/lean_spec/subspecs/forkchoice/store.py#L601-L609), [forkchoice/store.py#L685-L727](src/lean_spec/subspecs/forkchoice/store.py#L685-L727)

## 🔗 Related Issues or PRs

N/A

## ✅ Checklist

- [X] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [X] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
