### PR TITLE
refactor(types): rename aggregation.py to participation.py

### DIFF
--- a/src/lean_spec/types/__init__.py
+++ b/src/lean_spec/types/__init__.py
@@ -1,6 +1,5 @@
 """Reusable type definitions for the Lean Ethereum specification."""
 
-from .aggregation import VALIDATOR_REGISTRY_LIMIT, AggregationBits, ValidatorIndices
 from .base import CamelModel, StrictBaseModel
 from .bitfields import BaseBitlist, BaseBitvector
 from .boolean import Boolean
@@ -29,6 +28,7 @@ from .exceptions import (
     SSZTypeError,
     SSZValueError,
 )
+from .participation import VALIDATOR_REGISTRY_LIMIT, AggregationBits, ValidatorIndices
 from .rlp import RLPDecodingError, RLPItem, decode_rlp, decode_rlp_list, encode_rlp
 from .slot import IMMEDIATE_JUSTIFICATION_WINDOW, Slot
 from .ssz_base import SSZType

--- a/src/lean_spec/types/participation.py
+++ b/src/lean_spec/types/participation.py
@@ -1,14 +1,4 @@
-"""
-Validator participation: bitlist + index-list pair.
-
-Two SSZ types co-located because they round-trip:
-
-- `AggregationBits.to_validator_indices()` returns the indices set in the bitlist.
-- `ValidatorIndices.to_aggregation_bits()` packs an index list back into bits.
-
-Both are sized by `VALIDATOR_REGISTRY_LIMIT`. The shape is inherited by every
-validator-keyed bitfield and index list across the spec.
-"""
+"""Validator participation"""
 
 from typing import Final
 
@@ -23,12 +13,7 @@ VALIDATOR_REGISTRY_LIMIT: Final = Uint64(2**12)
 
 
 class AggregationBits(BaseBitlist):
-    """
-    Bitlist representing validator participation in an attestation or signature.
-
-    A general-purpose bitfield for tracking which validators have participated
-    in some collective action (attestation, signature aggregation, etc.).
-    """
+    """Bitlist representing validator participation in an attestation or signature."""
 
     LIMIT = int(VALIDATOR_REGISTRY_LIMIT)
 
@@ -37,10 +22,10 @@ class AggregationBits(BaseBitlist):
         Extract all validator indices encoded in these aggregation bits.
 
         Returns:
-            ValidatorIndices containing the indices, sorted in ascending order.
+            `ValidatorIndices` containing the indices, sorted in ascending order.
 
         Raises:
-            AssertionError: If no bits are set.
+            `AssertionError`: If no bits are set.
         """
         # Extract indices where bit is set; fail if none found.
         indices = [ValidatorIndex(i) for i, bit in enumerate(self.data) if bool(bit)]
@@ -60,11 +45,11 @@ class ValidatorIndices(SSZList[ValidatorIndex]):
         Convert to aggregation bits marking which validators are present.
 
         Returns:
-            AggregationBits with the corresponding indices set to True.
+            `AggregationBits` with the corresponding indices set to True.
 
         Raises:
-            AssertionError: If no indices are provided.
-            AssertionError: If any index is outside the supported LIMIT.
+            `AssertionError`: If no indices are provided.
+            `AssertionError`: If any index is outside the supported LIMIT.
         """
         index_list = self.data
 

--- a/src/lean_spec/types/participation.py
+++ b/src/lean_spec/types/participation.py
@@ -28,7 +28,7 @@ class AggregationBits(BaseBitlist):
             `AssertionError`: If no bits are set.
         """
         # Extract indices where bit is set; fail if none found.
-        indices = [ValidatorIndex(i) for i, bit in enumerate(self.data) if bool(bit)]
+        indices = [ValidatorIndex(i) for i, bit in enumerate(self.data) if bit]
         if not indices:
             raise AssertionError("Aggregated attestation must reference at least one validator")
 

--- a/tests/lean_spec/subspecs/containers/test_attestation_aggregation.py
+++ b/tests/lean_spec/subspecs/containers/test_attestation_aggregation.py
@@ -1,55 +1,16 @@
-"""Tests for attestation aggregation and signature ordering."""
-
-import pytest
+"""Tests for AggregatedAttestation structure."""
 
 from lean_spec.forks.lstar.containers.attestation import (
     AggregatedAttestation,
     AttestationData,
 )
 from lean_spec.types import (
-    AggregationBits,
-    Boolean,
     Bytes32,
     Checkpoint,
     Slot,
     ValidatorIndex,
     ValidatorIndices,
 )
-
-
-class TestAggregationBits:
-    """Test aggregation bits functionality."""
-
-    def test_reject_empty_aggregation_bits(self) -> None:
-        """Validate aggregated attestation must include at least one validator."""
-        bits = AggregationBits(data=[Boolean(False), Boolean(False), Boolean(False)])
-        with pytest.raises(AssertionError, match="at least one validator"):
-            bits.to_validator_indices()
-
-    def test_to_validator_indices_single_bit(self) -> None:
-        """Test conversion with a single bit set."""
-        bits = AggregationBits(data=[Boolean(False), Boolean(True), Boolean(False)])
-        indices = bits.to_validator_indices()
-        assert indices == ValidatorIndices(data=[ValidatorIndex(1)])
-
-    def test_to_validator_indices_multiple_bits(self) -> None:
-        """Test conversion with multiple bits set."""
-        bits = AggregationBits(
-            data=[Boolean(True), Boolean(False), Boolean(True), Boolean(True), Boolean(False)]
-        )
-        indices = bits.to_validator_indices()
-        assert indices == ValidatorIndices(
-            data=[ValidatorIndex(0), ValidatorIndex(2), ValidatorIndex(3)]
-        )
-
-    def test_to_aggregation_bits_roundtrip(self) -> None:
-        """Test that to_aggregation_bits and to_validator_indices are inverses."""
-        original_indices = ValidatorIndices(
-            data=[ValidatorIndex(1), ValidatorIndex(5), ValidatorIndex(7)]
-        )
-        bits = original_indices.to_aggregation_bits()
-        recovered_indices = bits.to_validator_indices()
-        assert recovered_indices == original_indices
 
 
 class TestAggregatedAttestation:

--- a/tests/lean_spec/types/test_participation.py
+++ b/tests/lean_spec/types/test_participation.py
@@ -1,0 +1,102 @@
+"""Tests for AggregationBits and ValidatorIndices conversions."""
+
+import pytest
+
+from lean_spec.types import (
+    VALIDATOR_REGISTRY_LIMIT,
+    AggregationBits,
+    Boolean,
+    ValidatorIndex,
+    ValidatorIndices,
+)
+
+
+class TestAggregationBitsToValidatorIndices:
+    """Convert an aggregation bitlist to the validator indices it encodes."""
+
+    def test_reject_empty_aggregation_bits(self) -> None:
+        """No bits set must raise."""
+        bits = AggregationBits(data=[Boolean(False), Boolean(False), Boolean(False)])
+        with pytest.raises(
+            AssertionError,
+            match="Aggregated attestation must reference at least one validator",
+        ):
+            bits.to_validator_indices()
+
+    def test_single_bit_set(self) -> None:
+        """One bit set yields a single-index list."""
+        bits = AggregationBits(data=[Boolean(False), Boolean(True), Boolean(False)])
+        assert bits.to_validator_indices() == ValidatorIndices(data=[ValidatorIndex(1)])
+
+    def test_multiple_bits_set(self) -> None:
+        """Multiple bits set yield indices in ascending order."""
+        bits = AggregationBits(
+            data=[Boolean(True), Boolean(False), Boolean(True), Boolean(True), Boolean(False)]
+        )
+        assert bits.to_validator_indices() == ValidatorIndices(
+            data=[ValidatorIndex(0), ValidatorIndex(2), ValidatorIndex(3)]
+        )
+
+
+class TestValidatorIndicesToAggregationBits:
+    """Convert a list of validator indices to an aggregation bitlist."""
+
+    def test_reject_empty_indices(self) -> None:
+        """An empty index list must raise."""
+        indices = ValidatorIndices(data=[])
+        with pytest.raises(
+            AssertionError,
+            match="Aggregated attestation must reference at least one validator",
+        ):
+            indices.to_aggregation_bits()
+
+    def test_reject_index_at_limit(self) -> None:
+        """An index equal to VALIDATOR_REGISTRY_LIMIT exceeds the bitfield range."""
+        indices = ValidatorIndices(data=[ValidatorIndex(VALIDATOR_REGISTRY_LIMIT)])
+        with pytest.raises(
+            AssertionError, match="Validator index out of range for aggregation bits"
+        ):
+            indices.to_aggregation_bits()
+
+    def test_reject_index_above_limit(self) -> None:
+        """An index above VALIDATOR_REGISTRY_LIMIT exceeds the bitfield range."""
+        indices = ValidatorIndices(data=[ValidatorIndex(int(VALIDATOR_REGISTRY_LIMIT) + 100)])
+        with pytest.raises(
+            AssertionError, match="Validator index out of range for aggregation bits"
+        ):
+            indices.to_aggregation_bits()
+
+    def test_deduplicates_repeated_indices(self) -> None:
+        """Repeated indices collapse to a single set bit per position."""
+        indices = ValidatorIndices(
+            data=[ValidatorIndex(1), ValidatorIndex(3), ValidatorIndex(1), ValidatorIndex(3)]
+        )
+        assert indices.to_aggregation_bits() == AggregationBits(
+            data=[Boolean(False), Boolean(True), Boolean(False), Boolean(True)]
+        )
+
+    def test_handles_unsorted_input(self) -> None:
+        """Unsorted indices produce a positionally correct bitfield."""
+        indices = ValidatorIndices(data=[ValidatorIndex(5), ValidatorIndex(1), ValidatorIndex(3)])
+        assert indices.to_aggregation_bits() == AggregationBits(
+            data=[
+                Boolean(False),
+                Boolean(True),
+                Boolean(False),
+                Boolean(True),
+                Boolean(False),
+                Boolean(True),
+            ]
+        )
+
+    def test_length_matches_max_index(self) -> None:
+        """Returned bitfield has length max_index + 1 — no trailing zeros."""
+        indices = ValidatorIndices(data=[ValidatorIndex(3)])
+        assert indices.to_aggregation_bits() == AggregationBits(
+            data=[Boolean(False), Boolean(False), Boolean(False), Boolean(True)]
+        )
+
+    def test_roundtrip_through_aggregation_bits(self) -> None:
+        """Indices to bits and back yields the original input."""
+        original = ValidatorIndices(data=[ValidatorIndex(1), ValidatorIndex(5), ValidatorIndex(7)])
+        assert original.to_aggregation_bits().to_validator_indices() == original


### PR DESCRIPTION
## Summary

- Renames `src/lean_spec/types/aggregation.py` → `src/lean_spec/types/participation.py`.
- The module holds both `AggregationBits` (bitlist form) and `ValidatorIndices` (index-list form). The unifying concept is validator *participation*; "aggregation" only described one of the two types.
- Updates the lone import in `src/lean_spec/types/__init__.py`. No public API change — all symbols (`AggregationBits`, `ValidatorIndices`, `VALIDATOR_REGISTRY_LIMIT`) remain re-exported from `lean_spec.types`.

## Test plan

- [x] `uv run --group lint ruff check`
- [x] `uv run --group lint ruff format --check`
- [x] `uv run --group lint ty check`
- [x] `uv run --group lint codespell`
- [x] `uv lock --check`
- [x] `uv run --group docs mdformat --check docs/`
- [x] `uv run pytest tests/lean_spec/subspecs/containers/test_attestation_aggregation.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)