### PR TITLE
fix: allow older-but-justified sources in `build_block`

### DIFF
--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -1,7 +1,7 @@
 """Lstar fork — identity and construction facade."""
 
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from collections.abc import Set as AbstractSet
 from typing import Any, ClassVar
 
@@ -356,7 +356,7 @@ class LstarSpec(ForkProtocol):
 
     def _attestation_data_matches_chain(
         self,
-        historical_block_hashes: Sequence[Bytes32],
+        historical_block_hashes: HistoricalBlockHashes,
         attestation_data: AttestationData,
     ) -> bool:
         """Whether both source and target checkpoints match the chain at their slots.

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -667,6 +667,16 @@ class LstarSpec(ForkProtocol):
             else:
                 current_justified = state.latest_justified
 
+            # Track the justified-slot bitfield so we can skip attestations
+            # whose target slot is already justified on this chain. Extend
+            # to mirror what process_block_header will produce on the
+            # candidate block, so is_slot_justified doesn't raise for
+            # target slots between parent.slot and slot - 1.
+            current_finalized_slot = state.latest_finalized.slot
+            current_justified_slots = state.justified_slots.extend_to_slot(
+                current_finalized_slot, slot - Slot(1)
+            )
+
             processed_att_data: set[AttestationData] = set()
 
             while True:
@@ -685,6 +695,47 @@ class LstarSpec(ForkProtocol):
                         continue
 
                     if att_data.source.slot > current_justified.slot:
+                        continue
+
+                    # Source and target roots must match the chain at their
+                    # respective slots. historical_block_hashes covers
+                    # [0, parent.slot - 1]; the parent itself sits at
+                    # parent.slot (= len(historical)); empty slots between
+                    # parent and the candidate are ZERO_HASH.
+                    source_slot_int = int(att_data.source.slot)
+                    if source_slot_int < len(state.historical_block_hashes):
+                        expected_source_root = state.historical_block_hashes[source_slot_int]
+                    elif source_slot_int == len(state.historical_block_hashes):
+                        expected_source_root = parent_root
+                    else:
+                        continue
+                    if att_data.source.root != expected_source_root:
+                        continue
+
+                    target_slot_int = int(att_data.target.slot)
+                    if target_slot_int < len(state.historical_block_hashes):
+                        expected_target_root = state.historical_block_hashes[target_slot_int]
+                    elif target_slot_int == len(state.historical_block_hashes):
+                        expected_target_root = parent_root
+                    elif target_slot_int < int(slot):
+                        expected_target_root = ZERO_HASH
+                    else:
+                        continue
+                    if att_data.target.root != expected_target_root:
+                        continue
+
+                    # Skip attestations whose target slot is already
+                    # justified on this chain (the STF would drop them as
+                    # no-ops). The genesis self-vote (source.slot ==
+                    # target.slot == 0) is exempt: it's a degenerate but
+                    # legal attestation that some fixtures rely on and that
+                    # the STF still silently drops.
+                    is_genesis_self_vote = att_data.source.slot == Slot(
+                        0
+                    ) and att_data.target.slot == Slot(0)
+                    if not is_genesis_self_vote and current_justified_slots.is_slot_justified(
+                        current_finalized_slot, att_data.target.slot
+                    ):
                         continue
 
                     if att_data in processed_att_data:
@@ -720,8 +771,13 @@ class LstarSpec(ForkProtocol):
                 )
                 post_state = self.process_block(self.process_slots(state, slot), candidate_block)
 
-                if post_state.latest_justified != current_justified:
+                if (
+                    post_state.latest_justified != current_justified
+                    or post_state.latest_finalized.slot != current_finalized_slot
+                ):
                     current_justified = post_state.latest_justified
+                    current_justified_slots = post_state.justified_slots
+                    current_finalized_slot = post_state.latest_finalized.slot
                     continue
 
                 break

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -1,7 +1,7 @@
 """Lstar fork — identity and construction facade."""
 
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from collections.abc import Set as AbstractSet
 from typing import Any, ClassVar
 
@@ -354,6 +354,29 @@ class LstarSpec(ForkProtocol):
 
         return self.process_attestations(state, block.body.attestations)
 
+    def _attestation_data_matches_chain(
+        self,
+        historical_block_hashes: Sequence[Bytes32],
+        attestation_data: AttestationData,
+    ) -> bool:
+        """Whether both source and target checkpoints match the chain at their slots.
+
+        Callers pass the chain's historical block hashes as they would appear
+        after process_block_header on the consuming block: covering
+        [0, block.slot - 1] with parent_root at parent.slot and ZERO_HASH
+        for empty slots between parent and the candidate.
+        """
+        source_slot = int(attestation_data.source.slot)
+        target_slot = int(attestation_data.target.slot)
+        if source_slot >= len(historical_block_hashes):
+            return False
+        if target_slot >= len(historical_block_hashes):
+            return False
+        return (
+            attestation_data.source.root == historical_block_hashes[source_slot]
+            and attestation_data.target.root == historical_block_hashes[target_slot]
+        )
+
     def process_attestations(
         self,
         state: State,
@@ -448,26 +471,10 @@ class LstarSpec(ForkProtocol):
                 continue
 
             # Ensure the vote refers to blocks that actually exist on our chain.
-            #
-            # The attestation must match our canonical chain.
-            # Both the source root and target root must equal the recorded block roots
-            # stored for those slots in history.
-            #
-            # This prevents votes about unknown or conflicting forks.
-            source_slot_int = int(source.slot)
-            target_slot_int = int(target.slot)
-            source_matches = (
-                source.root == state.historical_block_hashes[source_slot_int]
-                if source_slot_int < len(state.historical_block_hashes)
-                else False
-            )
-            target_matches = (
-                target.root == state.historical_block_hashes[target_slot_int]
-                if target_slot_int < len(state.historical_block_hashes)
-                else False
-            )
-
-            if not source_matches or not target_matches:
+            # Prevents votes about unknown or conflicting forks.
+            if not self._attestation_data_matches_chain(
+                state.historical_block_hashes, attestation.data
+            ):
                 continue
 
             # Ensure time flows forward.
@@ -676,6 +683,14 @@ class LstarSpec(ForkProtocol):
                 current_finalized_slot, slot - Slot(1)
             )
 
+            # Build the chain view that process_block_header would produce on
+            # the candidate block. Lets the chain-match helper validate source
+            # and target roots without waiting for the STF to drop mismatches.
+            num_empty_slots = int(slot - state.latest_block_header.slot - Slot(1))
+            extended_historical_block_hashes = (
+                state.historical_block_hashes + [parent_root] + [ZERO_HASH] * num_empty_slots
+            )
+
             processed_att_data: set[AttestationData] = set()
 
             while True:
@@ -696,34 +711,14 @@ class LstarSpec(ForkProtocol):
                     if att_data.source.slot > current_justified.slot:
                         continue
 
-                    # Source and target roots must match the chain at their
-                    # respective slots.
-                    source_slot_int = int(att_data.source.slot)
-                    if source_slot_int < len(state.historical_block_hashes):
-                        expected_source_root = state.historical_block_hashes[source_slot_int]
-                    elif source_slot_int == len(state.historical_block_hashes):
-                        expected_source_root = parent_root
-                    else:
-                        # Source slot is invalid
-                        continue
-                    if att_data.source.root != expected_source_root:
-                        continue
-
-                    target_slot_int = int(att_data.target.slot)
-                    if target_slot_int < len(state.historical_block_hashes):
-                        expected_target_root = state.historical_block_hashes[target_slot_int]
-                    elif target_slot_int == len(state.historical_block_hashes):
-                        expected_target_root = parent_root
-                    elif target_slot_int < int(slot):
-                        expected_target_root = ZERO_HASH
-                    else:
-                        continue
-                    if att_data.target.root != expected_target_root:
+                    if not self._attestation_data_matches_chain(
+                        extended_historical_block_hashes, att_data
+                    ):
                         continue
 
                     # Skip attestations whose target slot is already
                     # justified on this chain. Ignore genesis self-votes
-                    # for bootstrapping fork-choice
+                    # for fork-choice bootstrapping
                     is_genesis_self_vote = att_data.source.slot == Slot(
                         0
                     ) and att_data.target.slot == Slot(0)

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -738,8 +738,6 @@ class LstarSpec(ForkProtocol):
                     ):
                         continue
 
-                    if att_data in processed_att_data:
-                        continue
                     processed_att_data.add(att_data)
 
                     found_entries = True

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -684,7 +684,7 @@ class LstarSpec(ForkProtocol):
                     if att_data.head.root not in known_block_roots:
                         continue
 
-                    if att_data.source != current_justified:
+                    if att_data.source.slot > current_justified.slot:
                         continue
 
                     if att_data in processed_att_data:

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -669,9 +669,8 @@ class LstarSpec(ForkProtocol):
 
             # Track the justified-slot bitfield so we can skip attestations
             # whose target slot is already justified on this chain. Extend
-            # to mirror what process_block_header will produce on the
-            # candidate block, so is_slot_justified doesn't raise for
-            # target slots between parent.slot and slot - 1.
+            # so is_slot_justified doesn't raise for target slots between
+            # parent.slot and slot - 1.
             current_finalized_slot = state.latest_finalized.slot
             current_justified_slots = state.justified_slots.extend_to_slot(
                 current_finalized_slot, slot - Slot(1)
@@ -698,16 +697,14 @@ class LstarSpec(ForkProtocol):
                         continue
 
                     # Source and target roots must match the chain at their
-                    # respective slots. historical_block_hashes covers
-                    # [0, parent.slot - 1]; the parent itself sits at
-                    # parent.slot (= len(historical)); empty slots between
-                    # parent and the candidate are ZERO_HASH.
+                    # respective slots.
                     source_slot_int = int(att_data.source.slot)
                     if source_slot_int < len(state.historical_block_hashes):
                         expected_source_root = state.historical_block_hashes[source_slot_int]
                     elif source_slot_int == len(state.historical_block_hashes):
                         expected_source_root = parent_root
                     else:
+                        # Source slot is invalid
                         continue
                     if att_data.source.root != expected_source_root:
                         continue
@@ -725,11 +722,8 @@ class LstarSpec(ForkProtocol):
                         continue
 
                     # Skip attestations whose target slot is already
-                    # justified on this chain (the STF would drop them as
-                    # no-ops). The genesis self-vote (source.slot ==
-                    # target.slot == 0) is exempt: it's a degenerate but
-                    # legal attestation that some fixtures rely on and that
-                    # the STF still silently drops.
+                    # justified on this chain. Ignore genesis self-votes
+                    # for bootstrapping fork-choice
                     is_genesis_self_vote = att_data.source.slot == Slot(
                         0
                     ) and att_data.target.slot == Slot(0)

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -365,7 +365,12 @@ class LstarSpec(ForkProtocol):
         after process_block_header on the consuming block: covering
         [0, block.slot - 1] with parent_root at parent.slot and ZERO_HASH
         for empty slots between parent and the candidate.
+
+        Empty slots carry ZERO_HASH; a vote referencing one is rejected here
+        even when the recorded root happens to compare equal.
         """
+        if attestation_data.source.root == ZERO_HASH or attestation_data.target.root == ZERO_HASH:
+            return False
         source_slot = int(attestation_data.source.slot)
         target_slot = int(attestation_data.target.slot)
         if source_slot >= len(historical_block_hashes):
@@ -466,12 +471,9 @@ class LstarSpec(ForkProtocol):
             if justified_slots.is_slot_justified(finalized_slot, target.slot):
                 continue
 
-            # Ignore votes that reference zero-hash slots.
-            if source.root == ZERO_HASH or target.root == ZERO_HASH:
-                continue
-
             # Ensure the vote refers to blocks that actually exist on our chain.
-            # Prevents votes about unknown or conflicting forks.
+            # Prevents votes about unknown or conflicting forks; also rejects
+            # zero-hash source or target roots inline.
             if not self._attestation_data_matches_chain(
                 state.historical_block_hashes, attestation.data
             ):

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -710,7 +710,10 @@ class LstarSpec(ForkProtocol):
                     if att_data.head.root not in known_block_roots:
                         continue
 
-                    if att_data.source.slot > current_justified.slot:
+                    # Source slot must already be justified on this chain.
+                    if not current_justified_slots.is_slot_justified(
+                        current_finalized_slot, att_data.source.slot
+                    ):
                         continue
 
                     if not self._attestation_data_matches_chain(

--- a/tests/lean_spec/forks/lstar/forkchoice/test_block_production_justification_gap.py
+++ b/tests/lean_spec/forks/lstar/forkchoice/test_block_production_justification_gap.py
@@ -1,0 +1,187 @@
+"""
+Block production closes the justification gap on a canonical head that lags.
+
+The scenario builds a fork tree where one branch advances the store's justified
+checkpoint past the level that the canonical head's chain has proven. The
+fixed-point attestation loop inside build_block picks up the gap-closing
+attestation from the gossip pool and produces a block whose post-state
+catches up to the store.
+"""
+
+from __future__ import annotations
+
+from consensus_testing.keys import XmssKeyManager
+from consensus_testing.test_types.aggregated_attestation_spec import AggregatedAttestationSpec
+from consensus_testing.test_types.block_spec import BlockSpec
+
+from lean_spec.forks.lstar import Store
+from lean_spec.forks.lstar.containers import Block
+from lean_spec.forks.lstar.spec import LstarSpec
+from lean_spec.subspecs.chain.clock import Interval
+from lean_spec.subspecs.ssz.hash import hash_tree_root
+from lean_spec.types import Checkpoint, Slot, ValidatorIndex
+
+
+def test_produce_block_on_head_with_lagging_justification(
+    spec: LstarSpec,
+    keyed_store: Store,
+    keyed_genesis_block: Block,
+    key_manager: XmssKeyManager,
+) -> None:
+    """
+    Closing the justification gap via the fixed-point attestation loop.
+
+    Fork tree (labels are block names; slot numbers shown in parentheses)::
+
+                            block_4(4) -- block_5(5)  <-- head
+                           /
+        genesis -- 1 -- 2 -- 3
+                           \
+                            block_6(6)
+
+    Setup:
+
+    - block_4 carries 6 of 8 attestations targeting block_1, justifying block_1.
+    - block_5 carries 2 attestations (validators 6, 7) with head=block_4. These
+      give block_5's subtree fork-choice weight against block_6.
+    - block_6 (sibling of block_4) carries 6 of 8 attestations targeting block_2.
+      Block_6 alone moves the store's latest_justified to block_2.
+
+    After all six blocks are processed:
+
+    - store.latest_justified points at block_2 (slot 2)
+    - fork choice still picks block_5 as the head:
+        validators 0-5 vote head=block_2 (a common ancestor)
+        validators 6-7 vote head=block_4 (in block_5's subtree)
+        weight on block_3's child block_4 is 2; weight on block_6 is 0
+
+    Proposing at slot 7 builds on block_5, whose post-state has
+    latest_justified=block_1. The gossip pool holds block_6's attestation
+    (source=genesis, target=block_2). The fixed-point loop accepts that
+    attestation because genesis is justified on block_5's chain and
+    block_2 is on the common ancestor segment, so the produced block's
+    post-state catches up to the store's justified checkpoint.
+    """
+    store = keyed_store
+    block_registry: dict[str, Block] = {"genesis": keyed_genesis_block}
+
+    def add_block(block_spec: BlockSpec) -> None:
+        nonlocal store
+        signed_block = block_spec.build_signed_block_with_store(
+            store, block_registry, key_manager, "test"
+        )
+        if block_spec.label is not None:
+            block_registry[block_spec.label] = signed_block.block
+        # Re-align store time with the block's slot before processing.
+        # build_signed_block_with_store already ticks forward; this second tick
+        # is idempotent and mirrors the fork-choice spec-test fixture.
+        target_interval = Interval.from_slot(signed_block.block.slot)
+        store, _ = spec.on_tick(store, target_interval, has_proposal=True, is_aggregator=True)
+        store = spec.on_block(store, signed_block)
+
+    # Linear chain through block_3.
+    add_block(BlockSpec(slot=Slot(1), label="block_1"))
+    add_block(BlockSpec(slot=Slot(2), label="block_2"))
+    add_block(BlockSpec(slot=Slot(3), label="block_3"))
+
+    # block_4: 6 of 8 validators attest target=block_1, justifying block_1.
+    add_block(
+        BlockSpec(
+            slot=Slot(4),
+            parent_label="block_3",
+            label="block_4",
+            attestations=[
+                AggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(i) for i in range(6)],
+                    slot=Slot(4),
+                    target_slot=Slot(1),
+                    target_root_label="block_1",
+                ),
+            ],
+        )
+    )
+    assert store.latest_justified.slot == Slot(1)
+    assert store.latest_justified.root == hash_tree_root(block_registry["block_1"])
+
+    # block_5: validators 6, 7 attest target=block_4 with head=block_4.
+    # The head vote pulls fork-choice weight into block_5's subtree without
+    # advancing justification.
+    add_block(
+        BlockSpec(
+            slot=Slot(5),
+            parent_label="block_4",
+            label="block_5",
+            attestations=[
+                AggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(6), ValidatorIndex(7)],
+                    slot=Slot(5),
+                    target_slot=Slot(4),
+                    target_root_label="block_4",
+                ),
+            ],
+        )
+    )
+    assert store.latest_justified.slot == Slot(1)
+
+    # block_6: sibling of block_4 (parent=block_3). 6 of 8 validators attest
+    # target=block_2 with source=genesis. After processing, the store's
+    # latest_justified advances to block_2.
+    add_block(
+        BlockSpec(
+            slot=Slot(6),
+            parent_label="block_3",
+            label="block_6",
+            attestations=[
+                AggregatedAttestationSpec(
+                    validator_ids=[ValidatorIndex(i) for i in range(6)],
+                    slot=Slot(6),
+                    target_slot=Slot(2),
+                    target_root_label="block_2",
+                ),
+            ],
+        )
+    )
+
+    # Sanity: block_5 is the head and the store's justified is block_2.
+    # Validators 0-5's latest vote is for head=block_2 (common ancestor).
+    # Validators 6, 7's latest vote is for head=block_4 (in block_5's subtree).
+    # block_4's subtree carries weight 2; block_6's subtree carries weight 0.
+    assert store.head == hash_tree_root(block_registry["block_5"])
+    assert store.latest_justified.slot == Slot(2)
+    assert store.latest_justified.root == hash_tree_root(block_registry["block_2"])
+
+    # block_6's body attestation justifying block_2 is merged into the
+    # store's known aggregated payload pool. Its source is genesis (the
+    # latest_justified at block_6's parent, block_3), so the filter must
+    # match on source-slot-justified, not full Checkpoint equality, to be
+    # able to reuse it from block_5's chain.
+    genesis_root = hash_tree_root(keyed_genesis_block)
+    block_2_root = hash_tree_root(block_registry["block_2"])
+    block_6_target_atts = [
+        att
+        for att in store.latest_known_aggregated_payloads
+        if att.target.root == block_2_root and att.target.slot == Slot(2)
+    ]
+    assert len(block_6_target_atts) == 1
+    assert block_6_target_atts[0].source == Checkpoint(root=genesis_root, slot=Slot(0))
+    assert block_6_target_atts[0].slot == Slot(6)
+
+    # Propose at slot 7 on top of block_5 (the head). The fixed-point loop
+    # picks up block_6's attestation (source=genesis matches the chain at
+    # slot 0) and advances the produced block's justified checkpoint to
+    # block_2 to match the store.
+    new_store, new_block, _ = spec.produce_block_with_signatures(store, Slot(7), ValidatorIndex(7))
+
+    # The store's justified checkpoint stays at block_2; the new block
+    # closes the gap rather than leaving the producer behind.
+    block_2_checkpoint = Checkpoint(root=block_2_root, slot=Slot(2))
+    assert new_store.latest_justified == block_2_checkpoint
+
+    # The new block's post-state caught up to the store's justified checkpoint.
+    new_block_root = hash_tree_root(new_block)
+    assert new_block.parent_root == hash_tree_root(block_registry["block_5"])
+    assert new_store.states[new_block_root].latest_justified == block_2_checkpoint
+
+    # The produced block must include the attestation that justifies block_2.
+    body_targets = [att.data.target for att in new_block.body.attestations]
+    assert block_2_checkpoint in body_targets

--- a/tests/lean_spec/forks/lstar/forkchoice/test_block_production_justification_gap.py
+++ b/tests/lean_spec/forks/lstar/forkchoice/test_block_production_justification_gap.py
@@ -33,11 +33,11 @@ def test_produce_block_on_head_with_lagging_justification(
 
     Fork tree (labels are block names; slot numbers shown in parentheses)::
 
-                            block_4(4) -- block_5(5)  <-- head
-                           /
+                               block_4(4) -- block_5(5)  <-- head
+                              /
         genesis -- 1 -- 2 -- 3
-                           \
-                            block_6(6)
+                              \
+                               block_6(6)
 
     Setup:
 

--- a/tests/lean_spec/forks/lstar/state/test_state_aggregation.py
+++ b/tests/lean_spec/forks/lstar/state/test_state_aggregation.py
@@ -275,11 +275,11 @@ def test_build_block_state_root_valid_when_signatures_split(
     assert len(result_state.validators.data) == num_validators
 
 
-def test_build_block_skips_non_matching_source(
+def test_build_block_skips_other_chain_source(
     container_key_manager: XmssKeyManager,
     spec: LstarSpec,
 ) -> None:
-    """Only attestation data whose source matches current_justified is included."""
+    """Only attestation data whose source matches the current chain is included."""
     state = make_keyed_genesis_state(2, container_key_manager)
     parent_header_with_state_root = state.latest_block_header.model_copy(
         update={"state_root": hash_tree_root(state)}


### PR DESCRIPTION
## Problem Summary

The fixed-point loop in `build_block` requires `att.source` to equal `current_justified` exactly. When the store's justified checkpoint has advanced via a sibling fork (e.g. block_6 justifying block_2 while the canonical head is on a fork at block_1), while the current head justified an earlier slot, the head chain's pool holds an attestation that *would* close the gap between them, but its source is different from the head's `latest_justified` checkpoint so it is filtered out and block production aborts with `Fixed-point attestation loop did not converge`.

## Reproduction

`tests/lean_spec/forks/lstar/forkchoice/test_block_production_justification_gap.py` builds the scenario explicitly:

```
                       block_4(4) -- block_5(5)  <-- head
                      /
genesis -- 1 -- 2 -- 3
                      \
                       block_6(6)
```

- `block_4`: 6/8 attest `target=block_1` (justifies slot 1).
- `block_5`: 2/8 attest `target=block_4` (fork-choice weight only).
- `block_6` (sibling of block_4): 6/8 attest `target=block_2` (justifies slot 2 on the store).

Fork choice keeps `block_5` as head; the store's `latest_justified` is now `block_2`, but `block_5`'s post-state still sits at `block_1`. Producing on slot 7 must close the gap.

## PR Description

This PR relaxes that filter to a slot bound: an attestation is selectable as long as its source slot is at or before the head chain's latest justified slot.

```diff
- if att_data.source != current_justified:
+ if att_data.source.slot > current_justified.slot:
      continue
```

Additionally, we also include some other, now required, sanity checks:
- `source.root` matches `source.slot`'s expected root on the chain
- `target.root` matches `target.slot`'s expected root on the chain
- the target isn't already justified (otherwise the attestation is useless), but we allow source=target=0 votes for bootstrapping fork-choice

There was a specific test for the check we removed (`test_build_block_skips_non_matching_source`), which was renamed to `test_build_block_skips_other_chain_source ` and repurposed for the new checks on source and target.