### PR TITLE
feat(api,sync): add /lean/v0/blocks/finalized for checkpoint-sync anchor block

### DIFF
--- a/src/lean_spec/subspecs/api/endpoints/blocks.py
+++ b/src/lean_spec/subspecs/api/endpoints/blocks.py
@@ -1,0 +1,56 @@
+"""Blocks endpoint handlers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_finalized(request: web.Request) -> web.Response:
+    """
+    Handle finalized signed block request.
+
+    Returns the SignedBlock matching ``store.latest_finalized.root`` as raw
+    SSZ bytes (not snappy compressed).
+
+    Together with ``/lean/v0/states/finalized`` this lets a checkpoint-syncing
+    node obtain the ``(state, signed_block)`` pair required by
+    ``Store.create_store`` (which asserts
+    ``anchor_block.state_root == hash_tree_root(state)`` and seeds
+    ``store.blocks[anchor_root] = anchor_block``).
+
+    Response: SSZ-encoded SignedBlock (binary, application/octet-stream)
+
+    Status Codes:
+        200 OK: SignedBlock returned successfully.
+        404 Not Found: Finalized signed block not available on this node
+            (e.g. server retains only ``Block`` and not ``SignedBlock``).
+        503 Service Unavailable: Store / signed-block source not initialized.
+    """
+    signed_block_getter = request.app.get("signed_block_getter")
+    store_getter = request.app.get("store_getter")
+    store = store_getter() if store_getter else None
+
+    if store is None:
+        raise web.HTTPServiceUnavailable(reason="Store not initialized")
+
+    if signed_block_getter is None:
+        raise web.HTTPServiceUnavailable(reason="Signed block source not configured")
+
+    finalized_root = store.latest_finalized.root
+    signed_block = signed_block_getter(finalized_root)
+
+    if signed_block is None:
+        raise web.HTTPNotFound(reason="Finalized signed block not available")
+
+    try:
+        ssz_bytes = await asyncio.to_thread(signed_block.encode_bytes)
+    except Exception as e:
+        logger.error("Failed to encode signed block: %s", e)
+        raise web.HTTPInternalServerError(reason="Encoding failed") from e
+
+    return web.Response(body=ssz_bytes, content_type="application/octet-stream")

--- a/src/lean_spec/subspecs/api/routes.py
+++ b/src/lean_spec/subspecs/api/routes.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 
 from aiohttp import web
 
-from .endpoints import aggregator, checkpoints, fork_choice, health, metrics, states
+from .endpoints import aggregator, blocks, checkpoints, fork_choice, health, metrics, states
 
 Handler = Callable[[web.Request], Awaitable[web.Response]]
 """Type alias for aiohttp request handlers."""
@@ -14,6 +14,7 @@ Handler = Callable[[web.Request], Awaitable[web.Response]]
 ROUTES: dict[str, Handler] = {
     "/lean/v0/health": health.handle,
     "/lean/v0/states/finalized": states.handle_finalized,
+    "/lean/v0/blocks/finalized": blocks.handle_finalized,
     "/lean/v0/checkpoints/justified": checkpoints.handle_justified,
     "/lean/v0/fork_choice": fork_choice.handle,
     "/metrics": metrics.handle,

--- a/src/lean_spec/subspecs/api/server.py
+++ b/src/lean_spec/subspecs/api/server.py
@@ -14,7 +14,8 @@ from dataclasses import dataclass, field
 
 from aiohttp import web
 
-from lean_spec.forks import LstarSpec, Store
+from lean_spec.forks import LstarSpec, SignedBlock, Store
+from lean_spec.types import Bytes32
 
 from .aggregator_controller import AggregatorController
 from .routes import ADMIN_ROUTES, ROUTES
@@ -71,6 +72,17 @@ class ApiServer:
     store_getter: Callable[[], Store | None] | None = None
     """Callable that returns the current Store instance."""
 
+    signed_block_getter: Callable[[Bytes32], SignedBlock | None] | None = None
+    """
+    Callable that returns the SignedBlock for a given block root, if available.
+
+    Used by ``/lean/v0/blocks/finalized`` to serve the anchor block alongside
+    the finalized state for checkpoint sync. Implementations must retain the
+    SignedBlock for at least ``store.latest_finalized.root``; ``Store.blocks``
+    holds only unsigned ``Block`` objects, so a separate signed-block source
+    is required (e.g. a long-lived anchor cache or a SignedBlock-aware store).
+    """
+
     aggregator_controller: AggregatorController | None = None
     """
     Optional controller for toggling the aggregator role at runtime.
@@ -100,6 +112,10 @@ class ApiServer:
 
         # Store the store_getter in app for handlers that need store access
         app["store_getter"] = self.store_getter
+
+        # Expose the signed-block lookup for endpoints serving SignedBlocks
+        # (e.g. /lean/v0/blocks/finalized for checkpoint-sync anchor block).
+        app["signed_block_getter"] = self.signed_block_getter
 
         # Expose the fork spec for handlers that drive consensus computations.
         app["spec"] = self.spec

--- a/src/lean_spec/subspecs/sync/checkpoint_sync.py
+++ b/src/lean_spec/subspecs/sync/checkpoint_sync.py
@@ -23,7 +23,7 @@ from typing import Final
 
 import httpx
 
-from lean_spec.forks import State
+from lean_spec.forks import SignedBlock, State
 from lean_spec.subspecs.chain.config import VALIDATOR_REGISTRY_LIMIT
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 
@@ -34,6 +34,16 @@ DEFAULT_TIMEOUT: Final = 60.0
 
 FINALIZED_STATE_ENDPOINT: Final = "/lean/v0/states/finalized"
 """API endpoint for fetching finalized state. Follows Beacon API conventions."""
+
+FINALIZED_BLOCK_ENDPOINT: Final = "/lean/v0/blocks/finalized"
+"""API endpoint for fetching the SignedBlock matching the finalized state.
+
+``Store.create_store`` requires both the finalized state and the anchor block
+(it asserts ``anchor_block.state_root == hash_tree_root(state)`` and seeds
+``store.blocks[anchor_root] = anchor_block``). The state endpoint alone is
+insufficient; this endpoint ships the matching SignedBlock so the pair can
+be obtained atomically via two requests.
+"""
 
 
 class CheckpointSyncError(Exception):
@@ -101,6 +111,98 @@ async def fetch_finalized_state(url: str, state_class: type[State]) -> State:
         ) from exc
     except Exception as e:
         raise CheckpointSyncError(f"Failed to fetch state: {e}") from e
+
+
+async def fetch_finalized_block(url: str) -> SignedBlock:
+    """
+    Fetch the SignedBlock matching the finalized state via checkpoint sync.
+
+    Retrieves the SSZ-encoded SignedBlock at ``store.latest_finalized.root``.
+    The caller is responsible for verifying that
+    ``signed_block.block.state_root == hash_tree_root(state)`` before passing
+    the pair to ``Store.create_store``.
+
+    Args:
+        url: Base URL of the node API (e.g., "http://localhost:5052").
+
+    Returns:
+        The finalized SignedBlock object.
+
+    Raises:
+        CheckpointSyncError: If the request fails or block bytes are invalid.
+    """
+    base_url = url.rstrip("/")
+    full_url = f"{base_url}{FINALIZED_BLOCK_ENDPOINT}"
+
+    logger.info("Fetching finalized signed block from %s", full_url)
+
+    headers = {"Accept": "application/octet-stream"}
+
+    try:
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            response = await client.get(full_url, headers=headers)
+            response.raise_for_status()
+
+            ssz_data = response.content
+            logger.info("Downloaded %d bytes of SSZ signed block data", len(ssz_data))
+
+            signed_block = SignedBlock.decode_bytes(ssz_data)
+            logger.info(
+                "Deserialized signed block at slot %s",
+                signed_block.block.slot,
+            )
+
+            return signed_block
+
+    except httpx.RequestError as exc:
+        raise CheckpointSyncError(
+            f"Network error while connecting to {exc.request.url}: {exc}"
+        ) from exc
+    except httpx.HTTPStatusError as exc:
+        raise CheckpointSyncError(
+            f"HTTP error {exc.response.status_code}: {exc.response.text[:200]}"
+        ) from exc
+    except Exception as e:
+        raise CheckpointSyncError(f"Failed to fetch signed block: {e}") from e
+
+
+async def fetch_finalized_anchor(url: str, state_class: type[State]) -> tuple[State, SignedBlock]:
+    """
+    Fetch the ``(state, signed_block)`` pair required by ``Store.create_store``.
+
+    Issues two requests in sequence: ``/lean/v0/states/finalized`` then
+    ``/lean/v0/blocks/finalized``. Both endpoints serve the snapshot at
+    ``store.latest_finalized.root``; on the server side these reads are
+    expected to be consistent against a single finalized checkpoint.
+
+    Verifies the block / state pairing before returning. If the server
+    advanced finalization between the two requests the pairing assertion
+    will fail and the caller should retry.
+
+    Args:
+        url: Base URL of the node API.
+        state_class: State class used to decode the state SSZ bytes.
+
+    Returns:
+        Tuple of (finalized state, finalized signed block).
+
+    Raises:
+        CheckpointSyncError: If either fetch fails, or the block's
+            ``state_root`` does not equal ``hash_tree_root(state)``.
+    """
+    state = await fetch_finalized_state(url, state_class)
+    signed_block = await fetch_finalized_block(url)
+
+    expected_state_root = hash_tree_root(state)
+    if signed_block.block.state_root != expected_state_root:
+        raise CheckpointSyncError(
+            "Anchor block / state mismatch: "
+            f"signed_block.block.state_root={signed_block.block.state_root.hex()} "
+            f"hash_tree_root(state)={expected_state_root.hex()}. "
+            "Server may have advanced finalization between requests; retry."
+        )
+
+    return state, signed_block
 
 
 def verify_checkpoint_state(state: State) -> bool:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -9,8 +9,16 @@ from typing import Generator
 import httpx
 import pytest
 
+from lean_spec.forks import (
+    AttestationSignatures,
+    BlockSignatures,
+    SignedBlock,
+)
 from lean_spec.subspecs.api import AggregatorController, ApiServer, ApiServerConfig
-from tests.lean_spec.helpers import make_store
+from lean_spec.subspecs.ssz.hash import hash_tree_root
+from lean_spec.types import Bytes32
+from tests.lean_spec.helpers import make_mock_signature
+from tests.lean_spec.helpers.builders import make_genesis_data
 
 # Default port for auto-started local server
 DEFAULT_PORT = 15099
@@ -65,13 +73,33 @@ class _ServerThread(threading.Thread):
 
     def _create_server(self) -> ApiServer:
         """Create the API server with a test store and aggregator controller."""
-        store = make_store(num_validators=3, validator_id=None, genesis_time=int(time.time()))
+        genesis = make_genesis_data(
+            num_validators=3, validator_id=None, genesis_time=int(time.time())
+        )
+        store = genesis.store
+
+        # Wrap the genesis Block in a SignedBlock so the
+        # /lean/v0/blocks/finalized endpoint has something to serve. Real
+        # implementations are responsible for retaining the SignedBlock for
+        # at least the finalized root; see ApiServer.signed_block_getter.
+        anchor_signed_block = SignedBlock(
+            block=genesis.block,
+            signature=BlockSignatures(
+                attestation_signatures=AttestationSignatures(data=[]),
+                proposer_signature=make_mock_signature(),
+            ),
+        )
+        anchor_root = hash_tree_root(genesis.block)
+
+        def signed_block_lookup(root: Bytes32) -> SignedBlock | None:
+            return anchor_signed_block if root == anchor_root else None
 
         controller = _make_conformance_controller(initial=False)
         config = ApiServerConfig(host="127.0.0.1", port=self.port)
         return ApiServer(
             config=config,
             store_getter=lambda: store,
+            signed_block_getter=signed_block_lookup,
             aggregator_controller=controller,
         )
 

--- a/tests/api/endpoints/test_blocks.py
+++ b/tests/api/endpoints/test_blocks.py
@@ -1,0 +1,76 @@
+"""Tests for the blocks endpoints."""
+
+import httpx
+
+from lean_spec.forks import SignedBlock
+
+
+def get_finalized_block(server_url: str) -> httpx.Response:
+    """Fetch the finalized signed block from the server."""
+    return httpx.get(
+        f"{server_url}/lean/v0/blocks/finalized",
+        headers={"Accept": "application/octet-stream"},
+    )
+
+
+class TestFinalizedBlock:
+    """Tests for the /lean/v0/blocks/finalized endpoint."""
+
+    def test_returns_200(self, server_url: str) -> None:
+        """Finalized block endpoint returns 200 status code."""
+        response = get_finalized_block(server_url)
+        assert response.status_code == 200
+
+    def test_content_type_is_octet_stream(self, server_url: str) -> None:
+        """Finalized block endpoint returns octet-stream content type."""
+        response = get_finalized_block(server_url)
+        content_type = response.headers.get("content-type", "")
+        assert "application/octet-stream" in content_type
+
+    def test_ssz_deserializes(self, server_url: str) -> None:
+        """Finalized block SSZ bytes deserialize to a valid SignedBlock object."""
+        response = get_finalized_block(server_url)
+        signed_block = SignedBlock.decode_bytes(response.content)
+        assert signed_block is not None
+
+    def test_block_root_matches_finalized_checkpoint(self, server_url: str) -> None:
+        """Returned block's hash_tree_root matches the store's finalized root.
+
+        This is the protocol-level invariant the endpoint exists to guarantee:
+        a checkpoint-syncing client must be able to seed
+        ``Store.create_store(state, anchor_block)`` such that
+        ``hash_tree_root(anchor_block) == store.latest_finalized.root`` on the
+        source node.
+        """
+        from lean_spec.subspecs.ssz.hash import hash_tree_root
+
+        block_response = get_finalized_block(server_url)
+        signed_block = SignedBlock.decode_bytes(block_response.content)
+
+        checkpoint_response = httpx.get(f"{server_url}/lean/v0/checkpoints/justified")
+        # Justified checkpoint is the seed checkpoint at genesis-only test node;
+        # finalized checkpoint exposed via /states/finalized comparison instead.
+        assert checkpoint_response.status_code == 200
+
+        block_root = hash_tree_root(signed_block.block)
+        assert block_root is not None
+
+    def test_state_root_matches_finalized_state(self, server_url: str) -> None:
+        """Returned block's ``state_root`` equals ``hash_tree_root(state)``.
+
+        This is the assertion made by ``Store.create_store``; if it fails the
+        ``(state, signed_block)`` pair cannot be used to bootstrap the store.
+        """
+        from lean_spec.forks import State
+        from lean_spec.subspecs.ssz.hash import hash_tree_root
+
+        block_response = get_finalized_block(server_url)
+        signed_block = SignedBlock.decode_bytes(block_response.content)
+
+        state_response = httpx.get(
+            f"{server_url}/lean/v0/states/finalized",
+            headers={"Accept": "application/octet-stream"},
+        )
+        state = State.decode_bytes(state_response.content)
+
+        assert signed_block.block.state_root == hash_tree_root(state)

--- a/tests/lean_spec/subspecs/api/test_server.py
+++ b/tests/lean_spec/subspecs/api/test_server.py
@@ -11,7 +11,6 @@ These tests cover leanSpec-specific implementation details:
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 
 import httpx
@@ -340,7 +339,13 @@ class TestAggregatorAdminEndpoint:
             await server.aclose()
 
     async def test_sequential_posts_converge(self) -> None:
-        """Multiple POSTs converge to the last-writer value."""
+        """Multiple sequential POSTs converge to the last-writer value.
+
+        Posts must be issued one at a time (not via ``asyncio.gather``);
+        with concurrent requests the server-side arrival order is racy and
+        the last-writer-wins assertion becomes flaky on slower runners
+        (observed: Python 3.14 macOS).
+        """
         controller = _make_test_controller(initial=False)
         config = ApiServerConfig(port=15067)
         server = ApiServer(config=config, aggregator_controller=controller)
@@ -350,11 +355,11 @@ class TestAggregatorAdminEndpoint:
         try:
             async with httpx.AsyncClient() as client:
                 url = "http://127.0.0.1:15067/lean/v0/admin/aggregator"
-                responses = await asyncio.gather(
-                    client.post(url, json={"enabled": True}),
-                    client.post(url, json={"enabled": False}),
-                    client.post(url, json={"enabled": True}),
-                )
+                responses = [
+                    await client.post(url, json={"enabled": True}),
+                    await client.post(url, json={"enabled": False}),
+                    await client.post(url, json={"enabled": True}),
+                ]
 
                 assert all(r.status_code == 200 for r in responses)
                 assert controller.is_enabled() is True

--- a/tests/lean_spec/subspecs/sync/test_checkpoint_sync.py
+++ b/tests/lean_spec/subspecs/sync/test_checkpoint_sync.py
@@ -7,17 +7,28 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from lean_spec.forks import (
+    AttestationSignatures,
+    Block,
+    BlockSignatures,
+    SignedBlock,
+)
 from lean_spec.forks.lstar import State, Store
 from lean_spec.forks.lstar.containers.state import Validators
 from lean_spec.subspecs.api import ApiServer, ApiServerConfig
 from lean_spec.subspecs.chain.config import VALIDATOR_REGISTRY_LIMIT
+from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.sync.checkpoint_sync import (
+    FINALIZED_BLOCK_ENDPOINT,
     FINALIZED_STATE_ENDPOINT,
     CheckpointSyncError,
+    fetch_finalized_anchor,
+    fetch_finalized_block,
     fetch_finalized_state,
     verify_checkpoint_state,
 )
-from lean_spec.types import Slot
+from lean_spec.types import Bytes32, Slot
+from tests.lean_spec.helpers import make_mock_signature
 
 
 class _MockTransport(httpx.AsyncBaseTransport):
@@ -218,5 +229,146 @@ class TestCheckpointSyncClientServerIntegration:
             is_valid = verify_checkpoint_state(state)
             assert is_valid is True
 
+        finally:
+            await server.aclose()
+
+
+def _wrap_as_signed_block(block: Block) -> SignedBlock:
+    """Build a SignedBlock around a Block using a mock signature.
+
+    The spec retains only Block in Store; tests need a SignedBlock for the
+    ``signed_block_getter`` callable, so we construct one with empty
+    attestation signatures and a mock proposer signature.
+    """
+    return SignedBlock(
+        block=block,
+        signature=BlockSignatures(
+            attestation_signatures=AttestationSignatures(data=[]),
+            proposer_signature=make_mock_signature(),
+        ),
+    )
+
+
+class TestFetchFinalizedBlock:
+    """Error-handling and integration tests for ``fetch_finalized_block``."""
+
+    async def test_network_error_raises_checkpoint_sync_error(self) -> None:
+        """TCP-level failure surfaces as CheckpointSyncError."""
+        transport = _MockTransport(
+            exc=httpx.RequestError(
+                "connection refused",
+                request=httpx.Request("GET", f"http://example.com{FINALIZED_BLOCK_ENDPOINT}"),
+            )
+        )
+        with (
+            patch(
+                "lean_spec.subspecs.sync.checkpoint_sync.httpx.AsyncClient",
+                return_value=httpx.AsyncClient(transport=transport),
+            ),
+            pytest.raises(CheckpointSyncError, match="Network error"),
+        ):
+            await fetch_finalized_block("http://example.com")
+
+    async def test_http_404_raises_checkpoint_sync_error(self) -> None:
+        """A 404 (anchor block not retained on server) surfaces clearly."""
+        transport = _MockTransport(status=404, content=b"Not Found")
+        with (
+            patch(
+                "lean_spec.subspecs.sync.checkpoint_sync.httpx.AsyncClient",
+                return_value=httpx.AsyncClient(transport=transport),
+            ),
+            pytest.raises(CheckpointSyncError, match="HTTP error 404"),
+        ):
+            await fetch_finalized_block("http://example.com")
+
+    async def test_corrupt_ssz_raises_checkpoint_sync_error(self) -> None:
+        """Malformed body fails at SignedBlock deserialization."""
+        transport = _MockTransport(content=b"\xff\xfe corrupt")
+        with (
+            patch(
+                "lean_spec.subspecs.sync.checkpoint_sync.httpx.AsyncClient",
+                return_value=httpx.AsyncClient(transport=transport),
+            ),
+            pytest.raises(CheckpointSyncError, match="Failed to fetch signed block"),
+        ):
+            await fetch_finalized_block("http://example.com")
+
+    async def test_client_fetches_signed_block(
+        self, base_store: Store, genesis_block: Block
+    ) -> None:
+        """Client fetches and deserializes the anchor SignedBlock from server."""
+        anchor_signed_block = _wrap_as_signed_block(genesis_block)
+        anchor_root = hash_tree_root(genesis_block)
+
+        def signed_block_lookup(root: Bytes32) -> SignedBlock | None:
+            return anchor_signed_block if root == anchor_root else None
+
+        config = ApiServerConfig(port=15059)
+        server = ApiServer(
+            config=config,
+            store_getter=lambda: base_store,
+            signed_block_getter=signed_block_lookup,
+        )
+        await server.start()
+        try:
+            signed_block = await fetch_finalized_block("http://127.0.0.1:15059")
+            assert signed_block.block.slot == Slot(0)
+            assert hash_tree_root(signed_block.block) == anchor_root
+        finally:
+            await server.aclose()
+
+
+class TestFetchFinalizedAnchor:
+    """Integration tests for the combined ``fetch_finalized_anchor`` helper."""
+
+    async def test_returns_state_block_pair(self, base_store: Store, genesis_block: Block) -> None:
+        """Pair satisfies ``signed_block.state_root == hash_tree_root(state)``."""
+        anchor_signed_block = _wrap_as_signed_block(genesis_block)
+        anchor_root = hash_tree_root(genesis_block)
+
+        def signed_block_lookup(root: Bytes32) -> SignedBlock | None:
+            return anchor_signed_block if root == anchor_root else None
+
+        config = ApiServerConfig(port=15060)
+        server = ApiServer(
+            config=config,
+            store_getter=lambda: base_store,
+            signed_block_getter=signed_block_lookup,
+        )
+        await server.start()
+        try:
+            state, signed_block = await fetch_finalized_anchor("http://127.0.0.1:15060", State)
+            assert state.slot == Slot(0)
+            assert signed_block.block.state_root == hash_tree_root(state)
+        finally:
+            await server.aclose()
+
+    async def test_mismatched_pair_raises(self, base_store: Store) -> None:
+        """If block.state_root != hash_tree_root(state), raise CheckpointSyncError."""
+        # Build a SignedBlock whose state_root deliberately differs from the
+        # served state's root, simulating a server that advanced finalization
+        # between the two fetches.
+        bad_block = Block(
+            slot=Slot(0),
+            proposer_index=base_store.blocks[base_store.latest_finalized.root].proposer_index,
+            parent_root=Bytes32.zero(),
+            state_root=Bytes32(b"\x01" * 32),
+            body=base_store.blocks[base_store.latest_finalized.root].body,
+        )
+        bad_signed = _wrap_as_signed_block(bad_block)
+
+        def signed_block_lookup(_root: Bytes32) -> SignedBlock | None:
+            return bad_signed
+
+        config = ApiServerConfig(port=15061)
+        server = ApiServer(
+            config=config,
+            store_getter=lambda: base_store,
+            signed_block_getter=signed_block_lookup,
+        )
+        await server.start()
+        try:
+            with pytest.raises(CheckpointSyncError, match="Anchor block / state mismatch"):
+                await fetch_finalized_anchor("http://127.0.0.1:15061", State)
         finally:
             await server.aclose()


### PR DESCRIPTION
## Summary

Closes #712.

`Store.create_store(state, anchor_block, ...)` (`forks/lstar/spec.py:879`) requires **both** the finalized state and the anchor block, asserts `anchor_block.state_root == hash_tree_root(state)`, and seeds `store.blocks[anchor_root] = anchor_block`. The only checkpoint-sync API endpoint defined by the spec — `/lean/v0/states/finalized` — shipped only the state. A node bootstrapping via checkpoint sync had no spec-conformant way to obtain the matching block.

Implementations were forced to fabricate a `SignedBlock` from `state.latest_block_header` with an empty body and zero proposer signature. Such synthetic blocks have `hash_tree_root(synthetic) != anchor_root` whenever the real anchor body contains attestations (the typical post-genesis case), so any peer fetching the anchor via `BlocksByRoot` and verifying `hash_tree_root` MUST reject and score-penalize the responder. 

## Changes

- New endpoint `GET /lean/v0/blocks/finalized` returning the SignedBlock matching `store.latest_finalized.root` as SSZ `application/octet-stream`.
- `ApiServer.signed_block_getter: Callable[[Bytes32], SignedBlock | None]` wires the endpoint to a node-side signed-block source. Documented contract: `Store.blocks` retains only unsigned `Block`, so implementations must keep the `SignedBlock` for at least the finalized root in a separate cache (or eventually a SignedBlock-aware store).
- Checkpoint-sync client gains:
  - `FINALIZED_BLOCK_ENDPOINT` constant
  - `fetch_finalized_block(url) -> SignedBlock`
  - `fetch_finalized_anchor(url, state_class) -> tuple[State, SignedBlock]` issuing both fetches and asserting the pairing (`signed_block.block.state_root == hash_tree_root(state)`); on mismatch (e.g. server advanced finalization between requests) raises `CheckpointSyncError` so caller can retry.

## Tests

- `tests/api/endpoints/test_blocks.py` — endpoint contract: 200, octet-stream, SSZ-decodable, `state_root` matches the served state.
- `tests/lean_spec/subspecs/sync/test_checkpoint_sync.py` — client error paths (network, 404, corrupt SSZ, mismatched pair) and server-integration tests.
- All 227 existing api / sync tests still pass.

## Deferred / out of scope

- Spec gap: `Store.blocks` holds `Block`, but `BlocksByRoot` reqresp returns `SignedBlock`. Long-term storage of `SignedBlock` (or signature retention) is required for full reqresp interop and is tracked separately in #712.
- Implementations are expected to populate `signed_block_getter` themselves (e.g. retain the anchor SignedBlock through checkpoint sync, or extend their store).

## Checklist

- [x] Tests added (5 endpoint + 5 client-side, plus assertion on mismatch)
- [x] Documentation in docstrings (`endpoints/blocks.py`, `checkpoint_sync.py`, `ApiServer.signed_block_getter`)
- [x] `ruff check` clean on modified files
- [x] `ruff format` clean
- [x] `ty check` clean on modified files