### PR TITLE
refactor(forks): add Spec delegator surface (Stage 4A of #686)

### DIFF
--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -1,5 +1,7 @@
 """Lstar fork — identity and construction facade."""
 
+from collections.abc import Iterable
+from collections.abc import Set as AbstractSet
 from typing import ClassVar
 
 from lean_spec.forks.lstar.containers import (
@@ -16,6 +18,10 @@ from lean_spec.forks.lstar.containers import (
 from lean_spec.forks.lstar.containers.block.block import BlockSignatures
 from lean_spec.forks.lstar.containers.state import State
 from lean_spec.forks.lstar.containers.validator import Validators
+from lean_spec.subspecs.chain.clock import Interval
+from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
+from lean_spec.subspecs.xmss.interface import TARGET_SIGNATURE_SCHEME, GeneralizedXmssScheme
+from lean_spec.types import Bytes32, Slot, ValidatorIndex
 
 from ..protocol import ForkProtocol, SpecStateType
 from .store import Store
@@ -57,3 +63,123 @@ class LstarSpec(ForkProtocol):
         """
         assert isinstance(state, State)
         return state
+
+    # State transition surface
+    #
+    # The methods below mirror the existing State / Store / SignedBlock methods
+    # one-for-one. Stage 4A only adds the spec-class API surface; the bodies are
+    # pure delegators to the container methods. Stage 4C will move the bodies in.
+
+    def state_transition(
+        self,
+        state: State,
+        block: Block,
+        valid_signatures: bool = True,
+    ) -> State:
+        """Apply the full state transition function and return the post-state."""
+        return state.state_transition(block, valid_signatures)
+
+    def process_slots(self, state: State, target_slot: Slot) -> State:
+        """Advance the state through empty slots up to ``target_slot``."""
+        return state.process_slots(target_slot)
+
+    def process_block(self, state: State, block: Block) -> State:
+        """Apply full block processing (header + body) to the state."""
+        return state.process_block(block)
+
+    def process_block_header(self, state: State, block: Block) -> State:
+        """Apply block-header processing only."""
+        return state.process_block_header(block)
+
+    def process_attestations(
+        self,
+        state: State,
+        attestations: Iterable[AggregatedAttestation],
+    ) -> State:
+        """Apply aggregated attestations and update justification/finalization."""
+        return state.process_attestations(attestations)
+
+    def build_block(
+        self,
+        state: State,
+        slot: Slot,
+        proposer_index: ValidatorIndex,
+        parent_root: Bytes32,
+        known_block_roots: AbstractSet[Bytes32],
+        aggregated_payloads: dict[AttestationData, set[AggregatedSignatureProof]] | None = None,
+    ) -> tuple[Block, State, list[AggregatedAttestation], list[AggregatedSignatureProof]]:
+        """Build a valid block on top of ``state``."""
+        return state.build_block(
+            slot=slot,
+            proposer_index=proposer_index,
+            parent_root=parent_root,
+            known_block_roots=known_block_roots,
+            aggregated_payloads=aggregated_payloads,
+        )
+
+    # Block signature verification
+
+    def verify_signatures(
+        self,
+        signed_block: SignedBlock,
+        validators: Validators,
+        scheme: GeneralizedXmssScheme = TARGET_SIGNATURE_SCHEME,
+    ) -> bool:
+        """Verify all XMSS signatures in ``signed_block`` against ``validators``."""
+        return signed_block.verify_signatures(validators, scheme)
+
+    # Forkchoice surface
+
+    def on_block(
+        self,
+        store: Store,
+        signed_block: SignedBlock,
+        scheme: GeneralizedXmssScheme = TARGET_SIGNATURE_SCHEME,
+    ) -> Store:
+        """Process a new block and update the forkchoice store."""
+        return store.on_block(signed_block, scheme)
+
+    def on_tick(
+        self,
+        store: Store,
+        target_interval: Interval,
+        has_proposal: bool,
+        is_aggregator: bool = False,
+    ) -> tuple[Store, list[SignedAggregatedAttestation]]:
+        """Advance the forkchoice store time to ``target_interval``."""
+        return store.on_tick(target_interval, has_proposal, is_aggregator)
+
+    def on_gossip_attestation(
+        self,
+        store: Store,
+        signed_attestation: SignedAttestation,
+        scheme: GeneralizedXmssScheme = TARGET_SIGNATURE_SCHEME,
+        is_aggregator: bool = False,
+    ) -> Store:
+        """Process a single-validator attestation received via gossip."""
+        return store.on_gossip_attestation(signed_attestation, scheme, is_aggregator)
+
+    def on_gossip_aggregated_attestation(
+        self,
+        store: Store,
+        signed_attestation: SignedAggregatedAttestation,
+    ) -> Store:
+        """Process an aggregated attestation received via gossip."""
+        return store.on_gossip_aggregated_attestation(signed_attestation)
+
+    def produce_attestation_data(self, store: Store, slot: Slot) -> AttestationData:
+        """Produce attestation data for the given slot."""
+        return store.produce_attestation_data(slot)
+
+    def produce_block_with_signatures(
+        self,
+        store: Store,
+        slot: Slot,
+        validator_index: ValidatorIndex,
+    ) -> tuple[Store, Block, list[AggregatedSignatureProof]]:
+        """Produce a block plus its aggregated signature proofs for ``slot``."""
+        return store.produce_block_with_signatures(slot, validator_index)
+
+    def get_proposal_head(self, store: Store, slot: Slot) -> tuple[Store, Bytes32]:
+        """Return the head root that a block proposal at ``slot`` should build on."""
+        return store.get_proposal_head(slot)

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -9,6 +9,8 @@ from lean_spec.forks.lstar.containers import (
     Attestation,
     AttestationData,
     Block,
+    BlockBody,
+    BlockHeader,
     Config,
     SignedAggregatedAttestation,
     SignedAttestation,
@@ -16,6 +18,10 @@ from lean_spec.forks.lstar.containers import (
     Validator,
 )
 from lean_spec.forks.lstar.containers.block.block import BlockSignatures
+from lean_spec.forks.lstar.containers.block.types import (
+    AggregatedAttestations,
+    AttestationSignatures,
+)
 from lean_spec.forks.lstar.containers.state import State
 from lean_spec.forks.lstar.containers.validator import Validators
 from lean_spec.subspecs.chain.clock import Interval
@@ -38,8 +44,12 @@ class LstarSpec(ForkProtocol):
 
     state_class: type[State] = State
     block_class: type[Block] = Block
+    block_body_class: type[BlockBody] = BlockBody
+    block_header_class: type[BlockHeader] = BlockHeader
     signed_block_class: type[SignedBlock] = SignedBlock
     block_signatures_class: type[BlockSignatures] = BlockSignatures
+    aggregated_attestations_class: type[AggregatedAttestations] = AggregatedAttestations
+    attestation_signatures_class: type[AttestationSignatures] = AttestationSignatures
     store_class: type[Store] = Store
 
     attestation_data_class: type[AttestationData] = AttestationData

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -64,31 +64,25 @@ class LstarSpec(ForkProtocol):
         assert isinstance(state, State)
         return state
 
-    # State transition surface
-    #
-    # The methods below mirror the existing State / Store / SignedBlock methods
-    # one-for-one. Stage 4A only adds the spec-class API surface; the bodies are
-    # pure delegators to the container methods. Stage 4C will move the bodies in.
-
     def state_transition(
         self,
         state: State,
         block: Block,
         valid_signatures: bool = True,
     ) -> State:
-        """Apply the full state transition function and return the post-state."""
+        """Compute the post-state obtained by applying a block to a pre-state."""
         return state.state_transition(block, valid_signatures)
 
     def process_slots(self, state: State, target_slot: Slot) -> State:
-        """Advance the state through empty slots up to ``target_slot``."""
+        """Advance the state through empty slots up to a target slot."""
         return state.process_slots(target_slot)
 
     def process_block(self, state: State, block: Block) -> State:
-        """Apply full block processing (header + body) to the state."""
+        """Apply a full block (header and body) to the state."""
         return state.process_block(block)
 
     def process_block_header(self, state: State, block: Block) -> State:
-        """Apply block-header processing only."""
+        """Apply only the header portion of a block to the state."""
         return state.process_block_header(block)
 
     def process_attestations(
@@ -96,7 +90,7 @@ class LstarSpec(ForkProtocol):
         state: State,
         attestations: Iterable[AggregatedAttestation],
     ) -> State:
-        """Apply aggregated attestations and update justification/finalization."""
+        """Fold attestations into the state and update justification and finalization."""
         return state.process_attestations(attestations)
 
     def build_block(
@@ -108,7 +102,7 @@ class LstarSpec(ForkProtocol):
         known_block_roots: AbstractSet[Bytes32],
         aggregated_payloads: dict[AttestationData, set[AggregatedSignatureProof]] | None = None,
     ) -> tuple[Block, State, list[AggregatedAttestation], list[AggregatedSignatureProof]]:
-        """Build a valid block on top of ``state``."""
+        """Assemble a valid block on top of the given pre-state."""
         return state.build_block(
             slot=slot,
             proposer_index=proposer_index,
@@ -117,18 +111,14 @@ class LstarSpec(ForkProtocol):
             aggregated_payloads=aggregated_payloads,
         )
 
-    # Block signature verification
-
     def verify_signatures(
         self,
         signed_block: SignedBlock,
         validators: Validators,
         scheme: GeneralizedXmssScheme = TARGET_SIGNATURE_SCHEME,
     ) -> bool:
-        """Verify all XMSS signatures in ``signed_block`` against ``validators``."""
+        """Check that every signature carried by a signed block is valid."""
         return signed_block.verify_signatures(validators, scheme)
-
-    # Forkchoice surface
 
     def on_block(
         self,
@@ -136,7 +126,7 @@ class LstarSpec(ForkProtocol):
         signed_block: SignedBlock,
         scheme: GeneralizedXmssScheme = TARGET_SIGNATURE_SCHEME,
     ) -> Store:
-        """Process a new block and update the forkchoice store."""
+        """Incorporate a newly received block into the forkchoice view."""
         return store.on_block(signed_block, scheme)
 
     def on_tick(
@@ -146,7 +136,7 @@ class LstarSpec(ForkProtocol):
         has_proposal: bool,
         is_aggregator: bool = False,
     ) -> tuple[Store, list[SignedAggregatedAttestation]]:
-        """Advance the forkchoice store time to ``target_interval``."""
+        """Advance forkchoice time to a target interval and emit any due aggregates."""
         return store.on_tick(target_interval, has_proposal, is_aggregator)
 
     def on_gossip_attestation(
@@ -156,7 +146,7 @@ class LstarSpec(ForkProtocol):
         scheme: GeneralizedXmssScheme = TARGET_SIGNATURE_SCHEME,
         is_aggregator: bool = False,
     ) -> Store:
-        """Process a single-validator attestation received via gossip."""
+        """Incorporate a single-validator attestation received from the network."""
         return store.on_gossip_attestation(signed_attestation, scheme, is_aggregator)
 
     def on_gossip_aggregated_attestation(
@@ -164,11 +154,11 @@ class LstarSpec(ForkProtocol):
         store: Store,
         signed_attestation: SignedAggregatedAttestation,
     ) -> Store:
-        """Process an aggregated attestation received via gossip."""
+        """Incorporate an aggregated attestation received from the network."""
         return store.on_gossip_aggregated_attestation(signed_attestation)
 
     def produce_attestation_data(self, store: Store, slot: Slot) -> AttestationData:
-        """Produce attestation data for the given slot."""
+        """Build the attestation payload that a validator should sign at this slot."""
         return store.produce_attestation_data(slot)
 
     def produce_block_with_signatures(
@@ -177,9 +167,9 @@ class LstarSpec(ForkProtocol):
         slot: Slot,
         validator_index: ValidatorIndex,
     ) -> tuple[Store, Block, list[AggregatedSignatureProof]]:
-        """Produce a block plus its aggregated signature proofs for ``slot``."""
+        """Produce a proposal block together with the aggregated signature proofs it needs."""
         return store.produce_block_with_signatures(slot, validator_index)
 
     def get_proposal_head(self, store: Store, slot: Slot) -> tuple[Store, Bytes32]:
-        """Return the head root that a block proposal at ``slot`` should build on."""
+        """Resolve the head root that a proposal at this slot should extend."""
         return store.get_proposal_head(slot)

--- a/src/lean_spec/forks/protocol.py
+++ b/src/lean_spec/forks/protocol.py
@@ -71,6 +71,38 @@ class SpecBlockType(SpecSSZType, Protocol):
         ...
 
 
+class SpecBlockBodyType(SpecSSZType, Protocol):
+    """Structural contract: any fork's BlockBody container class.
+
+    Carries the variable-size payload attached to a block — typically
+    aggregated attestations and any future operation lists.
+    """
+
+
+class SpecBlockHeaderType(SpecSSZType, Protocol):
+    """Structural contract: any fork's BlockHeader container class.
+
+    The fixed-shape summary of a block used in state-transition tracking
+    and state-root caching. Carries slot, proposer, parent root, state
+    root, and body root.
+    """
+
+
+class SpecAggregatedAttestationsType(SpecSSZType, Protocol):
+    """Structural contract: any fork's AggregatedAttestations list class.
+
+    Bounded SSZ list of aggregated attestations included in a block body.
+    """
+
+
+class SpecAttestationSignaturesType(SpecSSZType, Protocol):
+    """Structural contract: any fork's AttestationSignatures list class.
+
+    Bounded SSZ list of aggregated signature proofs aligned one-for-one
+    with a block body's aggregated attestations.
+    """
+
+
 class SpecSignedBlockType(SpecSSZType, Protocol):
     """Structural contract: any fork's SignedBlock container class.
 
@@ -282,11 +314,23 @@ class ForkProtocol(ABC):
     block_class: type[SpecBlockType]
     """Concrete Block container class owned by this fork."""
 
+    block_body_class: type[SpecBlockBodyType]
+    """Concrete BlockBody container class owned by this fork."""
+
+    block_header_class: type[SpecBlockHeaderType]
+    """Concrete BlockHeader container class owned by this fork."""
+
     signed_block_class: type[SpecSignedBlockType]
     """Concrete SignedBlock container class — block + signatures envelope."""
 
     block_signatures_class: type[SpecBlockSignaturesType]
     """Concrete BlockSignatures container class — proposer + attestation signatures."""
+
+    aggregated_attestations_class: type[SpecAggregatedAttestationsType]
+    """Concrete AggregatedAttestations list class — block-body aggregated votes."""
+
+    attestation_signatures_class: type[SpecAttestationSignaturesType]
+    """Concrete AttestationSignatures list class — signature group bundle."""
 
     store_class: type[SpecStoreType]
     """Concrete forkchoice Store class owned by this fork."""

--- a/tests/lean_spec/forks/test_lstar_spec_delegators.py
+++ b/tests/lean_spec/forks/test_lstar_spec_delegators.py
@@ -1,13 +1,10 @@
-"""Tests for the LstarSpec delegator surface (Stage 4A of #686).
+"""Verify that every fork-class method forwards faithfully to the underlying container.
 
-LstarSpec exposes container methods (state transition, fork choice, block
-production, signature verification) as fork-class methods that delegate to
-the underlying State / Store / SignedBlock methods. Stage 4A only adds the
-surface; the bodies stay on the containers and call sites are unchanged.
+Each test patches the container method, calls the matching fork-class method,
+and asserts:
 
-Each test verifies that the delegator forwards its arguments to the
-corresponding container method and returns the container method's result
-unchanged. This locks the surface in place before Stage 4C moves the bodies.
+- The container method receives the same arguments.
+- The fork-class method returns the container's result unchanged.
 """
 
 from unittest.mock import patch
@@ -32,19 +29,19 @@ from tests.lean_spec.helpers.builders import (
 _NUM_VALIDATORS = 3
 _VALIDATOR_ID = ValidatorIndex(0)
 _SENTINEL = object()
-"""Unique object returned by patched container methods to confirm delegators forward unchanged."""
+"""Unique object returned by patched containers to confirm the result is forwarded unchanged."""
 
 
 def _spec() -> LstarSpec:
-    """Construct a fresh LstarSpec for each delegator test."""
+    """Build a fresh fork-class instance for one test."""
     return LstarSpec()
 
 
 class TestStateDelegators:
-    """LstarSpec methods that delegate to State."""
+    """Fork-class methods that route through the state container."""
 
     def test_state_transition_forwards(self) -> None:
-        """state_transition delegator forwards to State.state_transition."""
+        """The post-state computation forwards to the state container."""
         state = make_keyed_genesis_state(_NUM_VALIDATORS)
         block = Block.model_construct(slot=Slot(1))
 
@@ -55,7 +52,7 @@ class TestStateDelegators:
         assert result is _SENTINEL
 
     def test_process_slots_forwards(self) -> None:
-        """process_slots delegator forwards to State.process_slots."""
+        """Advancing through empty slots forwards to the state container."""
         state = make_keyed_genesis_state(_NUM_VALIDATORS)
         target = Slot(7)
 
@@ -66,7 +63,7 @@ class TestStateDelegators:
         assert result is _SENTINEL
 
     def test_process_block_forwards(self) -> None:
-        """process_block delegator forwards to State.process_block."""
+        """Full block processing forwards to the state container."""
         state = make_keyed_genesis_state(_NUM_VALIDATORS)
         block = Block.model_construct(slot=Slot(1))
 
@@ -77,7 +74,7 @@ class TestStateDelegators:
         assert result is _SENTINEL
 
     def test_process_block_header_forwards(self) -> None:
-        """process_block_header delegator forwards to State.process_block_header."""
+        """Header-only processing forwards to the state container."""
         state = make_keyed_genesis_state(_NUM_VALIDATORS)
         block = Block.model_construct(slot=Slot(1))
 
@@ -88,7 +85,7 @@ class TestStateDelegators:
         assert result is _SENTINEL
 
     def test_process_attestations_forwards(self) -> None:
-        """process_attestations delegator forwards to State.process_attestations."""
+        """Folding attestations into the state forwards to the state container."""
         state = make_keyed_genesis_state(_NUM_VALIDATORS)
         attestations: list[AggregatedAttestation] = []
 
@@ -99,7 +96,7 @@ class TestStateDelegators:
         assert result is _SENTINEL
 
     def test_build_block_forwards(self) -> None:
-        """build_block delegator forwards to State.build_block."""
+        """Block construction forwards to the state container."""
         state = make_keyed_genesis_state(_NUM_VALIDATORS)
         slot = Slot(1)
         proposer_index = ValidatorIndex(1)
@@ -126,10 +123,10 @@ class TestStateDelegators:
 
 
 class TestSignedBlockDelegator:
-    """LstarSpec method that delegates to SignedBlock."""
+    """Fork-class method that routes through the signed-block container."""
 
     def test_verify_signatures_forwards(self) -> None:
-        """verify_signatures delegator forwards to SignedBlock.verify_signatures."""
+        """Signature verification forwards to the signed-block container."""
         validators = make_validators(_NUM_VALIDATORS)
         signed_block = make_signed_block(
             slot=Slot(0),
@@ -146,14 +143,14 @@ class TestSignedBlockDelegator:
 
 
 class TestStoreDelegators:
-    """LstarSpec methods that delegate to Store."""
+    """Fork-class methods that route through the forkchoice store."""
 
     def _store(self) -> Store:
-        """Build a genesis store for delegator tests."""
+        """Build a genesis forkchoice store for one test."""
         return make_genesis_data(num_validators=_NUM_VALIDATORS, validator_id=_VALIDATOR_ID).store
 
     def test_on_block_forwards(self) -> None:
-        """on_block delegator forwards to Store.on_block."""
+        """Incorporating a new block forwards to the forkchoice store."""
         store = self._store()
         signed_block = make_signed_block(
             slot=Slot(1),
@@ -169,7 +166,7 @@ class TestStoreDelegators:
         assert result is _SENTINEL
 
     def test_on_tick_forwards(self) -> None:
-        """on_tick delegator forwards to Store.on_tick."""
+        """Advancing forkchoice time forwards to the forkchoice store."""
         store = self._store()
         target = Interval.from_slot(Slot(1))
 
@@ -180,7 +177,7 @@ class TestStoreDelegators:
         assert result is _SENTINEL
 
     def test_on_gossip_attestation_forwards(self) -> None:
-        """on_gossip_attestation delegator forwards to Store.on_gossip_attestation."""
+        """A single-validator attestation from gossip forwards to the forkchoice store."""
         store = self._store()
         attestation = SignedAttestation.model_construct()
 
@@ -191,7 +188,7 @@ class TestStoreDelegators:
         assert result is _SENTINEL
 
     def test_on_gossip_aggregated_attestation_forwards(self) -> None:
-        """Aggregated-attestation delegator forwards to the Store method."""
+        """An aggregated attestation from gossip forwards to the forkchoice store."""
         store = self._store()
         attestation = SignedAggregatedAttestation.model_construct()
 
@@ -204,7 +201,7 @@ class TestStoreDelegators:
         assert result is _SENTINEL
 
     def test_produce_attestation_data_forwards(self) -> None:
-        """produce_attestation_data delegator forwards to Store.produce_attestation_data."""
+        """Building attestation payload forwards to the forkchoice store."""
         store = self._store()
         slot = Slot(2)
 
@@ -215,7 +212,7 @@ class TestStoreDelegators:
         assert result is _SENTINEL
 
     def test_produce_block_with_signatures_forwards(self) -> None:
-        """Block-production delegator forwards to Store.produce_block_with_signatures."""
+        """Producing a proposal block with proofs forwards to the forkchoice store."""
         store = self._store()
         slot = Slot(2)
         validator_index = ValidatorIndex(1)
@@ -227,7 +224,7 @@ class TestStoreDelegators:
         assert result is _SENTINEL
 
     def test_get_proposal_head_forwards(self) -> None:
-        """get_proposal_head delegator forwards to Store.get_proposal_head."""
+        """Resolving the proposal head forwards to the forkchoice store."""
         store = self._store()
         slot = Slot(2)
 

--- a/tests/lean_spec/forks/test_lstar_spec_delegators.py
+++ b/tests/lean_spec/forks/test_lstar_spec_delegators.py
@@ -1,0 +1,238 @@
+"""Tests for the LstarSpec delegator surface (Stage 4A of #686).
+
+LstarSpec exposes container methods (state transition, fork choice, block
+production, signature verification) as fork-class methods that delegate to
+the underlying State / Store / SignedBlock methods. Stage 4A only adds the
+surface; the bodies stay on the containers and call sites are unchanged.
+
+Each test verifies that the delegator forwards its arguments to the
+corresponding container method and returns the container method's result
+unchanged. This locks the surface in place before Stage 4C moves the bodies.
+"""
+
+from unittest.mock import patch
+
+from lean_spec.forks.lstar import State, Store
+from lean_spec.forks.lstar.containers import Block, SignedAttestation, SignedBlock
+from lean_spec.forks.lstar.containers.attestation import (
+    AggregatedAttestation,
+    SignedAggregatedAttestation,
+)
+from lean_spec.forks.lstar.spec import LstarSpec
+from lean_spec.subspecs.chain.clock import Interval
+from lean_spec.subspecs.xmss.interface import TARGET_SIGNATURE_SCHEME
+from lean_spec.types import Bytes32, Slot, ValidatorIndex
+from tests.lean_spec.helpers.builders import (
+    make_genesis_data,
+    make_keyed_genesis_state,
+    make_signed_block,
+    make_validators,
+)
+
+_NUM_VALIDATORS = 3
+_VALIDATOR_ID = ValidatorIndex(0)
+_SENTINEL = object()
+"""Unique object returned by patched container methods to confirm delegators forward unchanged."""
+
+
+def _spec() -> LstarSpec:
+    """Construct a fresh LstarSpec for each delegator test."""
+    return LstarSpec()
+
+
+class TestStateDelegators:
+    """LstarSpec methods that delegate to State."""
+
+    def test_state_transition_forwards(self) -> None:
+        """state_transition delegator forwards to State.state_transition."""
+        state = make_keyed_genesis_state(_NUM_VALIDATORS)
+        block = Block.model_construct(slot=Slot(1))
+
+        with patch.object(State, "state_transition", return_value=_SENTINEL) as mock:
+            result = _spec().state_transition(state, block, valid_signatures=False)
+
+        mock.assert_called_once_with(block, False)
+        assert result is _SENTINEL
+
+    def test_process_slots_forwards(self) -> None:
+        """process_slots delegator forwards to State.process_slots."""
+        state = make_keyed_genesis_state(_NUM_VALIDATORS)
+        target = Slot(7)
+
+        with patch.object(State, "process_slots", return_value=_SENTINEL) as mock:
+            result = _spec().process_slots(state, target)
+
+        mock.assert_called_once_with(target)
+        assert result is _SENTINEL
+
+    def test_process_block_forwards(self) -> None:
+        """process_block delegator forwards to State.process_block."""
+        state = make_keyed_genesis_state(_NUM_VALIDATORS)
+        block = Block.model_construct(slot=Slot(1))
+
+        with patch.object(State, "process_block", return_value=_SENTINEL) as mock:
+            result = _spec().process_block(state, block)
+
+        mock.assert_called_once_with(block)
+        assert result is _SENTINEL
+
+    def test_process_block_header_forwards(self) -> None:
+        """process_block_header delegator forwards to State.process_block_header."""
+        state = make_keyed_genesis_state(_NUM_VALIDATORS)
+        block = Block.model_construct(slot=Slot(1))
+
+        with patch.object(State, "process_block_header", return_value=_SENTINEL) as mock:
+            result = _spec().process_block_header(state, block)
+
+        mock.assert_called_once_with(block)
+        assert result is _SENTINEL
+
+    def test_process_attestations_forwards(self) -> None:
+        """process_attestations delegator forwards to State.process_attestations."""
+        state = make_keyed_genesis_state(_NUM_VALIDATORS)
+        attestations: list[AggregatedAttestation] = []
+
+        with patch.object(State, "process_attestations", return_value=_SENTINEL) as mock:
+            result = _spec().process_attestations(state, attestations)
+
+        mock.assert_called_once_with(attestations)
+        assert result is _SENTINEL
+
+    def test_build_block_forwards(self) -> None:
+        """build_block delegator forwards to State.build_block."""
+        state = make_keyed_genesis_state(_NUM_VALIDATORS)
+        slot = Slot(1)
+        proposer_index = ValidatorIndex(1)
+        parent_root = Bytes32.zero()
+        known_block_roots = {parent_root}
+
+        with patch.object(State, "build_block", return_value=_SENTINEL) as mock:
+            result = _spec().build_block(
+                state,
+                slot=slot,
+                proposer_index=proposer_index,
+                parent_root=parent_root,
+                known_block_roots=known_block_roots,
+            )
+
+        mock.assert_called_once_with(
+            slot=slot,
+            proposer_index=proposer_index,
+            parent_root=parent_root,
+            known_block_roots=known_block_roots,
+            aggregated_payloads=None,
+        )
+        assert result is _SENTINEL
+
+
+class TestSignedBlockDelegator:
+    """LstarSpec method that delegates to SignedBlock."""
+
+    def test_verify_signatures_forwards(self) -> None:
+        """verify_signatures delegator forwards to SignedBlock.verify_signatures."""
+        validators = make_validators(_NUM_VALIDATORS)
+        signed_block = make_signed_block(
+            slot=Slot(0),
+            proposer_index=ValidatorIndex(0),
+            parent_root=Bytes32.zero(),
+            state_root=Bytes32.zero(),
+        )
+
+        with patch.object(SignedBlock, "verify_signatures", return_value=True) as mock:
+            result = _spec().verify_signatures(signed_block, validators)
+
+        mock.assert_called_once_with(validators, TARGET_SIGNATURE_SCHEME)
+        assert result is True
+
+
+class TestStoreDelegators:
+    """LstarSpec methods that delegate to Store."""
+
+    def _store(self) -> Store:
+        """Build a genesis store for delegator tests."""
+        return make_genesis_data(num_validators=_NUM_VALIDATORS, validator_id=_VALIDATOR_ID).store
+
+    def test_on_block_forwards(self) -> None:
+        """on_block delegator forwards to Store.on_block."""
+        store = self._store()
+        signed_block = make_signed_block(
+            slot=Slot(1),
+            proposer_index=ValidatorIndex(1),
+            parent_root=Bytes32.zero(),
+            state_root=Bytes32.zero(),
+        )
+
+        with patch.object(Store, "on_block", return_value=_SENTINEL) as mock:
+            result = _spec().on_block(store, signed_block)
+
+        mock.assert_called_once_with(signed_block, TARGET_SIGNATURE_SCHEME)
+        assert result is _SENTINEL
+
+    def test_on_tick_forwards(self) -> None:
+        """on_tick delegator forwards to Store.on_tick."""
+        store = self._store()
+        target = Interval.from_slot(Slot(1))
+
+        with patch.object(Store, "on_tick", return_value=_SENTINEL) as mock:
+            result = _spec().on_tick(store, target, has_proposal=True, is_aggregator=True)
+
+        mock.assert_called_once_with(target, True, True)
+        assert result is _SENTINEL
+
+    def test_on_gossip_attestation_forwards(self) -> None:
+        """on_gossip_attestation delegator forwards to Store.on_gossip_attestation."""
+        store = self._store()
+        attestation = SignedAttestation.model_construct()
+
+        with patch.object(Store, "on_gossip_attestation", return_value=_SENTINEL) as mock:
+            result = _spec().on_gossip_attestation(store, attestation, is_aggregator=True)
+
+        mock.assert_called_once_with(attestation, TARGET_SIGNATURE_SCHEME, True)
+        assert result is _SENTINEL
+
+    def test_on_gossip_aggregated_attestation_forwards(self) -> None:
+        """Aggregated-attestation delegator forwards to the Store method."""
+        store = self._store()
+        attestation = SignedAggregatedAttestation.model_construct()
+
+        with patch.object(
+            Store, "on_gossip_aggregated_attestation", return_value=_SENTINEL
+        ) as mock:
+            result = _spec().on_gossip_aggregated_attestation(store, attestation)
+
+        mock.assert_called_once_with(attestation)
+        assert result is _SENTINEL
+
+    def test_produce_attestation_data_forwards(self) -> None:
+        """produce_attestation_data delegator forwards to Store.produce_attestation_data."""
+        store = self._store()
+        slot = Slot(2)
+
+        with patch.object(Store, "produce_attestation_data", return_value=_SENTINEL) as mock:
+            result = _spec().produce_attestation_data(store, slot)
+
+        mock.assert_called_once_with(slot)
+        assert result is _SENTINEL
+
+    def test_produce_block_with_signatures_forwards(self) -> None:
+        """Block-production delegator forwards to Store.produce_block_with_signatures."""
+        store = self._store()
+        slot = Slot(2)
+        validator_index = ValidatorIndex(1)
+
+        with patch.object(Store, "produce_block_with_signatures", return_value=_SENTINEL) as mock:
+            result = _spec().produce_block_with_signatures(store, slot, validator_index)
+
+        mock.assert_called_once_with(slot, validator_index)
+        assert result is _SENTINEL
+
+    def test_get_proposal_head_forwards(self) -> None:
+        """get_proposal_head delegator forwards to Store.get_proposal_head."""
+        store = self._store()
+        slot = Slot(2)
+
+        with patch.object(Store, "get_proposal_head", return_value=_SENTINEL) as mock:
+            result = _spec().get_proposal_head(store, slot)
+
+        mock.assert_called_once_with(slot)
+        assert result is _SENTINEL


### PR DESCRIPTION
## Summary

Stage 4A of the multi-fork architecture refactor (#686): add the spec-class method surface that mirrors the existing container methods one-for-one. The surface is added as **pure delegators** — bodies stay on the containers, call sites are unchanged. Stage 4B will rewrite call sites to go through the spec; Stage 4C will move the bodies in.

The new `LstarSpec` methods:

| Domain | Methods |
| --- | --- |
| State transition | `state_transition`, `process_slots`, `process_block`, `process_block_header`, `process_attestations`, `build_block` |
| Forkchoice | `on_block`, `on_tick`, `on_gossip_attestation`, `on_gossip_aggregated_attestation`, `produce_attestation_data`, `produce_block_with_signatures`, `get_proposal_head` |
| Block signatures | `verify_signatures` |

Each delegator is a one-line forwarder to the existing State / Store / SignedBlock method.

## Why concrete on `LstarSpec` (not abstract on `ForkProtocol`)

Following Vision B (the chosen direction in #686): the architecture's central use case is "Devnet5 inherits from Devnet4 and overrides one attribute". Concrete delegators on `LstarSpec` propagate naturally through subclass inheritance — `Devnet5Spec(LstarSpec)` gets all of these for free until it needs to override one.

Adding abstract declarations on `ForkProtocol` would force every fork class to redeclare all delegators and would clash with the structural-protocol parameter types (which don't expose container methods like `state.process_block`). It is also premature without a second fork to validate the contract.

## Tests

`tests/lean_spec/forks/test_lstar_spec_delegators.py` adds 14 tests using `unittest.mock.patch.object` to verify each delegator:

- forwards its arguments to the container method unchanged, and
- returns the container method's result verbatim.

The mock pattern proves delegation precisely without depending on the underlying container behaviour — which is exactly what Stage 4A is about.

## Test plan

- [x] `uvx tox -e all-checks` (ruff check + format + ty + codespell + mdformat) green.
- [x] `uv run pytest tests/lean_spec/forks/` — 32 fork tests pass (18 existing + 14 new).
- [x] `uv run pytest tests/lean_spec/` — 3276 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)