### PR TITLE
refactor(types): tighten Boolean strictness, simplify dunders, full test coverage

### DIFF
--- a/src/lean_spec/types/boolean.py
+++ b/src/lean_spec/types/boolean.py
@@ -1,4 +1,4 @@
-"""Boolean Type Specification."""
+"""SSZ boolean type — true or false serialized as a single byte."""
 
 from __future__ import annotations
 
@@ -12,27 +12,34 @@ from .ssz_base import SSZType
 
 
 class Boolean(int, SSZType):
-    """
-    A strict SSZ Boolean type that inherits from `int` for `True`/`False` representation.
+    r"""
+    Strict SSZ boolean encoded as exactly one byte.
 
-    This class provides a distinct type for SSZ booleans (`True` as `1`, `False` as `0`).
+    - Inherits from int so true/false work natively in truthiness checks.
+    - Arithmetic (+ - * /) is disabled to prevent ambiguous operations.
+    - Bitwise ops (& | ^) reject operands of any other type.
+    - Equality rejects comparisons with anything but another boolean.
 
-    It integrates with Pydantic for strict validation.
+    Wire format:
 
-    It explicitly disallows standard integer arithmetic to prevent ambiguous operations.
+        true   ->  b"\x01"
+        false  ->  b"\x00"
     """
 
     __slots__ = ()
 
     def __new__(cls, value: bool | int) -> Self:
         """
-        Create and validate a new Boolean instance.
+        Construct and validate a new boolean.
 
-        Accepts only `True`, `False`, `1`, or `0`.
+        Only the four values true, false, 0, and 1 are accepted.
+
+        Args:
+            value: The raw value to wrap.
 
         Raises:
-            SSZTypeError: If `value` is not a bool or int.
-            SSZValueError: If `value` is an integer other than 0 or 1.
+            SSZTypeError: If value is not a bool or int.
+            SSZValueError: If value is an integer outside 0 or 1.
         """
         if not isinstance(value, int):
             raise SSZTypeError(f"Expected bool or int, got {type(value).__name__}")
@@ -52,55 +59,75 @@ class Boolean(int, SSZType):
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
         """
-        Hook into Pydantic's validation system for strict boolean validation.
+        Provide a Pydantic core schema that enforces strict boolean validation.
 
-        This schema ensures that only `True` or `False` are accepted during
-        Pydantic model validation.
+        Only true or false are accepted as input at the Pydantic layer.
+        Any other type — including int 0 or 1 — is rejected here, even though
+        the constructor itself accepts them.
         """
-        # Validator that takes a standard bool and returns an instance of our class.
+        # Validator that wraps a verified bool into a typed instance.
         from_bool_validator = core_schema.no_info_plain_validator_function(cls)
 
-        # Schema that first validates the input is a strict bool, then calls our validator.
+        # Two-step input validation:
+        #
+        #   - bool_schema(strict=True)   rejects anything that is not exactly a bool.
+        #   - from_bool_validator        wraps the validated bool into a Boolean.
         python_schema = core_schema.chain_schema(
             [core_schema.bool_schema(strict=True), from_bool_validator]
         )
 
+        # Final schema accepts either branch and serializes back to a plain bool:
+        #
+        #   - Branch 1: input is already a typed instance, pass through.
+        #   - Branch 2: input is a strict bool that needs wrapping.
         return core_schema.union_schema(
             [
-                # Case 1: The value is already our custom Boolean type.
                 core_schema.is_instance_schema(cls),
-                # Case 2: The value is a standard bool and needs to be validated and wrapped.
                 python_schema,
             ],
-            # For serialization (e.g., to JSON), convert the instance back to a plain bool.
             serialization=core_schema.plain_serializer_function_ser_schema(bool),
         )
 
     @classmethod
     @override
     def is_fixed_size(cls) -> bool:
-        """Return whether the type is fixed-size."""
+        """Always fixed-size — every boolean encodes to one byte."""
         return True
 
     @classmethod
     @override
     def get_byte_length(cls) -> int:
-        """Return the byte length of the type."""
+        """Return the byte length of the encoded form."""
         return 1
 
     @override
     def encode_bytes(self) -> bytes:
         r"""
-        Serializes the boolean to its SSZ byte representation.
-        - `True` -> `b'\\x01'`
-        - `False` -> `b'\\x00'`
+        Encode the boolean to its SSZ byte representation.
+
+        - true   -> b"\x01"
+        - false  -> b"\x00"
         """
         return b"\x01" if self else b"\x00"
 
     @classmethod
     @override
     def decode_bytes(cls, data: bytes) -> Self:
-        """Deserialize a single byte into a Boolean instance."""
+        """
+        Decode a single SSZ byte into a boolean.
+
+        Input must be exactly one byte with value 0x00 or 0x01.
+
+        Args:
+            data: SSZ-encoded byte.
+
+        Returns:
+            A boolean wrapping the decoded value.
+
+        Raises:
+            SSZSerializationError: If the input length is not 1, or the byte
+                is outside the 0x00 / 0x01 set.
+        """
         if len(data) != 1:
             raise SSZSerializationError(f"Boolean: expected 1 byte, got {len(data)}")
         if data[0] not in (0, 1):
@@ -109,7 +136,7 @@ class Boolean(int, SSZType):
 
     @override
     def serialize(self, stream: IO[bytes]) -> int:
-        """Serialize the boolean to a binary stream."""
+        """Write the SSZ-encoded byte to a binary stream."""
         encoded_data = self.encode_bytes()
         stream.write(encoded_data)
         return len(encoded_data)
@@ -117,7 +144,19 @@ class Boolean(int, SSZType):
     @classmethod
     @override
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
-        """Deserialize a boolean from a binary stream."""
+        """
+        Read one SSZ byte from a stream and decode into a boolean.
+
+        Args:
+            stream: Source binary stream.
+            scope: Number of bytes the caller has allocated for this value (must be 1).
+
+        Returns:
+            A boolean wrapping the decoded value.
+
+        Raises:
+            SSZSerializationError: If scope is not 1, or decoding fails.
+        """
         if scope != 1:
             raise SSZSerializationError(f"Boolean: expected scope of 1, got {scope}")
         return cls.decode_bytes(stream.read(1))
@@ -129,7 +168,7 @@ class Boolean(int, SSZType):
     __add__ = __radd__ = __sub__ = __rsub__ = _no_arithmetic
 
     def __and__(self, other: Any) -> Self:
-        """Handle the bitwise AND operator (`&`) strictly."""
+        """Bitwise AND between two booleans — rejects any other operand."""
         if not isinstance(other, type(self)):
             raise TypeError(
                 f"Unsupported operand type(s) for &: "
@@ -138,11 +177,11 @@ class Boolean(int, SSZType):
         return type(self)(int(self) & int(other))
 
     def __rand__(self, other: Any) -> Self:
-        """Handle the reverse bitwise AND operator (`&`) strictly."""
+        """Bitwise AND when the boolean is on the right of the operator."""
         return self.__and__(other)
 
     def __or__(self, other: Any) -> Self:
-        """Handle the bitwise OR operator (`|`) strictly."""
+        """Bitwise OR between two booleans — rejects any other operand."""
         if not isinstance(other, type(self)):
             raise TypeError(
                 f"Unsupported operand type(s) for |: "
@@ -151,11 +190,11 @@ class Boolean(int, SSZType):
         return type(self)(int(self) | int(other))
 
     def __ror__(self, other: Any) -> Self:
-        """Handle the reverse bitwise OR operator (`|`) strictly."""
+        """Bitwise OR when the boolean is on the right of the operator."""
         return self.__or__(other)
 
     def __xor__(self, other: Any) -> Self:
-        """Handle the bitwise XOR operator (`^`) strictly."""
+        """Bitwise XOR between two booleans — rejects any other operand."""
         if not isinstance(other, type(self)):
             raise TypeError(
                 f"Unsupported operand type(s) for ^: "
@@ -164,11 +203,11 @@ class Boolean(int, SSZType):
         return type(self)(int(self) ^ int(other))
 
     def __rxor__(self, other: Any) -> Self:
-        """Handle the reverse bitwise XOR operator (`^`) strictly."""
+        """Bitwise XOR when the boolean is on the right of the operator."""
         return self.__xor__(other)
 
     def __eq__(self, other: object) -> bool:
-        """Handle the equality operator strictly — only Boolean equals Boolean."""
+        """Strict equality — only another boolean compares; anything else raises."""
         if not isinstance(other, Boolean):
             raise TypeError(
                 f"Unsupported operand type(s) for ==: "
@@ -177,9 +216,11 @@ class Boolean(int, SSZType):
         return int(self) == int(other)
 
     def __ne__(self, other: object) -> bool:
-        """Handle the inequality operator strictly — only Boolean compares to Boolean.
+        """
+        Strict inequality — only another boolean compares; anything else raises.
 
-        Defined explicitly because int.__ne__ would bypass the strict __eq__ above.
+        Defined explicitly because the parent class's not-equal would otherwise
+        bypass the strict equality above.
         """
         if not isinstance(other, Boolean):
             raise TypeError(
@@ -189,13 +230,13 @@ class Boolean(int, SSZType):
         return int(self) != int(other)
 
     def __repr__(self) -> str:
-        """Return the official string representation of the object."""
+        """Return the official form: Boolean(True) or Boolean(False)."""
         return f"Boolean({bool(self)})"
 
     def __str__(self) -> str:
-        """Return the informal, user-friendly string representation."""
+        """Return the user-facing form: True or False."""
         return str(bool(self))
 
     def __hash__(self) -> int:
-        """Return a hash distinct from raw bool."""
+        """Return a hash distinct from the equivalent raw bool, matching strict equality."""
         return hash((type(self), int(self)))

--- a/src/lean_spec/types/boolean.py
+++ b/src/lean_spec/types/boolean.py
@@ -37,7 +37,12 @@ class Boolean(int, SSZType):
         if not isinstance(value, int):
             raise SSZTypeError(f"Expected bool or int, got {type(value).__name__}")
 
-        if value not in (0, 1):
+        # Coerce to a plain int before the membership test:
+        #
+        #   - value in (0, 1) does value == 0 or value == 1.
+        #   - For a Boolean operand, those comparisons hit strict equality and raise.
+        #   - int(value) returns a plain int, so == falls back to int equality.
+        if int(value) not in (0, 1):
             raise SSZValueError(f"Boolean value must be 0 or 1, not {value}")
 
         return super().__new__(cls, value)
@@ -115,26 +120,13 @@ class Boolean(int, SSZType):
         """Deserialize a boolean from a binary stream."""
         if scope != 1:
             raise SSZSerializationError(f"Boolean: expected scope of 1, got {scope}")
-        data = stream.read(1)
-        if len(data) != 1:
-            raise SSZSerializationError(f"Boolean: expected 1 byte, got {len(data)}")
-        return cls.decode_bytes(data)
+        return cls.decode_bytes(stream.read(1))
 
-    def __add__(self, other: Any) -> Self:
-        """Disable the addition operator (`+`)."""
+    def _no_arithmetic(self, other: Any) -> Self:
+        """Reject arithmetic on Boolean — use bitwise & | ^ instead."""
         raise TypeError("Arithmetic operations are not supported for Boolean.")
 
-    def __radd__(self, other: Any) -> Self:
-        """Disable the reverse addition operator (`+`)."""
-        raise TypeError("Arithmetic operations are not supported for Boolean.")
-
-    def __sub__(self, other: Any) -> Self:
-        """Disable the subtraction operator (`-`)."""
-        raise TypeError("Arithmetic operations are not supported for Boolean.")
-
-    def __rsub__(self, other: Any) -> Self:
-        """Disable the reverse subtraction operator (`-`)."""
-        raise TypeError("Arithmetic operations are not supported for Boolean.")
+    __add__ = __radd__ = __sub__ = __rsub__ = _no_arithmetic
 
     def __and__(self, other: Any) -> Self:
         """Handle the bitwise AND operator (`&`) strictly."""
@@ -176,23 +168,25 @@ class Boolean(int, SSZType):
         return self.__xor__(other)
 
     def __eq__(self, other: object) -> bool:
-        """
-        Handle the equality operator (`==`).
-
-        Allows comparison with native `bool` and `int` types (0 or 1).
-
-        It returns `False` for all other types.
-        """
-        return isinstance(other, int) and int(self) == int(other)
+        """Handle the equality operator strictly — only Boolean equals Boolean."""
+        if not isinstance(other, Boolean):
+            raise TypeError(
+                f"Unsupported operand type(s) for ==: "
+                f"'{type(self).__name__}' and '{type(other).__name__}'"
+            )
+        return int(self) == int(other)
 
     def __ne__(self, other: object) -> bool:
-        """
-        Handle the inequality operator (`!=`).
+        """Handle the inequality operator strictly — only Boolean compares to Boolean.
 
-        Must be defined explicitly because `int.__ne__` would bypass
-        our custom `__eq__` type-checking logic.
+        Defined explicitly because int.__ne__ would bypass the strict __eq__ above.
         """
-        return not self.__eq__(other)
+        if not isinstance(other, Boolean):
+            raise TypeError(
+                f"Unsupported operand type(s) for !=: "
+                f"'{type(self).__name__}' and '{type(other).__name__}'"
+            )
+        return int(self) != int(other)
 
     def __repr__(self) -> str:
         """Return the official string representation of the object."""

--- a/src/lean_spec/types/boolean.py
+++ b/src/lean_spec/types/boolean.py
@@ -125,8 +125,9 @@ class Boolean(int, SSZType):
             A boolean wrapping the decoded value.
 
         Raises:
-            SSZSerializationError: If the input length is not 1, or the byte
-                is outside the 0x00 / 0x01 set.
+            SSZSerializationError:
+                - When the input length is not 1.
+                - When the byte value is outside the 0x00 / 0x01 set.
         """
         if len(data) != 1:
             raise SSZSerializationError(f"Boolean: expected 1 byte, got {len(data)}")
@@ -155,7 +156,9 @@ class Boolean(int, SSZType):
             A boolean wrapping the decoded value.
 
         Raises:
-            SSZSerializationError: If scope is not 1, or decoding fails.
+            SSZSerializationError:
+                - When scope is not 1.
+                - When the underlying byte decode fails.
         """
         if scope != 1:
             raise SSZSerializationError(f"Boolean: expected scope of 1, got {scope}")

--- a/tests/lean_spec/types/test_boolean.py
+++ b/tests/lean_spec/types/test_boolean.py
@@ -1,6 +1,7 @@
-""" "Tests for the Boolean Type."""
+"""Tests for the Boolean Type."""
 
 import io
+import re
 from typing import Any, Callable
 
 import pytest
@@ -31,6 +32,20 @@ def test_pydantic_strict_mode_rejects_invalid_types(invalid_value: Any) -> None:
         BooleanModel(value=invalid_value)
 
 
+def test_pydantic_accepts_existing_boolean_instance() -> None:
+    """Pydantic schema accepts an already-typed Boolean instance via the is_instance branch."""
+    instance = BooleanModel(value=Boolean(True))
+    assert isinstance(instance.value, Boolean)
+    assert int(instance.value) == 1
+
+
+def test_pydantic_serializes_boolean_to_plain_bool() -> None:
+    """Pydantic serializes Boolean back to a plain bool for JSON output."""
+    serialized = BooleanModel(value=True).model_dump()
+    assert serialized == {"value": True}
+    assert type(serialized["value"]) is bool
+
+
 @pytest.mark.parametrize("valid_value", [True, False, 1, 0])
 def test_instantiation_from_valid_types(valid_value: bool | int) -> None:
     """Tests that a Boolean can be instantiated from valid bools and ints."""
@@ -41,15 +56,26 @@ def test_instantiation_from_valid_types(valid_value: bool | int) -> None:
 @pytest.mark.parametrize("invalid_int", [-1, 2, 100])
 def test_instantiation_from_invalid_int_raises_error(invalid_int: int) -> None:
     """Tests that instantiating with an int other than 0 or 1 raises SSZValueError."""
-    with pytest.raises(SSZValueError, match="Boolean value must be 0 or 1"):
+    with pytest.raises(
+        SSZValueError,
+        match=re.escape(f"Boolean value must be 0 or 1, not {invalid_int}"),
+    ):
         Boolean(invalid_int)
 
 
 @pytest.mark.parametrize("invalid_type", [1.0, "True", b"\x01", None])
 def test_instantiation_from_invalid_types_raises_error(invalid_type: Any) -> None:
     """Tests that instantiating with non-bool/non-int types raises SSZTypeError."""
-    with pytest.raises(SSZTypeError, match="Expected bool or int"):
+    name = type(invalid_type).__name__
+    with pytest.raises(SSZTypeError, match=re.escape(f"Expected bool or int, got {name}")):
         Boolean(invalid_type)
+
+
+def test_wrapping_existing_boolean_succeeds() -> None:
+    """Boolean(Boolean(x)) must succeed — int() in __new__ avoids the strict __eq__ trap."""
+    outer = Boolean(Boolean(True))
+    assert isinstance(outer, Boolean)
+    assert int(outer) == 1
 
 
 def test_instantiation_and_type() -> None:
@@ -70,7 +96,10 @@ def test_instantiation_and_type() -> None:
 )
 def test_arithmetic_operators_raise_error(op: Callable[[Any, Any], Any]) -> None:
     """Tests that all arithmetic operators are disabled and raise TypeError."""
-    with pytest.raises(TypeError, match="Arithmetic operations are not supported"):
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Arithmetic operations are not supported for Boolean."),
+    ):
         op(Boolean(True), Boolean(False))
 
 
@@ -90,79 +119,113 @@ def test_bitwise_operators() -> None:
 @pytest.mark.parametrize("invalid_operand", [1, True, 0.0, "a"])
 def test_bitwise_operators_with_other_types_raise_error(invalid_operand: Any) -> None:
     """Tests that bitwise operations with non-Boolean types raise TypeError."""
-    with pytest.raises(TypeError):
+    name = type(invalid_operand).__name__
+    with pytest.raises(
+        TypeError,
+        match=re.escape(f"Unsupported operand type(s) for &: 'Boolean' and '{name}'"),
+    ):
         _ = Boolean(True) & invalid_operand
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(f"Unsupported operand type(s) for |: 'Boolean' and '{name}'"),
+    ):
         _ = Boolean(True) | invalid_operand
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(f"Unsupported operand type(s) for ^: 'Boolean' and '{name}'"),
+    ):
         _ = Boolean(True) ^ invalid_operand
 
 
-def test_strict_equality_with_same_type() -> None:
-    """Tests the strict `==` and `!=` operators between two Boolean instances."""
-    assert Boolean(True) == Boolean(True)
-    assert Boolean(False) == Boolean(False)
-    assert Boolean(True) != Boolean(False)
+@pytest.mark.parametrize("other", [1, 0, "x", 1.0, None])
+def test_reverse_bitwise_with_other_types_raise(other: Any) -> None:
+    """Bitwise ops with a non-Boolean LHS raise TypeError via the reflected dunder."""
+    name = type(other).__name__
+    with pytest.raises(
+        TypeError,
+        match=re.escape(f"Unsupported operand type(s) for &: 'Boolean' and '{name}'"),
+    ):
+        _ = other & Boolean(True)
+    with pytest.raises(
+        TypeError,
+        match=re.escape(f"Unsupported operand type(s) for |: 'Boolean' and '{name}'"),
+    ):
+        _ = other | Boolean(True)
+    with pytest.raises(
+        TypeError,
+        match=re.escape(f"Unsupported operand type(s) for ^: 'Boolean' and '{name}'"),
+    ):
+        _ = other ^ Boolean(True)
 
 
 @pytest.mark.parametrize(
-    "left_operand, right_operand, expected_result",
+    "left, right, expected",
     [
-        # --- Comparisons between two Boolean instances ---
-        (Boolean(True), Boolean(False), False),
         (Boolean(True), Boolean(True), True),
         (Boolean(False), Boolean(False), True),
-        # --- Comparisons with compatible native types (Boolean on the left) ---
-        (Boolean(True), True, True),
-        (Boolean(True), 1, True),
-        (Boolean(True), False, False),
-        (Boolean(True), 0, False),
-        # --- Comparisons with compatible native types (Boolean on the right) ---
-        (True, Boolean(True), True),
-        (1, Boolean(True), True),
-        (False, Boolean(True), False),
-        (0, Boolean(True), False),
-        # --- Comparisons with incompatible types ---
-        (Boolean(True), "a string", False),
-        ("a string", Boolean(True), False),
-        (Boolean(True), 1.0, False),
-        (Boolean(True), None, False),
-        (None, Boolean(True), False),
+        (Boolean(True), Boolean(False), False),
+        (Boolean(False), Boolean(True), False),
     ],
 )
-def test_equality_operator(left_operand: Any, right_operand: Any, expected_result: bool) -> None:
-    """Tests the `__eq__` equality operator (`==`) for various type combinations."""
-    assert (left_operand == right_operand) is expected_result
+def test_equality_same_type(left: Boolean, right: Boolean, expected: bool) -> None:
+    """Boolean == Boolean returns True or False by value."""
+    assert (left == right) is expected
 
 
 @pytest.mark.parametrize(
-    "left_operand, right_operand, expected_result",
+    "left, right, expected",
     [
-        # --- Comparisons between two Boolean instances ---
-        (Boolean(True), Boolean(False), True),
         (Boolean(True), Boolean(True), False),
         (Boolean(False), Boolean(False), False),
-        # --- Comparisons with compatible native types (Boolean on the left) ---
-        (Boolean(True), True, False),
-        (Boolean(True), 1, False),
-        (Boolean(True), False, True),
-        (Boolean(True), 0, True),
-        # --- Comparisons with compatible native types (Boolean on the right) ---
-        (True, Boolean(True), False),
-        (1, Boolean(True), False),
-        (False, Boolean(True), True),
-        (0, Boolean(True), True),
-        # --- Comparisons with incompatible types ---
-        (Boolean(True), "a string", True),
-        ("a string", Boolean(True), True),
-        (Boolean(True), 1.0, True),
-        (Boolean(True), None, True),
-        (None, Boolean(True), True),
+        (Boolean(True), Boolean(False), True),
+        (Boolean(False), Boolean(True), True),
     ],
 )
-def test_inequality_operator(left_operand: Any, right_operand: Any, expected_result: bool) -> None:
-    """Tests the `__ne__` inequality operator (`!=`) for various type combinations."""
-    assert (left_operand != right_operand) is expected_result
+def test_inequality_same_type(left: Boolean, right: Boolean, expected: bool) -> None:
+    """Boolean != Boolean returns True or False by value."""
+    assert (left != right) is expected
+
+
+@pytest.mark.parametrize("other", [True, False, 1, 0, "a string", 1.0, None])
+def test_equality_cross_type_raises(other: Any) -> None:
+    """Boolean compared to any non-Boolean value raises TypeError on the LHS."""
+    name = type(other).__name__
+    with pytest.raises(
+        TypeError,
+        match=re.escape(f"Unsupported operand type(s) for ==: 'Boolean' and '{name}'"),
+    ):
+        _ = Boolean(True) == other
+
+
+@pytest.mark.parametrize("other", [True, False, 1, 0, "a string", 1.0, None])
+def test_inequality_cross_type_raises(other: Any) -> None:
+    """Boolean != non-Boolean value raises TypeError on the LHS."""
+    name = type(other).__name__
+    with pytest.raises(
+        TypeError,
+        match=re.escape(f"Unsupported operand type(s) for !=: 'Boolean' and '{name}'"),
+    ):
+        _ = Boolean(True) != other
+
+
+@pytest.mark.parametrize("other", [1, 0])
+def test_equality_reflected_int_raises(other: int) -> None:
+    """int == Boolean: Boolean subclasses int so its __eq__ runs first and raises."""
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Unsupported operand type(s) for ==: 'Boolean' and 'int'"),
+    ):
+        _ = other == Boolean(True)
+
+
+@pytest.mark.parametrize("other", [1, 0])
+def test_inequality_reflected_int_raises(other: int) -> None:
+    """int != Boolean: Boolean subclasses int so its __ne__ runs first and raises."""
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Unsupported operand type(s) for !=: 'Boolean' and 'int'"),
+    ):
+        _ = other != Boolean(True)
 
 
 def test_repr_and_str() -> None:
@@ -211,16 +274,22 @@ class TestBooleanSSZ:
 
     def test_decode_invalid_length(self) -> None:
         """Tests that decode_bytes fails with incorrect byte length."""
-        with pytest.raises(SSZSerializationError, match="expected 1 byte"):
+        with pytest.raises(SSZSerializationError, match=r"^Boolean: expected 1 byte, got 0$"):
             Boolean.decode_bytes(b"")
-        with pytest.raises(SSZSerializationError, match="expected 1 byte"):
+        with pytest.raises(SSZSerializationError, match=r"^Boolean: expected 1 byte, got 2$"):
             Boolean.decode_bytes(b"\x00\x01")
 
     def test_decode_invalid_value(self) -> None:
         """Tests that decode_bytes fails with an invalid byte value."""
-        with pytest.raises(SSZSerializationError, match="must be 0x00 or 0x01"):
+        with pytest.raises(
+            SSZSerializationError,
+            match=r"^Boolean: byte must be 0x00 or 0x01, got 0x02$",
+        ):
             Boolean.decode_bytes(b"\x02")
-        with pytest.raises(SSZSerializationError, match="must be 0x00 or 0x01"):
+        with pytest.raises(
+            SSZSerializationError,
+            match=r"^Boolean: byte must be 0x00 or 0x01, got 0xff$",
+        ):
             Boolean.decode_bytes(b"\xff")
 
     @pytest.mark.parametrize("value", [True, False])
@@ -242,15 +311,15 @@ class TestBooleanSSZ:
     def test_deserialize_invalid_scope(self) -> None:
         """Tests that deserialize fails with an incorrect scope."""
         stream = io.BytesIO(b"\x01")
-        with pytest.raises(SSZSerializationError, match="expected scope of 1"):
+        with pytest.raises(SSZSerializationError, match=r"^Boolean: expected scope of 1, got 0$"):
             Boolean.deserialize(stream, scope=0)
 
         stream.seek(0)
-        with pytest.raises(SSZSerializationError, match="expected scope of 1"):
+        with pytest.raises(SSZSerializationError, match=r"^Boolean: expected scope of 1, got 2$"):
             Boolean.deserialize(stream, scope=2)
 
     def test_deserialize_premature_stream_end(self) -> None:
         """Tests that deserialize fails if the stream ends prematurely."""
         stream = io.BytesIO(b"")  # Empty stream
-        with pytest.raises(SSZSerializationError, match="expected 1 byte, got 0"):
+        with pytest.raises(SSZSerializationError, match=r"^Boolean: expected 1 byte, got 0$"):
             Boolean.deserialize(stream, scope=1)

--- a/tests/lean_spec/types/test_boolean.py
+++ b/tests/lean_spec/types/test_boolean.py
@@ -41,7 +41,7 @@ def test_pydantic_accepts_existing_boolean_instance() -> None:
 
 def test_pydantic_serializes_boolean_to_plain_bool() -> None:
     """Pydantic serializes Boolean back to a plain bool for JSON output."""
-    serialized = BooleanModel(value=True).model_dump()
+    serialized = BooleanModel(value=True).model_dump()  # type: ignore[arg-type]
     assert serialized == {"value": True}
     assert type(serialized["value"]) is bool
 


### PR DESCRIPTION
## Summary

Aligns `Boolean` with the strict-typing philosophy already used by `BaseUint` across SSZ primitive types, simplifies a few duplicative dunders, and brings `boolean.py` to 100% test coverage.

### Code changes (`src/lean_spec/types/boolean.py`)

- **`__eq__` and `__ne__` are now strict**: any non-`Boolean` operand raises `TypeError`. The previous loose behavior (`Boolean(1) == 1` returning `True`) silently bypassed the type contract and was asymmetric with bitwise ops, which already raised — a real footgun. Matches the established `BaseUint` pattern.
- **`__new__` uses `int(value)`** before the `(0, 1)` membership test so the new strict `__eq__` does not fire when wrapping an existing `Boolean`.
- **Four no-op arithmetic dunders** (`__add__`/`__radd__`/`__sub__`/`__rsub__`) collapse into a single `_no_arithmetic` method with class-level aliasing. One source of truth.
- **`deserialize`** drops a redundant length check; `decode_bytes` already validates and produces the right error.

### Test changes (`tests/lean_spec/types/test_boolean.py`)

- **Coverage**: `boolean.py` is now 100% (every line, every branch).
- **Removed duplicate** `test_strict_equality_with_same_type` — fully subsumed by parametrized `test_equality_same_type` / `test_inequality_same_type`.
- **Added gap-filling tests** for:
  - `Boolean(Boolean(x))` construction (the `int()` coercion path).
  - Reverse bitwise dunders (`__rand__`, `__ror__`, `__rxor__`) via `int & Boolean` etc.
  - Reflected `__ne__` (`1 != Boolean(True)`).
  - Pydantic schema's `is_instance` branch (passing a typed `Boolean`).
  - Pydantic serialization back to a plain `bool`.
- **Full-message matching everywhere**: every `pytest.raises` `match=` now asserts the complete error message — either via `re.escape(f"...")` for parametrized cases or anchored `r"^...$"` for static messages.

## Test plan

- [x] `uv run --group lint ruff check`
- [x] `uv run --group lint ruff format --check`
- [x] `uv run --group lint ty check`
- [x] `uv run pytest tests/lean_spec/types/test_boolean.py` — 72 tests pass
- [x] Coverage check confirms 100% on `boolean.py`
- [x] `tests/lean_spec/forks/lstar/forkchoice/test_attestation_target.py` — passes (verifies the `__new__` coercion fix on the integration path)

## Breaking change note

This **changes runtime behavior** for `Boolean.__eq__` / `__ne__`: comparing a `Boolean` against any non-Boolean (including raw `int`, `bool`, `None`, strings) now raises `TypeError` instead of returning a boolean. A codebase-wide audit confirmed no production callers rely on the old loose behavior — all `Boolean` comparisons either use `if bit:` (truthiness, unaffected) or `Boolean == Boolean` (same-type, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)