### PR TITLE
refactor(forks): rename GOSSIP_DIGEST from devnet0 to 12345678

### DIFF
--- a/src/lean_spec/__main__.py
+++ b/src/lean_spec/__main__.py
@@ -504,7 +504,7 @@ async def run_node(
     # Set the network name for incoming message validation.
     #
     # Without this, the event source defaults to "0x00000000" and rejects
-    # all messages from other clients that use "devnet0".
+    # all messages from other clients that use "12345678".
     event_source.set_network_name(fork.GOSSIP_DIGEST)
 
     # Subscribe to gossip topics.

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -14,7 +14,7 @@ class LstarSpec(ForkProtocol):
 
     NAME: ClassVar[str] = "lstar"
     VERSION: ClassVar[int] = 4
-    GOSSIP_DIGEST: ClassVar[str] = "devnet0"
+    GOSSIP_DIGEST: ClassVar[str] = "12345678"
 
     previous: ClassVar[type[ForkProtocol] | None] = None
 

--- a/src/lean_spec/subspecs/node/node.py
+++ b/src/lean_spec/subspecs/node/node.py
@@ -105,7 +105,7 @@ class NodeConfig:
     """
     Network name for gossip topics.
 
-    For devnet testing with ream, use "devnet0".
+    For devnet testing with ream, use "12345678".
     """
 
     is_aggregator: bool = field(default=False)

--- a/tests/interop/helpers/node_runner.py
+++ b/tests/interop/helpers/node_runner.py
@@ -199,7 +199,7 @@ class NodeCluster:
     _genesis_time: int = field(default=0, repr=False)
     """Genesis time for all nodes."""
 
-    network_name: str = field(default="devnet0")
+    network_name: str = field(default="12345678")
     """Network name for gossip topics."""
 
     def __post_init__(self) -> None:

--- a/tests/lean_spec/forks/test_fork_protocol.py
+++ b/tests/lean_spec/forks/test_fork_protocol.py
@@ -60,7 +60,7 @@ class TestLstarSpec:
 
     def test_gossip_digest(self) -> None:
         """LstarSpec carries the gossipsub fork digest as fork metadata."""
-        assert LstarSpec.GOSSIP_DIGEST == "devnet0"
+        assert LstarSpec.GOSSIP_DIGEST == "12345678"
 
     def test_previous_is_none(self) -> None:
         """LstarSpec is the root of the upgrade chain."""


### PR DESCRIPTION
Addresses #693

## 🗒️ Description

Renamed `GOSSIP_DIGEST` from "devnet0" to "12345678" (hex placeholder). This changes gossip topic strings from `/leanconsensus/devnet0/*` to `/leanconsensus/12345678/*`.

**Changed:**
- `LstarSpec.GOSSIP_DIGEST` constant in `spec.py`
- Test assertion in `test_fork_protocol.py`
- Default `network_name` in interop test helper
- Documentation comments

**Note:** Using "12345678" as a temporary hex identifier. Future work will move to a proper fork digest

## 🔗 Related Issues or PRs

Closes #693

## ✅ Checklist

- [x] Ran `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox
    ```
- [x] Considered adding appropriate tests for the changes.