### PR TITLE
refactor(forks): move fork-stable types to lean_spec.types (Stage 2 of #686)

### DIFF
--- a/packages/testing/src/consensus_testing/genesis.py
+++ b/packages/testing/src/consensus_testing/genesis.py
@@ -1,13 +1,12 @@
 """Consensus layer pre-state generation."""
 
 from lean_spec.forks.lstar.containers.block import AggregatedAttestations, Block, BlockBody
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import State, Validators
-from lean_spec.forks.lstar.containers.validator import Validator, ValidatorIndex
+from lean_spec.forks.lstar.containers.validator import Validator
 from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.forks.protocol import ForkProtocol
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes52, Uint64
+from lean_spec.types import Bytes52, Slot, Uint64, ValidatorIndex
 
 from .keys import XmssKeyManager
 

--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -40,12 +40,14 @@ from pathlib import Path
 from typing import ClassVar, Literal
 
 from lean_spec.config import LEAN_ENV
-from lean_spec.forks.lstar.containers import AttestationData, ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers import (
+    AttestationData,
+    ValidatorIndices,
+)
 from lean_spec.forks.lstar.containers.block.types import (
     AggregatedAttestations,
     AttestationSignatures,
 )
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.koalabear import Fp
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
@@ -62,7 +64,7 @@ from lean_spec.subspecs.xmss.types import (
     HashTreeOpening,
     Randomness,
 )
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 
 SecretField = Literal["attestation_secret", "proposal_secret"]
 """Discriminator for which secret key to load from a validator key pair."""

--- a/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
@@ -4,13 +4,13 @@ from collections.abc import Callable
 from typing import Any, ClassVar
 
 from lean_spec.forks.lstar import Store
-from lean_spec.forks.lstar.containers import BlockBody, Slot, ValidatorIndex
+from lean_spec.forks.lstar.containers import BlockBody
 from lean_spec.forks.lstar.containers.block import Block
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
 from lean_spec.forks.lstar.containers.state import State
 from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 
 from ..genesis import build_anchor, generate_pre_state
 from .base import BaseConsensusFixture

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -19,12 +19,10 @@ from lean_spec.forks.lstar.containers.block import (
 from lean_spec.forks.lstar.containers.block.types import (
     AggregatedAttestations,
 )
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import State, Validators
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.ssz import hash_tree_root
-from lean_spec.types import Uint64
+from lean_spec.types import Slot, Uint64, ValidatorIndex
 
 from ..keys import (
     LEAN_ENV_TO_SCHEMES,

--- a/packages/testing/src/consensus_testing/test_fixtures/justifiability.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/justifiability.py
@@ -13,7 +13,7 @@ Every client must implement this identically for consensus.
 
 from typing import Any, ClassVar
 
-from lean_spec.forks.lstar.containers.slot import Slot
+from lean_spec.types import Slot
 
 from .base import BaseConsensusFixture
 

--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -2,7 +2,6 @@
 
 from typing import Any, ClassVar
 
-from lean_spec.forks.lstar.containers.validator import SubnetId
 from lean_spec.snappy import compress, decompress, frame_compress, frame_decompress
 from lean_spec.subspecs.networking.discovery.codec import decode_message, encode_message
 from lean_spec.subspecs.networking.discovery.messages import (
@@ -56,7 +55,7 @@ from lean_spec.subspecs.networking.reqresp.codec import (
 from lean_spec.subspecs.networking.transport.peer_id import KeyType, PeerId, PublicKeyProto
 from lean_spec.subspecs.networking.types import NodeId, SeqNumber
 from lean_spec.subspecs.networking.varint import decode_varint, encode_varint
-from lean_spec.types import Bytes16, Bytes33, Bytes64
+from lean_spec.types import Bytes16, Bytes33, Bytes64, SubnetId
 
 from .base import BaseConsensusFixture
 

--- a/packages/testing/src/consensus_testing/test_fixtures/sync.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/sync.py
@@ -7,10 +7,9 @@ sync-layer decisions bit-for-bit.
 
 from typing import Any, ClassVar
 
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.sync.checkpoint_sync import verify_checkpoint_state
-from lean_spec.types import Uint64
+from lean_spec.types import Slot, Uint64
 
 from ..genesis import build_anchor, generate_pre_state
 from .base import BaseConsensusFixture

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -16,8 +16,7 @@ from lean_spec.forks.lstar.containers.block.types import (
     AttestationSignatures,
 )
 from lean_spec.forks.lstar.containers.state import State
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
-from lean_spec.types import Boolean
+from lean_spec.types import Boolean, ValidatorIndex
 
 from ..keys import XmssKeyManager
 from ..test_types import BlockSpec

--- a/packages/testing/src/consensus_testing/test_types/aggregated_attestation_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/aggregated_attestation_spec.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from lean_spec.forks.lstar.containers.attestation import AggregatedAttestation, AttestationData
 from lean_spec.forks.lstar.containers.block.block import Block
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import State
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
-from lean_spec.types import ByteListMiB, Bytes32, CamelModel
+from lean_spec.types import ByteListMiB, Bytes32, CamelModel, Checkpoint, Slot, ValidatorIndex
 
 from ..keys import XmssKeyManager
 from .utils import resolve_checkpoint

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -20,15 +20,14 @@ from lean_spec.forks.lstar.containers.block.types import (
     AggregatedAttestations,
     AttestationSignatures,
 )
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import State
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.forks.lstar.store import Store
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.subspecs.xmss.containers import Signature
-from lean_spec.types import Bytes32, CamelModel
+from lean_spec.types import Bytes32, CamelModel, Slot, ValidatorIndex
 
 from ..keys import LEAN_ENV_TO_SCHEMES, XmssKeyManager, create_dummy_signature
 from .aggregated_attestation_spec import AggregatedAttestationSpec

--- a/packages/testing/src/consensus_testing/test_types/gossip_aggregated_attestation_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/gossip_aggregated_attestation_spec.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from lean_spec.forks.lstar.containers.attestation import AttestationData
 from lean_spec.forks.lstar.containers.attestation.attestation import SignedAggregatedAttestation
 from lean_spec.forks.lstar.containers.block.block import Block
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import State
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
-from lean_spec.types import ByteListMiB, Bytes32, CamelModel
+from lean_spec.types import ByteListMiB, Bytes32, CamelModel, Checkpoint, Slot, ValidatorIndex
 
 from ..keys import XmssKeyManager
 from .utils import resolve_checkpoint

--- a/packages/testing/src/consensus_testing/test_types/gossip_attestation_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/gossip_attestation_spec.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 from lean_spec.forks.lstar.containers.attestation import AttestationData, SignedAttestation
 from lean_spec.forks.lstar.containers.block.block import Block
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.forks.lstar.store import Store
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, CamelModel
+from lean_spec.types import Bytes32, CamelModel, Checkpoint, Slot, ValidatorIndex
 
 from ..keys import XmssKeyManager, create_dummy_signature
 from .utils import resolve_checkpoint

--- a/packages/testing/src/consensus_testing/test_types/state_expectation.py
+++ b/packages/testing/src/consensus_testing/test_types/state_expectation.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from typing import Any, ClassVar
 
 from lean_spec.forks.lstar.containers.block.block import Block
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import State
 from lean_spec.forks.lstar.containers.state.types import (
     HistoricalBlockHashes,
@@ -12,7 +11,7 @@ from lean_spec.forks.lstar.containers.state.types import (
     JustificationValidators,
     JustifiedSlots,
 )
-from lean_spec.types import Bytes32, CamelModel
+from lean_spec.types import Bytes32, CamelModel, Slot
 
 from .utils import resolve_block_root
 

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -4,11 +4,9 @@ from typing import Literal
 
 from lean_spec.forks.lstar.containers import AttestationData
 from lean_spec.forks.lstar.containers.block.block import Block, BlockLookup
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.forks.lstar.store import Store
 from lean_spec.subspecs.ssz import hash_tree_root
-from lean_spec.types import ZERO_HASH, Bytes32, CamelModel, Uint64
+from lean_spec.types import ZERO_HASH, Bytes32, CamelModel, Slot, Uint64, ValidatorIndex
 
 from .utils import resolve_block_root
 

--- a/packages/testing/src/consensus_testing/test_types/utils.py
+++ b/packages/testing/src/consensus_testing/test_types/utils.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 from lean_spec.forks.lstar.containers.block.block import Block
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot
 
 
 def resolve_block_root(

--- a/src/lean_spec/__main__.py
+++ b/src/lean_spec/__main__.py
@@ -35,10 +35,11 @@ from pathlib import Path
 from typing import cast
 
 from lean_spec.forks import DEFAULT_REGISTRY, ForkProtocol, State, Store
-from lean_spec.forks.lstar.containers import Block, BlockBody, Checkpoint
+from lean_spec.forks.lstar.containers import (
+    Block,
+    BlockBody,
+)
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import SubnetId
 from lean_spec.subspecs.api import ApiServerConfig
 from lean_spec.subspecs.chain.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.subspecs.genesis import GenesisConfig
@@ -57,7 +58,7 @@ from lean_spec.subspecs.sync.checkpoint_sync import (
     verify_checkpoint_state,
 )
 from lean_spec.subspecs.validator import ValidatorRegistry
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Checkpoint, Slot, SubnetId, Uint64
 
 logger = logging.getLogger(__name__)
 

--- a/src/lean_spec/forks/lstar/containers/__init__.py
+++ b/src/lean_spec/forks/lstar/containers/__init__.py
@@ -22,10 +22,8 @@ from .block import (
     BlockHeader,
     SignedBlock,
 )
-from .checkpoint import Checkpoint
 from .config import Config
-from .slot import Slot
-from .validator import Validator, ValidatorIndex, ValidatorIndices
+from .validator import Validator, ValidatorIndices
 
 __all__ = [
     "AggregatedAttestation",
@@ -35,13 +33,10 @@ __all__ = [
     "Block",
     "BlockBody",
     "BlockHeader",
-    "Checkpoint",
     "Config",
     "SignedAggregatedAttestation",
     "SignedAttestation",
     "SignedBlock",
-    "Slot",
     "Validator",
-    "ValidatorIndex",
     "ValidatorIndices",
 ]

--- a/src/lean_spec/forks/lstar/containers/attestation/aggregation_bits.py
+++ b/src/lean_spec/forks/lstar/containers/attestation/aggregation_bits.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.chain.config import VALIDATOR_REGISTRY_LIMIT
+from lean_spec.types import ValidatorIndex
 from lean_spec.types.bitfields import BaseBitlist
 
 

--- a/src/lean_spec/forks/lstar/containers/attestation/attestation.py
+++ b/src/lean_spec/forks/lstar/containers/attestation/attestation.py
@@ -13,13 +13,10 @@ Attestations can be aggregated by common data to save space and bandwidth.
 
 from __future__ import annotations
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.subspecs.xmss.containers import Signature
-from lean_spec.types import Container
+from lean_spec.types import Checkpoint, Container, Slot, ValidatorIndex
 
-from ..checkpoint import Checkpoint
 from .aggregation_bits import AggregationBits
 
 

--- a/src/lean_spec/forks/lstar/containers/block/block.py
+++ b/src/lean_spec/forks/lstar/containers/block/block.py
@@ -6,13 +6,12 @@ Each references its parent, forming a chain.
 The proposer is determined by slot assignment.
 """
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, Validators
+from lean_spec.forks.lstar.containers.validator import Validators
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregationError
 from lean_spec.subspecs.xmss.containers import Signature
 from lean_spec.subspecs.xmss.interface import TARGET_SIGNATURE_SCHEME, GeneralizedXmssScheme
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 from lean_spec.types.container import Container
 
 from .types import (

--- a/src/lean_spec/forks/lstar/containers/state/state.py
+++ b/src/lean_spec/forks/lstar/containers/state/state.py
@@ -8,16 +8,14 @@ from collections.abc import Set as AbstractSet
 from lean_spec.forks.lstar.containers.attestation import AggregatedAttestation, AttestationData
 from lean_spec.forks.lstar.containers.block import Block, BlockBody, BlockHeader
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
 from lean_spec.forks.lstar.containers.config import Config
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state.types import (
     HistoricalBlockHashes,
     JustificationRoots,
     JustificationValidators,
     JustifiedSlots,
 )
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, Validators
+from lean_spec.forks.lstar.containers.validator import Validators
 from lean_spec.subspecs.chain.config import MAX_ATTESTATIONS_DATA
 from lean_spec.subspecs.observability import observe_state_transition
 from lean_spec.subspecs.ssz.hash import hash_tree_root
@@ -26,9 +24,12 @@ from lean_spec.types import (
     ZERO_HASH,
     Boolean,
     Bytes32,
+    Checkpoint,
     Container,
+    Slot,
     Uint8,
     Uint64,
+    ValidatorIndex,
 )
 
 

--- a/src/lean_spec/forks/lstar/containers/state/types.py
+++ b/src/lean_spec/forks/lstar/containers/state/types.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 from lean_spec.subspecs.chain.config import HISTORICAL_ROOTS_LIMIT, VALIDATOR_REGISTRY_LIMIT
-from lean_spec.types import Boolean, Bytes32, SSZList
+from lean_spec.types import Boolean, Bytes32, Slot, SSZList
 from lean_spec.types.bitfields import BaseBitlist
-
-from ..slot import Slot
 
 
 class HistoricalBlockHashes(SSZList[Bytes32]):

--- a/src/lean_spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/forks/lstar/containers/validator.py
@@ -5,40 +5,7 @@ from __future__ import annotations
 import lean_spec.forks.lstar.containers.attestation.aggregation_bits as _aggregation_bits
 from lean_spec.subspecs.chain.config import VALIDATOR_REGISTRY_LIMIT
 from lean_spec.subspecs.xmss.containers import PublicKey
-from lean_spec.types import Boolean, Bytes52, Container, SSZList, Uint64
-
-from .slot import Slot
-
-
-class SubnetId(Uint64):
-    """Subnet identifier (0-63) for attestation subnet partitioning."""
-
-
-class ValidatorIndex(Uint64):
-    """Represents a validator's unique index as a 64-bit unsigned integer."""
-
-    def is_proposer_for(self, slot: Slot, num_validators: Uint64) -> bool:
-        """
-        Check if this validator is the proposer for the given slot.
-
-        Uses round-robin proposer selection per the lean protocol spec.
-        """
-        return int(slot) % int(num_validators) == int(self)
-
-    def is_valid(self, num_validators: Uint64) -> bool:
-        """Check if this index is within valid bounds for a registry of given size."""
-        return int(self) < int(num_validators)
-
-    def compute_subnet_id(self, num_committees: Uint64) -> SubnetId:
-        """Compute the attestation subnet id for this validator.
-
-        Args:
-            num_committees: Positive number of committees.
-
-        Returns:
-            A SubnetId in 0..(num_committees-1).
-        """
-        return SubnetId(int(self) % int(num_committees))
+from lean_spec.types import Boolean, Bytes52, Container, SSZList, ValidatorIndex
 
 
 class ValidatorIndices(SSZList[ValidatorIndex]):

--- a/src/lean_spec/forks/lstar/store.py
+++ b/src/lean_spec/forks/lstar/store.py
@@ -12,15 +12,12 @@ from typing import NamedTuple
 from lean_spec.forks.lstar.containers import (
     AttestationData,
     Block,
-    Checkpoint,
     Config,
     SignedAttestation,
     SignedBlock,
-    ValidatorIndex,
 )
 from lean_spec.forks.lstar.containers.attestation.attestation import SignedAggregatedAttestation
 from lean_spec.forks.lstar.containers.block import BlockLookup
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import (
@@ -40,8 +37,11 @@ from lean_spec.subspecs.xmss.interface import TARGET_SIGNATURE_SCHEME, Generaliz
 from lean_spec.types import (
     ZERO_HASH,
     Bytes32,
+    Checkpoint,
+    Slot,
     Uint8,
     Uint64,
+    ValidatorIndex,
 )
 from lean_spec.types.base import StrictBaseModel
 

--- a/src/lean_spec/forks/protocol.py
+++ b/src/lean_spec/forks/protocol.py
@@ -7,7 +7,7 @@ This module is deliberately agnostic of any individual devnet.
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Protocol, Self
 
-from lean_spec.types import Bytes32, SSZList, Uint64
+from lean_spec.types import Bytes32, SSZList, Uint64, ValidatorIndex
 
 
 class SpecStateType(Protocol):
@@ -33,7 +33,7 @@ class SpecStoreType(Protocol):
         cls,
         state: SpecStateType,
         anchor_block: SpecBlockType,
-        validator_id: Uint64 | None,
+        validator_id: ValidatorIndex | None,
     ) -> Self:
         """Construct a forkchoice store anchored at the given state/block."""
         ...
@@ -81,7 +81,7 @@ class ForkProtocol(ABC):
         self,
         state: SpecStateType,
         anchor_block: SpecBlockType,
-        validator_id: Uint64 | None,
+        validator_id: ValidatorIndex | None,
     ) -> SpecStoreType:
         """Construct a forkchoice store anchored at the given state and block."""
         return self.store_class.from_anchor(state, anchor_block, validator_id)

--- a/src/lean_spec/subspecs/chain/clock.py
+++ b/src/lean_spec/subspecs/chain/clock.py
@@ -15,8 +15,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from time import time as wall_time
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.types import Uint64
+from lean_spec.types import Slot, Uint64
 
 from .config import (
     INTERVALS_PER_SLOT,

--- a/src/lean_spec/subspecs/genesis/config.py
+++ b/src/lean_spec/subspecs/genesis/config.py
@@ -22,8 +22,7 @@ from pydantic import Field, field_validator, model_validator
 
 from lean_spec.forks.lstar.containers import Validator
 from lean_spec.forks.lstar.containers.state import Validators
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
-from lean_spec.types import Bytes52, StrictBaseModel, Uint64
+from lean_spec.types import Bytes52, StrictBaseModel, Uint64, ValidatorIndex
 
 
 class GenesisValidatorEntry(StrictBaseModel):

--- a/src/lean_spec/subspecs/networking/client/reqresp_client.py
+++ b/src/lean_spec/subspecs/networking/client/reqresp_client.py
@@ -32,7 +32,7 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 
-from lean_spec.forks.lstar.containers import SignedBlock, Slot
+from lean_spec.forks.lstar.containers import SignedBlock
 from lean_spec.subspecs.networking.config import MAX_REQUEST_BLOCKS
 from lean_spec.subspecs.networking.reqresp.codec import (
     CodecError,
@@ -54,7 +54,7 @@ from lean_spec.subspecs.networking.transport.quic.connection import (
     QuicConnectionManager,
 )
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64
 
 logger = logging.getLogger(__name__)
 

--- a/src/lean_spec/subspecs/networking/enr/eth2.py
+++ b/src/lean_spec/subspecs/networking/enr/eth2.py
@@ -18,9 +18,8 @@ See: https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-in
 
 from typing import ClassVar, Final
 
-from lean_spec.forks.lstar.containers.validator import SubnetId
 from lean_spec.subspecs.networking.types import ForkDigest, Version
-from lean_spec.types import StrictBaseModel, Uint64
+from lean_spec.types import StrictBaseModel, SubnetId, Uint64
 from lean_spec.types.bitfields import BaseBitvector
 from lean_spec.types.boolean import Boolean
 

--- a/src/lean_spec/subspecs/networking/gossipsub/topic.py
+++ b/src/lean_spec/subspecs/networking/gossipsub/topic.py
@@ -62,8 +62,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Final
 
-from lean_spec.forks.lstar.containers.validator import SubnetId
 from lean_spec.subspecs.networking.gossipsub.types import TopicId
+from lean_spec.types import SubnetId
 
 
 class ForkMismatchError(ValueError):

--- a/src/lean_spec/subspecs/networking/reqresp/handler.py
+++ b/src/lean_spec/subspecs/networking/reqresp/handler.py
@@ -64,7 +64,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Final
 
-from lean_spec.forks.lstar.containers import SignedBlock, Slot
+from lean_spec.forks.lstar.containers import SignedBlock
 from lean_spec.snappy import SnappyDecompressionError, frame_decompress
 from lean_spec.subspecs.networking.config import (
     MAX_ERROR_MESSAGE_SIZE,
@@ -74,7 +74,7 @@ from lean_spec.subspecs.networking.config import (
 from lean_spec.subspecs.networking.transport.protocols import InboundStreamProtocol
 from lean_spec.subspecs.networking.types import ProtocolId
 from lean_spec.subspecs.networking.varint import VarintError, decode_varint
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64
 
 from .codec import ResponseCode
 from .message import (

--- a/src/lean_spec/subspecs/networking/reqresp/message.py
+++ b/src/lean_spec/subspecs/networking/reqresp/message.py
@@ -7,8 +7,7 @@ domain. All messages are SSZ-encoded and then compressed with Snappy frames.
 
 from typing import ClassVar, Final
 
-from lean_spec.forks.lstar.containers import Checkpoint, Slot
-from lean_spec.types import Bytes32, SSZList, Uint64
+from lean_spec.types import Bytes32, Checkpoint, Slot, SSZList, Uint64
 from lean_spec.types.container import Container
 
 from ..config import MAX_REQUEST_BLOCKS

--- a/src/lean_spec/subspecs/networking/service/service.py
+++ b/src/lean_spec/subspecs/networking/service/service.py
@@ -30,13 +30,13 @@ from lean_spec.forks.lstar.containers.attestation import (
     SignedAggregatedAttestation,
     SignedAttestation,
 )
-from lean_spec.forks.lstar.containers.validator import SubnetId
 from lean_spec.snappy import compress
 from lean_spec.subspecs.networking.client.event_source import EventSource
 from lean_spec.subspecs.networking.gossipsub.topic import GossipTopic
 from lean_spec.subspecs.networking.peer import PeerInfo
 from lean_spec.subspecs.networking.types import ConnectionState
 from lean_spec.subspecs.sync import SyncService
+from lean_spec.types import SubnetId
 
 from .events import (
     GossipAggregatedAttestationEvent,

--- a/src/lean_spec/subspecs/node/node.py
+++ b/src/lean_spec/subspecs/node/node.py
@@ -20,12 +20,14 @@ from pathlib import Path
 from typing import Final, cast
 
 from lean_spec.forks import ForkProtocol, State, Store
-from lean_spec.forks.lstar.containers import Block, BlockBody, SignedBlock
+from lean_spec.forks.lstar.containers import (
+    Block,
+    BlockBody,
+    SignedBlock,
+)
 from lean_spec.forks.lstar.containers.attestation import SignedAttestation
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import Validators
-from lean_spec.forks.lstar.containers.validator import SubnetId, ValidatorIndex
 from lean_spec.subspecs.api import AggregatorController, ApiServer, ApiServerConfig
 from lean_spec.subspecs.chain import SlotClock
 from lean_spec.subspecs.chain.clock import Interval
@@ -38,7 +40,7 @@ from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.storage import Database, SQLiteDatabase
 from lean_spec.subspecs.sync import BlockCache, NetworkRequester, PeerManager, SyncService
 from lean_spec.subspecs.validator import ValidatorRegistry, ValidatorService
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, SubnetId, Uint64, ValidatorIndex
 
 logger = logging.getLogger(__name__)
 

--- a/src/lean_spec/subspecs/storage/database.py
+++ b/src/lean_spec/subspecs/storage/database.py
@@ -12,11 +12,9 @@ from contextlib import contextmanager
 from typing import Protocol
 
 from lean_spec.forks import State
-from lean_spec.forks.lstar.containers import Block, Checkpoint
+from lean_spec.forks.lstar.containers import Block
 from lean_spec.forks.lstar.containers.attestation import AttestationData
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Checkpoint, Slot, Uint64, ValidatorIndex
 
 
 class Database(Protocol):

--- a/src/lean_spec/subspecs/storage/sqlite.py
+++ b/src/lean_spec/subspecs/storage/sqlite.py
@@ -24,10 +24,9 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from lean_spec.forks import State
-from lean_spec.forks.lstar.containers import Block, Checkpoint, ValidatorIndex
+from lean_spec.forks.lstar.containers import Block
 from lean_spec.forks.lstar.containers.attestation import AttestationData
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Checkpoint, Slot, Uint64, ValidatorIndex
 
 from .exceptions import StorageCorruptionError, StorageReadError, StorageWriteError
 from .namespaces import (

--- a/src/lean_spec/subspecs/sync/backfill_sync.py
+++ b/src/lean_spec/subspecs/sync/backfill_sync.py
@@ -42,10 +42,10 @@ import logging
 from dataclasses import dataclass, field
 from typing import Protocol
 
-from lean_spec.forks.lstar.containers import SignedBlock, Slot
+from lean_spec.forks.lstar.containers import SignedBlock
 from lean_spec.subspecs.networking.config import MAX_REQUEST_BLOCKS
 from lean_spec.subspecs.networking.transport.peer_id import PeerId
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64
 
 from .block_cache import BlockCache
 from .config import MAX_BACKFILL_DEPTH, MAX_BLOCKS_PER_REQUEST

--- a/src/lean_spec/subspecs/sync/block_cache.py
+++ b/src/lean_spec/subspecs/sync/block_cache.py
@@ -45,10 +45,9 @@ from time import time
 
 from lean_spec.forks import Store
 from lean_spec.forks.lstar.containers import SignedBlock
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.networking.transport.peer_id import PeerId
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Slot
 
 from .config import MAX_CACHED_BLOCKS
 

--- a/src/lean_spec/subspecs/sync/head_sync.py
+++ b/src/lean_spec/subspecs/sync/head_sync.py
@@ -49,10 +49,10 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from lean_spec.forks import Store
-from lean_spec.forks.lstar.containers import SignedBlock, Slot
+from lean_spec.forks.lstar.containers import SignedBlock
 from lean_spec.subspecs.networking.transport.peer_id import PeerId
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64
 
 from .backfill_sync import BackfillSync
 from .block_cache import BlockCache

--- a/src/lean_spec/subspecs/sync/peer_manager.py
+++ b/src/lean_spec/subspecs/sync/peer_manager.py
@@ -11,10 +11,10 @@ from collections import Counter
 from dataclasses import dataclass, field
 from typing import Final
 
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.networking.peer import PeerInfo
 from lean_spec.subspecs.networking.reqresp.message import Status
 from lean_spec.subspecs.networking.transport.peer_id import PeerId
+from lean_spec.types import Slot
 
 from .config import MAX_CONCURRENT_REQUESTS
 

--- a/src/lean_spec/subspecs/sync/service.py
+++ b/src/lean_spec/subspecs/sync/service.py
@@ -48,15 +48,13 @@ from lean_spec.forks.lstar.containers import (
     SignedBlock,
 )
 from lean_spec.forks.lstar.containers.block import BlockLookup
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import SubnetId
 from lean_spec.subspecs.chain.clock import SlotClock
 from lean_spec.subspecs.metrics import registry as metrics
 from lean_spec.subspecs.networking.reqresp.message import Status
 from lean_spec.subspecs.networking.transport.peer_id import PeerId
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.storage import Database
-from lean_spec.types import ZERO_HASH, Bytes32
+from lean_spec.types import ZERO_HASH, Bytes32, Slot, SubnetId
 
 from .backfill_sync import BackfillSync, NetworkRequester
 from .block_cache import BlockCache

--- a/src/lean_spec/subspecs/validator/registry.py
+++ b/src/lean_spec/subspecs/validator/registry.py
@@ -32,9 +32,9 @@ from pathlib import Path
 import yaml
 from pydantic import BaseModel, field_validator
 
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.xmss import SecretKey
-from lean_spec.types import Bytes52
+from lean_spec.types import Bytes52, ValidatorIndex
 
 logger = logging.getLogger(__name__)
 

--- a/src/lean_spec/subspecs/validator/service.py
+++ b/src/lean_spec/subspecs/validator/service.py
@@ -42,20 +42,18 @@ from lean_spec.forks.lstar.containers import (
     Block,
     SignedAttestation,
     SignedBlock,
-    ValidatorIndex,
 )
 from lean_spec.forks.lstar.containers.block import (
     AttestationSignatures,
     BlockSignatures,
 )
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.chain.clock import Interval, SlotClock
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.sync import SyncService
 from lean_spec.subspecs.xmss import TARGET_SIGNATURE_SCHEME
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.subspecs.xmss.containers import Signature
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 
 from .registry import ValidatorEntry, ValidatorRegistry
 

--- a/src/lean_spec/subspecs/xmss/aggregation.py
+++ b/src/lean_spec/subspecs/xmss/aggregation.py
@@ -14,9 +14,8 @@ from lean_multisig_py import (
 
 from lean_spec.config import LEAN_ENV, LeanEnvMode
 from lean_spec.forks.lstar.containers.attestation import AggregationBits
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
-from lean_spec.types import ByteListMiB, Bytes32, Container
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
+from lean_spec.types import ByteListMiB, Bytes32, Container, Slot, ValidatorIndex
 
 from .containers import PublicKey, Signature
 

--- a/src/lean_spec/subspecs/xmss/containers.py
+++ b/src/lean_spec/subspecs/xmss/containers.py
@@ -12,7 +12,7 @@ from typing import NamedTuple, override
 
 from pydantic import model_serializer
 
-from lean_spec.forks.lstar.containers.slot import Slot
+from lean_spec.types import Slot
 
 from ...types import Uint64
 from ...types.container import Container

--- a/src/lean_spec/subspecs/xmss/interface.py
+++ b/src/lean_spec/subspecs/xmss/interface.py
@@ -11,13 +11,12 @@ from __future__ import annotations
 from pydantic import model_validator
 
 from lean_spec.config import LEAN_ENV
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.xmss.target_sum import (
     PROD_TARGET_SUM_ENCODER,
     TEST_TARGET_SUM_ENCODER,
     TargetSumEncoder,
 )
-from lean_spec.types import Bytes32, StrictBaseModel, Uint64
+from lean_spec.types import Bytes32, Slot, StrictBaseModel, Uint64
 
 from ._validation import enforce_strict_types
 from .constants import (

--- a/src/lean_spec/types/__init__.py
+++ b/src/lean_spec/types/__init__.py
@@ -19,6 +19,7 @@ from .byte_arrays import (
     Bytes64,
     Bytes65,
 )
+from .checkpoint import Checkpoint
 from .collections import SSZList, SSZVector
 from .container import Container
 from .exceptions import (
@@ -28,9 +29,11 @@ from .exceptions import (
     SSZValueError,
 )
 from .rlp import RLPDecodingError, RLPItem, decode_rlp, decode_rlp_list, encode_rlp
+from .slot import IMMEDIATE_JUSTIFICATION_WINDOW, Slot
 from .ssz_base import SSZType
 from .uint import Uint8, Uint16, Uint32, Uint64
 from .union import SSZUnion
+from .validator import SubnetId, ValidatorIndex
 
 __all__ = [
     # Core types
@@ -62,6 +65,12 @@ __all__ = [
     "SSZUnion",
     "Boolean",
     "Container",
+    # Domain types — fork-stable
+    "Checkpoint",
+    "IMMEDIATE_JUSTIFICATION_WINDOW",
+    "Slot",
+    "SubnetId",
+    "ValidatorIndex",
     # RLP encoding/decoding
     "encode_rlp",
     "decode_rlp",

--- a/src/lean_spec/types/checkpoint.py
+++ b/src/lean_spec/types/checkpoint.py
@@ -6,9 +6,9 @@ identifier with a slot number. Checkpoints are used for justification and
 finalization.
 """
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.types import Bytes32
+from lean_spec.types.byte_arrays import Bytes32
 from lean_spec.types.container import Container
+from lean_spec.types.slot import Slot
 
 
 class Checkpoint(Container):

--- a/src/lean_spec/types/slot.py
+++ b/src/lean_spec/types/slot.py
@@ -1,11 +1,15 @@
-"""Slot container."""
+"""Slot type — fork-stable consensus-time index.
 
-from __future__ import annotations
+A slot is the smallest unit of consensus time. The numeric type and the
+justifiability rule are stable across the leanSpec fork chain; later forks
+that change the rule should override the relevant fork-class methods rather
+than fork the type itself.
+"""
 
 import math
 from typing import Final
 
-from lean_spec.types import Uint64
+from lean_spec.types.uint import Uint64
 
 IMMEDIATE_JUSTIFICATION_WINDOW: Final = 5
 """First N slots after finalization are always justifiable."""
@@ -14,7 +18,7 @@ IMMEDIATE_JUSTIFICATION_WINDOW: Final = 5
 class Slot(Uint64):
     """Represents a slot number as a 64-bit unsigned integer."""
 
-    def justified_index_after(self, finalized_slot: Slot) -> int | None:
+    def justified_index_after(self, finalized_slot: "Slot") -> int | None:
         """
         Return the relative bitfield index for justification tracking.
 
@@ -27,7 +31,7 @@ class Slot(Uint64):
         # Slot (finalized_slot + 1) maps to index 0.
         return int(self - finalized_slot) - 1
 
-    def is_justifiable_after(self, finalized_slot: Slot) -> bool:
+    def is_justifiable_after(self, finalized_slot: "Slot") -> bool:
         """
         Checks if this slot is a valid candidate for justification after a given finalized slot.
 

--- a/src/lean_spec/types/validator.py
+++ b/src/lean_spec/types/validator.py
@@ -1,0 +1,40 @@
+"""Validator-side scalar types — fork-stable.
+
+Defines the integer-keyed validator identifier and the networking subnet id.
+The XMSS-bound `Validator` container itself stays in the fork package because
+its key shape is signature-scheme specific.
+"""
+
+from lean_spec.types.slot import Slot
+from lean_spec.types.uint import Uint64
+
+
+class SubnetId(Uint64):
+    """Subnet identifier (0-63) for attestation subnet partitioning."""
+
+
+class ValidatorIndex(Uint64):
+    """Represents a validator's unique index as a 64-bit unsigned integer."""
+
+    def is_proposer_for(self, slot: Slot, num_validators: Uint64) -> bool:
+        """
+        Check if this validator is the proposer for the given slot.
+
+        Uses round-robin proposer selection per the lean protocol spec.
+        """
+        return int(slot) % int(num_validators) == int(self)
+
+    def is_valid(self, num_validators: Uint64) -> bool:
+        """Check if this index is within valid bounds for a registry of given size."""
+        return int(self) < int(num_validators)
+
+    def compute_subnet_id(self, num_committees: Uint64) -> SubnetId:
+        """Compute the attestation subnet id for this validator.
+
+        Args:
+            num_committees: Positive number of committees.
+
+        Returns:
+            A SubnetId in 0..(num_committees-1).
+        """
+        return SubnetId(int(self) % int(num_committees))

--- a/tests/consensus/devnet/fc/test_attestation_source_divergence.py
+++ b/tests/consensus/devnet/fc/test_attestation_source_divergence.py
@@ -10,8 +10,7 @@ from consensus_testing import (
     StoreChecks,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_attestation_target_selection.py
+++ b/tests/consensus/devnet/fc/test_attestation_target_selection.py
@@ -9,9 +9,8 @@ from consensus_testing import (
     StoreChecks,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.chain.config import JUSTIFICATION_LOOKBACK_SLOTS
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_block_attestation_limits.py
+++ b/tests/consensus/devnet/fc/test_block_attestation_limits.py
@@ -12,9 +12,8 @@ from consensus_testing import (
 )
 from consensus_testing.keys import XmssKeyManager
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.chain.config import MAX_ATTESTATIONS_DATA
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_block_production.py
+++ b/tests/consensus/devnet/fc/test_block_production.py
@@ -16,14 +16,13 @@ from consensus_testing import (
     TickStep,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.chain.config import (
     INTERVALS_PER_SLOT,
     MAX_ATTESTATIONS_DATA,
     MILLISECONDS_PER_INTERVAL,
     SECONDS_PER_SLOT,
 )
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_checkpoint_sync.py
+++ b/tests/consensus/devnet/fc/test_checkpoint_sync.py
@@ -11,11 +11,9 @@ from consensus_testing import (
     build_anchor,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.chain.config import INTERVALS_PER_SLOT, SECONDS_PER_SLOT
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Devnet")
 

--- a/tests/consensus/devnet/fc/test_duplicate_attestation_data.py
+++ b/tests/consensus/devnet/fc/test_duplicate_attestation_data.py
@@ -9,8 +9,7 @@ from consensus_testing import (
     StoreChecks,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Devnet")
 

--- a/tests/consensus/devnet/fc/test_equivocation.py
+++ b/tests/consensus/devnet/fc/test_equivocation.py
@@ -16,8 +16,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_finalization_mid_processing.py
+++ b/tests/consensus/devnet/fc/test_finalization_mid_processing.py
@@ -15,8 +15,7 @@ from consensus_testing import (
     StoreChecks,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_fork_choice_head.py
+++ b/tests/consensus/devnet/fc/test_fork_choice_head.py
@@ -10,8 +10,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_fork_choice_reorgs.py
+++ b/tests/consensus/devnet/fc/test_fork_choice_reorgs.py
@@ -10,8 +10,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_gossip_aggregated_attestation_validation.py
+++ b/tests/consensus/devnet/fc/test_gossip_aggregated_attestation_validation.py
@@ -11,11 +11,9 @@ from consensus_testing import (
     TickStep,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import GOSSIP_DISPARITY_INTERVALS
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_gossip_attestation_validation.py
+++ b/tests/consensus/devnet/fc/test_gossip_attestation_validation.py
@@ -11,11 +11,9 @@ from consensus_testing import (
     TickStep,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import GOSSIP_DISPARITY_INTERVALS
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_lexicographic_tiebreaker.py
+++ b/tests/consensus/devnet/fc/test_lexicographic_tiebreaker.py
@@ -13,7 +13,7 @@ from consensus_testing import (
     StoreChecks,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
+from lean_spec.types import Slot
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_safe_target.py
+++ b/tests/consensus/devnet/fc/test_safe_target.py
@@ -14,8 +14,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_signature_aggregation.py
+++ b/tests/consensus/devnet/fc/test_signature_aggregation.py
@@ -10,8 +10,7 @@ from consensus_testing import (
     StoreChecks,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_store_pruning.py
+++ b/tests/consensus/devnet/fc/test_store_pruning.py
@@ -16,8 +16,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/fc/test_tick_system.py
+++ b/tests/consensus/devnet/fc/test_tick_system.py
@@ -12,9 +12,7 @@ from consensus_testing import (
     TickStep,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
-from lean_spec.types import Uint64
+from lean_spec.types import Slot, Uint64, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/ssz/test_consensus_containers.py
+++ b/tests/consensus/devnet/ssz/test_consensus_containers.py
@@ -12,14 +12,11 @@ from lean_spec.forks.lstar.containers import (
     Block,
     BlockBody,
     BlockHeader,
-    Checkpoint,
     Config,
     SignedAggregatedAttestation,
     SignedAttestation,
     SignedBlock,
-    Slot,
     Validator,
-    ValidatorIndex,
 )
 from lean_spec.forks.lstar.containers.attestation import AggregationBits
 from lean_spec.forks.lstar.containers.block import BlockSignatures
@@ -35,7 +32,16 @@ from lean_spec.forks.lstar.containers.state.types import (
 )
 from lean_spec.forks.lstar.containers.validator import Validators
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
-from lean_spec.types import Boolean, ByteListMiB, Bytes32, Bytes52, Uint64
+from lean_spec.types import (
+    Boolean,
+    ByteListMiB,
+    Bytes32,
+    Bytes52,
+    Checkpoint,
+    Slot,
+    Uint64,
+    ValidatorIndex,
+)
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/ssz/test_networking_containers.py
+++ b/tests/consensus/devnet/ssz/test_networking_containers.py
@@ -3,13 +3,12 @@
 import pytest
 from consensus_testing import SSZTestFiller
 
-from lean_spec.forks.lstar.containers import Checkpoint, Slot
 from lean_spec.subspecs.networking.reqresp.message import (
     BlocksByRootRequest,
     RequestedBlockRoots,
     Status,
 )
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/ssz/test_xmss_containers.py
+++ b/tests/consensus/devnet/ssz/test_xmss_containers.py
@@ -4,9 +4,7 @@ import pytest
 from consensus_testing import SSZTestFiller
 from consensus_testing.keys import XmssKeyManager, create_dummy_signature
 
-from lean_spec.forks.lstar.containers import ValidatorIndex
 from lean_spec.forks.lstar.containers.attestation import AggregationBits
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.koalabear import Fp
 from lean_spec.subspecs.xmss import PublicKey
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
@@ -18,7 +16,7 @@ from lean_spec.subspecs.xmss.types import (
     HashTreeOpening,
     Parameter,
 )
-from lean_spec.types import Boolean, ByteListMiB, Bytes32, Uint64
+from lean_spec.types import Boolean, ByteListMiB, Bytes32, Slot, Uint64, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/state_transition/test_block_processing.py
+++ b/tests/consensus/devnet/state_transition/test_block_processing.py
@@ -8,10 +8,8 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state.types import JustifiedSlots
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
-from lean_spec.types import Boolean, Bytes32
+from lean_spec.types import Boolean, Bytes32, Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/state_transition/test_finalization.py
+++ b/tests/consensus/devnet/state_transition/test_finalization.py
@@ -9,15 +9,13 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state.types import (
     JustificationRoots,
     JustificationValidators,
     JustifiedSlots,
 )
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Boolean
+from lean_spec.types import Boolean, Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/state_transition/test_genesis.py
+++ b/tests/consensus/devnet/state_transition/test_genesis.py
@@ -18,16 +18,14 @@ from consensus_testing import (
 
 from lean_spec.forks.lstar.containers.block import BlockBody
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state.types import (
     HistoricalBlockHashes,
     JustificationRoots,
     JustificationValidators,
     JustifiedSlots,
 )
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/state_transition/test_justification.py
+++ b/tests/consensus/devnet/state_transition/test_justification.py
@@ -9,14 +9,12 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state.types import (
     JustificationRoots,
     JustificationValidators,
     JustifiedSlots,
 )
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
-from lean_spec.types import ZERO_HASH, Boolean, Bytes32
+from lean_spec.types import ZERO_HASH, Boolean, Bytes32, Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/state_transition/test_slot_monotonicity.py
+++ b/tests/consensus/devnet/state_transition/test_slot_monotonicity.py
@@ -7,7 +7,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
+from lean_spec.types import Slot
 
 pytestmark = pytest.mark.valid_until("Devnet")
 

--- a/tests/consensus/devnet/verify_signatures/test_empty_aggregation_bits.py
+++ b/tests/consensus/devnet/verify_signatures/test_empty_aggregation_bits.py
@@ -8,8 +8,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Devnet")
 

--- a/tests/consensus/devnet/verify_signatures/test_index_out_of_range.py
+++ b/tests/consensus/devnet/verify_signatures/test_index_out_of_range.py
@@ -8,8 +8,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Devnet")
 

--- a/tests/consensus/devnet/verify_signatures/test_invalid_signatures.py
+++ b/tests/consensus/devnet/verify_signatures/test_invalid_signatures.py
@@ -8,8 +8,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/devnet/verify_signatures/test_proposer_index_bounds.py
+++ b/tests/consensus/devnet/verify_signatures/test_proposer_index_bounds.py
@@ -7,7 +7,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
+from lean_spec.types import Slot
 
 pytestmark = pytest.mark.valid_until("Devnet")
 

--- a/tests/consensus/devnet/verify_signatures/test_structural_rejections.py
+++ b/tests/consensus/devnet/verify_signatures/test_structural_rejections.py
@@ -14,8 +14,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Devnet")
 

--- a/tests/consensus/devnet/verify_signatures/test_valid_signatures.py
+++ b/tests/consensus/devnet/verify_signatures/test_valid_signatures.py
@@ -8,8 +8,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/interop/helpers/node_runner.py
+++ b/tests/interop/helpers/node_runner.py
@@ -13,10 +13,8 @@ from dataclasses import dataclass, field
 from typing import cast
 
 from lean_spec.forks.lstar import Store
-from lean_spec.forks.lstar.containers import Checkpoint, Validator
-from lean_spec.forks.lstar.containers.slot import Slot
+from lean_spec.forks.lstar.containers import Validator
 from lean_spec.forks.lstar.containers.state import Validators
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.chain.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.subspecs.networking import PeerId
@@ -29,7 +27,7 @@ from lean_spec.subspecs.node import Node, NodeConfig
 from lean_spec.subspecs.validator import ValidatorRegistry
 from lean_spec.subspecs.validator.registry import ValidatorEntry
 from lean_spec.subspecs.xmss import TARGET_SIGNATURE_SCHEME, SecretKey
-from lean_spec.types import Bytes52, Uint64
+from lean_spec.types import Bytes52, Checkpoint, Slot, Uint64, ValidatorIndex
 
 from .diagnostics import PipelineDiagnostics
 from .port_allocator import PortAllocator

--- a/tests/interop/test_consensus_lifecycle.py
+++ b/tests/interop/test_consensus_lifecycle.py
@@ -19,7 +19,7 @@ import logging
 
 import pytest
 
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import ValidatorIndex
 
 from .helpers import (
     NodeCluster,

--- a/tests/lean_spec/conftest.py
+++ b/tests/lean_spec/conftest.py
@@ -14,8 +14,7 @@ from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.forks.lstar import State, Store
 from lean_spec.forks.lstar.containers import Block
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import Slot, ValidatorIndex
 from tests.lean_spec.helpers import (
     GenesisData,
     make_genesis_block,

--- a/tests/lean_spec/forks/test_fork_protocol.py
+++ b/tests/lean_spec/forks/test_fork_protocol.py
@@ -14,9 +14,8 @@ from lean_spec.forks import (
     protocol,
 )
 from lean_spec.forks.lstar.containers.block import Block
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import State
-from lean_spec.types import Uint64
+from lean_spec.types import Slot, Uint64
 from tests.lean_spec.helpers.builders import make_validators
 
 

--- a/tests/lean_spec/helpers/__init__.py
+++ b/tests/lean_spec/helpers/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.types import ValidatorIndex
 
 from .builders import (
     GenesisData,

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -16,7 +16,6 @@ from lean_spec.forks.lstar.containers import (
     AttestationData,
     Block,
     BlockBody,
-    Checkpoint,
     SignedAttestation,
     SignedBlock,
     Validator,
@@ -30,9 +29,8 @@ from lean_spec.forks.lstar.containers.block.types import (
     AggregatedAttestations,
     AttestationSignatures,
 )
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import Validators
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.chain.clock import Interval, SlotClock
 from lean_spec.subspecs.koalabear import Fp
 from lean_spec.subspecs.networking import PeerId
@@ -53,7 +51,7 @@ from lean_spec.subspecs.xmss.types import (
     HashTreeOpening,
     Randomness,
 )
-from lean_spec.types import Bytes32, Bytes52, Uint64
+from lean_spec.types import Bytes32, Bytes52, Checkpoint, Slot, Uint64, ValidatorIndex
 
 from .mocks import MockForkchoiceStore, MockNetworkRequester
 

--- a/tests/lean_spec/helpers/mocks.py
+++ b/tests/lean_spec/helpers/mocks.py
@@ -14,11 +14,10 @@ from types import MappingProxyType
 from lean_spec.forks.lstar.containers import SignedBlock
 from lean_spec.forks.lstar.containers.attestation import SignedAttestation
 from lean_spec.forks.lstar.containers.attestation.attestation import SignedAggregatedAttestation
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.networking.service.events import NetworkEvent
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64
 
 
 class MockNetworkRequester:

--- a/tests/lean_spec/subspecs/chain/test_clock.py
+++ b/tests/lean_spec/subspecs/chain/test_clock.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 
-from lean_spec.forks.lstar.containers import Slot
 from lean_spec.subspecs.chain import Interval, SlotClock
 from lean_spec.subspecs.chain.config import (
     INTERVALS_PER_SLOT,
@@ -12,7 +11,7 @@ from lean_spec.subspecs.chain.config import (
     MILLISECONDS_PER_SLOT,
     SECONDS_PER_SLOT,
 )
-from lean_spec.types import Uint64
+from lean_spec.types import Slot, Uint64
 
 GENESIS_TIME = Uint64(1_700_000_000)
 

--- a/tests/lean_spec/subspecs/chain/test_service.py
+++ b/tests/lean_spec/subspecs/chain/test_service.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from unittest.mock import patch
 
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.chain import SlotClock
 from lean_spec.subspecs.chain.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.subspecs.chain.service import ChainService
-from lean_spec.types import ZERO_HASH, Bytes32, Uint64
+from lean_spec.types import ZERO_HASH, Bytes32, Slot, Uint64
 
 
 @dataclass

--- a/tests/lean_spec/subspecs/containers/conftest.py
+++ b/tests/lean_spec/subspecs/containers/conftest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from consensus_testing.keys import XmssKeyManager
 
-from lean_spec.forks.lstar.containers.slot import Slot
+from lean_spec.types import Slot
 
 
 @pytest.fixture

--- a/tests/lean_spec/subspecs/containers/test_attestation_aggregation.py
+++ b/tests/lean_spec/subspecs/containers/test_attestation_aggregation.py
@@ -7,10 +7,8 @@ from lean_spec.forks.lstar.containers.attestation import (
     AggregationBits,
     AttestationData,
 )
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
-from lean_spec.types import Boolean, Bytes32
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
+from lean_spec.types import Boolean, Bytes32, Checkpoint, Slot, ValidatorIndex
 
 
 class TestAggregationBits:

--- a/tests/lean_spec/subspecs/containers/test_checkpoint.py
+++ b/tests/lean_spec/subspecs/containers/test_checkpoint.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot
 
 # Two distinct roots to verify ordering ignores root content.
 ROOT_A = Bytes32(b"\xa0" * 32)

--- a/tests/lean_spec/subspecs/containers/test_state_aggregation.py
+++ b/tests/lean_spec/subspecs/containers/test_state_aggregation.py
@@ -8,11 +8,9 @@ from lean_spec.forks.lstar import AttestationSignatureEntry
 from lean_spec.forks.lstar.containers.attestation import AttestationData
 from lean_spec.forks.lstar.containers.block import Block, BlockBody
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers import (
     make_aggregated_proof,
     make_attestation_data_simple,

--- a/tests/lean_spec/subspecs/containers/test_state_justified_slots.py
+++ b/tests/lean_spec/subspecs/containers/test_state_justified_slots.py
@@ -9,14 +9,11 @@ from __future__ import annotations
 
 import pytest
 
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state.types import (
     JustificationRoots,
     JustificationValidators,
 )
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
-from lean_spec.types import Boolean
+from lean_spec.types import Boolean, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers import make_aggregated_attestation, make_block, make_genesis_state
 
 

--- a/tests/lean_spec/subspecs/containers/test_state_process_attestations.py
+++ b/tests/lean_spec/subspecs/containers/test_state_process_attestations.py
@@ -43,14 +43,12 @@ from lean_spec.forks.lstar.containers.attestation import (
     AggregatedAttestation,
     AttestationData,
 )
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state.types import (
     HistoricalBlockHashes,
     JustifiedSlots,
 )
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
-from lean_spec.types import Boolean
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
+from lean_spec.types import Boolean, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers import make_bytes32, make_genesis_state
 
 

--- a/tests/lean_spec/subspecs/forkchoice/test_attestation_target.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_attestation_target.py
@@ -9,18 +9,15 @@ from lean_spec.forks.lstar import Store
 from lean_spec.forks.lstar.containers import (
     Attestation,
     AttestationData,
-    Checkpoint,
     SignedBlock,
 )
 from lean_spec.forks.lstar.containers.attestation import SignedAttestation
 from lean_spec.forks.lstar.containers.block import BlockSignatures
 from lean_spec.forks.lstar.containers.block.types import AttestationSignatures
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import JUSTIFICATION_LOOKBACK_SLOTS
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers import make_store
 
 

--- a/tests/lean_spec/subspecs/forkchoice/test_compute_block_weights.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_compute_block_weights.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from lean_spec.forks.lstar import Store
 from lean_spec.forks.lstar.containers.attestation import AttestationData
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
+from lean_spec.types import Checkpoint, Slot, ValidatorIndex
 from lean_spec.types.byte_arrays import ByteListMiB
 from tests.lean_spec.helpers import make_bytes32, make_signed_block
 

--- a/tests/lean_spec/subspecs/forkchoice/test_store_attestations.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_store_attestations.py
@@ -11,14 +11,12 @@ from lean_spec.forks.lstar.containers.attestation import (
     SignedAggregatedAttestation,
     SignedAttestation,
 )
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import INTERVALS_PER_SLOT
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
-from lean_spec.types import ByteListMiB, Bytes32, Uint64
+from lean_spec.types import ByteListMiB, Bytes32, Checkpoint, Slot, Uint64, ValidatorIndex
 from tests.lean_spec.helpers import (
     TEST_VALIDATOR_ID,
     make_aggregated_proof,

--- a/tests/lean_spec/subspecs/forkchoice/test_store_pruning.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_store_pruning.py
@@ -1,10 +1,9 @@
 """Tests for Store attestation data pruning."""
 
 from lean_spec.forks.lstar import AttestationSignatureEntry, Store
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
-from lean_spec.types import ByteListMiB, Bytes32
+from lean_spec.types import ByteListMiB, Bytes32, Slot, ValidatorIndex
 from tests.lean_spec.helpers import (
     make_attestation_data,
     make_bytes32,

--- a/tests/lean_spec/subspecs/forkchoice/test_time_management.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_time_management.py
@@ -5,9 +5,7 @@ from hypothesis import strategies as st
 
 from lean_spec.forks.lstar import State, Store
 from lean_spec.forks.lstar.containers import Block
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import Validators
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import (
     INTERVALS_PER_SLOT,
@@ -16,7 +14,7 @@ from lean_spec.subspecs.chain.config import (
     SECONDS_PER_SLOT,
 )
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 from tests.lean_spec.helpers import TEST_VALIDATOR_ID, make_empty_block_body
 
 

--- a/tests/lean_spec/subspecs/forkchoice/test_validate_attestation.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_validate_attestation.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import pytest
 
 from lean_spec.forks.lstar import Store
-from lean_spec.forks.lstar.containers import Attestation, AttestationData, Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
+from lean_spec.forks.lstar.containers import (
+    Attestation,
+    AttestationData,
+)
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import GOSSIP_DISPARITY_INTERVALS, INTERVALS_PER_SLOT
 from lean_spec.subspecs.ssz.hash import hash_tree_root
+from lean_spec.types import Checkpoint, Slot, ValidatorIndex
 
 # Slot used by every time-check case below.
 ATTESTATION_SLOT = Slot(2)

--- a/tests/lean_spec/subspecs/forkchoice/test_validator.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_validator.py
@@ -9,16 +9,13 @@ from lean_spec.forks.lstar.containers import (
     AttestationData,
     Block,
     BlockBody,
-    Checkpoint,
     Config,
     SignedAttestation,
-    ValidatorIndex,
 )
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Checkpoint, Slot, Uint64, ValidatorIndex
 from tests.lean_spec.helpers import TEST_VALIDATOR_ID, make_aggregated_proof, make_store
 
 

--- a/tests/lean_spec/subspecs/genesis/test_state.py
+++ b/tests/lean_spec/subspecs/genesis/test_state.py
@@ -2,11 +2,10 @@
 
 from lean_spec.forks.lstar.containers.block import Block, BlockBody
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import State, Validators
-from lean_spec.forks.lstar.containers.validator import Validator, ValidatorIndex
+from lean_spec.forks.lstar.containers.validator import Validator
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Bytes52, Uint64
+from lean_spec.types import Bytes32, Bytes52, Slot, Uint64, ValidatorIndex
 
 
 def test_genesis_block_hash_comparison() -> None:

--- a/tests/lean_spec/subspecs/networking/client/test_event_source.py
+++ b/tests/lean_spec/subspecs/networking/client/test_event_source.py
@@ -9,9 +9,6 @@ import pytest
 
 from lean_spec.forks.lstar.containers import SignedBlock
 from lean_spec.forks.lstar.containers.attestation import SignedAttestation
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.snappy import compress
 from lean_spec.subspecs.networking.client.event_source import (
     SUPPORTED_PROTOCOLS,
@@ -41,7 +38,7 @@ from lean_spec.subspecs.networking.transport.quic.connection import (
     QuicConnectionManager,
 )
 from lean_spec.subspecs.networking.varint import encode_varint
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers.builders import make_signed_attestation, make_signed_block
 
 FORK_DIGEST = "0xaabbccdd"

--- a/tests/lean_spec/subspecs/networking/client/test_gossip_reception.py
+++ b/tests/lean_spec/subspecs/networking/client/test_gossip_reception.py
@@ -17,9 +17,6 @@ import pytest
 
 from lean_spec.forks.lstar.containers import SignedBlock
 from lean_spec.forks.lstar.containers.attestation import SignedAttestation
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.snappy import compress, decompress
 from lean_spec.subspecs.networking.client.event_source import (
     GossipHandler,
@@ -33,7 +30,7 @@ from lean_spec.subspecs.networking.gossipsub.topic import (
     TopicKind,
 )
 from lean_spec.subspecs.networking.varint import encode_varint
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers.builders import make_signed_attestation, make_signed_block
 
 

--- a/tests/lean_spec/subspecs/networking/client/test_reqresp_client.py
+++ b/tests/lean_spec/subspecs/networking/client/test_reqresp_client.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 
-from lean_spec.forks.lstar.containers import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.networking.client.reqresp_client import (
     REQUEST_TIMEOUT_SECONDS,
     ReqRespClient,
@@ -21,7 +19,7 @@ from lean_spec.subspecs.networking.reqresp.message import (
     Status,
 )
 from lean_spec.subspecs.networking.transport import PeerId
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot
 from tests.lean_spec.helpers import make_test_block, make_test_status
 
 

--- a/tests/lean_spec/subspecs/networking/client/test_reqresp_client_range.py
+++ b/tests/lean_spec/subspecs/networking/client/test_reqresp_client_range.py
@@ -7,14 +7,16 @@ from dataclasses import dataclass, field
 
 import pytest
 
-from lean_spec.forks.lstar.containers import Block, BlockBody, SignedBlock
+from lean_spec.forks.lstar.containers import (
+    Block,
+    BlockBody,
+    SignedBlock,
+)
 from lean_spec.forks.lstar.containers.block import BlockSignatures
 from lean_spec.forks.lstar.containers.block.types import (
     AggregatedAttestations,
     AttestationSignatures,
 )
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.networking.client.reqresp_client import ReqRespClient
 from lean_spec.subspecs.networking.config import MAX_REQUEST_BLOCKS
 from lean_spec.subspecs.networking.reqresp.codec import (
@@ -26,7 +28,7 @@ from lean_spec.subspecs.networking.reqresp.message import (
 )
 from lean_spec.subspecs.networking.transport import PeerId
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 from tests.lean_spec.helpers import make_mock_signature
 
 

--- a/tests/lean_spec/subspecs/networking/enr/test_eth2.py
+++ b/tests/lean_spec/subspecs/networking/enr/test_eth2.py
@@ -3,7 +3,6 @@
 import pytest
 from pydantic import ValidationError
 
-from lean_spec.forks.lstar.containers.validator import SubnetId
 from lean_spec.subspecs.networking.enr import Eth2Data
 from lean_spec.subspecs.networking.enr.eth2 import (
     FAR_FUTURE_EPOCH,
@@ -11,7 +10,7 @@ from lean_spec.subspecs.networking.enr.eth2 import (
     SyncCommitteeSubnets,
 )
 from lean_spec.subspecs.networking.types import ForkDigest, Version
-from lean_spec.types import Uint64
+from lean_spec.types import SubnetId, Uint64
 
 
 class TestEth2Data:

--- a/tests/lean_spec/subspecs/networking/gossipsub/test_gossipsub.py
+++ b/tests/lean_spec/subspecs/networking/gossipsub/test_gossipsub.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from lean_spec.forks.lstar.containers.validator import SubnetId
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.networking.client.event_source import GossipHandler
 from lean_spec.subspecs.networking.gossipsub import (
@@ -25,6 +24,7 @@ from lean_spec.subspecs.networking.gossipsub.rpc import (
     SubOpts,
 )
 from lean_spec.subspecs.networking.gossipsub.types import TopicId
+from lean_spec.types import SubnetId
 
 
 def peer(name: str) -> PeerId:

--- a/tests/lean_spec/subspecs/networking/reqresp/test_handler.py
+++ b/tests/lean_spec/subspecs/networking/reqresp/test_handler.py
@@ -8,8 +8,7 @@ from typing import Final
 
 import pytest
 
-from lean_spec.forks.lstar.containers import Checkpoint, SignedBlock
-from lean_spec.forks.lstar.containers.slot import Slot
+from lean_spec.forks.lstar.containers import SignedBlock
 from lean_spec.subspecs.networking.config import MAX_ERROR_MESSAGE_SIZE, MAX_REQUEST_BLOCKS
 from lean_spec.subspecs.networking.reqresp.codec import (
     ResponseCode,
@@ -34,7 +33,7 @@ from lean_spec.subspecs.networking.reqresp.message import (
 from lean_spec.subspecs.networking.types import ProtocolId
 from lean_spec.subspecs.networking.varint import encode_varint
 from lean_spec.subspecs.ssz import hash_tree_root
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Checkpoint, Slot, Uint64
 from lean_spec.types.exceptions import SSZSerializationError
 from tests.lean_spec.helpers import make_test_block, make_test_status
 

--- a/tests/lean_spec/subspecs/networking/service/test_service.py
+++ b/tests/lean_spec/subspecs/networking/service/test_service.py
@@ -6,13 +6,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from lean_spec.forks.lstar.containers import (
-    AttestationData,
-    Checkpoint,
-)
+from lean_spec.forks.lstar.containers import AttestationData
 from lean_spec.forks.lstar.containers.attestation import SignedAttestation
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import SubnetId, ValidatorIndex
 from lean_spec.snappy import compress
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.networking.gossipsub.topic import GossipTopic
@@ -29,7 +24,7 @@ from lean_spec.subspecs.networking.service.events import (
     PeerStatusEvent,
 )
 from lean_spec.subspecs.networking.types import ConnectionState
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot, SubnetId, ValidatorIndex
 from tests.lean_spec.helpers import (
     MockEventSource,
     create_mock_sync_service,

--- a/tests/lean_spec/subspecs/networking/test_network_service.py
+++ b/tests/lean_spec/subspecs/networking/test_network_service.py
@@ -6,13 +6,8 @@ from typing import cast
 
 import pytest
 
-from lean_spec.forks.lstar.containers import (
-    AttestationData,
-    Checkpoint,
-)
+from lean_spec.forks.lstar.containers import AttestationData
 from lean_spec.forks.lstar.containers.attestation import SignedAttestation
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.networking.gossipsub.topic import GossipTopic, TopicKind
 from lean_spec.subspecs.networking.reqresp.message import Status
@@ -25,7 +20,7 @@ from lean_spec.subspecs.networking.service import (
 )
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.sync.states import SyncState
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Checkpoint, Slot, Uint64, ValidatorIndex
 from tests.lean_spec.helpers import (
     MockEventSource,
     MockForkchoiceStore,

--- a/tests/lean_spec/subspecs/networking/test_peer.py
+++ b/tests/lean_spec/subspecs/networking/test_peer.py
@@ -2,8 +2,6 @@
 
 import time
 
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.networking.enr import ENR
 from lean_spec.subspecs.networking.enr.eth2 import FAR_FUTURE_EPOCH
@@ -11,7 +9,7 @@ from lean_spec.subspecs.networking.enr.keys import EnrKey
 from lean_spec.subspecs.networking.peer import PeerInfo
 from lean_spec.subspecs.networking.reqresp import Status
 from lean_spec.subspecs.networking.types import ConnectionState, Direction, Multiaddr, SeqNumber
-from lean_spec.types import Bytes32, Bytes64
+from lean_spec.types import Bytes32, Bytes64, Checkpoint, Slot
 
 
 def peer(name: str) -> PeerId:

--- a/tests/lean_spec/subspecs/node/test_node.py
+++ b/tests/lean_spec/subspecs/node/test_node.py
@@ -17,9 +17,7 @@ from lean_spec.forks.lstar.containers import (
 )
 from lean_spec.forks.lstar.containers.block import BlockHeader
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
 from lean_spec.forks.lstar.containers.config import Config
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import Validators
 from lean_spec.forks.lstar.containers.state.types import (
     HistoricalBlockHashes,
@@ -27,7 +25,6 @@ from lean_spec.forks.lstar.containers.state.types import (
     JustificationValidators,
     JustifiedSlots,
 )
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.api import ApiServerConfig
 from lean_spec.subspecs.chain.config import (
@@ -40,7 +37,7 @@ from lean_spec.subspecs.node import Node, NodeConfig
 from lean_spec.subspecs.storage.sqlite import SQLiteDatabase
 from lean_spec.subspecs.validator import ValidatorRegistry
 from lean_spec.subspecs.validator.registry import ValidatorEntry
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Checkpoint, Slot, Uint64, ValidatorIndex
 from tests.lean_spec.helpers import MockEventSource, MockNetworkRequester, make_validators
 
 GENESIS_TIME = Uint64(1704067200)

--- a/tests/lean_spec/subspecs/ssz/test_block.py
+++ b/tests/lean_spec/subspecs/ssz/test_block.py
@@ -8,9 +8,7 @@ from lean_spec.forks.lstar.containers.block.types import (
     AggregatedAttestations,
     AttestationSignatures,
 )
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Slot, ValidatorIndex
 from tests.lean_spec.helpers.builders import make_mock_signature
 
 

--- a/tests/lean_spec/subspecs/ssz/test_signed_attestation.py
+++ b/tests/lean_spec/subspecs/ssz/test_signed_attestation.py
@@ -1,7 +1,8 @@
-from lean_spec.forks.lstar.containers import AttestationData, Checkpoint, SignedAttestation
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
-from lean_spec.types import Bytes32
+from lean_spec.forks.lstar.containers import (
+    AttestationData,
+    SignedAttestation,
+)
+from lean_spec.types import Bytes32, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers.builders import make_mock_signature
 
 

--- a/tests/lean_spec/subspecs/ssz/test_state.py
+++ b/tests/lean_spec/subspecs/ssz/test_state.py
@@ -2,17 +2,15 @@ from lean_spec.forks.lstar import State
 from lean_spec.forks.lstar.containers.block.block import (
     BlockHeader,
 )
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
 from lean_spec.forks.lstar.containers.config import Config
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state.types import (
     HistoricalBlockHashes,
     JustificationRoots,
     JustificationValidators,
     JustifiedSlots,
 )
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, Validators
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.forks.lstar.containers.validator import Validators
+from lean_spec.types import Bytes32, Checkpoint, Slot, Uint64, ValidatorIndex
 
 
 def test_encode_decode_state_roundtrip() -> None:

--- a/tests/lean_spec/subspecs/storage/test_sqlite.py
+++ b/tests/lean_spec/subspecs/storage/test_sqlite.py
@@ -9,11 +9,12 @@ from pathlib import Path
 import pytest
 
 from lean_spec.forks.lstar import State
-from lean_spec.forks.lstar.containers import Block, BlockBody, Checkpoint
+from lean_spec.forks.lstar.containers import (
+    Block,
+    BlockBody,
+)
 from lean_spec.forks.lstar.containers.attestation import AttestationData
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.storage import (
     SQLiteDatabase,
@@ -21,7 +22,7 @@ from lean_spec.subspecs.storage import (
     StorageReadError,
     StorageWriteError,
 )
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Checkpoint, Slot, Uint64, ValidatorIndex
 
 
 @pytest.fixture

--- a/tests/lean_spec/subspecs/sync/conftest.py
+++ b/tests/lean_spec/subspecs/sync/conftest.py
@@ -8,10 +8,8 @@ from __future__ import annotations
 
 import pytest
 
-from lean_spec.forks.lstar.containers import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.networking.reqresp.message import Status
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot
 
 
 @pytest.fixture

--- a/tests/lean_spec/subspecs/sync/test_backfill_sync.py
+++ b/tests/lean_spec/subspecs/sync/test_backfill_sync.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass, field
 
 import pytest
 
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.networking.peer import PeerInfo
 from lean_spec.subspecs.networking.types import ConnectionState
@@ -21,7 +19,7 @@ from lean_spec.subspecs.sync.peer_manager import (
     PeerManager,
     SyncPeer,
 )
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 from tests.lean_spec.helpers import MockNetworkRequester, make_signed_block
 
 

--- a/tests/lean_spec/subspecs/sync/test_block_cache.py
+++ b/tests/lean_spec/subspecs/sync/test_block_cache.py
@@ -6,13 +6,11 @@ from time import time
 from typing import cast
 
 from lean_spec.forks.lstar import Store
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.sync.block_cache import BlockCache, PendingBlock
 from lean_spec.subspecs.sync.config import MAX_CACHED_BLOCKS
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Slot, ValidatorIndex
 from tests.lean_spec.helpers import MockForkchoiceStore, make_signed_block
 
 

--- a/tests/lean_spec/subspecs/sync/test_checkpoint_sync.py
+++ b/tests/lean_spec/subspecs/sync/test_checkpoint_sync.py
@@ -8,7 +8,6 @@ import httpx
 import pytest
 
 from lean_spec.forks.lstar import State, Store
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.containers.state import Validators
 from lean_spec.subspecs.api import ApiServer, ApiServerConfig
 from lean_spec.subspecs.chain.config import VALIDATOR_REGISTRY_LIMIT
@@ -18,6 +17,7 @@ from lean_spec.subspecs.sync.checkpoint_sync import (
     fetch_finalized_state,
     verify_checkpoint_state,
 )
+from lean_spec.types import Slot
 
 
 class _MockTransport(httpx.AsyncBaseTransport):

--- a/tests/lean_spec/subspecs/sync/test_head_sync.py
+++ b/tests/lean_spec/subspecs/sync/test_head_sync.py
@@ -9,14 +9,12 @@ import pytest
 
 from lean_spec.forks.lstar import Store
 from lean_spec.forks.lstar.containers import SignedBlock
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.sync.backfill_sync import BackfillSync
 from lean_spec.subspecs.sync.block_cache import BlockCache
 from lean_spec.subspecs.sync.head_sync import HeadSync, HeadSyncResult
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Slot, ValidatorIndex
 from tests.lean_spec.helpers import MockForkchoiceStore, make_signed_block
 
 

--- a/tests/lean_spec/subspecs/sync/test_head_sync_backfill_routing.py
+++ b/tests/lean_spec/subspecs/sync/test_head_sync_backfill_routing.py
@@ -15,14 +15,12 @@ from typing import Any, cast
 
 from lean_spec.forks.lstar import Store
 from lean_spec.forks.lstar.containers import SignedBlock
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.sync.backfill_sync import BackfillSync
 from lean_spec.subspecs.sync.block_cache import BlockCache
 from lean_spec.subspecs.sync.head_sync import HeadSync, HeadSyncResult
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 from tests.lean_spec.helpers import MockForkchoiceStore, make_signed_block
 
 

--- a/tests/lean_spec/subspecs/sync/test_peer_manager.py
+++ b/tests/lean_spec/subspecs/sync/test_peer_manager.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.networking.peer import PeerInfo
 from lean_spec.subspecs.networking.reqresp.message import Status
@@ -17,7 +15,7 @@ from lean_spec.subspecs.sync.peer_manager import (
     PeerManager,
     SyncPeer,
 )
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot
 
 
 def peer(name: str) -> PeerId:

--- a/tests/lean_spec/subspecs/sync/test_service.py
+++ b/tests/lean_spec/subspecs/sync/test_service.py
@@ -13,9 +13,6 @@ from lean_spec.forks.lstar.containers import (
     SignedAggregatedAttestation,
     SignedBlock,
 )
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex
 from lean_spec.forks.lstar.store import Store
 from lean_spec.subspecs.networking import PeerId
 from lean_spec.subspecs.networking.reqresp.message import Status
@@ -24,7 +21,7 @@ from lean_spec.subspecs.storage.database import Database
 from lean_spec.subspecs.sync.config import MAX_PENDING_ATTESTATIONS
 from lean_spec.subspecs.sync.service import SyncProgress, SyncService
 from lean_spec.subspecs.sync.states import SyncState
-from lean_spec.types import Bytes32
+from lean_spec.types import Bytes32, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers import (
     MockForkchoiceStore,
     RecordedCall,

--- a/tests/lean_spec/subspecs/validator/test_registry.py
+++ b/tests/lean_spec/subspecs/validator/test_registry.py
@@ -9,8 +9,6 @@ import yaml
 from consensus_testing.keys import XmssKeyManager
 from pydantic import ValidationError
 
-from lean_spec.forks.lstar.containers import ValidatorIndex
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.validator import ValidatorRegistry
 from lean_spec.subspecs.validator.registry import (
     ValidatorEntry,
@@ -18,7 +16,7 @@ from lean_spec.subspecs.validator.registry import (
     ValidatorManifestEntry,
     load_node_validator_mapping,
 )
-from lean_spec.types import Bytes52
+from lean_spec.types import Bytes52, Slot, ValidatorIndex
 from lean_spec.types.exceptions import SSZValueError
 
 

--- a/tests/lean_spec/subspecs/validator/test_service.py
+++ b/tests/lean_spec/subspecs/validator/test_service.py
@@ -13,10 +13,8 @@ from lean_spec.forks.lstar.containers import (
     Block,
     SignedAttestation,
     SignedBlock,
-    ValidatorIndex,
     ValidatorIndices,
 )
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.chain.clock import SlotClock
 from lean_spec.subspecs.chain.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.subspecs.ssz.hash import hash_tree_root
@@ -27,7 +25,7 @@ from lean_spec.subspecs.validator import ValidatorRegistry, ValidatorService
 from lean_spec.subspecs.validator.registry import ValidatorEntry
 from lean_spec.subspecs.xmss import TARGET_SIGNATURE_SCHEME
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 from tests.lean_spec.helpers import (
     TEST_VALIDATOR_ID,
     MockNetworkRequester,

--- a/tests/lean_spec/subspecs/xmss/test_aggregation.py
+++ b/tests/lean_spec/subspecs/xmss/test_aggregation.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import pytest
 from consensus_testing.keys import XmssKeyManager
 
-from lean_spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.forks.lstar.containers.validator import ValidatorIndex, ValidatorIndices
+from lean_spec.forks.lstar.containers.validator import ValidatorIndices
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof, AggregationError
-from lean_spec.types import ByteListMiB
+from lean_spec.types import ByteListMiB, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers import make_attestation_data_simple, make_bytes32
 
 

--- a/tests/lean_spec/subspecs/xmss/test_interface.py
+++ b/tests/lean_spec/subspecs/xmss/test_interface.py
@@ -4,12 +4,11 @@ End-to-end tests for the Generalized XMSS signature scheme.
 
 import pytest
 
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.xmss.interface import (
     TEST_SIGNATURE_SCHEME,
     GeneralizedXmssScheme,
 )
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64
 
 
 def _test_correctness_roundtrip(

--- a/tests/lean_spec/subspecs/xmss/test_ssz_serialization.py
+++ b/tests/lean_spec/subspecs/xmss/test_ssz_serialization.py
@@ -1,10 +1,9 @@
 """Tests for SSZ serialization of XMSS types."""
 
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.subspecs.xmss.constants import TEST_CONFIG
 from lean_spec.subspecs.xmss.containers import PublicKey, SecretKey, Signature
 from lean_spec.subspecs.xmss.interface import TEST_SIGNATURE_SCHEME
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64
 
 
 def test_public_key_ssz_roundtrip() -> None:

--- a/tests/lean_spec/test_cli.py
+++ b/tests/lean_spec/test_cli.py
@@ -20,15 +20,17 @@ from lean_spec.__main__ import (
     create_anchor_block,
     resolve_bootnode,
 )
-from lean_spec.forks.lstar.containers import Block, BlockBody
+from lean_spec.forks.lstar.containers import (
+    Block,
+    BlockBody,
+)
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
-from lean_spec.forks.lstar.containers.slot import Slot
 from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.genesis import GenesisConfig
 from lean_spec.subspecs.node import Node
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.sync.checkpoint_sync import CheckpointSyncError
-from lean_spec.types import Bytes32, Uint64
+from lean_spec.types import Bytes32, Slot, Uint64
 from lean_spec.types.rlp import RLPItem, encode_rlp
 from tests.lean_spec.helpers import make_genesis_state
 

--- a/tests/lean_spec/types/test_validator_utils.py
+++ b/tests/lean_spec/types/test_validator_utils.py
@@ -2,9 +2,7 @@
 
 import pytest
 
-from lean_spec.forks.lstar.containers import ValidatorIndex
-from lean_spec.forks.lstar.containers.slot import Slot
-from lean_spec.types import Uint64
+from lean_spec.types import Slot, Uint64, ValidatorIndex
 
 
 class TestValidatorIndexIsProposerFor:


### PR DESCRIPTION
## Summary

Stage 2 of the multi-fork architecture refactor (#686). Promotes data primitives whose *shape* is stable across the leanSpec fork chain out of `forks/lstar/containers/` and into `lean_spec.types`, so the fork package contains only what genuinely changes per fork.

**Moved to `lean_spec.types`:**
- `Slot` (with `is_justifiable_after`, `justified_index_after`, `IMMEDIATE_JUSTIFICATION_WINDOW`)
- `ValidatorIndex`, `SubnetId`
- `Checkpoint`

**Stayed in the fork (intentionally):**
- `Validator` / `Validators` — XMSS-bound `Bytes52` keys are signature-scheme specific.
- `ValidatorIndices` — `to_aggregation_bits` couples it to the fork's `AggregationBits`; the decomposition (e.g. moving the conversion onto `AggregationBits.from_validator_indices`) is a clean follow-up.
- `Config` — single-field today, but the most likely container to grow per fork (deposits, RANDAO, fee parameters). Both reviewers agreed promoting it to `subspecs/chain/` now would just churn it back out.

**Method placement:** kept current methods on the moved types (`Slot.is_justifiable_after`, `ValidatorIndex.is_proposer_for`, etc.) rather than pre-emptively pushing them to the fork class. Per CLAUDE.md ("don't design for hypothetical future requirements"), the migration to fork-class methods can happen when divergence is real.

## Notable changes

- `src/lean_spec/types/{slot,checkpoint,validator}.py` — new files; re-exported from `types/__init__.py`.
- `src/lean_spec/forks/lstar/containers/{slot,checkpoint}.py` — deleted.
- `src/lean_spec/forks/lstar/containers/validator.py` — keeps only `Validator`, `Validators`, `ValidatorIndices`.
- `src/lean_spec/forks/lstar/containers/__init__.py` — drops moved names (no re-export shim per CLAUDE.md).
- `ForkProtocol`: `validator_id: Uint64 | None` → `ValidatorIndex | None` in `SpecStoreType.from_anchor` and `ForkProtocol.create_store`.
- 130+ call sites across `src/`, `tests/`, and `packages/` updated to import from `lean_spec.types` directly.

## Reviewer input

Pre-implementation reviews from the consensus-researcher and py-architect agents confirmed the moves. They diverged on whether the methods (e.g. `Slot.is_justifiable_after`) should travel with the types or move to the fork class — the py-architect's "don't pre-emptively abstract" view prevailed and matches the CLAUDE.md guidance.

## Test plan

- [x] `uvx tox -e all-checks` — passes (ruff, ruff-format, ty, codespell, mdformat).
- [x] `uv run pytest --co` — all 3290 tests collect cleanly.
- [ ] CI pytest on this PR.

Refs #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)