### PR TITLE
test(fc): tighten non-zero finality and equivocation test vectors

### DIFF
--- a/tests/consensus/devnet/fc/test_attestation_target_selection.py
+++ b/tests/consensus/devnet/fc/test_attestation_target_selection.py
@@ -631,6 +631,9 @@ def test_attestation_target_selection_after_finality_has_moved(
                     latest_finalized_slot=Slot(1),
                 ),
             ),
+            # First block after finality moves.
+            # Full check that the walkback respects the new finalized boundary
+            # instead of falling back to genesis.
             BlockStep(
                 block=BlockSpec(slot=Slot(9), parent_label="block_8", label="block_9"),
                 checks=StoreChecks(
@@ -642,14 +645,11 @@ def test_attestation_target_selection_after_finality_has_moved(
                     attestation_target_slot=Slot(7),
                 ),
             ),
+            # Target must stay pinned on block_7 as the head extends.
             BlockStep(
                 block=BlockSpec(slot=Slot(10), parent_label="block_9", label="block_10"),
                 checks=StoreChecks(
                     head_slot=Slot(10),
-                    latest_justified_slot=Slot(7),
-                    latest_finalized_slot=Slot(1),
-                    safe_target_slot=Slot(7),
-                    safe_target_root_label="block_7",
                     attestation_target_slot=Slot(7),
                 ),
             ),
@@ -657,10 +657,6 @@ def test_attestation_target_selection_after_finality_has_moved(
                 block=BlockSpec(slot=Slot(11), parent_label="block_10", label="block_11"),
                 checks=StoreChecks(
                     head_slot=Slot(11),
-                    latest_justified_slot=Slot(7),
-                    latest_finalized_slot=Slot(1),
-                    safe_target_slot=Slot(7),
-                    safe_target_root_label="block_7",
                     attestation_target_slot=Slot(7),
                 ),
             ),

--- a/tests/consensus/devnet/fc/test_block_production.py
+++ b/tests/consensus/devnet/fc/test_block_production.py
@@ -444,8 +444,12 @@ def test_block_builder_recovers_finality_after_non_zero_boundary_stall(
     6. latest_finalized_slot is 10
     7. The block body contains exactly both aggregated attestations
     """
+    # Slot 11, interval 2 (aggregate phase).
+    # Pool is empty here, so the trigger is a no-op.
     aggregate_interval = 11 * int(INTERVALS_PER_SLOT) + 2
     aggregate_time = math.ceil(aggregate_interval * int(MILLISECONDS_PER_INTERVAL) / 1000)
+    # Slot 12 boundary. Crosses slot 11, interval 4,
+    # which migrates aggregates from "new" to "known".
     block_time = 12 * int(SECONDS_PER_SLOT)
 
     fork_choice_test(
@@ -541,7 +545,7 @@ def test_block_builder_recovers_finality_after_non_zero_boundary_stall(
                         parent_label=f"block_{n - 1}",
                         label=f"block_{n}",
                     ),
-                    checks=(StoreChecks(head_slot=Slot(n)) if n == 9 or n == 11 else None),
+                    checks=StoreChecks(head_slot=Slot(n)),
                 )
                 for n in range(9, 12)
             ],

--- a/tests/consensus/devnet/fc/test_equivocation.py
+++ b/tests/consensus/devnet/fc/test_equivocation.py
@@ -3,6 +3,7 @@
 import pytest
 from consensus_testing import (
     AggregatedAttestationSpec,
+    AttestationCheck,
     AttestationStep,
     BlockSpec,
     BlockStep,
@@ -264,17 +265,17 @@ def test_same_slot_equivocating_attesters_count_once(
     --------
     Eight validators. Two forks diverge from a common ancestor:
 
-    - fork_a receives slot-3 votes from validators 0, 1, and 2
-    - fork_b receives slot-3 votes from validators 0, 1, 3, and 4
+    - fork_a (slot 2) receives slot-3 votes from V0, V1, V2
+    - fork_b (slot 3) receives slot-3 votes from V0, V1, V3, V4
 
-    Validators 0 and 1 equivocate by signing both fork votes at the same
-    attestation slot. Their later conflicting vote must not add weight to
-    fork_b while still counting for fork_a.
+    Both gossip aggregates carry attestation slot 3.
+    V0 and V1 equivocate by voting on both forks.
+    The later conflicting vote must not shift weight to fork_b.
 
     Expected Behavior
     -----------------
-    1. fork_a has effective weight 3
-    2. fork_b has effective weight 2
+    1. fork_a has effective weight 3 (V0, V1, V2)
+    2. fork_b has effective weight 2 (V3, V4)
     3. Head stays on fork_a
     4. No checkpoint is justified by the below-threshold votes
     """
@@ -293,7 +294,12 @@ def test_same_slot_equivocating_attesters_count_once(
                 block=BlockSpec(slot=Slot(3), parent_label="common", label="fork_b"),
                 checks=StoreChecks(lexicographic_head_among=["fork_a", "fork_b"]),
             ),
+            # Slot 3, interval 3 (aggregate phase).
+            # Pool is empty, so the trigger is a no-op.
             TickStep(interval=18),
+            # fork_a is gossiped first.
+            # Insertion-ordered dicts make this deterministic.
+            # V0 and V1's first votes stick on fork_a.
             GossipAggregatedAttestationStep(
                 attestation=GossipAggregatedAttestationSpec(
                     validator_ids=[
@@ -319,6 +325,8 @@ def test_same_slot_equivocating_attesters_count_once(
                     target_root_label="fork_b",
                 ),
             ),
+            # 16s = interval 20. Crosses interval 19 (slot 3, interval 4),
+            # which migrates aggregates from "new" to "known".
             TickStep(
                 time=16,
                 checks=StoreChecks(
@@ -327,6 +335,42 @@ def test_same_slot_equivocating_attesters_count_once(
                     latest_justified_slot=Slot(0),
                     latest_finalized_slot=Slot(0),
                     latest_known_aggregated_target_slots=[Slot(2), Slot(3)],
+                    # Per-validator votes pin down the first-vote-wins rule.
+                    # - V0, V1 equivocated;
+                    # - V2 only fork_a;
+                    # - V3, V4 only fork_b.
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(0),
+                            location="known",
+                            attestation_slot=Slot(3),
+                            target_slot=Slot(2),
+                        ),
+                        AttestationCheck(
+                            validator=ValidatorIndex(1),
+                            location="known",
+                            attestation_slot=Slot(3),
+                            target_slot=Slot(2),
+                        ),
+                        AttestationCheck(
+                            validator=ValidatorIndex(2),
+                            location="known",
+                            attestation_slot=Slot(3),
+                            target_slot=Slot(2),
+                        ),
+                        AttestationCheck(
+                            validator=ValidatorIndex(3),
+                            location="known",
+                            attestation_slot=Slot(3),
+                            target_slot=Slot(3),
+                        ),
+                        AttestationCheck(
+                            validator=ValidatorIndex(4),
+                            location="known",
+                            attestation_slot=Slot(3),
+                            target_slot=Slot(3),
+                        ),
+                    ],
                 ),
             ),
         ],


### PR DESCRIPTION
## 🗒️ Description

Follow-up to #690. Tightens the three new fork-choice test vectors so they pin down the spec behaviour they claim to verify, and trims redundant assertions.

### Equivocation test (`test_same_slot_equivocating_attesters_count_once`)

The previous version asserted only the head, justified slot, and finalized slot. Multiple non-equivalent buggy implementations would have passed (e.g. dropping equivocators from both forks, or keeping them on the wrong fork).

- Adds five `AttestationCheck` entries (one per voting validator) so the first-vote-wins rule is verified at the per-validator level: V0/V1 must show `target_slot=2` (fork_a, their first vote), V2 must show `target_slot=2`, V3/V4 must show `target_slot=3` (fork_b only).
- Documents the gossip ordering dependency (insertion-ordered dicts make fork_a-first deterministic).
- Documents the magic interval/time numbers (`interval=18` = slot 3 aggregate phase; `time=16s` crosses interval 19 = slot 3 interval 4 = new→known migration).
- Tightens the docstring (shorter sentences, scannable).

### Block production test (`test_block_builder_recovers_finality_after_non_zero_boundary_stall`)

- Removes the `n == 9 or n == 11 else None` skip in the block-9-to-11 extension loop. As written, a regression breaking head advancement only at slot 10 could pass undetected. Now every extension slot is checked.
- Adds inline comments documenting the `aggregate_interval` and `block_time` arithmetic (slot 11 interval 2 = aggregate phase; slot 12 boundary crosses slot 11 interval 4).

### Attestation target selection test (`test_attestation_target_selection_after_finality_has_moved`)

- Slot 9 keeps the full check (the moment of truth, immediately after finality moves) with a comment explaining why.
- Slots 10/11 trimmed to `head_slot` + `attestation_target_slot` only — once the target stabilises on block_7, repeating the same five-field check three times adds no spec coverage. A one-line comment captures the "stays pinned" intent.

## 🔗 Related Issues or PRs

Follow-up to #690.

## ✅ Checklist

- [X] Ran `uv run fill --fork=devnet --clean -n auto` on the three modified files (14 passed).
- [X] Ran `uvx tox -e all-checks` (clean).
- [X] No new tests added; existing tests strengthened in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)