### PR TITLE
docs(types): rewrite bitfields.py docs + overhaul doc system

### DIFF
--- a/.claude/agents/doc-writer.md
+++ b/.claude/agents/doc-writer.md
@@ -1,421 +1,122 @@
 ---
 name: doc-writer
-description: "Use this agent when documentation needs to be written, improved, or reviewed for the leanSpec Ethereum specification codebase. This includes writing docstrings, adding inline comments that explain 'why' not 'what', creating module-level documentation, or reviewing existing documentation for clarity and educational value. The agent follows a specific documentation philosophy where every line teaches and readers are treated as learners.\n\nExamples:\n\n<example>\nContext: User has just written a new function for SSZ serialization and needs documentation.\nuser: \"Please write a function that serializes a Uint64 to bytes\"\nassistant: \"Here is the serialization function:\n```python\ndef serialize_uint64(value: Uint64) -> bytes:\n    return value.to_bytes(8, 'little')\n```\"\n<commentary>\nSince new specification code was written, use the Task tool to launch the doc-writer agent to add proper documentation that explains the why, not just the what.\n</commentary>\nassistant: \"Now let me use the doc-writer agent to add educational documentation to this function.\"\n</example>\n\n<example>\nContext: User asks for documentation review on existing code.\nuser: \"Can you review the documentation in state/types.py for clarity?\"\nassistant: \"I'm going to use the Task tool to launch the doc-writer agent to review the documentation for clarity and educational value.\"\n<commentary>\nThe user is asking for documentation review, which is exactly what the doc-writer agent specializes in - ensuring documentation guides readers through complex protocol logic with clarity.\n</commentary>\n</example>\n\n<example>\nContext: User has written a complex state transition function.\nuser: \"I just finished implementing process_epoch in the spec\"\nassistant: \"Let me review what you've implemented...\n<code review omitted for brevity>\nThe implementation looks correct.\"\n<commentary>\nSince a significant piece of specification code was written, use the Task tool to launch the doc-writer agent to add comprehensive documentation that explains the protocol logic progressively.\n</commentary>\nassistant: \"Now let me use the doc-writer agent to add documentation that explains the epoch processing logic for learners.\"\n</example>\n\n<example>\nContext: User wants inline comments added to existing code.\nuser: \"Add inline documentation to the verify_attestation function\"\nassistant: \"I'm going to use the Task tool to launch the doc-writer agent to add inline comments that explain why each step exists and what invariants are being preserved.\"\n<commentary>\nThe user is requesting inline documentation, which requires the doc-writer agent's expertise in writing comments that explain purpose, not restate code.\n</commentary>\n</example>"
+description: "Use this agent when documentation needs to be written, improved, or reviewed for the leanSpec Ethereum specification codebase. This includes writing docstrings, adding inline comments that explain 'why' not 'what', creating module-level documentation, or reviewing existing documentation for clarity and educational value. The agent follows a specific documentation philosophy where every line teaches and readers are treated as learners.\n\nExamples:\n\n<example>\nContext: User has just written a new function for SSZ serialization and needs documentation.\nuser: \"Please write a function that serializes a Uint64 to bytes\"\nassistant: \"Here is the serialization function:\n```python\ndef serialize_uint64(value: Uint64) -> bytes:\n    return value.to_bytes(8, 'little')\n```\"\n<commentary>\nSince new specification code was written, use the Task tool to launch the doc-writer agent to add proper documentation that explains the why, not just the what.\n</commentary>\nassistant: \"Now let me use the doc-writer agent to add educational documentation to this function.\"\n</example>\n\n<example>\nContext: User asks for documentation review on existing code.\nuser: \"Can you review the documentation in state/types.py for clarity?\"\nassistant: \"I'm going to use the Task tool to launch the doc-writer agent to review the documentation for clarity and educational value.\"\n<commentary>\nThe user is asking for documentation review, which is exactly what the doc-writer agent specializes in - ensuring documentation guides readers through complex protocol logic with clarity.\n</commentary>\n</example>\n\n<example>\nContext: User wants inline comments added to existing code.\nuser: \"Add inline documentation to the verify_attestation function\"\nassistant: \"I'm going to use the Task tool to launch the doc-writer agent to add inline comments that explain why each step exists and what invariants are being preserved.\"\n<commentary>\nThe user is requesting inline documentation, which requires the doc-writer agent's expertise in writing comments that explain purpose, not restate code.\n</commentary>\n</example>"
 model: inherit
 color: pink
 ---
 
-You are SpecScribe, a Documentation Specialist for Ethereum Specification Clarity. Your philosophy is: "The spec teaches. Every line is a lesson."
+You are SpecScribe, a documentation specialist for the leanSpec Ethereum consensus specification.
+Your philosophy: the spec teaches — every line is a lesson.
 
 ## Mission
 
-Make leanSpec readable by anyone studying Ethereum consensus. Write documentation that guides readers through complex protocol logic with clarity, patience, and precision. The spec is educational material—treat every reader as a learner.
+Make leanSpec readable by anyone studying Ethereum consensus.
+Guide readers through complex protocol logic with clarity, patience, and precision.
+Treat every reader as a learner.
 
-## ABSOLUTE RULES (never violate these)
+## Sources of truth
 
-### 1. No AI filler
+Defer to these files for atomic rules — do not restate them in your output:
 
-Never write vague, generic, or inflated prose. Every sentence must carry information.
+- `.claude/rules/documentation.md` — hard rules, style requirements, anti-patterns.
+- `.claude/rules/code-style.md` — no-backticks rule, import discipline.
+- `.claude/skills/doc/SKILL.md` — scope handling, gold-standard exemplar, workflow checklist.
 
-**Banned patterns:**
-- "This method is responsible for..." → just say what it does
-- "This is used to..." → say when/why
-- "This function handles the logic for..." → describe the logic
-- Any sentence that could apply to any function is too vague
+If you find yourself writing a rule that lives in those files, you are duplicating.
+Reference them instead.
 
-### 2. Never reference function names, method names, or variable names in documentation
+## Consensus-domain patterns
 
-Names change. Documentation becomes stale. Use plain English.
+These patterns are specific to consensus protocol code.
+They supplement the atomic rules — they do not replace them.
 
-**Bad:**
+### Structured labels for protocol code
+
+Use these inline-comment labels when they add clarity.
+They are the leanSpec vocabulary for protocol-aware comments:
+
+- `# Threshold:` — supermajority or quorum arithmetic, with the numbers shown.
+- `# Timing:` — interval, slot, or epoch calculations.
+- `# Justification:` — when a block becomes justified or finalized.
+- `# Fork choice:` — head selection or weight comparison.
+- `# Invariant:` — a rule the surrounding code preserves.
+- `# Why:` — load-bearing rationale that is not obvious from the code.
+
+### Concrete protocol examples
+
+Always anchor explanations in real numbers from the context.
+
+Bad:
 ```python
-# The shutdown task waits for stop() to be called
+# Check if the slot is justifiable.
 ```
 
-**Good:**
+Good:
 ```python
-# A separate task monitors the shutdown signal.
+# Slot 3 is justifiable: delta=2 from finalized=1, within the immediate window of 5.
 ```
 
-### 3. Never use backticks in comments or docstrings
+### ASCII chain topology
 
-This is source code, not rendered documentation. Backticks (`` `` ``) add visual noise and make comments harder to scan. Just write identifiers as plain text.
-
-**Bad:**
-```python
-# The ``GossipAggregatedAttestationStep`` puts payloads
-# into ``latest_new_aggregated_payloads``.
-```
-
-**Good:**
-```python
-# Gossip aggregated steps place payloads into the "new" pool.
-```
-
-### 4. Docstrings are short and scannable — education goes inline
-
-The docstring gives a bird's-eye view. The inline comments teach.
-
-For **production code**, the docstring tells the reader:
-- What this accomplishes (one line)
-- Why it exists / when to use it (bullets)
-- Args, Returns, Raises
-
-For **test functions**, the docstring has:
-- One summary line
-- Short named sections with bullets and ASCII diagrams
-- No prose blocks, no algorithm recaps, no framework internals
-
-Do NOT recapitulate the step-by-step algorithm in the docstring. That belongs in the inline comments glued to the code it describes.
-
-**Bad** — dense prose block in test docstring:
-```python
-"""
-Delivery mechanism: GossipAggregatedAttestationStep puts payloads
-into latest_new_aggregated_payloads. A TickStep advances time past
-interval 4 of the slot, triggering accept_new_attestations which
-migrates the payloads to latest_known_aggregated_payloads. The
-subsequent BlockStep at slot 5 calls build_signed_block_with_store
-which passes latest_known_aggregated_payloads to State.build_block.
-"""
-```
-
-**Good** — scannable sections with bullets:
-```python
-"""
-Fixed-point loop: justification from attestation A unlocks attestation B.
-
-Scenario
---------
-Four validators. Linear chain through slot 4::
-
-    genesis(0) -> block_1(1) -> block_2(2) -> block_3(3) -> block_4(4)
-
-Two gossip attestations with different sources:
-
-- A: source=1, target=2, validators {0, 1, 2}
-- B: source=2, target=4, validators {1, 2, 3}
-
-Expected post-state
--------------------
-- Justified slot: 4
-- Finalized slot: 1
-- Block body: 2 aggregated attestations (A and B)
-"""
-```
-
-### 5. Line-by-line documentation inside every function body
-
-This is **the most important rule**. Every logical step gets a comment block BEFORE it. This applies everywhere: spec code, utility code, **and test code**. Tests are functions — the same rules apply without exception.
-
-Each comment block:
-- Starts with a short summary line
-- Optionally followed by a blank `#` line and detail lines
-- Is separated from the previous block by a blank line
+When a comment involves a chain of blocks, draw it.
 
 ```python
-def verify(self, state: State) -> bool:
-    """Verify all signatures in this signed block."""
-
-    # Extract the attestation list and its matching signature proofs.
-    attestations = self.block.body.attestations.data
-    signatures = self.signature.attestation_signatures.data
-
-    # Every attestation must have exactly one corresponding proof.
-    assert len(attestations) == len(signatures)
-
-    # Walk each attestation-signature pair and verify the aggregated proof.
-    #
-    # An aggregated proof bundles votes from multiple validators.
-    # Verification confirms all claimed participants actually signed.
-    for attestation, proof in zip(attestations, signatures):
-        participants = attestation.aggregation_bits.to_validator_indices()
-        ...
-```
-
-### 6. Concrete over abstract — use real numbers
-
-Never write vague comments. Use actual values from the context.
-
-**Bad:**
-```python
-# Validate the threshold.
-```
-
-**Good:**
-```python
-# Threshold: 3 * count >= 2 * total -> 3*3=9 >= 2*4=8 -> passes.
-```
-
-**Bad:**
-```python
-# Check that this slot is justifiable.
-```
-
-**Good:**
-```python
-# Slot 3 is justifiable: delta=2 from finalized=1, within the
-# immediate window of 5.
-```
-
-### 7. ASCII diagrams for data flow and chain topology
-
-Whenever code transforms, compares, or rearranges data — or when a chain of blocks is involved — show the layout visually.
-
-```python
-# Chain setup
+# Chain setup:
 #
-#   genesis(0) -> block_1(1) -> block_2(2) -> block_3(3) -> block_4(4)
+#     genesis(0) -> block_1(1) -> block_2(2) -> block_3(3) -> block_4(4)
 #
 # Slot 3 carries a supermajority attestation that justifies slot 1.
-# This establishes the baseline: justified=1, finalized=0.
 ```
+
+### Role-labeled flow for multi-party logic
+
+When the comment describes prover/verifier, sender/receiver, or producer/consumer interaction, align the roles in a block:
 
 ```python
-# Fixed-point loop:
+# Aggregation flow:
 #
-#   Pass 1: justified=1 -> A selected -> justifies 2
-#           Finalization: range(1+1, 2) is empty -> finalizes 1
-#           justified advances to 2
-#
-#   Pass 2: justified=2 -> B selected -> justifies 4
-#           justified advances to 4
-#
-#   Pass 3: nothing new -> break
+#     proposer  : selects attestations targeting their head.
+#     attesters : sign once per slot for the head they observed.
+#     network   : gossip with mesh of size 8, slot timeout 6s.
 ```
 
-### 8. Structured labels in inline comments
+The reader sees both roles aligned at a glance instead of parsing prose.
 
-Use labeled sub-sections when they add clarity:
+## Workflow
 
-- `# Why:` — when the reason is not obvious from the code
-- `# Invariant:` — the rule being enforced or relied upon
-- `# Timing:` — for interval/slot calculations
-- `# Threshold:` — for supermajority arithmetic
+1. Understand the code.
+   Read the implementation.
+   Map the data flow.
+   Identify the non-obvious mechanics.
+2. Identify the educational angle.
+   What does a reader new to Ethereum consensus need to learn here?
+3. Write the header tightly.
+   Use the standard section vocabulary from the skill file.
+4. Add inline WHY comments.
+   Glue each one to the code it explains.
+5. Re-read as a learner.
+   If a fresh reader would stall, add one more comment — and only one.
 
-```python
-# Migrate attestations: tick to 20s (interval 24 fires acceptance).
-#
-# Invariant: justified is still slot 1.
-# Attestations are stored but not processed until a block is built.
-#
-# We check two validators unique to each attestation:
-# - V0 appears only in A (source=1, target=2)
-# - V3 appears only in B (source=2, target=4)
-```
+## Voice
 
-### 9. Short, scannable sentences
-
+- Simple, direct sentences.
+- Active voice, present tense.
 - One idea per line.
-- Under 15 words is ideal.
-- Break long explanations into multiple short lines.
-- Add blank lines between logical groups.
+  Under 15 words is the target.
+- Educational — never condescending.
+- No marketing language.
+- No filler phrases.
 
-**Bad:**
-```python
-# The state includes initial checkpoints, validator registry,
-# and configuration derived from genesis time.
-```
+## Output discipline
 
-**Good:**
-```python
-# Includes initial checkpoints, validator registry, and config.
-```
+When reviewing or rewriting documentation:
 
-### 10. Formatting creates readability
+- Preserve existing documentation that is still correct.
+  Do not rewrite for aesthetics.
+- Edit, do not replace.
+  Surgical changes preserve context for reviewers.
+- Do not touch code that was not in the scope of the request.
+- If you find a rule conflict, surface it instead of silently picking one.
 
-Use visual structure so readers WANT to read:
-
-- Blank lines between comment blocks (breathing room)
-- Bullet points or numbered steps for lists
-- Short paragraphs (2-3 lines max per comment block)
-- Never wall-of-text comments
-
-**Bad:**
-```python
-# Validate input length.
-# The minimum valid message is 10 bytes.
-if len(data) < 10:
-    raise Error("Too short")
-# Extract the header.
-header = data[:10]
-```
-
-**Good:**
-```python
-# Validate input length.
-#
-# The minimum valid message is 10 bytes.
-if len(data) < 10:
-    raise Error("Too short")
-
-# Extract the header.
-#
-# Header format is defined in section 4.1 of the spec.
-header = data[:10]
-```
-
-### 11. Use bullet points or enumeration for lists
-
-When listing multiple items, use structured formatting.
-
-**Bad:**
-```python
-"""
-The verification checks structural validity, cryptographic correctness,
-and state transition rules before accepting the block.
-"""
-```
-
-**Good:**
-```python
-"""
-The verification checks:
-
-- Structural validity
-- Cryptographic correctness
-- State transition rules
-"""
-```
-
-**Good** - Numbered steps for sequential operations:
-```python
-"""
-Processing proceeds in order:
-
-1. Validate input format
-2. Check signatures
-3. Apply state transition
-4. Update forkchoice
-"""
-```
-
-## Documentation Style
-
-### Voice
-- Simple, direct sentences
-- Active voice preferred
-- Present tense for descriptions
-- Educational, never condescending
-
-### Structure
-- One idea per comment block
-- Blank lines create breathing room
-- Comments explain WHY, code shows WHAT
-- Progressive disclosure: overview first, details follow
-
-### Length
-- Short sentences (under 15 words ideal)
-- Docstrings: complete but concise
-- Inline comments: one to three lines per block
-
-## Docstring Format
-
-Follow Google docstring style (no docstrings for `__init__`):
-
-```python
-def function_name(self, param: Type) -> ReturnType:
-    """
-    One-line summary of what this does.
-
-    Expanded explanation if needed.
-    Break into paragraphs for distinct concepts.
-    Use simple words over jargon.
-
-    Key insight or important note about behavior.
-
-    Args:
-        param: What this parameter represents.
-
-    Returns:
-        What the caller receives and when.
-
-    Raises:
-        ErrorType: Under what conditions.
-    """
-```
-
-## Inline Comment Pattern
-
-The gold standard. Inspired by the best systems code in the world:
-
-```python
-def process(self, data: bytes) -> Result:
-    """Process incoming data according to protocol rules."""
-
-    # Validate the input before any processing.
-    #
-    # This catches malformed data early and provides clear errors.
-    if not data:
-        raise CodecError("Empty input")
-
-    # Extract the header fields.
-    #
-    # The header is always 4 bytes: [type: 1][length: 3 LE].
-    chunk_type = data[0]
-    chunk_length = int.from_bytes(data[1:4], "little")
-
-    # Decode the payload using the type-specific codec.
-    #
-    # Each type has its own encoding rules defined in the protocol spec.
-    payload = self._decode_payload(chunk_type, data[4:])
-```
-
-## Documentation Checklist
-
-### Module level
-- Purpose of the module
-- Key concepts introduced
-- References to specs or papers
-
-### Class level
-- What this type represents
-- How it fits in the protocol
-- Key invariants it maintains
-
-### Method level
-- What it accomplishes (one line)
-- Context: why it exists, when to use it
-- Args, Returns, Raises sections
-- NO algorithm recap (that's inline)
-
-### Inline level
-- Why this step exists
-- What invariant it preserves
-- Edge cases being handled
-- Grouped logically with blank line separators
-
-## Project-Specific Requirements
-
-- Line length: 100 characters maximum
-- Type hints everywhere
-- Repository is `leanSpec` (not `lean-spec`)
-- SSZ types use domain-specific names (e.g., `JustificationValidators`, not `Bitlist68719476736`)
-- Pydantic models are used throughout
-- Reference the Ethereum consensus specification when relevant
-
-## Your Workflow
-
-1. **Understand the code**: Read the implementation carefully before documenting
-2. **Identify the purpose**: What problem does this solve? Why does it exist?
-3. **Find the educational angle**: How would you teach this to someone learning Ethereum?
-4. **Write progressively**: Start simple, add complexity only as needed
-5. **Review for clarity**: Can a learner understand this without additional context?
-
-## Quality Standards
-
-- Every docstring must explain PURPOSE, not just describe parameters
-- Inline comments must justify decisions, not restate code
-- Use blank lines to create visual groupings
-- Keep sentences short and direct
-- Avoid jargon unless defined
-- Reference specification sections when applicable
-- NEVER mention function/method/variable names in comments — use plain English
-- NEVER use backticks in comments or docstrings — this is source code, not docs
-- ALWAYS use concrete numbers from the context (thresholds, deltas, slot values)
-- ALWAYS use ASCII diagrams for chain topology and data flow
-- ALWAYS use structured labels (Why:, Invariant:, Timing:, Threshold:) where they add clarity
-- Docstrings for tests: keep SHORT — one summary line + scannable sections with bullets
-- Education goes INLINE, glued to the code, not in the docstring
-
-When documenting, always ask yourself: "Would this help someone learning Ethereum consensus understand not just WHAT the code does, but WHY it does it this way?"
+When in doubt, ask:
+"Would this comment help someone learning Ethereum consensus understand not just what this code does, but why it does it this way?"

--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -5,94 +5,198 @@ paths:
 
 # Documentation Rules (CRITICAL)
 
-**NEVER use explicit function or method names in documentation.**
+These rules govern every docstring and inline comment in the codebase.
+They apply equally to production code, helpers, and tests.
+Violations should be fixed on sight.
 
-Names change. Documentation becomes stale. Use plain language instead.
+## Hard rules
+
+### 1. Never reference function, method, variable, or type names in doc text
+
+Names change.
+Documentation becomes stale.
+Use plain English instead.
 
 Bad:
 ```python
-# The shutdown task waits for stop() to be called, then signals
-# all services to terminate. Once all services exit, TaskGroup completes.
+# The shutdown task waits for stop() to be called, then signals all services to terminate.
 ```
 
 Good:
 ```python
 # A separate task monitors the shutdown signal.
 # When triggered, it stops all services.
-# Once services exit, execution completes.
 ```
 
-**Write short, scannable sentences.**
+### 2. Never use backticks in comments or docstrings
 
-Attention spans are short. Capture the reader precisely and concisely.
-
-- One idea per line.
-- Add blank lines between logical groups.
-- Avoid long compound sentences.
+This is source code, not rendered documentation.
+No single backticks, no double backticks.
+Write identifiers as plain text or quote literal values with normal double quotes.
 
 Bad:
 ```python
-# The state includes initial checkpoints, validator registry,
-# and configuration derived from genesis time.
+# The ``GossipAggregatedAttestationStep`` puts payloads into ``latest_new_aggregated_payloads``.
 ```
 
 Good:
 ```python
-# Includes initial checkpoints, validator registry, and config.
+# Gossip aggregated steps place payloads into the "new" pool.
 ```
 
-**Use bullet points or enumeration for lists.**
+### 3. One sentence per line — hard rule
 
-When listing multiple items, use structured formatting. Helps readers maintain focus.
+Every docstring, doc comment, and inline comment splits one sentence per line.
+Two sentences on one line means the second moves to a new line.
+Multi-clause sentences joined by "and", "but", or semicolons split into separate lines.
+Short lines expose structural meaning at a glance.
 
 Bad:
 ```python
-"""
-The verification checks structural validity, cryptographic correctness,
-and state transition rules before accepting the block.
-"""
+# Accepts lists, tuples, or iterables of bool-like values; stored as a tuple after validation.
 ```
 
 Good:
 ```python
-"""
-The verification checks:
-
-- Structural validity
-- Cryptographic correctness
-- State transition rules
-"""
+# Accepts lists, tuples, or iterables of bool-like values.
+# Stored as an immutable tuple after validation.
 ```
 
-Or with numbered steps:
-```python
-"""
-Processing proceeds in order:
+### 4. Default to no comments
 
-1. Validate input format
-2. Check signatures
-3. Apply state transition
-4. Update forkchoice
-"""
-```
+Add a comment only when the WHY is non-obvious.
+Do not restate code.
+Do not narrate steps.
+If removing the comment would not confuse a future reader, do not write it.
+
+### 5. Preserve existing documentation
+
+Never remove or rewrite a comment or docstring unless the documented behavior actually changed.
+Removing valid docs creates diff noise and destroys context.
+
+## Style requirements
+
+### Sentences
+
+- Under 15 words per sentence is the target.
+- Active voice, present tense.
+- No filler ("This is responsible for...", "This is used to...", "This handles...").
+- No marketing tone ("powerful", "seamless", "elegant").
+
+### Structure
+
+- Bullet points for any list of more than two items.
+- Numbered steps for sequential operations.
+- Blank lines between logical groups inside a comment block.
+- Never include code examples in docstrings.
+  Unit tests serve as usage examples.
+
+### Constants
+
+Document the WHY behind the value, not just what it is.
+Cite the constraint, math, or protocol reference that drives the choice.
 
 Bad:
 ```python
-"""
-Wait for shutdown signal then stop services.
-
-This task runs alongside the services. When shutdown is signaled,
-it stops both services, allowing their run loops to exit gracefully.
-"""
+MAX_VALIDATORS = 4096
+"""Maximum number of validators."""
 ```
 
 Good:
 ```python
-"""
-Wait for shutdown signal then stop services.
-
-Runs alongside the services.
-When shutdown is signaled, stops all services gracefully.
-"""
+MAX_VALIDATORS = 4096
+"""Cap derived from the bitfield budget.
+One bit per validator must fit in 512 bytes."""
 ```
 
+### File-level headers
+
+Single short line unless the module introduces complex math or non-obvious domain context.
+Do not pad simple modules with prose that restates the file name.
+
+## Standard doc sections
+
+Use these section headers when a header doc expands past one overview line.
+They are the shared vocabulary for navigating doc-heavy code.
+
+- **Overview** — what this item does and why it exists, at a high level.
+- **Algorithm** — step-by-step description, only when the math or CS concept is non-obvious.
+- **Performance** — complexity, allocation behavior, hot-path notes.
+- **Invariants** — preconditions and rules the caller must preserve.
+- **Args / Returns / Raises** — Google style, one bullet per item.
+- **Why X** — load-bearing rationale that deserves a header instead of being buried in prose.
+  Examples: "Why this threshold", "Why we skip the first byte", "Why a delimiter".
+
+## Inline comment patterns
+
+Inline comments must be educative.
+A reader new to the domain should understand the invariant and the data flow without looking elsewhere.
+
+### Structured labels
+
+Use these labels inside inline comments where they add clarity:
+
+- `# Why:` — when the reason is not obvious from the code.
+- `# Invariant:` — the rule being enforced or relied upon.
+- `# Threshold:` — for supermajority or quorum arithmetic.
+- `# Timing:` — for interval, slot, or epoch calculations.
+- `# Phase N:` — for multi-step algorithms.
+- `# Fixture state:` — concrete numbers in tests.
+
+### Concrete values over abstract descriptions
+
+Bad:
+```python
+# Validate the count.
+```
+
+Good:
+```python
+# Three rounds means three commitments and three openings expected.
+```
+
+### ASCII diagrams
+
+When code transforms, packs, or rearranges data, show the before/after layout.
+Use them for bit layouts, chain topology, and data flow.
+
+```python
+# Layout:
+#
+#     bits = [1, 0, 1]   ->  byte 0:  0 0 0 0 [1] 1 0 1   (delimiter at bit 3)
+#     bits = [1] * 8     ->  byte 1:  0 0 0 0 0 0 0 [1]   (delimiter spills)
+```
+
+### Role-labeled flow
+
+When the comment describes prover/verifier, sender/receiver, or producer/consumer interaction, align the roles in a block:
+
+```python
+# Aggregation flow:
+#
+#     proposer  : selects attestations targeting their head.
+#     attesters : sign once per slot for the head they observed.
+#     network   : gossip with mesh of size 8, slot timeout 6s.
+```
+
+The reader sees both roles aligned at a glance instead of parsing prose.
+
+### Comments are glued to code
+
+Every comment sits directly above the line or block it explains.
+No floating explanation blocks separated from the code they describe.
+
+## Anti-patterns — never do these
+
+- Multi-clause sentences on one line.
+- Function, method, or variable names in doc prose.
+- Backticks anywhere in docstrings or comments.
+- Filler phrases ("This method is responsible for...", "This is used to...").
+- Restating obvious code as comments (e.g. `# increment i` above `i += 1`).
+- Documenting code that was not changed in the current task.
+- Padding simple module or file headers with prose.
+- Describing individual methods inside the class header — each gets its own docstring.
+- Banner-style separator comments such as `# =====` or `# -----`.
+- Dense prose blocks longer than three contiguous lines — break into bullets or labeled sub-sections.
+- Algorithm recap in the docstring when the body already has labeled phase comments.
+- Skipping the WHY comment when behavior is non-obvious from code.

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: doc
+description: Document code in this repository.
+---
+
+# /doc — document code
+
+Write or refine documentation for leanSpec code.
+The atomic style rules live in `.claude/rules/documentation.md` — defer to that file.
+This skill defines what to document, how to scope the work, and shows a gold-standard exemplar.
+
+## Scope
+
+Determine what to document from the argument passed to `/doc`:
+
+1. **No argument** — document only new or modified code.
+   Run `git diff` and `git diff --cached` to identify scope.
+   Do not touch unchanged code.
+2. **File or folder path** — document everything inside that path recursively.
+3. **Module, class, or function name** — locate the item in the codebase, then document it and everything inside it.
+
+When an argument is provided, document the target fully — not just uncommitted changes.
+The argument overrides the diff-only restriction.
+
+## What to document
+
+- **Module-level docstrings** — single short line unless the module introduces complex math or non-obvious domain context.
+- **All public items** — classes, methods, functions, constants, type aliases, module-level Pydantic fields.
+- **Constants** — explain the WHY behind the value, with the constraint or protocol reference that drives the choice.
+- **Inline comments** — add them only where the WHY is non-obvious.
+  Do not paper every line.
+
+## Standard sections — use these names
+
+When a header doc grows past one overview line, organize the detail under these section names:
+
+- **Overview** — what and why at a high level.
+- **Algorithm** — step-by-step, only for genuinely non-obvious math or CS concepts.
+- **Performance** — complexity, allocation, hot-path notes.
+- **Invariants** — preconditions and rules the caller must preserve.
+- **Why X** — load-bearing rationale that deserves a header instead of buried prose.
+- **Args / Returns / Raises** — Google style, bullets.
+
+## Workflow
+
+1. Read the implementation carefully before writing a single line of documentation.
+2. Identify the educational angle.
+   What does a reader new to Ethereum consensus need to know?
+3. Write the header tightly.
+   Use the standard section vocabulary when overview alone is not enough.
+4. Add inline WHY comments.
+   Glue each comment to the code it explains.
+5. Re-read as a learner.
+   If a fresh reader would stall, add one more comment — and only one.
+
+## Test-specific format
+
+Test docstrings stay short.
+A one-line summary is usually enough.
+Education goes inline in structured blocks:
+
+```
+Invariant: <rule the test enforces>
+
+Fixture state: <concrete numbers>
+
+Mutation: <what we change and why>
+
+    <ASCII diagram of before/after>
+```
+
+Never write essay-style prose blocks in test docstrings.
+
+## Project-specific anti-patterns
+
+These are the failure modes most likely to slip into leanSpec PRs:
+
+- **Backticks in docstrings or comments.**
+  Banned everywhere — single or double backticks alike.
+  See `.claude/rules/documentation.md` rule 2.
+- **Function names in prose.**
+  Names rot.
+  Describe behavior in plain English.
+- **Module docstring listing every class inside.**
+  The module name and public exports describe the module.
+  Do not pad with a class roster.
+- **Algorithm recap in both docstring and inline comments.**
+  Pick one.
+  Default: phase-labeled inline comments in the body, short overview in the header.
+- **Backward-compatibility justifications.**
+  The project mandates no backward compatibility.
+  Do not write docs that pretend a deprecated path still exists.
+- **Documenting code outside the requested scope.**
+  Respect the scope rules above.
+
+## Gold-standard exemplar
+
+The target style for a well-documented Python function in this project.
+Note the tight one-sentence-per-line header, the structured WHY section, the phase-labeled body, and the ASCII layout diagram.
+
+```python
+def encode_bitlist(bits: Sequence[Boolean]) -> bytes:
+    """
+    Encode a variable-length bitlist to SSZ bytes.
+
+    # Overview
+
+    Data bits are packed little-endian within each byte.
+    A single 1 bit is placed immediately after the last data bit.
+    The trailing bit lets the decoder recover the original count.
+
+    # Why a delimiter
+
+    SSZ encodes bitlists as raw bytes with no length prefix.
+    Without a marker, [1, 0] and [1, 0, 0, 0, 0, 0, 0, 0] would share the byte 0x01.
+    A trailing 1 bit is the smallest sentinel that disambiguates them.
+
+    # Layout
+
+        bits = [1, 0, 1]   ->  byte 0:  0 0 0 0 [1] 1 0 1   (delimiter at bit 3)
+        bits = [1] * 8     ->  byte 0:  1 1 1 1 1 1 1 1
+                               byte 1:  0 0 0 0 0 0 0 [1]   (delimiter spills)
+
+    Args:
+        bits: The variable-length bit data.
+
+    Returns:
+        SSZ-encoded bytes containing the data bits and the delimiter.
+    """
+    # Phase 1: handle the empty case.
+    #
+    # No data bits means the encoding is just the delimiter.
+    num_bits = len(bits)
+    if num_bits == 0:
+        return b"\x01"
+
+    # Phase 2: pack data bits little-endian into a byte array.
+    #
+    # Bit i of the input lands in byte i // 8 at position i % 8.
+    byte_len = (num_bits + 7) // 8
+    byte_array = bytearray(byte_len)
+    for i, bit in enumerate(bits):
+        if bit:
+            byte_array[i // 8] |= 1 << (i % 8)
+
+    # Phase 3: place the delimiter immediately after the last data bit.
+    #
+    # When the bit count is a multiple of 8, the delimiter has no room
+    # in the existing array and spills into a fresh trailing byte.
+    if num_bits % 8 == 0:
+        return bytes(byte_array) + b"\x01"
+    byte_array[num_bits // 8] |= 1 << (num_bits % 8)
+    return bytes(byte_array)
+```
+
+Match this density of structure, brevity of lines, and use of concrete numbers and diagrams.
+
+## Workflow checklist
+
+Before finishing a documentation pass, verify:
+
+- Every sentence is on its own line.
+- No backticks anywhere.
+- No function or variable names referenced in prose.
+- All non-obvious WHYs are documented.
+- No banner-style separator comments.
+- No documentation added to code that was not in scope.
+- Standard section names used where headers expand past one line.

--- a/src/lean_spec/types/bitfields.py
+++ b/src/lean_spec/types/bitfields.py
@@ -1,18 +1,20 @@
-"""Bitvector and Bitlist type specifications.
+"""
+SSZ bitfield types.
 
-Provides two SSZ bitfield types:
+A bitfield is a packed sequence of booleans serialized to bytes.
 
-- BaseBitvector: fixed-length sequence of booleans
-- BaseBitlist: variable-length sequence with max capacity
+Two flavors are defined by the SSZ spec:
 
-Both pack bits little-endian within each byte (bit 0 -> LSB).
-Bitlist appends a delimiter bit set to 1 after the last data bit.
+- Fixed-length: exactly N bits encoded in ceil(N / 8) bytes.
+- Variable-length: 0 to N bits encoded with a trailing delimiter bit that marks the end.
 
-Subclasses must define LENGTH (bitvector) or LIMIT (bitlist).
+Both flavors pack bits little-endian within each byte.
+Bit i of the input lands in byte i // 8 at position i % 8.
 """
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from typing import (
     IO,
@@ -32,9 +34,19 @@ from .ssz_base import SSZModel
 
 class BaseBitvector(SSZModel):
     """
-    Base class for fixed-length bit vectors using SSZModel pattern.
+    Fixed-length SSZ bitfield with exactly N bits.
 
-    Immutable collection with exact LENGTH bits.
+    - Subclasses pin the bit count by setting the class-level length.
+    - Serialization packs bits little-endian into ceil(N / 8) bytes.
+    - Trailing bits in the last byte are zero when N is not a multiple of 8.
+
+    For example, [1, 1, 1, 1, 1] (5 bits, all set) encodes to a single byte.
+    list[i] lands at bit i, where bit 0 is the LSB (rightmost in the byte):
+
+        bit position:  7 6 5 4 3 2 1 0
+        byte 0:        0 0 0 1 1 1 1 1   ->  0b00011111
+
+    Bits 5, 6, 7 are trailing zeros — only the lowest 5 hold data.
     """
 
     LENGTH: ClassVar[int]
@@ -42,40 +54,44 @@ class BaseBitvector(SSZModel):
 
     data: Sequence[Boolean] = Field(default_factory=tuple)
     """
-    The immutable bit data stored as a sequence of Booleans.
+    The immutable bit data stored as a sequence of booleans.
 
-    Accepts lists, tuples, or iterables of bool-like values on input;
-    stored as a tuple of Boolean after validation.
+    Accepts lists, tuples, or iterables of bool-like values on input.
+    Stored as an immutable tuple after validation.
     """
 
     @field_validator("data", mode="before")
     @classmethod
     def _coerce_and_validate(cls, v: Any) -> tuple[Boolean, ...]:
-        """Validate and convert input data to typed tuple of Booleans."""
+        """Enforce the exact bit count and coerce inputs into booleans."""
+        # Subclasses must declare LENGTH before any instances can be validated.
         if not hasattr(cls, "LENGTH"):
             raise SSZTypeError(f"{cls.__name__} must define LENGTH")
 
+        # Materialize generic iterables into a tuple so the length check works.
         if not isinstance(v, (list, tuple)):
             v = tuple(v)
 
+        # Fixed-length type: the input must contain exactly LENGTH elements.
         if len(v) != cls.LENGTH:
             raise SSZValueError(
                 f"{cls.__name__} requires exactly {cls.LENGTH} elements, got {len(v)}"
             )
 
+        # Wrap each value in Boolean — the constructor rejects anything outside 0 or 1.
         return tuple(Boolean(bit) for bit in v)
 
     @classmethod
     @override
     def is_fixed_size(cls) -> bool:
-        """A Bitvector is always fixed-size."""
+        """Always fixed-size by definition."""
         return True
 
     @classmethod
     @override
     def get_byte_length(cls) -> int:
-        """Get the byte length for the fixed-size bitvector."""
-        return (cls.LENGTH + 7) // 8  # Ceiling division
+        """Return the number of bytes needed to pack the bits."""
+        return math.ceil(cls.LENGTH / 8)
 
     @override
     def serialize(self, stream: IO[bytes]) -> int:
@@ -88,10 +104,10 @@ class BaseBitvector(SSZModel):
     @override
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
         """Read SSZ bytes from a stream and return an instance."""
-        expected_len = cls.get_byte_length()
-        if scope != expected_len:
+        expected_byte_count = cls.get_byte_length()
+        if scope != expected_byte_count:
             raise SSZSerializationError(
-                f"{cls.__name__}: expected {expected_len} bytes, got {scope}"
+                f"{cls.__name__}: expected {expected_byte_count} bytes, got {scope}"
             )
         data = stream.read(scope)
         if len(data) != scope:
@@ -101,39 +117,103 @@ class BaseBitvector(SSZModel):
     @override
     def encode_bytes(self) -> bytes:
         """
-        Encode to SSZ bytes.
+        Encode the bitfield to SSZ bytes.
 
-        Packs bits little-endian within each byte:
-        bit i goes to byte i // 8 at bit position (i % 8).
+        Bits are packed little-endian within each byte.
+        Bit i of the input lands in byte i // 8 at position i % 8.
+
+        Returns:
+            ceil(N / 8) bytes containing the packed bits.
         """
-        byte_len = (self.LENGTH + 7) // 8
-        byte_array = bytearray(byte_len)
+        # Zero-filled buffer sized for every bit — only the 1 bits need writing.
+        byte_array = bytearray(math.ceil(self.LENGTH / 8))
+
+        # Walk every input bit and set its position in the output.
+        #
+        # For bit index i:
+        #
+        #   - i // 8        identifies the target byte.
+        #   - i % 8         is the position within that byte (0 = LSB).
+        #   - 1 << (i % 8)  builds a one-hot mask for that position.
+        #   - |=            sets the bit while preserving everything already there.
+        #
+        # Example: bits = [1, 0, 1, 0, 0, 0, 0, 0, 1]  (9 bits, crosses a byte boundary)
+        #
+        #   i=0, bit=1:  byte_array[0] |= 1 << 0  ->  [0b00000001]
+        #   i=2, bit=1:  byte_array[0] |= 1 << 2  ->  [0b00000101]
+        #   i=8, bit=1:  byte_array[1] |= 1 << 0  ->  [0b00000101, 0b00000001]
         for i, bit in enumerate(self.data):
             if bit:
                 byte_array[i // 8] |= 1 << (i % 8)
+
         return bytes(byte_array)
 
     @classmethod
     @override
     def decode_bytes(cls, data: bytes) -> Self:
         """
-        Decode from SSZ bytes.
+        Decode SSZ bytes into a bitfield.
 
-        Expects exactly ceil(LENGTH / 8) bytes. No delimiter bit for Bitvector.
+        Input must be exactly ceil(N / 8) bytes.
+        Fixed-length bitfields carry no delimiter — the byte count alone is enough to recover N.
+
+        Args:
+            data: SSZ-encoded bytes with the packed bits.
+
+        Returns:
+            A bitfield instance with N bits read from the input.
+
+        Raises:
+            SSZValueError: If the input length does not match the expected byte count.
         """
-        expected = cls.get_byte_length()
-        if len(data) != expected:
-            raise SSZValueError(f"{cls.__name__}: expected {expected} bytes, got {len(data)}")
+        # Reject inputs whose byte count does not match the expected size.
+        expected_byte_count = cls.get_byte_length()
+        if len(data) != expected_byte_count:
+            raise SSZValueError(
+                f"{cls.__name__}: expected {expected_byte_count} bytes, got {len(data)}"
+            )
 
-        bits = tuple(Boolean((data[i // 8] >> (i % 8)) & 1) for i in range(cls.LENGTH))
-        return cls(data=bits)
+        # Read every bit position out of the byte stream.
+        #
+        # For bit index i:
+        #
+        #   - data[i // 8]  picks the byte that holds bit i.
+        #   - >> (i % 8)    shifts that byte so bit i is in the LSB.
+        #   - & 1           masks off every other bit.
+        #
+        # Example: data = [0b00000101, 0b00000001]  (encoding of 9 bits, 2 bytes)
+        #
+        #   i=0:  (data[0] >> 0) & 1  =  0b00000101 & 1  =  1
+        #   i=1:  (data[0] >> 1) & 1  =  0b00000010 & 1  =  0
+        #   i=2:  (data[0] >> 2) & 1  =  0b00000001 & 1  =  1
+        #   i=3:  (data[0] >> 3) & 1  =  0b00000000 & 1  =  0
+        #   ...
+        #   i=7:  (data[0] >> 7) & 1  =  0b00000000 & 1  =  0
+        #   i=8:  (data[1] >> 0) & 1  =  0b00000001 & 1  =  1
+        #
+        # Recovered bits: [1, 0, 1, 0, 0, 0, 0, 0, 1]
+        return cls(data=[Boolean((data[i // 8] >> (i % 8)) & 1) for i in range(cls.LENGTH)])
 
 
 class BaseBitlist(SSZModel):
     """
-    Base class for variable-length bit lists using SSZModel pattern.
+    Variable-length SSZ bitfield with 0 to N bits.
 
-    Immutable collection with 0 to LIMIT bits.
+    - Subclasses pin the maximum bit count by setting the class-level limit.
+    - Serialization packs data bits little-endian, then appends a single 1 bit as a delimiter.
+    - The delimiter is what lets the decoder recover the original bit count.
+
+    For example, [1, 0, 1] (3 data bits) encodes to a single byte.
+
+    list[i] lands at bit i, where bit 0 is the LSB (rightmost in the byte):
+
+        bit position:  7 6 5 4  3  2 1 0
+        byte 0:        0 0 0 0 [1] 1 0 1   ->  0b00001101   (bracketed bit is the delimiter)
+
+    Without the delimiter, two different lists would collide:
+
+        [1, 0, 1]                ->  0b00000101
+        [1, 0, 1, 0, 0, 0, 0, 0] ->  0b00000101
     """
 
     LIMIT: ClassVar[int]
@@ -141,20 +221,25 @@ class BaseBitlist(SSZModel):
 
     data: Sequence[Boolean] = Field(default_factory=tuple)
     """
-    The immutable bit data stored as a sequence of Booleans.
+    The immutable bit data stored as a sequence of booleans.
 
-    Accepts lists, tuples, or iterables of bool-like values on input;
-    stored as a tuple of Boolean after validation.
+    Accepts lists, tuples, or iterables of bool-like values on input.
+    Stored as an immutable tuple after validation.
     """
 
     @field_validator("data", mode="before")
     @classmethod
     def _coerce_and_validate(cls, v: Any) -> tuple[Boolean, ...]:
-        """Validate and convert input to a tuple of Boolean elements."""
+        """Enforce the maximum bit count and coerce inputs into booleans."""
+        # Subclasses must declare LIMIT before any instances can be validated.
         if not hasattr(cls, "LIMIT"):
             raise SSZTypeError(f"{cls.__name__} must define LIMIT")
 
-        # Handle various input types
+        # Accept different input shapes:
+        #
+        #   - list or tuple    pass through directly.
+        #   - other iterables  materialize into a list so length is known.
+        #   - str or bytes     rejected — iterable but elements are not booleans.
         if isinstance(v, (list, tuple)):
             elements = v
         elif hasattr(v, "__iter__") and not isinstance(v, (str, bytes)):
@@ -162,10 +247,11 @@ class BaseBitlist(SSZModel):
         else:
             raise SSZTypeError(f"Expected iterable, got {type(v).__name__}")
 
-        # Check limit
+        # Variable-length type: any count is fine, up to LIMIT.
         if len(elements) > cls.LIMIT:
             raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {len(elements)}")
 
+        # Wrap each value in Boolean — the constructor rejects anything outside 0 or 1.
         return tuple(Boolean(bit) for bit in elements)
 
     @overload
@@ -181,7 +267,7 @@ class BaseBitlist(SSZModel):
         return self.data[key]
 
     def __add__(self, other: Any) -> Self:
-        """Concatenate this bitlist with another sequence."""
+        """Concatenate with another bit sequence."""
         if isinstance(other, BaseBitlist):
             new_data = (*self.data, *other.data)
         elif isinstance(other, (list, tuple)):
@@ -193,13 +279,18 @@ class BaseBitlist(SSZModel):
     @classmethod
     @override
     def is_fixed_size(cls) -> bool:
-        """A Bitlist is never fixed-size (length varies from 0 to LIMIT)."""
+        """Variable-size by definition — the bit count ranges from zero to the class limit."""
         return False
 
     @classmethod
     @override
     def get_byte_length(cls) -> int:
-        """Lists are variable-size, so this raises an SSZTypeError."""
+        """
+        Variable-size types have no fixed byte length.
+
+        Raises:
+            SSZTypeError: Always — call this only on fixed-size types.
+        """
         raise SSZTypeError(f"{cls.__name__}: variable-size bitlist has no fixed byte length")
 
     @override
@@ -221,64 +312,163 @@ class BaseBitlist(SSZModel):
     @override
     def encode_bytes(self) -> bytes:
         """
-        Encode to SSZ bytes with a trailing delimiter bit.
+        Encode the bitlist to SSZ bytes with a trailing delimiter.
+
+        # Overview
 
         Data bits are packed little-endian within each byte.
-        Then a single delimiter bit set to 1 is placed immediately after
-        the last data bit. If the last data bit ends a byte (num_bits % 8 == 0),
-        the delimiter is a new byte 0b00000001 appended at the end.
+        A single 1 bit is placed immediately after the last data bit.
+        The trailing bit is what lets the decoder recover the original count.
+
+        # Why a delimiter
+
+        SSZ encodes bitlists as raw bytes with no length prefix.
+        Without a marker, [1, 0] and [1, 0, 0, 0, 0, 0, 0, 0] would share the byte 0x01.
+        A trailing 1 bit is the smallest sentinel that disambiguates them.
+
+        # Layout
+
+            bits = [1, 0, 1]   ->  byte 0:  0 0 0 0 [1] 1 0 1   (delimiter at bit 3)
+
+            bits = [1] * 8     ->  byte 0:  1 1 1 1 1 1 1 1
+                                   byte 1:  0 0 0 0 0 0 0 [1]   (delimiter spills)
+
+        Returns:
+            SSZ bytes containing the data bits followed by the delimiter.
         """
+        # Phase 1: handle the empty case.
+        #
+        # No data bits means the encoding is just the delimiter byte.
         num_bits = len(self.data)
         if num_bits == 0:
-            # Empty list: just the delimiter byte.
             return b"\x01"
 
-        byte_len = (num_bits + 7) // 8
-        byte_array = bytearray(byte_len)
-
-        # Pack data bits.
+        # Phase 2: pack data bits little-endian into a byte array.
+        #
+        # For bit index i:
+        #
+        #   - i // 8        identifies the target byte.
+        #   - i % 8         is the position within that byte (0 = LSB).
+        #   - 1 << (i % 8)  builds a one-hot mask for that position.
+        #   - |=            sets the bit, preserving anything already there.
+        #
+        # Example: bits = [1, 0, 1, 0, 0, 0, 0, 0, 1]  (9 bits, crosses a byte boundary)
+        #
+        #   i=0, bit=1:  byte_array[0] |= 1 << 0  ->  [0b00000001]
+        #   i=2, bit=1:  byte_array[0] |= 1 << 2  ->  [0b00000101]
+        #   i=8, bit=1:  byte_array[1] |= 1 << 0  ->  [0b00000101, 0b00000001]
+        byte_array = bytearray(math.ceil(num_bits / 8))
         for i, bit in enumerate(self.data):
             if bit:
                 byte_array[i // 8] |= 1 << (i % 8)
 
-        # Place delimiter bit (1) immediately after the last data bit.
+        # Phase 3: place the delimiter immediately after the last data bit.
+        #
+        # Two cases, by where the last data bit fell:
+        #
+        #   - num_bits % 8 == 0   data fills its bytes; delimiter spills into a new trailing byte.
+        #   - otherwise           delimiter lands at bit (num_bits % 8) of the last byte.
+        #
+        # Example A: data bits = [1, 0, 1]  (num_bits = 3, fits in same byte)
+        #
+        #   byte_array after Phase 2:   [0b00000101]
+        #   byte_array[0] |= 1 << 3  -> [0b00001101]   (delimiter at bit 3)
+        #
+        # Example B: data bits = [1, 1, 1, 1, 1, 1, 1, 1]  (num_bits = 8, spills)
+        #
+        #   byte_array after Phase 2:   [0b11111111]
+        #   bytes(byte_array) + 0x01 -> [0b11111111, 0b00000001]
         if num_bits % 8 == 0:
-            # Delimiter starts a new byte.
             return bytes(byte_array) + b"\x01"
-        else:
-            # Delimiter lives in the last byte at position num_bits % 8.
-            byte_array[num_bits // 8] |= 1 << (num_bits % 8)
-            return bytes(byte_array)
+        byte_array[num_bits // 8] |= 1 << (num_bits % 8)
+        return bytes(byte_array)
 
     @classmethod
     @override
     def decode_bytes(cls, data: bytes) -> Self:
         """
-        Decode from SSZ bytes with a delimiter bit.
+        Decode SSZ bytes into a bitlist by locating the delimiter bit.
 
-        The data must contain a delimiter bit set to 1 immediately after
-        the last data bit. All bits after the delimiter are assumed to be 0.
+        # Overview
+
+        - The highest set bit in the input is the delimiter.
+        - Bits below it are data.
+        - Bits above it are zero padding.
+        - Empty input is invalid (the empty bitlist still encodes as one byte, 0x01).
+
+        # Why integer interpretation
+
+        Reading the byte stream as a little-endian integer aligns bits and bytes perfectly:
+
+            byte 0 bit j  ->  integer bit j
+            byte 1 bit j  ->  integer bit (8 + j)
+            byte k bit j  ->  integer bit (8 * k + j)
+
+        For example, data = [0b00000101, 0b00000010]:
+
+            int.from_bytes(data, "little")  =  0b1000000101
+
+            byte 0 bit 0 (=1)  ->  integer bit 0
+            byte 0 bit 2 (=1)  ->  integer bit 2
+            byte 1 bit 1 (=1)  ->  integer bit 9      (= 8 * 1 + 1)
+
+        The highest set bit of the integer is exactly the delimiter position.
+
+        Args:
+            data: SSZ-encoded bytes containing data bits followed by a single 1 delimiter.
+
+        Returns:
+            A bitlist instance with the recovered data bits.
+
+        Raises:
+            SSZSerializationError: If the input is empty or contains no 1 bits.
+            SSZValueError: If the recovered bit count exceeds the class limit.
         """
+        # Phase 1: reject empty input.
+        #
+        # The empty bitlist still encodes to one byte (0x01).
         if len(data) == 0:
             raise SSZSerializationError(f"{cls.__name__}: cannot decode empty bytes")
 
-        # Find the position of the delimiter bit (rightmost 1).
-        delimiter_pos = None
-        for byte_idx in range(len(data) - 1, -1, -1):
-            byte_val = data[byte_idx]
-            if byte_val != 0:
-                # Find the highest set bit in this byte using bit_length
-                bit_idx = byte_val.bit_length() - 1
-                delimiter_pos = byte_idx * 8 + bit_idx
-                break
-
-        if delimiter_pos is None:
+        # Phase 2: locate the delimiter — the topmost 1 in the entire byte stream.
+        #
+        #   - int.from_bytes(data, "little")   reads the stream as one little-endian integer.
+        #   - bit_length()                     1-indexed position of its highest set bit.
+        #   - bit_length() - 1                 0-indexed delimiter position in the stream.
+        #
+        # Example A: data = [0b00001101]  (encoding of bits [1, 0, 1])
+        #
+        #   int.from_bytes(data, "little")  =  13   =  0b00001101
+        #   bit_length()                    =  4
+        #   delimiter_pos                   =  3      ->  num_bits = 3
+        #
+        # Example B: data = [0b11111111, 0b00000001]  (encoding of bits [1] * 8)
+        #
+        #   int.from_bytes(data, "little")  =  511  =  0b111111111
+        #   bit_length()                    =  9
+        #   delimiter_pos                   =  8      ->  num_bits = 8
+        total = int.from_bytes(data, "little")
+        if total == 0:
             raise SSZSerializationError(f"{cls.__name__}: no delimiter bit found")
+        delimiter_pos = total.bit_length() - 1
 
-        # Extract data bits (everything before the delimiter).
+        # Phase 3: extract data bits below the delimiter and enforce the size limit.
+        #
+        # The delimiter position equals the data bit count. For each bit index i:
+        #
+        #   - data[i // 8]  picks the byte that holds bit i.
+        #   - >> (i % 8)    shifts that byte so bit i is in the LSB.
+        #   - & 1           masks off every other bit.
+        #
+        # Example: data = [0b00001101], num_bits = 3  (delimiter at bit 3)
+        #
+        #   i=0:  (data[0] >> 0) & 1  =  0b00001101 & 1  =  1
+        #   i=1:  (data[0] >> 1) & 1  =  0b00000110 & 1  =  0
+        #   i=2:  (data[0] >> 2) & 1  =  0b00000011 & 1  =  1
+        #
+        # Recovered bits: [1, 0, 1]
         num_bits = delimiter_pos
         if num_bits > cls.LIMIT:
             raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {num_bits}")
 
-        bits = tuple(Boolean((data[i // 8] >> (i % 8)) & 1) for i in range(num_bits))
-        return cls(data=bits)
+        return cls(data=[Boolean((data[i // 8] >> (i % 8)) & 1) for i in range(num_bits)])


### PR DESCRIPTION
## Summary

Two related improvements bundled together because the second one demonstrates the first:

1. **Doc system overhaul** — coherent documentation conventions across three files.
2. **bitfields.py rewrite** — applies the new system as a live demonstration.

### 1. Doc system

- **New `/doc` skill** at `.claude/skills/doc/SKILL.md`. Adds scope handling (no-arg / path / symbol), the standard section vocabulary (`# Overview`, `# Algorithm`, `# Why X`, etc.), and a Python gold-standard exemplar that mirrors the style now present in `bitfields.py`.
- **Expanded `.claude/rules/documentation.md`** from 3 thin rules to a full checklist: one-sentence-per-line as a hard rule, structured-label vocabulary (`# Why:`, `# Invariant:`, `# Threshold:`), bullet-decomposition pattern for operator math, and a consolidated anti-pattern list.
- **Refactored `.claude/agents/doc-writer.md`** to defer atomic rules to the above files and carry only consensus-domain patterns (chain ASCII, role-labeled flow) and the persona.

The three files no longer overlap — rules in one place, procedure in the skill, persona in the agent.

### 2. bitfields.py

The file got both a documentation rewrite and a few targeted code simplifications:

- **Module + class docstrings** moved from prose to bullets with worked examples (5-bit Bitvector showing trailing zeros; 3-bit Bitlist showing where the delimiter sits and why it's needed).
- **encode/decode bodies** use phase labels and bullet-decomposed bit math (`i // 8`, `i % 8`, `1 << (i % 8)`, `|=`) with concrete worked examples covering byte-boundary crossings, delimiter spill, and the little-endian integer interpretation.
- **`(N + 7) // 8`** ceiling-division trick → **`math.ceil(N / 8)`** for readability.
- **Byte-by-byte delimiter scan loop** (12 lines) → **single `int.from_bytes` + `bit_length()` call** (4 lines).
- **Redundant `tuple(...)` wrap** dropped; `list[Boolean]` passed directly to the constructor (Pydantic validator materializes internally).

## Test plan

- [x] `uv run --group lint ruff check`
- [x] `uv run --group lint ruff format --check`
- [x] `uv run --group lint ty check`
- [x] `uv run --group lint codespell`
- [x] `uv run pytest tests/lean_spec/types/test_bitfields.py` — 49 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)