### PR TITLE
refactor(forks): rewrite test call sites through the spec (Stage 4B of #686)

### DIFF
--- a/packages/testing/src/consensus_testing/genesis.py
+++ b/packages/testing/src/consensus_testing/genesis.py
@@ -11,7 +11,10 @@ from lean_spec.types import Bytes52, Slot, Uint64, ValidatorIndex
 from .keys import XmssKeyManager
 
 _DEFAULT_GENESIS_TIME = Uint64(0)
-_DEFAULT_FORK: ForkProtocol = LstarSpec()
+_SPEC = LstarSpec()
+"""Active fork spec — stateless, safe to share across all helper invocations."""
+
+_DEFAULT_FORK: ForkProtocol = _SPEC
 """Stateless fork instance used when callers do not pass one explicitly."""
 
 
@@ -121,7 +124,8 @@ def build_anchor(
     for next_slot in range(1, int(anchor_slot) + 1):
         slot = Slot(next_slot)
         proposer_index = ValidatorIndex(int(slot) % int(num_validators_u64))
-        current_block, state, _, _ = state.build_block(
+        current_block, state, _, _ = _SPEC.build_block(
+            state,
             slot=slot,
             proposer_index=proposer_index,
             parent_root=parent_root,

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -20,6 +20,7 @@ from lean_spec.forks.lstar.containers.block.types import (
     AggregatedAttestations,
 )
 from lean_spec.forks.lstar.containers.state import State, Validators
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.ssz import hash_tree_root
 from lean_spec.types import Slot, Uint64, ValidatorIndex
@@ -36,6 +37,9 @@ from ..test_types import (
     TickStep,
 )
 from .base import BaseConsensusFixture
+
+_SPEC = LstarSpec()
+"""Active fork spec — stateless, safe to share across all fixture invocations."""
 
 
 class ForkChoiceTest(BaseConsensusFixture):
@@ -289,7 +293,8 @@ class ForkChoiceTest(BaseConsensusFixture):
                             target_interval = Interval.from_unix_time(
                                 Uint64(step.time), store.config.genesis_time
                             )
-                        store, _ = store.on_tick(
+                        store, _ = _SPEC.on_tick(
+                            store,
                             target_interval,
                             has_proposal=step.has_proposal,
                             is_aggregator=True,
@@ -321,13 +326,14 @@ class ForkChoiceTest(BaseConsensusFixture):
                         # This tick includes a block (has proposal).
                         # Always act as aggregator to ensure gossip signatures are aggregated
                         target_interval = Interval.from_slot(block.slot)
-                        store, _ = store.on_tick(
-                            target_interval, has_proposal=True, is_aggregator=True
+                        store, _ = _SPEC.on_tick(
+                            store, target_interval, has_proposal=True, is_aggregator=True
                         )
 
                         # Process the block through Store.
                         # This validates, applies state transition, and updates the store's head.
-                        store = store.on_block(
+                        store = _SPEC.on_block(
+                            store,
                             signed_block,
                             scheme=LEAN_ENV_TO_SCHEMES[self.lean_env],
                         )
@@ -344,7 +350,8 @@ class ForkChoiceTest(BaseConsensusFixture):
                             step.valid,
                         )
                         step._filled_attestation = signed_attestation
-                        store = store.on_gossip_attestation(
+                        store = _SPEC.on_gossip_attestation(
+                            store,
                             signed_attestation,
                             scheme=LEAN_ENV_TO_SCHEMES[self.lean_env],
                             is_aggregator=step.is_aggregator,
@@ -357,7 +364,7 @@ class ForkChoiceTest(BaseConsensusFixture):
                             key_manager,
                         )
                         step._filled_attestation = signed_aggregated
-                        store = store.on_gossip_aggregated_attestation(signed_aggregated)
+                        store = _SPEC.on_gossip_aggregated_attestation(store, signed_aggregated)
 
                     case _:
                         raise ValueError(f"Step {i}: unknown step type {type(step).__name__}")

--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -8,6 +8,7 @@ from lean_spec.forks.lstar.containers.attestation import AggregatedAttestation, 
 from lean_spec.forks.lstar.containers.block.block import Block, BlockBody
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
 from lean_spec.forks.lstar.containers.state import State
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
 from lean_spec.types import Bytes32, ValidatorIndices
@@ -15,6 +16,9 @@ from lean_spec.types import Bytes32, ValidatorIndices
 from ..keys import XmssKeyManager
 from ..test_types import AggregatedAttestationSpec, BlockSpec, StateExpectation
 from .base import BaseConsensusFixture
+
+_SPEC = LstarSpec()
+"""Active fork spec — stateless, safe to share across all fixture invocations."""
 
 
 class StateTransitionTest(BaseConsensusFixture):
@@ -136,9 +140,10 @@ class StateTransitionTest(BaseConsensusFixture):
                 if cached_state is not None:
                     state = cached_state
                 elif getattr(block_spec, "skip_slot_processing", False):
-                    state = state.process_block(block)
+                    state = _SPEC.process_block(state, block)
                 else:
-                    state = state.state_transition(
+                    state = _SPEC.state_transition(
+                        state,
                         block=block,
                         valid_signatures=True,
                     )
@@ -212,7 +217,7 @@ class StateTransitionTest(BaseConsensusFixture):
         # Advance slots unless the spec intentionally skips slot processing.
         slot_advanced_state: State | None = None
         if not spec.skip_slot_processing:
-            slot_advanced_state = state.process_slots(spec.slot)
+            slot_advanced_state = _SPEC.process_slots(state, spec.slot)
 
         # Resolve the parent root.
         # Default: latest block header from the slot-advanced state.
@@ -255,7 +260,8 @@ class StateTransitionTest(BaseConsensusFixture):
 
             known_block_roots = frozenset(hash_tree_root(b) for b in block_registry.values())
 
-            block, post_state, _, _ = state.build_block(
+            block, post_state, _, _ = _SPEC.build_block(
+                state,
                 slot=spec.slot,
                 proposer_index=proposer_index,
                 parent_root=parent_root,
@@ -289,7 +295,8 @@ class StateTransitionTest(BaseConsensusFixture):
             # The body changed, so re-run the transition to get the correct
             # post-state and state root.
             if post_state is not None:
-                post_state = state.process_slots(spec.slot).process_block(block)
+                post_state = _SPEC.process_slots(state, spec.slot)
+                post_state = _SPEC.process_block(post_state, block)
                 block = block.model_copy(update={"state_root": hash_tree_root(post_state)})
 
         return block, post_state

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -15,11 +15,15 @@ from lean_spec.forks.lstar.containers.block.types import (
     AttestationSignatures,
 )
 from lean_spec.forks.lstar.containers.state import State
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.types import AggregationBits, Boolean, ValidatorIndex
 
 from ..keys import XmssKeyManager
 from ..test_types import BlockSpec
 from .base import BaseConsensusFixture
+
+_SPEC = LstarSpec()
+"""Active fork spec — stateless, safe to share across all fixture invocations."""
 
 
 class VerifySignaturesTest(BaseConsensusFixture):
@@ -111,7 +115,7 @@ class VerifySignaturesTest(BaseConsensusFixture):
 
         # Verify signatures
         try:
-            signed_block.verify_signatures(self.anchor_state.validators)
+            _SPEC.verify_signatures(signed_block, self.anchor_state.validators)
         except AssertionError as e:
             exception_raised = e
             # If we expect an exception, this is fine

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -21,6 +21,7 @@ from lean_spec.forks.lstar.containers.block.types import (
     AttestationSignatures,
 )
 from lean_spec.forks.lstar.containers.state import State
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.forks.lstar.store import Store
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.ssz.hash import hash_tree_root
@@ -30,6 +31,9 @@ from lean_spec.types import Bytes32, CamelModel, Slot, ValidatorIndex, Validator
 
 from ..keys import LEAN_ENV_TO_SCHEMES, XmssKeyManager, create_dummy_signature
 from .aggregated_attestation_spec import AggregatedAttestationSpec
+
+_SPEC = LstarSpec()
+"""Active fork spec — stateless, safe to share across all spec invocations."""
 
 
 class BlockSpec(CamelModel):
@@ -304,7 +308,7 @@ class BlockSpec(CamelModel):
 
         # Resolve the parent root.
         # The default is the latest block header from the slot-advanced state.
-        parent_state = state.process_slots(self.slot)
+        parent_state = _SPEC.process_slots(state, self.slot)
         parent_root = self.resolve_parent_root(
             block_registry,
             default_root=hash_tree_root(parent_state.latest_block_header),
@@ -360,7 +364,8 @@ class BlockSpec(CamelModel):
             for agg_att, proof in zip(aggregated_attestations, attestation_sigs.data, strict=True)
         }
 
-        final_block, _, _, aggregated_signatures = state.build_block(
+        final_block, _, _, aggregated_signatures = _SPEC.build_block(
+            state,
             slot=self.slot,
             proposer_index=proposer_index,
             parent_root=parent_root,
@@ -424,7 +429,9 @@ class BlockSpec(CamelModel):
         # check rejects votes whose slot has not yet started locally.
         block_slot_interval = Interval.from_slot(self.slot)
         if store.time < block_slot_interval:
-            store, _ = store.on_tick(block_slot_interval, has_proposal=True, is_aggregator=True)
+            store, _ = _SPEC.on_tick(
+                store, block_slot_interval, has_proposal=True, is_aggregator=True
+            )
 
         # Gossip valid attestation signatures into the Store.
         # This runs signature verification through the spec's validation path.
@@ -435,7 +442,8 @@ class BlockSpec(CamelModel):
                 or (signature := sigs_for_data.get(attestation.validator_id)) is None
             ):
                 continue
-            store = store.on_gossip_attestation(
+            store = _SPEC.on_gossip_attestation(
+                store,
                 SignedAttestation(
                     validator_id=attestation.validator_id,
                     data=attestation.data,
@@ -450,7 +458,8 @@ class BlockSpec(CamelModel):
         merged_store = aggregation_store.accept_new_attestations()
 
         # Build the block through the spec's State.build_block().
-        final_block, _, _, block_proofs = parent_state.build_block(
+        final_block, _, _, block_proofs = _SPEC.build_block(
+            parent_state,
             slot=self.slot,
             proposer_index=proposer_index,
             parent_root=parent_root,
@@ -486,7 +495,8 @@ class BlockSpec(CamelModel):
                 )
 
             # Recompute state root with the modified body.
-            post_state = parent_state.process_slots(self.slot).process_block(final_block)
+            post_state = _SPEC.process_slots(parent_state, self.slot)
+            post_state = _SPEC.process_block(post_state, final_block)
             final_block = final_block.model_copy(update={"state_root": hash_tree_root(post_state)})
 
         return self._sign_block(final_block, block_proofs, proposer_index, key_manager)

--- a/packages/testing/src/consensus_testing/test_types/gossip_attestation_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/gossip_attestation_spec.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from lean_spec.forks.lstar.containers.attestation import AttestationData, SignedAttestation
 from lean_spec.forks.lstar.containers.block.block import Block
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.forks.lstar.store import Store
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.types import Bytes32, CamelModel, Checkpoint, Slot, ValidatorIndex
 
 from ..keys import XmssKeyManager, create_dummy_signature
 from .utils import resolve_checkpoint
+
+_SPEC = LstarSpec()
+"""Active fork spec — stateless, safe to share across all spec invocations."""
 
 
 class GossipAttestationSpec(CamelModel):
@@ -200,7 +204,7 @@ class GossipAttestationSpec(CamelModel):
             attestation_data = self.build_attestation_data(block_registry, anchor_block)
         else:
             # Honest path: use the Store's own attestation data production.
-            attestation_data = store.produce_attestation_data(self.slot)
+            attestation_data = _SPEC.produce_attestation_data(store, self.slot)
 
         signature = (
             key_manager.sign_attestation_data(self.validator_id, attestation_data)

--- a/tests/lean_spec/conftest.py
+++ b/tests/lean_spec/conftest.py
@@ -14,6 +14,7 @@ from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.forks.lstar import State, Store
 from lean_spec.forks.lstar.containers import Block
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.types import Slot, ValidatorIndex
 from tests.lean_spec.helpers import (
     GenesisData,
@@ -22,6 +23,12 @@ from tests.lean_spec.helpers import (
     make_genesis_state,
     make_store,
 )
+
+
+@pytest.fixture(scope="session")
+def spec() -> LstarSpec:
+    """Active fork spec used to drive state transition and forkchoice operations."""
+    return LstarSpec()
 
 
 @pytest.fixture

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -30,6 +30,7 @@ from lean_spec.forks.lstar.containers.block.types import (
     AttestationSignatures,
 )
 from lean_spec.forks.lstar.containers.state import Validators
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.chain.clock import Interval, SlotClock
 from lean_spec.subspecs.koalabear import Fp
 from lean_spec.subspecs.networking import PeerId
@@ -61,6 +62,9 @@ from lean_spec.types import (
 )
 
 from .mocks import MockForkchoiceStore, MockNetworkRequester
+
+_SPEC = LstarSpec()
+"""Active fork spec — stateless, safe to share across all helper invocations."""
 
 
 def make_bytes32(seed: int) -> Bytes32:
@@ -367,7 +371,7 @@ def make_store_with_attestation_data(
         key_manager=key_manager,
     )
     store = store.model_copy(update={"time": Interval.from_slot(attestation_slot)})
-    attestation_data = store.produce_attestation_data(attestation_slot)
+    attestation_data = _SPEC.produce_attestation_data(store, attestation_slot)
     return store, attestation_data
 
 
@@ -480,7 +484,7 @@ def make_signed_block_from_store(
 
     Returns the updated store (with time advanced) and the signed block.
     """
-    _, block, _ = store.produce_block_with_signatures(slot, proposer_index)
+    _, block, _ = _SPEC.produce_block_with_signatures(store, slot, proposer_index)
     block_root = hash_tree_root(block)
     proposer_signature = key_manager.sign_block_root(proposer_index, slot, block_root)
     attestation_signatures = key_manager.build_attestation_signatures(block.body.attestations)
@@ -494,7 +498,7 @@ def make_signed_block_from_store(
     )
 
     target_interval = Interval.from_slot(block.slot)
-    advanced_store, _ = store.on_tick(target_interval, has_proposal=True)
+    advanced_store, _ = _SPEC.on_tick(store, target_interval, has_proposal=True)
 
     return advanced_store, signed_block
 

--- a/tests/lean_spec/subspecs/containers/test_state_aggregation.py
+++ b/tests/lean_spec/subspecs/containers/test_state_aggregation.py
@@ -8,6 +8,7 @@ from lean_spec.forks.lstar import AttestationSignatureEntry
 from lean_spec.forks.lstar.containers.attestation import AttestationData
 from lean_spec.forks.lstar.containers.block import Block, BlockBody
 from lean_spec.forks.lstar.containers.block.types import AggregatedAttestations
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.types import Bytes32, Checkpoint, Slot, ValidatorIndex, ValidatorIndices
 from tests.lean_spec.helpers import (
@@ -59,6 +60,7 @@ def test_aggregated_signatures_prefers_full_gossip_payload(
 
 def test_build_block_collects_valid_available_attestations(
     container_key_manager: XmssKeyManager,
+    spec: LstarSpec,
 ) -> None:
     state = make_keyed_genesis_state(2, container_key_manager)
     parent_header_with_state_root = state.latest_block_header.model_copy(
@@ -78,7 +80,8 @@ def test_build_block_collects_valid_available_attestations(
     proof = make_aggregated_proof(container_key_manager, [ValidatorIndex(0)], att_data)
     aggregated_payloads = {att_data: {proof}}
 
-    block, post_state, aggregated_atts, aggregated_proofs = state.build_block(
+    block, post_state, aggregated_atts, aggregated_proofs = spec.build_block(
+        state,
         slot=Slot(1),
         proposer_index=ValidatorIndex(1),
         parent_root=parent_root,
@@ -105,6 +108,7 @@ def test_build_block_collects_valid_available_attestations(
 
 def test_build_block_skips_attestations_without_signatures(
     container_key_manager: XmssKeyManager,
+    spec: LstarSpec,
 ) -> None:
     state = make_keyed_genesis_state(1, container_key_manager)
     parent_header_with_state_root = state.latest_block_header.model_copy(
@@ -112,7 +116,8 @@ def test_build_block_skips_attestations_without_signatures(
     )
     parent_root = hash_tree_root(parent_header_with_state_root)
 
-    block, post_state, aggregated_atts, aggregated_proofs = state.build_block(
+    block, post_state, aggregated_atts, aggregated_proofs = spec.build_block(
+        state,
         slot=Slot(1),
         proposer_index=ValidatorIndex(0),
         parent_root=parent_root,
@@ -190,6 +195,7 @@ def test_aggregated_signatures_with_multiple_data_groups(
 
 def test_build_block_state_root_valid_when_signatures_split(
     container_key_manager: XmssKeyManager,
+    spec: LstarSpec,
 ) -> None:
     """
     Verify state root validity when attestations split across signature sources.
@@ -239,7 +245,8 @@ def test_build_block_state_root_valid_when_signatures_split(
     )
     aggregated_payloads = {att_data: {proof_0, fallback_proof}}
 
-    block, _, aggregated_atts, _ = pre_state.build_block(
+    block, _, aggregated_atts, _ = spec.build_block(
+        pre_state,
         slot=Slot(1),
         proposer_index=ValidatorIndex(1),
         parent_root=parent_root,
@@ -254,7 +261,7 @@ def test_build_block_state_root_valid_when_signatures_split(
         "Compacted attestation should cover all three validators"
     )
 
-    result_state = pre_state.state_transition(block, valid_signatures=True)
+    result_state = spec.state_transition(pre_state, block, valid_signatures=True)
 
     assert result_state.slot == Slot(1)
     assert result_state.latest_block_header.slot == Slot(1)
@@ -267,6 +274,7 @@ def test_build_block_state_root_valid_when_signatures_split(
 
 def test_build_block_skips_non_matching_source(
     container_key_manager: XmssKeyManager,
+    spec: LstarSpec,
 ) -> None:
     """Only attestation data whose source matches current_justified is included."""
     state = make_keyed_genesis_state(2, container_key_manager)
@@ -293,7 +301,8 @@ def test_build_block_skips_non_matching_source(
     proof_good = make_aggregated_proof(container_key_manager, [ValidatorIndex(0)], att_data_good)
     proof_bad = make_aggregated_proof(container_key_manager, [ValidatorIndex(1)], att_data_bad)
 
-    _, _, aggregated_atts, _ = state.build_block(
+    _, _, aggregated_atts, _ = spec.build_block(
+        state,
         slot=Slot(1),
         proposer_index=ValidatorIndex(1),
         parent_root=parent_root,
@@ -307,6 +316,7 @@ def test_build_block_skips_non_matching_source(
 
 def test_build_block_skips_unknown_head_root(
     container_key_manager: XmssKeyManager,
+    spec: LstarSpec,
 ) -> None:
     """Attestation data with head root not in known_block_roots is excluded."""
     state = make_keyed_genesis_state(2, container_key_manager)
@@ -335,7 +345,8 @@ def test_build_block_skips_unknown_head_root(
         container_key_manager, [ValidatorIndex(1)], att_data_unknown
     )
 
-    _, _, aggregated_atts, _ = state.build_block(
+    _, _, aggregated_atts, _ = spec.build_block(
+        state,
         slot=Slot(1),
         proposer_index=ValidatorIndex(1),
         parent_root=parent_root,
@@ -363,6 +374,7 @@ def test_aggregate_with_no_signatures(
 
 def test_build_block_fixed_point_closes_justified_divergence(
     container_key_manager: XmssKeyManager,
+    spec: LstarSpec,
 ) -> None:
     """
     Fixed-point loop advances justification when pool attestations are available.
@@ -398,7 +410,8 @@ def test_build_block_fixed_point_closes_justified_divergence(
         state_root=Bytes32.zero(),
         body=BlockBody(attestations=AggregatedAttestations(data=[])),
     )
-    state_1 = state_0.process_slots(Slot(1)).process_block(block_1)
+    state_1 = spec.process_slots(state_0, Slot(1))
+    state_1 = spec.process_block(state_1, block_1)
 
     # After block_1: justified = (genesis_root, slot=0).
     assert state_1.latest_justified == Checkpoint(root=genesis_root, slot=Slot(0))
@@ -414,7 +427,8 @@ def test_build_block_fixed_point_closes_justified_divergence(
         state_root=Bytes32.zero(),
         body=BlockBody(attestations=AggregatedAttestations(data=[])),
     )
-    state_2 = state_1.process_slots(Slot(2)).process_block(block_2)
+    state_2 = spec.process_slots(state_1, Slot(2))
+    state_2 = spec.process_block(state_2, block_2)
 
     # Still at genesis justified — no attestations processed.
     assert state_2.latest_justified == Checkpoint(root=genesis_root, slot=Slot(0))
@@ -452,7 +466,8 @@ def test_build_block_fixed_point_closes_justified_divergence(
     #   Pass 1: current_justified = genesis -> attestations match (source=genesis)
     #           3/4 supermajority -> justifies slot 1
     #   Pass 2: no new entries -> done
-    _, post_state, aggregated_atts, _ = state_2.build_block(
+    _, post_state, aggregated_atts, _ = spec.build_block(
+        state_2,
         slot=Slot(3),
         proposer_index=ValidatorIndex(3),
         parent_root=block_2_root,

--- a/tests/lean_spec/subspecs/containers/test_state_justified_slots.py
+++ b/tests/lean_spec/subspecs/containers/test_state_justified_slots.py
@@ -13,42 +13,43 @@ from lean_spec.forks.lstar.containers.state.types import (
     JustificationRoots,
     JustificationValidators,
 )
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.types import Boolean, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers import make_aggregated_attestation, make_block, make_genesis_state
 
 
-def test_justified_slots_do_not_include_finalized_boundary() -> None:
+def test_justified_slots_do_not_include_finalized_boundary(spec: LstarSpec) -> None:
     state = make_genesis_state(num_validators=4)
 
     # First post-genesis block at slot 1.
-    state_slot_1 = state.process_slots(Slot(1))
+    state_slot_1 = spec.process_slots(state, Slot(1))
     block_1 = make_block(state_slot_1, Slot(1), attestations=[])
-    post_1 = state_slot_1.process_block_header(block_1)
+    post_1 = spec.process_block_header(state_slot_1, block_1)
 
     # latest_finalized.slot is 0, so justified_slots starts at slot 1.
     # Processing block_1 only materializes the parent slot 0, which must not be stored.
     assert len(post_1.justified_slots) == 0
 
     # Second block at slot 2 materializes parent slot 1, which is the first bit.
-    post_1_slot_2 = post_1.process_slots(Slot(2))
+    post_1_slot_2 = spec.process_slots(post_1, Slot(2))
     block_2 = make_block(post_1_slot_2, Slot(2), attestations=[])
-    post_2 = post_1_slot_2.process_block_header(block_2)
+    post_2 = spec.process_block_header(post_1_slot_2, block_2)
 
     assert len(post_2.justified_slots) == 1
     assert bool(post_2.justified_slots[0]) is False
 
 
-def test_justified_slots_rebases_when_finalization_advances() -> None:
+def test_justified_slots_rebases_when_finalization_advances(spec: LstarSpec) -> None:
     # Use 3 validators so a 2-of-3 aggregation is a supermajority.
     state = make_genesis_state(num_validators=3)
 
     # Block 1 (slot 1): initializes history (stores slot 0 root), but no justified_slots bits yet.
-    state = state.process_slots(Slot(1))
+    state = spec.process_slots(state, Slot(1))
     block_1 = make_block(state, Slot(1), attestations=[])
-    state = state.process_block(block_1)
+    state = spec.process_block(state, block_1)
 
     # Block 2 (slot 2): justify slot 1 with source=0 -> target=1.
-    state = state.process_slots(Slot(2))
+    state = spec.process_slots(state, Slot(2))
     block_2 = make_block(state, Slot(2), attestations=[])
 
     source_0 = Checkpoint(root=block_1.parent_root, slot=Slot(0))
@@ -61,10 +62,10 @@ def test_justified_slots_rebases_when_finalization_advances() -> None:
     )
 
     block_2 = make_block(state, Slot(2), attestations=[att_0_to_1])
-    state = state.process_block(block_2)
+    state = spec.process_block(state, block_2)
 
     # Block 3 (slot 3): justify slot 2 with source=1 -> target=2, which finalizes slot 1.
-    state = state.process_slots(Slot(3))
+    state = spec.process_slots(state, Slot(3))
     block_3 = make_block(state, Slot(3), attestations=[])
 
     source_1 = Checkpoint(root=block_2.parent_root, slot=Slot(1))
@@ -77,7 +78,7 @@ def test_justified_slots_rebases_when_finalization_advances() -> None:
     )
 
     block_3 = make_block(state, Slot(3), attestations=[att_1_to_2])
-    state = state.process_block(block_3)
+    state = spec.process_block(state, block_3)
 
     assert state.latest_finalized.slot == Slot(1)
 
@@ -98,7 +99,7 @@ def test_is_slot_justified_raises_on_out_of_bounds() -> None:
         make_genesis_state(num_validators=1).justified_slots.is_slot_justified(Slot(0), Slot(1))
 
 
-def test_pruning_keeps_pending_justifications() -> None:
+def test_pruning_keeps_pending_justifications(spec: LstarSpec) -> None:
     """
     Verify pruning keeps pending justifications after finalization advances.
 
@@ -116,11 +117,11 @@ def test_pruning_keeps_pending_justifications() -> None:
     #
     # We need an existing justified checkpoint before we can test pruning.
 
-    state = state.process_slots(Slot(1))
+    state = spec.process_slots(state, Slot(1))
     block_1 = make_block(state, Slot(1), attestations=[])
-    state = state.process_block(block_1)
+    state = spec.process_block(state, block_1)
 
-    state = state.process_slots(Slot(2))
+    state = spec.process_slots(state, Slot(2))
     block_2 = make_block(state, Slot(2), attestations=[])
     source_0 = Checkpoint(root=block_1.parent_root, slot=Slot(0))
     target_1 = Checkpoint(root=block_2.parent_root, slot=Slot(1))
@@ -131,24 +132,24 @@ def test_pruning_keeps_pending_justifications() -> None:
         target=target_1,
     )
     block_2 = make_block(state, Slot(2), attestations=[att_0_to_1])
-    state = state.process_block(block_2)
+    state = spec.process_block(state, block_2)
 
     assert state.latest_finalized.slot == Slot(0)
     assert state.latest_justified.slot == Slot(1)
 
     # Phase 2: Extend chain to populate more history entries.
 
-    state = state.process_slots(Slot(3))
+    state = spec.process_slots(state, Slot(3))
     block_3 = make_block(state, Slot(3), attestations=[])
-    state = state.process_block(block_3)
+    state = spec.process_block(state, block_3)
 
-    state = state.process_slots(Slot(4))
+    state = spec.process_slots(state, Slot(4))
     block_4 = make_block(state, Slot(4), attestations=[])
-    state = state.process_block(block_4)
+    state = spec.process_block(state, block_4)
 
-    state = state.process_slots(Slot(5))
+    state = spec.process_slots(state, Slot(5))
     block_5 = make_block(state, Slot(5), attestations=[])
-    state = state.process_block_header(block_5)
+    state = spec.process_block_header(state, block_5)
 
     slot_3_root = state.historical_block_hashes[3]
 
@@ -186,7 +187,7 @@ def test_pruning_keeps_pending_justifications() -> None:
     #
     # Pruning iterates over all slots for each root in history.
     # Duplicate roots must map to multiple slots, not just one.
-    state = state.process_attestations([att_1_to_2])
+    state = spec.process_attestations(state, [att_1_to_2])
 
     # Verify finalization succeeded.
     assert state.latest_finalized.slot == Slot(1)

--- a/tests/lean_spec/subspecs/containers/test_state_process_attestations.py
+++ b/tests/lean_spec/subspecs/containers/test_state_process_attestations.py
@@ -47,6 +47,7 @@ from lean_spec.forks.lstar.containers.state.types import (
     HistoricalBlockHashes,
     JustifiedSlots,
 )
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.types import Boolean, Checkpoint, Slot, ValidatorIndex, ValidatorIndices
 from tests.lean_spec.helpers import make_bytes32, make_genesis_state
 
@@ -54,7 +55,9 @@ from tests.lean_spec.helpers import make_bytes32, make_genesis_state
 class TestProcessAttestationsBoundsCheck:
     """Verify attestations with out-of-bounds slot references are rejected safely."""
 
-    def test_attestation_with_target_beyond_history_is_silently_rejected(self) -> None:
+    def test_attestation_with_target_beyond_history_is_silently_rejected(
+        self, spec: LstarSpec
+    ) -> None:
         """
         Reject attestations whose target slot exceeds history bounds.
 
@@ -131,7 +134,7 @@ class TestProcessAttestationsBoundsCheck:
         # Process the attestation.
         #
         # This is the critical line: it must NOT raise IndexError.
-        result_state = state.process_attestations([attestation])
+        result_state = spec.process_attestations(state, [attestation])
 
         # Verify the attestation was silently rejected.
         #
@@ -146,7 +149,9 @@ class TestProcessAttestationsBoundsCheck:
         assert result_state.latest_justified == state.latest_justified
         assert result_state.latest_finalized == state.latest_finalized
 
-    def test_attestation_with_source_beyond_history_is_silently_rejected(self) -> None:
+    def test_attestation_with_source_beyond_history_is_silently_rejected(
+        self, spec: LstarSpec
+    ) -> None:
         """
         Reject attestations where history lookup would fail for any referenced slot.
 
@@ -213,7 +218,7 @@ class TestProcessAttestationsBoundsCheck:
         # Process the attestation.
         #
         # Must NOT raise IndexError.
-        result_state = state.process_attestations([attestation])
+        result_state = spec.process_attestations(state, [attestation])
 
         # Verify the attestation was silently rejected.
         #

--- a/tests/lean_spec/subspecs/forkchoice/test_attestation_target.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_attestation_target.py
@@ -14,6 +14,7 @@ from lean_spec.forks.lstar.containers import (
 from lean_spec.forks.lstar.containers.attestation import SignedAttestation
 from lean_spec.forks.lstar.containers.block import BlockSignatures
 from lean_spec.forks.lstar.containers.block.types import AttestationSignatures
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import JUSTIFICATION_LOOKBACK_SLOTS
 from lean_spec.subspecs.ssz.hash import hash_tree_root
@@ -46,6 +47,7 @@ class TestGetAttestationTarget:
         self,
         observer_store: Store,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
     ) -> None:
         """Target should walk back toward safe_target when head is ahead."""
         store = observer_store
@@ -55,7 +57,7 @@ class TestGetAttestationTarget:
             slot = Slot(slot_num)
             proposer = ValidatorIndex(slot_num % len(store.states[store.head].validators))
 
-            store, block, _ = store.produce_block_with_signatures(slot, proposer)
+            store, block, _ = spec.produce_block_with_signatures(store, slot, proposer)
 
         # Head has advanced (the exact slot depends on forkchoice without attestations)
         head_slot = store.blocks[store.head].slot
@@ -77,6 +79,7 @@ class TestGetAttestationTarget:
     def test_attestation_target_respects_justifiable_slots(
         self,
         observer_store: Store,
+        spec: LstarSpec,
     ) -> None:
         """Target should land on a slot that is_justifiable_after the finalized slot."""
         store = observer_store
@@ -85,7 +88,7 @@ class TestGetAttestationTarget:
         for slot_num in range(1, 10):
             slot = Slot(slot_num)
             proposer = ValidatorIndex(slot_num % len(store.states[store.head].validators))
-            store, _, _ = store.produce_block_with_signatures(slot, proposer)
+            store, _, _ = spec.produce_block_with_signatures(store, slot, proposer)
 
         target = store.get_attestation_target()
         finalized_slot = store.latest_finalized.slot
@@ -93,7 +96,9 @@ class TestGetAttestationTarget:
         # The target slot must be justifiable after the finalized slot
         assert target.slot.is_justifiable_after(finalized_slot)
 
-    def test_attestation_target_consistency_with_head(self, observer_store: Store) -> None:
+    def test_attestation_target_consistency_with_head(
+        self, observer_store: Store, spec: LstarSpec
+    ) -> None:
         """Target should be on the path from head to finalized checkpoint."""
         store = observer_store
 
@@ -101,7 +106,7 @@ class TestGetAttestationTarget:
         for slot_num in range(1, 4):
             slot = Slot(slot_num)
             proposer = ValidatorIndex(slot_num % len(store.states[store.head].validators))
-            store, _, _ = store.produce_block_with_signatures(slot, proposer)
+            store, _, _ = spec.produce_block_with_signatures(store, slot, proposer)
 
         target = store.get_attestation_target()
 
@@ -128,6 +133,7 @@ class TestSafeTargetAdvancement:
         self,
         keyed_store: Store,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
     ) -> None:
         """Safe target should only advance with 2/3+ attestation support."""
         store = keyed_store
@@ -135,14 +141,14 @@ class TestSafeTargetAdvancement:
         # Produce a block at slot 1
         slot = Slot(1)
         proposer = ValidatorIndex(1)
-        store, block, _ = store.produce_block_with_signatures(slot, proposer)
+        store, block, _ = spec.produce_block_with_signatures(store, slot, proposer)
         block_root = hash_tree_root(block)
 
         # Add attestations from fewer than 2/3 of validators
         num_validators = len(store.states[block_root].validators)
         threshold = (num_validators * 2 + 2) // 3  # Ceiling of 2/3
 
-        attestation_data = store.produce_attestation_data(slot)
+        attestation_data = spec.produce_attestation_data(store, slot)
 
         # Create signed attestations and process them
         for i in range(threshold - 1):
@@ -154,7 +160,7 @@ class TestSafeTargetAdvancement:
                 signature=sig,
             )
             # Process as gossip (requires aggregator flag)
-            store = store.on_gossip_attestation(signed_attestation, is_aggregator=True)
+            store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=True)
 
         # Aggregate the signatures
         store, _ = store.aggregate()
@@ -173,6 +179,7 @@ class TestSafeTargetAdvancement:
         self,
         keyed_store: Store,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
     ) -> None:
         """Safe target should advance when 2/3+ validators attest to same target."""
         store = keyed_store
@@ -180,10 +187,10 @@ class TestSafeTargetAdvancement:
         # Produce a block at slot 1
         slot = Slot(1)
         proposer = ValidatorIndex(1)
-        store, _, _ = store.produce_block_with_signatures(slot, proposer)
+        store, _, _ = spec.produce_block_with_signatures(store, slot, proposer)
 
         # Get attestation data for slot 1
-        attestation_data = store.produce_attestation_data(slot)
+        attestation_data = spec.produce_attestation_data(store, slot)
 
         # Add attestations from at least 2/3 of validators
         num_validators = len(store.states[store.head].validators)
@@ -198,7 +205,7 @@ class TestSafeTargetAdvancement:
                 data=attestation_data,
                 signature=sig,
             )
-            store = store.on_gossip_attestation(signed_attestation, is_aggregator=True)
+            store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=True)
 
         # Aggregate the signatures
         store, _ = store.aggregate()
@@ -215,6 +222,7 @@ class TestSafeTargetAdvancement:
         self,
         keyed_store: Store,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
     ) -> None:
         """update_safe_target should use new aggregated payloads."""
         store = keyed_store
@@ -222,9 +230,9 @@ class TestSafeTargetAdvancement:
         # Produce block at slot 1
         slot = Slot(1)
         proposer = ValidatorIndex(1)
-        store, block, _ = store.produce_block_with_signatures(slot, proposer)
+        store, block, _ = spec.produce_block_with_signatures(store, slot, proposer)
 
-        attestation_data = store.produce_attestation_data(slot)
+        attestation_data = spec.produce_attestation_data(store, slot)
         num_validators = len(store.states[store.head].validators)
 
         # Create signed attestations and process them
@@ -236,7 +244,7 @@ class TestSafeTargetAdvancement:
                 data=attestation_data,
                 signature=sig,
             )
-            store = store.on_gossip_attestation(signed_attestation, is_aggregator=True)
+            store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=True)
 
         # Aggregate into new payloads
         store, _ = store.aggregate()
@@ -255,6 +263,7 @@ class TestJustificationLogic:
         self,
         keyed_store: Store,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
     ) -> None:
         """Justification should occur when 2/3 validators attest to the same target."""
         store = keyed_store
@@ -262,7 +271,7 @@ class TestJustificationLogic:
         # Produce block at slot 1
         slot_1 = Slot(1)
         proposer_1 = ValidatorIndex(1)
-        store, block_1, _ = store.produce_block_with_signatures(slot_1, proposer_1)
+        store, block_1, _ = spec.produce_block_with_signatures(store, slot_1, proposer_1)
         block_1_root = hash_tree_root(block_1)
 
         # Produce block at slot 2 with attestations to slot 1
@@ -289,13 +298,13 @@ class TestJustificationLogic:
                 data=attestation_data,
                 signature=sig,
             )
-            store = store.on_gossip_attestation(signed_attestation, is_aggregator=True)
+            store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=True)
 
         # Aggregate signatures before producing the next block
         store, _ = store.aggregate()
 
         # Produce block 2 which includes these attestations
-        store, block_2, signatures = store.produce_block_with_signatures(slot_2, proposer_2)
+        store, block_2, signatures = spec.produce_block_with_signatures(store, slot_2, proposer_2)
 
         # Check that attestations were included
         assert len(block_2.body.attestations) > 0
@@ -311,6 +320,7 @@ class TestJustificationLogic:
         self,
         observer_store: Store,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
     ) -> None:
         """Attestations must have a valid (already justified) source."""
         store = observer_store
@@ -318,7 +328,7 @@ class TestJustificationLogic:
         # Produce block at slot 1
         slot = Slot(1)
         proposer = ValidatorIndex(1)
-        store, block, _ = store.produce_block_with_signatures(slot, proposer)
+        store, block, _ = spec.produce_block_with_signatures(store, slot, proposer)
         block_root = hash_tree_root(block)
 
         # Create attestation with invalid source (not justified)
@@ -345,6 +355,7 @@ class TestJustificationLogic:
         self,
         keyed_store: Store,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
     ) -> None:
         """Justification should track votes for multiple potential targets."""
         store = keyed_store
@@ -353,14 +364,14 @@ class TestJustificationLogic:
         for slot_num in range(1, 4):
             slot = Slot(slot_num)
             proposer = ValidatorIndex(slot_num % len(store.states[store.head].validators))
-            store, _, _ = store.produce_block_with_signatures(slot, proposer)
+            store, _, _ = spec.produce_block_with_signatures(store, slot, proposer)
 
         # Create attestations to different targets from different validators
         head_block = store.blocks[store.head]
         num_validators = len(store.states[store.head].validators)
 
         # Half validators attest to head
-        attestation_data_head = store.produce_attestation_data(head_block.slot)
+        attestation_data_head = spec.produce_attestation_data(store, head_block.slot)
 
         for i in range(num_validators // 2):
             vid = ValidatorIndex(i)
@@ -370,7 +381,7 @@ class TestJustificationLogic:
                 data=attestation_data_head,
                 signature=sig,
             )
-            store = store.on_gossip_attestation(signed_attestation, is_aggregator=True)
+            store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=True)
 
         store, _ = store.aggregate()
         store = store.update_safe_target()
@@ -386,6 +397,7 @@ class TestFinalizationFollowsJustification:
         self,
         keyed_store: Store,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
     ) -> None:
         """Finalization should follow when justification advances without gaps."""
         store = keyed_store
@@ -418,9 +430,11 @@ class TestFinalizationFollowsJustification:
                         data=attestation_data,
                         signature=sig,
                     )
-                    store = store.on_gossip_attestation(signed_attestation, is_aggregator=True)
+                    store = spec.on_gossip_attestation(
+                        store, signed_attestation, is_aggregator=True
+                    )
 
-            store, block, _ = store.produce_block_with_signatures(slot, proposer)
+            store, block, _ = spec.produce_block_with_signatures(store, slot, proposer)
 
         # After processing blocks with attestations, check finalization
         # The exact finalization behavior depends on 3SF-mini rules
@@ -436,14 +450,15 @@ class TestAttestationTargetEdgeCases:
     def test_attestation_target_with_skipped_slots(
         self,
         observer_store: Store,
+        spec: LstarSpec,
     ) -> None:
         """Attestation target should handle chains with skipped slots."""
         store = observer_store
 
         # Produce blocks with gaps (skipped slots)
-        store, _, _ = store.produce_block_with_signatures(Slot(1), ValidatorIndex(1))
+        store, _, _ = spec.produce_block_with_signatures(store, Slot(1), ValidatorIndex(1))
         # Skip slot 2, 3
-        store, _, _ = store.produce_block_with_signatures(Slot(4), ValidatorIndex(4))
+        store, _, _ = spec.produce_block_with_signatures(store, Slot(4), ValidatorIndex(4))
 
         target = store.get_attestation_target()
 
@@ -465,6 +480,7 @@ class TestAttestationTargetEdgeCases:
     def test_attestation_target_at_justification_lookback_boundary(
         self,
         observer_store: Store,
+        spec: LstarSpec,
     ) -> None:
         """Test target when head is exactly JUSTIFICATION_LOOKBACK_SLOTS ahead."""
         store = observer_store
@@ -474,7 +490,7 @@ class TestAttestationTargetEdgeCases:
         for slot_num in range(1, lookback + 2):
             slot = Slot(slot_num)
             proposer = ValidatorIndex(slot_num % len(store.states[store.head].validators))
-            store, _, _ = store.produce_block_with_signatures(slot, proposer)
+            store, _, _ = spec.produce_block_with_signatures(store, slot, proposer)
 
         target = store.get_attestation_target()
         head_slot = store.blocks[store.head].slot
@@ -490,6 +506,7 @@ class TestIntegrationScenarios:
         self,
         keyed_store: Store,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
     ) -> None:
         """Test complete cycle: produce block, attest, justify."""
         store = keyed_store
@@ -497,11 +514,11 @@ class TestIntegrationScenarios:
         # Phase 1: Produce initial block
         slot_1 = Slot(1)
         proposer_1 = ValidatorIndex(1)
-        store, block_1, _ = store.produce_block_with_signatures(slot_1, proposer_1)
+        store, block_1, _ = spec.produce_block_with_signatures(store, slot_1, proposer_1)
         block_1_root = hash_tree_root(block_1)
 
         # Phase 2: Create attestations from multiple validators
-        attestation_data = store.produce_attestation_data(slot_1)
+        attestation_data = spec.produce_attestation_data(store, slot_1)
 
         num_validators = len(store.states[block_1_root].validators)
         for i in range(num_validators):
@@ -513,7 +530,7 @@ class TestIntegrationScenarios:
                 signature=sig,
             )
             # Process as gossip
-            store = store.on_gossip_attestation(signed_attestation, is_aggregator=True)
+            store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=True)
 
         # Phase 3: Aggregate signatures into payloads
         store, _ = store.aggregate()
@@ -527,7 +544,7 @@ class TestIntegrationScenarios:
         # Phase 5: Produce another block including attestations
         slot_2 = Slot(2)
         proposer_2 = ValidatorIndex(2)
-        store, block_2, _ = store.produce_block_with_signatures(slot_2, proposer_2)
+        store, block_2, _ = spec.produce_block_with_signatures(store, slot_2, proposer_2)
 
         # Verify final state
         assert len(store.blocks) >= 3  # Genesis + 2 blocks
@@ -538,6 +555,7 @@ class TestIntegrationScenarios:
         self,
         observer_store: Store,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
     ) -> None:
         """Test attestation target is correct after processing a block via on_block."""
         store = observer_store
@@ -545,7 +563,7 @@ class TestIntegrationScenarios:
         # Produce a block
         slot_1 = Slot(1)
         proposer_1 = ValidatorIndex(1)
-        store, block, signatures = store.produce_block_with_signatures(slot_1, proposer_1)
+        store, block, signatures = spec.produce_block_with_signatures(store, slot_1, proposer_1)
         block_root = hash_tree_root(block)
 
         # Sign the block root with the proposal key
@@ -562,8 +580,8 @@ class TestIntegrationScenarios:
         # Process block via on_block on a fresh consumer store
         consumer_store = observer_store
         target_interval = Interval.from_slot(block.slot)
-        consumer_store, _ = consumer_store.on_tick(target_interval, has_proposal=True)
-        consumer_store = consumer_store.on_block(signed_block)
+        consumer_store, _ = spec.on_tick(consumer_store, target_interval, has_proposal=True)
+        consumer_store = spec.on_block(consumer_store, signed_block)
 
         # Get attestation target after on_block
         target = consumer_store.get_attestation_target()

--- a/tests/lean_spec/subspecs/forkchoice/test_store_attestations.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_store_attestations.py
@@ -11,6 +11,7 @@ from lean_spec.forks.lstar.containers.attestation import (
     SignedAggregatedAttestation,
     SignedAttestation,
 )
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import INTERVALS_PER_SLOT
 from lean_spec.subspecs.ssz.hash import hash_tree_root
@@ -34,13 +35,15 @@ from tests.lean_spec.helpers import (
 )
 
 
-def test_on_block_processes_multi_validator_aggregations(key_manager: XmssKeyManager) -> None:
+def test_on_block_processes_multi_validator_aggregations(
+    key_manager: XmssKeyManager, spec: LstarSpec
+) -> None:
     """Ensure Store.on_block handles aggregated attestations with many validators."""
     base_store = make_store(num_validators=3, key_manager=key_manager)
 
     # Producer view knows about attestations from validators 1 and 2
     attestation_slot = Slot(1)
-    attestation_data = base_store.produce_attestation_data(attestation_slot)
+    attestation_data = spec.produce_attestation_data(base_store, attestation_slot)
 
     participants = [ValidatorIndex(1), ValidatorIndex(2)]
 
@@ -59,7 +62,7 @@ def test_on_block_processes_multi_validator_aggregations(key_manager: XmssKeyMan
         producer_store, key_manager, attestation_slot, proposer_index
     )
 
-    updated_store = consumer_store.on_block(signed_block)
+    updated_store = spec.on_block(consumer_store, signed_block)
 
     # Verify attestations can be extracted from aggregated payloads
     extracted_attestations = updated_store.extract_attestations_from_aggregated_payloads(
@@ -73,6 +76,7 @@ def test_on_block_processes_multi_validator_aggregations(key_manager: XmssKeyMan
 
 def test_on_block_preserves_immutability_of_aggregated_payloads(
     key_manager: XmssKeyManager,
+    spec: LstarSpec,
 ) -> None:
     """Verify that Store.on_block doesn't mutate previous store's latest_new_aggregated_payloads."""
     base_store = make_store(
@@ -81,7 +85,7 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
 
     # First block with attestations from validators 1 and 2
     attestation_slot_1 = Slot(1)
-    attestation_data_1 = base_store.produce_attestation_data(attestation_slot_1)
+    attestation_data_1 = spec.produce_attestation_data(base_store, attestation_slot_1)
 
     gossip_sigs_1 = {
         attestation_data_1: {
@@ -101,11 +105,11 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
     consumer_store_1, signed_block_1 = make_signed_block_from_store(
         producer_store_1, key_manager, attestation_slot_1, ValidatorIndex(1)
     )
-    store_after_block_1 = consumer_store_1.on_block(signed_block_1)
+    store_after_block_1 = spec.on_block(consumer_store_1, signed_block_1)
 
     # Second block with attestations for the SAME validators
     attestation_slot_2 = Slot(2)
-    attestation_data_2 = store_after_block_1.produce_attestation_data(attestation_slot_2)
+    attestation_data_2 = spec.produce_attestation_data(store_after_block_1, attestation_slot_2)
 
     gossip_sigs_2 = {
         attestation_data_2: {
@@ -132,7 +136,7 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
     }
 
     # Process the second block
-    store_after_block_2 = store_before_block_2.on_block(signed_block_2)
+    store_after_block_2 = spec.on_block(store_before_block_2, signed_block_2)
 
     # Verify immutability: the list lengths in store_before_block_2 should not have changed
     for key, original_length in original_sig_lengths.items():
@@ -159,7 +163,9 @@ class TestOnGossipAttestationImportGating:
     drop everything.
     """
 
-    def test_aggregator_stores_received_attestation(self, key_manager: XmssKeyManager) -> None:
+    def test_aggregator_stores_received_attestation(
+        self, key_manager: XmssKeyManager, spec: LstarSpec
+    ) -> None:
         """Aggregator stores any attestation that reaches the store."""
         current_validator = ValidatorIndex(0)
         attester_validator = ValidatorIndex(1)
@@ -178,14 +184,16 @@ class TestOnGossipAttestationImportGating:
             "Precondition: no signatures before processing"
         )
 
-        updated_store = store.on_gossip_attestation(signed_attestation, is_aggregator=True)
+        updated_store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=True)
 
         sigs = updated_store.attestation_signatures.get(attestation_data, set())
         assert attester_validator in {entry.validator_id for entry in sigs}, (
             "Aggregator should store any attestation it receives"
         )
 
-    def test_aggregator_stores_multiple_attestations(self, key_manager: XmssKeyManager) -> None:
+    def test_aggregator_stores_multiple_attestations(
+        self, key_manager: XmssKeyManager, spec: LstarSpec
+    ) -> None:
         """Aggregator stores all attestations regardless of which validator sent them."""
         current_validator = ValidatorIndex(0)
         attesters = [ValidatorIndex(1), ValidatorIndex(2), ValidatorIndex(3)]
@@ -203,7 +211,7 @@ class TestOnGossipAttestationImportGating:
 
         updated = store
         for v in attesters:
-            updated = updated.on_gossip_attestation(make_signed(v), is_aggregator=True)
+            updated = spec.on_gossip_attestation(updated, make_signed(v), is_aggregator=True)
 
         stored_ids = {
             entry.validator_id
@@ -213,7 +221,9 @@ class TestOnGossipAttestationImportGating:
             "Aggregator should store attestations from all received validators"
         )
 
-    def test_non_aggregator_never_stores_signature(self, key_manager: XmssKeyManager) -> None:
+    def test_non_aggregator_never_stores_signature(
+        self, key_manager: XmssKeyManager, spec: LstarSpec
+    ) -> None:
         """Non-aggregator nodes drop all gossip attestations regardless of sender."""
         current_validator = ValidatorIndex(0)
         attester_validator = ValidatorIndex(1)
@@ -228,7 +238,7 @@ class TestOnGossipAttestationImportGating:
             signature=key_manager.sign_attestation_data(attester_validator, attestation_data),
         )
 
-        updated_store = store.on_gossip_attestation(signed_attestation, is_aggregator=False)
+        updated_store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=False)
 
         sigs = updated_store.attestation_signatures.get(attestation_data, set())
         assert attester_validator not in {entry.validator_id for entry in sigs}, (
@@ -236,7 +246,7 @@ class TestOnGossipAttestationImportGating:
         )
 
     def test_non_aggregator_does_not_create_signatures_entry(
-        self, key_manager: XmssKeyManager
+        self, key_manager: XmssKeyManager, spec: LstarSpec
     ) -> None:
         """Non-aggregator leaves attestation_signatures unchanged."""
         current_validator = ValidatorIndex(0)
@@ -252,7 +262,7 @@ class TestOnGossipAttestationImportGating:
             signature=key_manager.sign_attestation_data(attester_validator, attestation_data),
         )
 
-        updated_store = store.on_gossip_attestation(signed_attestation, is_aggregator=False)
+        updated_store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=False)
 
         assert attestation_data not in updated_store.attestation_signatures, (
             "Non-aggregator should not create any attestation_signatures entry"
@@ -266,7 +276,9 @@ class TestOnGossipAggregatedAttestation:
     Tests aggregated proof verification and storage in latest_new_aggregated_payloads.
     """
 
-    def test_valid_proof_stored_correctly(self, key_manager: XmssKeyManager) -> None:
+    def test_valid_proof_stored_correctly(
+        self, key_manager: XmssKeyManager, spec: LstarSpec
+    ) -> None:
         """
         Valid aggregated attestation is verified and stored.
 
@@ -303,7 +315,7 @@ class TestOnGossipAggregatedAttestation:
             proof=proof,
         )
 
-        updated_store = store.on_gossip_aggregated_attestation(signed_aggregated)
+        updated_store = spec.on_gossip_aggregated_attestation(store, signed_aggregated)
 
         # Verify proof is stored keyed by attestation data
         assert attestation_data in updated_store.latest_new_aggregated_payloads, (
@@ -313,7 +325,9 @@ class TestOnGossipAggregatedAttestation:
         assert len(proofs) == 1
         assert proof in proofs
 
-    def test_attestation_data_used_as_key(self, key_manager: XmssKeyManager) -> None:
+    def test_attestation_data_used_as_key(
+        self, key_manager: XmssKeyManager, spec: LstarSpec
+    ) -> None:
         """
         Attestation data is used directly as the key in aggregated payloads.
 
@@ -348,12 +362,12 @@ class TestOnGossipAggregatedAttestation:
             proof=proof,
         )
 
-        updated_store = store.on_gossip_aggregated_attestation(signed_aggregated)
+        updated_store = spec.on_gossip_aggregated_attestation(store, signed_aggregated)
 
         assert attestation_data in updated_store.latest_new_aggregated_payloads
         assert proof in updated_store.latest_new_aggregated_payloads[attestation_data]
 
-    def test_invalid_proof_rejected(self, key_manager: XmssKeyManager) -> None:
+    def test_invalid_proof_rejected(self, key_manager: XmssKeyManager, spec: LstarSpec) -> None:
         """
         Corrupted aggregated proof is rejected with AssertionError.
 
@@ -398,9 +412,9 @@ class TestOnGossipAggregatedAttestation:
         )
 
         with pytest.raises(AssertionError, match="signature verification failed"):
-            store.on_gossip_aggregated_attestation(signed_aggregated)
+            spec.on_gossip_aggregated_attestation(store, signed_aggregated)
 
-    def test_multiple_proofs_accumulate(self, key_manager: XmssKeyManager) -> None:
+    def test_multiple_proofs_accumulate(self, key_manager: XmssKeyManager, spec: LstarSpec) -> None:
         """
         Multiple aggregated proofs for same validator accumulate.
 
@@ -455,11 +469,11 @@ class TestOnGossipAggregatedAttestation:
             slot=attestation_data.slot,
         )
 
-        store = store.on_gossip_aggregated_attestation(
-            SignedAggregatedAttestation(data=attestation_data, proof=proof_1)
+        store = spec.on_gossip_aggregated_attestation(
+            store, SignedAggregatedAttestation(data=attestation_data, proof=proof_1)
         )
-        store = store.on_gossip_aggregated_attestation(
-            SignedAggregatedAttestation(data=attestation_data, proof=proof_2)
+        store = spec.on_gossip_aggregated_attestation(
+            store, SignedAggregatedAttestation(data=attestation_data, proof=proof_2)
         )
 
         # Both proofs should be stored under the same attestation data
@@ -560,7 +574,7 @@ class TestAggregateCommitteeSignatures:
         assert len(updated_store.latest_new_aggregated_payloads) == 0
 
     def test_multiple_attestation_data_grouped_separately(
-        self, key_manager: XmssKeyManager
+        self, key_manager: XmssKeyManager, spec: LstarSpec
     ) -> None:
         """
         Signatures for different attestation data are aggregated separately.
@@ -572,7 +586,7 @@ class TestAggregateCommitteeSignatures:
         )
 
         # Create two different attestation data (different slots)
-        att_data_1 = base_store.produce_attestation_data(Slot(1))
+        att_data_1 = spec.produce_attestation_data(base_store, Slot(1))
         # Create a second attestation data with different head
         att_data_2 = AttestationData(
             slot=Slot(1),
@@ -734,7 +748,9 @@ class TestEndToEndAggregationFlow:
     interval-triggered aggregation to proof storage.
     """
 
-    def test_gossip_to_aggregation_to_storage(self, key_manager: XmssKeyManager) -> None:
+    def test_gossip_to_aggregation_to_storage(
+        self, key_manager: XmssKeyManager, spec: LstarSpec
+    ) -> None:
         """
         Complete flow: gossip attestation -> aggregation -> proof storage.
 
@@ -753,7 +769,7 @@ class TestEndToEndAggregationFlow:
         # Advance the clock to slot 1 so the attestation's slot has begun.
         store = store.model_copy(update={"time": Interval.from_slot(Slot(1))})
 
-        attestation_data = store.produce_attestation_data(Slot(1))
+        attestation_data = spec.produce_attestation_data(store, Slot(1))
         data_root = hash_tree_root(attestation_data)
 
         # Step 1: Receive gossip attestations from validators 1 and 2
@@ -766,7 +782,8 @@ class TestEndToEndAggregationFlow:
                 data=attestation_data,
                 signature=key_manager.sign_attestation_data(vid, attestation_data),
             )
-            store = store.on_gossip_attestation(
+            store = spec.on_gossip_attestation(
+                store,
                 signed_attestation,
                 is_aggregator=True,
             )

--- a/tests/lean_spec/subspecs/forkchoice/test_time_management.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_time_management.py
@@ -6,6 +6,7 @@ from hypothesis import strategies as st
 from lean_spec.forks.lstar import State, Store
 from lean_spec.forks.lstar.containers import Block
 from lean_spec.forks.lstar.containers.state import Validators
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import (
     INTERVALS_PER_SLOT,
@@ -53,43 +54,43 @@ class TestGetForkchoiceStore:
 class TestOnTick:
     """Test Store on_tick functionality."""
 
-    def test_on_tick_basic(self, sample_store: Store) -> None:
+    def test_on_tick_basic(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test basic on_tick."""
         initial_time = sample_store.time
         # 200 seconds = 200*1000/800 = 250 intervals
         target_interval = Interval(200 * 1000 // int(MILLISECONDS_PER_INTERVAL))
 
-        sample_store, _ = sample_store.on_tick(target_interval, has_proposal=True)
+        sample_store, _ = spec.on_tick(sample_store, target_interval, has_proposal=True)
 
         # Time should advance
         assert sample_store.time > initial_time
 
-    def test_on_tick_no_proposal(self, sample_store: Store) -> None:
+    def test_on_tick_no_proposal(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test on_tick without proposal."""
         initial_time = sample_store.time
         # 100 seconds = 125 intervals
         target_interval = Interval(100 * 1000 // int(MILLISECONDS_PER_INTERVAL))
 
-        sample_store, _ = sample_store.on_tick(target_interval, has_proposal=False)
+        sample_store, _ = spec.on_tick(sample_store, target_interval, has_proposal=False)
 
         # Time should still advance
         assert sample_store.time >= initial_time
 
-    def test_on_tick_already_current(self, sample_store: Store) -> None:
+    def test_on_tick_already_current(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test on_tick when already at target time (should be no-op)."""
         initial_time = sample_store.time
 
-        sample_store, _ = sample_store.on_tick(Interval(initial_time), has_proposal=True)
+        sample_store, _ = spec.on_tick(sample_store, Interval(initial_time), has_proposal=True)
 
         # No-op: target equals current time
         assert sample_store.time == initial_time
 
-    def test_on_tick_small_increment(self, sample_store: Store) -> None:
+    def test_on_tick_small_increment(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test on_tick with small interval increment."""
         initial_time = sample_store.time
         target_interval = Interval(int(initial_time) + 1)
 
-        sample_store, _ = sample_store.on_tick(target_interval, has_proposal=False)
+        sample_store, _ = spec.on_tick(sample_store, target_interval, has_proposal=False)
 
         # Should advance by exactly one interval
         assert sample_store.time == target_interval
@@ -184,7 +185,7 @@ class TestAttestationProcessingTiming:
 class TestProposalHeadTiming:
     """Test proposal head timing logic."""
 
-    def test_get_proposal_head_basic(self, sample_store: Store) -> None:
+    def test_get_proposal_head_basic(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test getting proposal head for a slot."""
         # Add a block to make the test more realistic
         genesis_block = Block(
@@ -202,28 +203,30 @@ class TestProposalHeadTiming:
         sample_store = sample_store.model_copy(update={"blocks": new_blocks, "head": genesis_hash})
 
         # Get proposal head for slot 0
-        store, head = sample_store.get_proposal_head(Slot(0))
+        store, head = spec.get_proposal_head(sample_store, Slot(0))
 
         # Should return the store's head
         assert head == store.head
 
-    def test_get_proposal_head_advances_time(self, sample_store: Store) -> None:
+    def test_get_proposal_head_advances_time(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test that get_proposal_head advances store time appropriately."""
         initial_time = sample_store.time
 
         # Get proposal head for a future slot
         future_slot = Slot(5)
-        store, _ = sample_store.get_proposal_head(future_slot)
+        store, _ = spec.get_proposal_head(sample_store, future_slot)
 
         # Time may have advanced (depending on slot timing)
         # This is mainly testing that the call doesn't fail
         assert store.time >= initial_time
 
-    def test_get_proposal_head_processes_attestations(self, sample_store: Store) -> None:
+    def test_get_proposal_head_processes_attestations(
+        self, sample_store: Store, spec: LstarSpec
+    ) -> None:
         """Test that get_proposal_head processes pending aggregated payloads."""
         # Attestations are now tracked via aggregated payloads
         # Test simplified to verify the method runs correctly
-        store, head = sample_store.get_proposal_head(Slot(1))
+        store, head = spec.get_proposal_head(sample_store, Slot(1))
 
         # get_proposal_head should have called accept_new_attestations
         # which migrates new payloads to known payloads

--- a/tests/lean_spec/subspecs/forkchoice/test_validate_attestation.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_validate_attestation.py
@@ -9,6 +9,7 @@ from lean_spec.forks.lstar.containers import (
     Attestation,
     AttestationData,
 )
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import GOSSIP_DISPARITY_INTERVALS, INTERVALS_PER_SLOT
 from lean_spec.subspecs.ssz.hash import hash_tree_root
@@ -36,6 +37,7 @@ class TestValidateAttestationHeadChecks:
 
     def test_head_checkpoint_slot_mismatch_rejected(
         self,
+        spec: LstarSpec,
         observer_store: Store,
     ) -> None:
         """Head checkpoint slot must match the actual block slot."""
@@ -45,7 +47,7 @@ class TestValidateAttestationHeadChecks:
         # This gives us a real block whose actual slot is 1.
         slot_1 = Slot(1)
         proposer = ValidatorIndex(1)
-        store, block, _ = store.produce_block_with_signatures(slot_1, proposer)
+        store, block, _ = spec.produce_block_with_signatures(store, slot_1, proposer)
         block_root = hash_tree_root(block)
 
         genesis_root = store.latest_justified.root
@@ -68,6 +70,7 @@ class TestValidateAttestationHeadChecks:
 
     def test_head_slot_less_than_source_rejected(
         self,
+        spec: LstarSpec,
         observer_store: Store,
     ) -> None:
         """Head cannot be older than the justified source."""
@@ -77,10 +80,10 @@ class TestValidateAttestationHeadChecks:
         slot_1 = Slot(1)
         slot_2 = Slot(2)
         proposer = ValidatorIndex(1)
-        store, block_1, _ = store.produce_block_with_signatures(slot_1, proposer)
+        store, block_1, _ = spec.produce_block_with_signatures(store, slot_1, proposer)
         block_1_root = hash_tree_root(block_1)
 
-        store, block_2, _ = store.produce_block_with_signatures(slot_2, ValidatorIndex(2))
+        store, block_2, _ = spec.produce_block_with_signatures(store, slot_2, ValidatorIndex(2))
         block_2_root = hash_tree_root(block_2)
 
         genesis_root = store.latest_justified.root
@@ -104,6 +107,7 @@ class TestValidateAttestationHeadChecks:
 
     def test_head_slot_less_than_target_rejected(
         self,
+        spec: LstarSpec,
         observer_store: Store,
     ) -> None:
         """Head cannot be older than the target."""
@@ -113,10 +117,10 @@ class TestValidateAttestationHeadChecks:
         slot_1 = Slot(1)
         slot_2 = Slot(2)
         proposer = ValidatorIndex(1)
-        store, block_1, _ = store.produce_block_with_signatures(slot_1, proposer)
+        store, block_1, _ = spec.produce_block_with_signatures(store, slot_1, proposer)
         block_1_root = hash_tree_root(block_1)
 
-        store, block_2, _ = store.produce_block_with_signatures(slot_2, ValidatorIndex(2))
+        store, block_2, _ = spec.produce_block_with_signatures(store, slot_2, ValidatorIndex(2))
         block_2_root = hash_tree_root(block_2)
 
         genesis_root = store.latest_justified.root
@@ -140,6 +144,7 @@ class TestValidateAttestationHeadChecks:
 
     def test_valid_attestation_with_correct_head_passes(
         self,
+        spec: LstarSpec,
         observer_store: Store,
     ) -> None:
         """An attestation with all checkpoints consistent should pass."""
@@ -148,7 +153,7 @@ class TestValidateAttestationHeadChecks:
         # Produce a single block at slot 1.
         slot_1 = Slot(1)
         proposer = ValidatorIndex(1)
-        store, block, _ = store.produce_block_with_signatures(slot_1, proposer)
+        store, block, _ = spec.produce_block_with_signatures(store, slot_1, proposer)
         block_root = hash_tree_root(block)
 
         genesis_root = store.latest_justified.root
@@ -209,11 +214,11 @@ class TestValidateAttestationTimeCheck:
     """
 
     @staticmethod
-    def _build_two_block_chain(store: Store) -> tuple[Store, AttestationData]:
+    def _build_two_block_chain(spec: LstarSpec, store: Store) -> tuple[Store, AttestationData]:
         """Produce blocks at slots 1 and ATTESTATION_SLOT; return ATTESTATION_SLOT data."""
-        store, _, _ = store.produce_block_with_signatures(Slot(1), ValidatorIndex(1))
-        store, block_2, _ = store.produce_block_with_signatures(
-            ATTESTATION_SLOT, ValidatorIndex(int(ATTESTATION_SLOT))
+        store, _, _ = spec.produce_block_with_signatures(store, Slot(1), ValidatorIndex(1))
+        store, block_2, _ = spec.produce_block_with_signatures(
+            store, ATTESTATION_SLOT, ValidatorIndex(int(ATTESTATION_SLOT))
         )
         block_2_root = hash_tree_root(block_2)
         genesis_root = store.latest_justified.root
@@ -226,43 +231,49 @@ class TestValidateAttestationTimeCheck:
         )
         return store, data
 
-    def test_attestation_at_current_slot_passes(self, observer_store: Store) -> None:
+    def test_attestation_at_current_slot_passes(
+        self, spec: LstarSpec, observer_store: Store
+    ) -> None:
         """A vote at the current slot is always accepted, every interval."""
-        store, data = self._build_two_block_chain(observer_store)
+        store, data = self._build_two_block_chain(spec, observer_store)
 
         # Sweep every interval in the attestation's slot.
         for offset in range(int(INTERVALS_PER_SLOT)):
             local = store.model_copy(update={"time": ATTESTATION_START_INTERVAL + Interval(offset)})
             local.validate_attestation(data)
 
-    def test_attestation_in_past_passes(self, observer_store: Store) -> None:
+    def test_attestation_in_past_passes(self, spec: LstarSpec, observer_store: Store) -> None:
         """A vote from a past slot is always accepted."""
-        store, data = self._build_two_block_chain(observer_store)
+        store, data = self._build_two_block_chain(spec, observer_store)
 
         # Place the local clock several slots ahead.
         far_future = ATTESTATION_START_INTERVAL + INTERVALS_PER_SLOT * Interval(10)
         store = store.model_copy(update={"time": far_future})
         store.validate_attestation(data)
 
-    def test_attestation_at_disparity_boundary_passes(self, observer_store: Store) -> None:
+    def test_attestation_at_disparity_boundary_passes(
+        self, spec: LstarSpec, observer_store: Store
+    ) -> None:
         """At the disparity boundary the attestation is still accepted."""
-        store, data = self._build_two_block_chain(observer_store)
+        store, data = self._build_two_block_chain(spec, observer_store)
 
         store = store.model_copy(update={"time": DISPARITY_BOUNDARY_INTERVAL})
         store.validate_attestation(data)
 
     def test_attestation_just_beyond_disparity_boundary_rejected(
-        self, observer_store: Store
+        self, spec: LstarSpec, observer_store: Store
     ) -> None:
         """One interval past the disparity boundary the attestation is rejected."""
-        store, data = self._build_two_block_chain(observer_store)
+        store, data = self._build_two_block_chain(spec, observer_store)
 
         store = store.model_copy(update={"time": JUST_BEYOND_DISPARITY_BOUNDARY_INTERVAL})
 
         with pytest.raises(AssertionError, match="Attestation too far in future"):
             store.validate_attestation(data)
 
-    def test_attestation_one_full_slot_in_future_rejected(self, observer_store: Store) -> None:
+    def test_attestation_one_full_slot_in_future_rejected(
+        self, spec: LstarSpec, observer_store: Store
+    ) -> None:
         """
         Regression: a full-slot future window must be rejected.
 
@@ -270,7 +281,7 @@ class TestValidateAttestationTimeCheck:
         That window let an adversary pre-publish next-slot aggregates
         before any honest validator could produce them.
         """
-        store, data = self._build_two_block_chain(observer_store)
+        store, data = self._build_two_block_chain(spec, observer_store)
 
         store = store.model_copy(update={"time": ONE_FULL_SLOT_BEHIND_INTERVAL})
 

--- a/tests/lean_spec/subspecs/forkchoice/test_validator.py
+++ b/tests/lean_spec/subspecs/forkchoice/test_validator.py
@@ -12,6 +12,7 @@ from lean_spec.forks.lstar.containers import (
     Config,
     SignedAttestation,
 )
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
@@ -22,12 +23,14 @@ from tests.lean_spec.helpers import TEST_VALIDATOR_ID, make_aggregated_proof, ma
 class TestBlockProduction:
     """Test validator block production functionality."""
 
-    def test_produce_block_basic(self, sample_store: Store) -> None:
+    def test_produce_block_basic(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test basic block production by authorized proposer."""
         slot = Slot(1)
         validator_idx = ValidatorIndex(1)  # Proposer for slot 1
 
-        store, block, _signatures = sample_store.produce_block_with_signatures(slot, validator_idx)
+        store, block, _signatures = spec.produce_block_with_signatures(
+            sample_store, slot, validator_idx
+        )
         # Verify block structure
         assert block.slot == slot
         assert block.proposer_index == validator_idx
@@ -40,16 +43,18 @@ class TestBlockProduction:
         assert block_hash in store.blocks
         assert block_hash in store.states
 
-    def test_produce_block_unauthorized_proposer(self, sample_store: Store) -> None:
+    def test_produce_block_unauthorized_proposer(
+        self, sample_store: Store, spec: LstarSpec
+    ) -> None:
         """Test block production fails for unauthorized proposer."""
         slot = Slot(1)
         wrong_validator = ValidatorIndex(2)  # Not proposer for slot 1
 
         with pytest.raises(AssertionError, match="is not the proposer for slot"):
-            sample_store.produce_block_with_signatures(slot, wrong_validator)
+            spec.produce_block_with_signatures(sample_store, slot, wrong_validator)
 
     def test_produce_block_with_attestations(
-        self, sample_store: Store, key_manager: XmssKeyManager
+        self, sample_store: Store, key_manager: XmssKeyManager, spec: LstarSpec
     ) -> None:
         """Test block production includes available attestations."""
         head_block = sample_store.blocks[sample_store.head]
@@ -106,7 +111,8 @@ class TestBlockProduction:
         slot = Slot(2)
         validator_idx = ValidatorIndex(2)  # Proposer for slot 2
 
-        store, block, signatures = sample_store.produce_block_with_signatures(
+        store, block, signatures = spec.produce_block_with_signatures(
+            sample_store,
             slot,
             validator_idx,
         )
@@ -130,10 +136,11 @@ class TestBlockProduction:
                 slot=agg_att.data.slot,
             )
 
-    def test_produce_block_sequential_slots(self, sample_store: Store) -> None:
+    def test_produce_block_sequential_slots(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test producing blocks in sequential slots."""
         # Produce block for slot 1
-        sample_store, block1, _signatures1 = sample_store.produce_block_with_signatures(
+        sample_store, block1, _signatures1 = spec.produce_block_with_signatures(
+            sample_store,
             Slot(1),
             ValidatorIndex(1),
         )
@@ -150,7 +157,8 @@ class TestBlockProduction:
         # So block2 should build on genesis, not block1
 
         # Produce block for slot 2 (will build on genesis due to forkchoice)
-        sample_store, block2, _signatures2 = sample_store.produce_block_with_signatures(
+        sample_store, block2, _signatures2 = spec.produce_block_with_signatures(
+            sample_store,
             Slot(2),
             ValidatorIndex(2),
         )
@@ -169,7 +177,7 @@ class TestBlockProduction:
         assert block2_hash in sample_store.blocks
         assert genesis_hash in sample_store.blocks
 
-    def test_produce_block_empty_attestations(self, sample_store: Store) -> None:
+    def test_produce_block_empty_attestations(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test block production with no available attestations."""
         slot = Slot(3)
         validator_idx = ValidatorIndex(3)
@@ -181,7 +189,8 @@ class TestBlockProduction:
             }
         )
 
-        store, block, _signatures = sample_store.produce_block_with_signatures(
+        store, block, _signatures = spec.produce_block_with_signatures(
+            sample_store,
             slot,
             validator_idx,
         )
@@ -193,7 +202,7 @@ class TestBlockProduction:
         assert block.state_root != Bytes32.zero()
 
     def test_produce_block_state_consistency(
-        self, sample_store: Store, key_manager: XmssKeyManager
+        self, sample_store: Store, key_manager: XmssKeyManager, spec: LstarSpec
     ) -> None:
         """Test that produced block's state is consistent with block content."""
         slot = Slot(4)
@@ -227,7 +236,8 @@ class TestBlockProduction:
             }
         )
 
-        store, block, signatures = sample_store.produce_block_with_signatures(
+        store, block, signatures = spec.produce_block_with_signatures(
+            sample_store,
             slot,
             validator_idx,
         )
@@ -251,12 +261,12 @@ class TestBlockProduction:
 class TestValidatorIntegration:
     """Test integration between block production and attestations."""
 
-    def test_block_production_then_attestation(self, sample_store: Store) -> None:
+    def test_block_production_then_attestation(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test producing a block then creating attestation for it."""
         # Proposer produces block for slot 1
         proposer_slot = Slot(1)
         proposer_idx = ValidatorIndex(1)
-        sample_store.produce_block_with_signatures(proposer_slot, proposer_idx)
+        spec.produce_block_with_signatures(sample_store, proposer_slot, proposer_idx)
 
         # Update store state after block production
         sample_store = sample_store.update_head()
@@ -264,7 +274,7 @@ class TestValidatorIntegration:
         # Other validator creates attestation for slot 2
         attestor_slot = Slot(2)
         attestor_idx = ValidatorIndex(7)
-        attestation_data = sample_store.produce_attestation_data(attestor_slot)
+        attestation_data = spec.produce_attestation_data(sample_store, attestor_slot)
         attestation = Attestation(validator_id=attestor_idx, data=attestation_data)
 
         # Attestation should reference the new block as head (if it became head)
@@ -274,10 +284,11 @@ class TestValidatorIntegration:
         # The attestation should be consistent with current forkchoice state
         assert attestation.data.source == sample_store.latest_justified
 
-    def test_multiple_validators_coordination(self, sample_store: Store) -> None:
+    def test_multiple_validators_coordination(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test multiple validators producing blocks and attestations."""
         # Validator 1 produces block for slot 1
-        sample_store, block1, _signatures1 = sample_store.produce_block_with_signatures(
+        sample_store, block1, _signatures1 = spec.produce_block_with_signatures(
+            sample_store,
             Slot(1),
             ValidatorIndex(1),
         )
@@ -287,7 +298,7 @@ class TestValidatorIntegration:
         # These will be based on the current forkchoice head (genesis)
         attestations = []
         for i in range(2, 6):
-            attestation_data = sample_store.produce_attestation_data(Slot(2))
+            attestation_data = spec.produce_attestation_data(sample_store, Slot(2))
             attestation = Attestation(validator_id=ValidatorIndex(i), data=attestation_data)
             attestations.append(attestation)
 
@@ -301,7 +312,8 @@ class TestValidatorIntegration:
         # Validator 2 produces next block for slot 2
         # After processing block1, head should be block1 (fork choice walks the tree)
         # So block2 will build on block1
-        sample_store, block2, _signatures2 = sample_store.produce_block_with_signatures(
+        sample_store, block2, _signatures2 = spec.produce_block_with_signatures(
+            sample_store,
             Slot(2),
             ValidatorIndex(2),
         )
@@ -328,34 +340,36 @@ class TestValidatorIntegration:
         assert block1.parent_root == genesis_hash
         assert block2.parent_root == block1_hash
 
-    def test_validator_edge_cases(self, sample_store: Store) -> None:
+    def test_validator_edge_cases(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test edge cases in validator operations."""
         # Test with validator index equal to number of validators - 1
         max_validator = ValidatorIndex(7)  # Last validator (0-indexed, 8 total)
         slot = Slot(7)  # This validator's slot
 
         # Should be able to produce block
-        store, block, _signatures = sample_store.produce_block_with_signatures(
+        store, block, _signatures = spec.produce_block_with_signatures(
+            sample_store,
             slot,
             max_validator,
         )
         assert block.proposer_index == max_validator
 
         # Should be able to produce attestation
-        attestation_data = sample_store.produce_attestation_data(Slot(10))
+        attestation_data = spec.produce_attestation_data(sample_store, Slot(10))
         attestation = Attestation(validator_id=max_validator, data=attestation_data)
         assert attestation.validator_id == max_validator
 
-    def test_validator_operations_empty_store(self) -> None:
+    def test_validator_operations_empty_store(self, spec: LstarSpec) -> None:
         """Test validator operations with minimal store state."""
         store = make_store(num_validators=3)
 
         # Should be able to produce block and attestation
-        store, block, _signatures = store.produce_block_with_signatures(
+        store, block, _signatures = spec.produce_block_with_signatures(
+            store,
             Slot(1),
             ValidatorIndex(1),
         )
-        attestation_data = store.produce_attestation_data(Slot(1))
+        attestation_data = spec.produce_attestation_data(store, Slot(1))
         attestation = Attestation(validator_id=ValidatorIndex(2), data=attestation_data)
 
         assert isinstance(block, Block)
@@ -365,17 +379,17 @@ class TestValidatorIntegration:
 class TestValidatorErrorHandling:
     """Test error handling in validator operations."""
 
-    def test_produce_block_wrong_proposer(self, sample_store: Store) -> None:
+    def test_produce_block_wrong_proposer(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test error when wrong validator tries to produce block."""
         slot = Slot(5)
         wrong_proposer = ValidatorIndex(3)  # Should be validator 5 for slot 5
 
         with pytest.raises(AssertionError) as exc_info:
-            sample_store.produce_block_with_signatures(slot, wrong_proposer)
+            spec.produce_block_with_signatures(sample_store, slot, wrong_proposer)
 
         assert "is not the proposer for slot" in str(exc_info.value)
 
-    def test_produce_block_missing_parent_state(self) -> None:
+    def test_produce_block_missing_parent_state(self, spec: LstarSpec) -> None:
         """Test error when parent state is missing."""
         config = Config(genesis_time=Uint64(1000))
         checkpoint = Checkpoint(root=Bytes32(b"missing" + b"\x00" * 25), slot=Slot(0))
@@ -394,9 +408,11 @@ class TestValidatorErrorHandling:
         )
 
         with pytest.raises(KeyError):  # Missing head in get_proposal_head
-            store.produce_block_with_signatures(Slot(1), ValidatorIndex(1))
+            spec.produce_block_with_signatures(store, Slot(1), ValidatorIndex(1))
 
-    def test_validator_operations_invalid_parameters(self, sample_store: Store) -> None:
+    def test_validator_operations_invalid_parameters(
+        self, sample_store: Store, spec: LstarSpec
+    ) -> None:
         """Test validator operations with invalid parameters."""
         # Very large validator index (should work mathematically)
         large_validator = ValidatorIndex(1000000)
@@ -412,6 +428,6 @@ class TestValidatorErrorHandling:
         assert isinstance(result, bool)
 
         # Attestation can be created for any validator
-        attestation_data = sample_store.produce_attestation_data(Slot(1))
+        attestation_data = spec.produce_attestation_data(sample_store, Slot(1))
         attestation = Attestation(validator_id=large_validator, data=attestation_data)
         assert attestation.validator_id == large_validator

--- a/tests/lean_spec/subspecs/validator/test_service.py
+++ b/tests/lean_spec/subspecs/validator/test_service.py
@@ -14,6 +14,7 @@ from lean_spec.forks.lstar.containers import (
     SignedAttestation,
     SignedBlock,
 )
+from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.chain.clock import SlotClock
 from lean_spec.subspecs.chain.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.subspecs.ssz.hash import hash_tree_root
@@ -160,11 +161,11 @@ class TestSignBlock:
         )
 
     def test_attestation_signatures_included(
-        self, sync_service: SyncService, key_manager: XmssKeyManager
+        self, sync_service: SyncService, key_manager: XmssKeyManager, spec: LstarSpec
     ) -> None:
         """Aggregated attestation proofs passed in are present in the returned signature."""
         service, block = self._setup(sync_service, key_manager)
-        attestation_data = sync_service.store.produce_attestation_data(Slot(1))
+        attestation_data = spec.produce_attestation_data(sync_service.store, Slot(1))
         agg_proof = make_aggregated_proof(key_manager, [ValidatorIndex(0)], attestation_data)
 
         result = service._sign_block(block, ValidatorIndex(0), [agg_proof])
@@ -199,6 +200,7 @@ class TestSignAttestation:
         self,
         sync_service: SyncService,
         key_manager: XmssKeyManager,
+        spec: LstarSpec,
         index: int = 0,
     ) -> tuple[ValidatorService, AttestationData]:
         registry = _make_registry(key_manager, index)
@@ -207,14 +209,14 @@ class TestSignAttestation:
             clock=SlotClock(genesis_time=Uint64(0)),
             registry=registry,
         )
-        att_data = sync_service.store.produce_attestation_data(Slot(1))
+        att_data = spec.produce_attestation_data(sync_service.store, Slot(1))
         return service, att_data
 
     def test_fields_populated_correctly(
-        self, sync_service: SyncService, key_manager: XmssKeyManager
+        self, sync_service: SyncService, key_manager: XmssKeyManager, spec: LstarSpec
     ) -> None:
         """The signed attestation contains the correct validator ID, data, and a valid signature."""
-        service, att_data = self._setup(sync_service, key_manager, index=3)
+        service, att_data = self._setup(sync_service, key_manager, spec, index=3)
 
         result = service._sign_attestation(att_data, ValidatorIndex(3))
 
@@ -230,10 +232,10 @@ class TestSignAttestation:
         )
 
     def test_uses_attestation_key_not_proposal_key(
-        self, sync_service: SyncService, key_manager: XmssKeyManager
+        self, sync_service: SyncService, key_manager: XmssKeyManager, spec: LstarSpec
     ) -> None:
         """Attestation signature verifies with the attestation public key, not the proposal key."""
-        service, att_data = self._setup(sync_service, key_manager)
+        service, att_data = self._setup(sync_service, key_manager, spec)
 
         result = service._sign_attestation(att_data, ValidatorIndex(0))
 
@@ -246,7 +248,7 @@ class TestSignAttestation:
         )
 
     def test_missing_validator_raises_value_error(
-        self, sync_service: SyncService, key_manager: XmssKeyManager
+        self, sync_service: SyncService, key_manager: XmssKeyManager, spec: LstarSpec
     ) -> None:
         """Signing an attestation with an unregistered validator index raises ValueError."""
         service = ValidatorService(
@@ -254,7 +256,7 @@ class TestSignAttestation:
             clock=SlotClock(genesis_time=Uint64(0)),
             registry=ValidatorRegistry(),
         )
-        att_data = sync_service.store.produce_attestation_data(Slot(1))
+        att_data = spec.produce_attestation_data(sync_service.store, Slot(1))
 
         with pytest.raises(ValueError, match="No secret key for validator 99"):
             service._sign_attestation(att_data, ValidatorIndex(99))
@@ -1097,6 +1099,7 @@ class TestValidatorServiceIntegration:
         key_manager: XmssKeyManager,
         real_sync_service: SyncService,
         real_registry: ValidatorRegistry,
+        spec: LstarSpec,
     ) -> None:
         """
         Verify attestations from the pool are included in produced blocks.
@@ -1105,7 +1108,7 @@ class TestValidatorServiceIntegration:
         and include them in the block body.
         """
         store = real_sync_service.store
-        attestation_data = store.produce_attestation_data(Slot(0))
+        attestation_data = spec.produce_attestation_data(store, Slot(0))
         data_root = hash_tree_root(attestation_data)
 
         participants = [ValidatorIndex(3), ValidatorIndex(4)]

--- a/tests/lean_spec/test_cli.py
+++ b/tests/lean_spec/test_cli.py
@@ -257,12 +257,12 @@ class TestCreateAnchorBlock:
         assert anchor_block.state_root == expected_state_root
         assert anchor_block.state_root != Bytes32.zero()
 
-    def test_preserves_non_zero_state_root(self) -> None:
+    def test_preserves_non_zero_state_root(self, spec: LstarSpec) -> None:
         """Non-zero state root in header is preserved."""
         # Arrange: Create a state and process a slot to fill in state root
         state = make_genesis_state(num_validators=3, genesis_time=1000)
         # Process slot advances and fills in the state root
-        state_with_root = state.process_slots(Slot(1))
+        state_with_root = spec.process_slots(state, Slot(1))
 
         # The state root should now be non-zero in the header
         assert state_with_root.latest_block_header.state_root != Bytes32.zero()


### PR DESCRIPTION
## Summary

Stage 4B of the multi-fork architecture refactor (#686): rewrite test call sites that go through container methods to instead go through the fork's spec class.

The pattern:

| Before | After |
|---|---|
| \`state.process_block(block)\` | \`spec.process_block(state, block)\` |
| \`store.on_block(signed_block)\` | \`spec.on_block(store, signed_block)\` |
| \`signed_block.verify_signatures(vs)\` | \`spec.verify_signatures(signed_block, vs)\` |
| \`store.produce_attestation_data(slot)\` | \`spec.produce_attestation_data(store, slot)\` |
| ... | ... |

## How tests get \`spec\`

Two patterns:

- **Test functions**: a session-scoped \`spec\` pytest fixture in \`tests/lean_spec/conftest.py\` returns \`LstarSpec()\`. Tests add \`spec: LstarSpec\` to their signature.
- **Helper / library code** (\`tests/lean_spec/helpers/builders.py\`, \`packages/testing/...\`): a module-level \`_SPEC = LstarSpec()\` constant. \`LstarSpec\` is stateless so a single shared instance is fine.

## Out of scope

Internal Store helpers (\`aggregate\`, \`update_head\`, \`accept_new_attestations\`, \`update_safe_target\`, \`tick_interval\`, \`validate_attestation\`, \`prune_stale_attestation_data\`, \`extract_attestations_from_aggregated_payloads\`, \`compute_block_weights\`) are not yet on the spec surface and are left as direct method calls — they migrate alongside the body move in the next stage.

Subspec call sites (\`subspecs/sync/\`, \`subspecs/validator/\`, etc.) are also out of scope here — they migrate when the bodies move.

## Test plan

- [x] \`uvx tox -e all-checks\` (ruff check + format + ty + codespell + mdformat) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)