### PR TITLE
fix: generating leanSpec test assets

### DIFF
--- a/.github/workflows/prod-vectors.yml
+++ b/.github/workflows/prod-vectors.yml
@@ -100,7 +100,7 @@ jobs:
           mkdir -p fixtures/keys
           cp -r packages/testing/src/consensus_testing/test_keys/prod_scheme fixtures/keys/
 
-      - name: Create fixture archive
+      - name: Create reproducible fixture archive
         run: |
           tar \
             --sort=name \

--- a/.github/workflows/prod-vectors.yml
+++ b/.github/workflows/prod-vectors.yml
@@ -6,7 +6,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+
+concurrency:
+  group: prod-vectors-latest
+  cancel-in-progress: true
 
 jobs:
   check:
@@ -24,7 +28,7 @@ jobs:
       - name: Check if scheme changed
         id: scheme-diff
         run: |
-          if git diff HEAD~1 --name-only | grep -qE '^src/lean_spec/subspecs/(xmss|poseidon2)/'; then
+          if git diff HEAD~1 --name-only | grep -qE '^src/lean_spec/subspecs/(xmss|poseidon1)/'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
@@ -33,7 +37,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: /tmp/prod-keys-probe
-          key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon2/**') }}
+          key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon1/**') }}
           lookup-only: true
 
   keygen:
@@ -75,7 +79,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: packages/testing/src/consensus_testing/test_keys/prod_scheme
-          key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon2/**') }}
+          key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon1/**') }}
 
       - name: Download keys
         if: steps.key-cache.outputs.cache-hit != 'true'
@@ -86,7 +90,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: packages/testing/src/consensus_testing/test_keys/prod_scheme
-          key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon2/**') }}
+          key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon1/**') }}
 
       - name: Fill production test fixtures
         run: just fill-ci --scheme=prod
@@ -96,9 +100,34 @@ jobs:
           mkdir -p fixtures/keys
           cp -r packages/testing/src/consensus_testing/test_keys/prod_scheme fixtures/keys/
 
-      - name: Upload fixtures + keys
+      - name: Create fixture archive
+        run: |
+          tar \
+            --sort=name \
+            --owner=0 \
+            --group=0 \
+            --numeric-owner \
+            --mtime='UTC 2020-01-01' \
+            -cf - fixtures | gzip --no-name > fixtures-prod-scheme.tar.gz
+          sha256sum fixtures-prod-scheme.tar.gz > fixtures-prod-scheme.tar.gz.sha256
+
+      - name: Upload fixture archive
         uses: actions/upload-artifact@v4
         with:
           name: fixtures-prod-scheme
-          path: fixtures/
+          path: |
+            fixtures-prod-scheme.tar.gz
+            fixtures-prod-scheme.tar.gz.sha256
           if-no-files-found: error
+
+      - name: Publish latest release
+        run: |
+          gh release delete latest --cleanup-tag --yes || true
+          gh release create latest \
+            fixtures-prod-scheme.tar.gz \
+            fixtures-prod-scheme.tar.gz.sha256 \
+            --target "${{ github.sha }}" \
+            --title "Latest production fixtures" \
+            --notes "Auto-generated from leanSpec@${{ github.sha }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

  Fixes #711.

  Publishes the production fixture bundle from the `prod-vectors` workflow to a rolling `latest` GitHub release.

  ## Changes

  - Generate production fixtures with the existing `just fill-ci --scheme=prod` path.
  - Bundle `fixtures/` together with `fixtures/keys/prod_scheme`.
  - Create release assets:
    - `fixtures-prod-scheme.tar.gz`
    - `fixtures-prod-scheme.tar.gz.sha256`
  - Publish both assets to the rolling `latest` release.
  - Replace the existing `latest` release/tag on each successful run.
  - Update workflow permissions to `contents: write`.
  - Add workflow concurrency to avoid racing release replacement.
  - Fix stale `poseidon2` cache hash paths to `poseidon1`.

  ## Notes

  The implementation follows the fixture artifact/release pattern used by `ethereum/execution-specs`, adapted to this repo’s requested rolling `latest` release model.

  ## Verification

  - Parsed `.github/workflows/prod-vectors.yml` with Ruby YAML loader.
  - Ran `git diff --check`.
  - Confirmed no remaining `poseidon2` references in `prod-vectors.yml`.