### PR TITLE
test(bitfields): reach 100% coverage and assert full error messages

### DIFF
--- a/tests/lean_spec/types/test_bitfields.py
+++ b/tests/lean_spec/types/test_bitfields.py
@@ -1,6 +1,7 @@
-""" "Tests for the Bitvector and Bitlist types."""
+"""Tests for the Bitvector and Bitlist types."""
 
 import io
+import re
 from typing import Any
 
 import pytest
@@ -10,11 +11,10 @@ from lean_spec.types.bitfields import BaseBitlist, BaseBitvector
 from lean_spec.types.boolean import Boolean
 from lean_spec.types.exceptions import SSZSerializationError, SSZTypeError, SSZValueError
 
-# Type alias for errors that can be SSZValueError or wrapped in ValidationError
+# Errors that may be raised either directly or wrapped by Pydantic at construction time.
 ValueOrValidationError = (SSZValueError, ValidationError)
 
 
-# Define bitfield types at module level for reuse and model classes
 class Bitvector4(BaseBitvector):
     """A bitvector of exactly 4 bits."""
 
@@ -40,10 +40,10 @@ class Bitlist8Model(BaseModel):
 
 
 class TestBitvector:
-    """Tests for the fixed-length, immutable Bitvector type."""
+    """Tests for the fixed-length Bitvector type."""
 
     def test_class_creates_specialized_type(self) -> None:
-        """Tests that concrete Bitvector classes have the correct length."""
+        """Concrete Bitvector classes carry the declared length."""
 
         class Bitvector8(BaseBitvector):
             LENGTH = 8
@@ -56,32 +56,46 @@ class TestBitvector:
         assert "Bitvector8" in repr(Bitvector8)
 
     def test_instantiate_raw_type_raises_error(self) -> None:
-        """Tests that the raw, non-specialized BaseBitvector cannot be instantiated."""
-        with pytest.raises(SSZTypeError, match="must define LENGTH"):
+        """Direct instantiation of the abstract base raises SSZTypeError."""
+        with pytest.raises(SSZTypeError, match=re.escape("BaseBitvector must define LENGTH")):
             BaseBitvector(data=[])
 
     def test_instantiation_success(self) -> None:
-        """Tests successful instantiation with the correct number of valid boolean items."""
+        """Instantiation succeeds with exactly LENGTH boolean items."""
         instance = Bitvector4(data=[Boolean(True), Boolean(False), Boolean(1), Boolean(0)])
         assert len(instance) == 4
         assert instance == Bitvector4(
             data=[Boolean(True), Boolean(False), Boolean(True), Boolean(False)]
         )
 
+    def test_instantiation_from_generator(self) -> None:
+        """Fixed-length type materializes a generator into a tuple before validation."""
+        bits_gen = (Boolean(b) for b in [True, False, True, False])
+        instance = Bitvector4(data=bits_gen)  # type: ignore[arg-type]
+        assert len(instance) == 4
+
     @pytest.mark.parametrize(
-        "values",
+        "values, count",
         [
-            [Boolean(True), Boolean(False), Boolean(True)],  # Too few
-            [Boolean(True), Boolean(False), Boolean(True), Boolean(False), Boolean(True)],
+            ([Boolean(True), Boolean(False), Boolean(True)], 3),
+            (
+                [Boolean(True), Boolean(False), Boolean(True), Boolean(False), Boolean(True)],
+                5,
+            ),
         ],
     )
-    def test_instantiation_with_wrong_length_raises_error(self, values: list[Boolean]) -> None:
-        """Tests that providing the wrong number of items during instantiation fails."""
-        with pytest.raises(ValueOrValidationError):
+    def test_instantiation_with_wrong_length_raises_error(
+        self, values: list[Boolean], count: int
+    ) -> None:
+        """Wrong-length input raises with the exact element count in the message."""
+        with pytest.raises(
+            ValueOrValidationError,
+            match=re.escape(f"Bitvector4 requires exactly 4 elements, got {count}"),
+        ):
             Bitvector4(data=values)
 
     def test_pydantic_validation_accepts_valid_list(self) -> None:
-        """Tests that Pydantic validation correctly accepts a valid list of booleans."""
+        """Pydantic validation accepts a valid list of booleans."""
         bits = [Boolean(True), Boolean(False), Boolean(True), Boolean(False)]
         instance = Bitvector4Model(value={"data": bits})  # type: ignore[arg-type]
         assert isinstance(instance.value, Bitvector4)
@@ -90,31 +104,31 @@ class TestBitvector:
     @pytest.mark.parametrize(
         "invalid_value",
         [
-            {"data": [Boolean(True), Boolean(False), Boolean(True)]},  # Too short
-            {"data": [Boolean(b) for b in [True, False, True, False, True]]},  # Too long
+            {"data": [Boolean(True), Boolean(False), Boolean(True)]},
+            {"data": [Boolean(b) for b in [True, False, True, False, True]]},
         ],
     )
-    def test_pydantic_validation_rejects_invalid_values(self, invalid_value: Any) -> None:
-        """Tests that Pydantic validation rejects lists of the wrong length."""
+    def test_pydantic_validation_rejects_wrong_length(self, invalid_value: Any) -> None:
+        """Pydantic validation rejects lists of the wrong length."""
         with pytest.raises(ValueOrValidationError):
             Bitvector4Model(value=invalid_value)
 
     def test_bitvector_is_immutable(self) -> None:
-        """Tests that attempting to change an item in a Bitvector raises a TypeError."""
+        """Item assignment on a Bitvector raises TypeError — Pydantic models are immutable."""
 
         class Bitvector2(BaseBitvector):
             LENGTH = 2
 
         vec = Bitvector2(data=[Boolean(True), Boolean(False)])
         with pytest.raises(TypeError):
-            vec[0] = False  # type: ignore[index]  # Should fail because SSZModel is immutable
+            vec[0] = False  # type: ignore[index]
 
 
 class TestBitlist:
-    """Tests for the variable-length, capacity-limited Bitlist type."""
+    """Tests for the variable-length Bitlist type."""
 
     def test_class_creates_specialized_type(self) -> None:
-        """Tests that concrete Bitlist classes have the correct limit."""
+        """Concrete Bitlist classes carry the declared limit."""
 
         class Bitlist8(BaseBitlist):
             LIMIT = 8
@@ -127,46 +141,92 @@ class TestBitlist:
         assert "Bitlist8" in repr(Bitlist8)
 
     def test_instantiate_raw_type_raises_error(self) -> None:
-        """Tests that the raw, non-specialized BaseBitlist cannot be instantiated."""
-        with pytest.raises(SSZTypeError, match="must define LIMIT"):
+        """Direct instantiation of the abstract base raises SSZTypeError."""
+        with pytest.raises(SSZTypeError, match=re.escape("BaseBitlist must define LIMIT")):
             BaseBitlist(data=[])
 
     def test_instantiation_success(self) -> None:
-        """Tests successful instantiation with a valid number of items."""
+        """Instantiation succeeds with any number of items up to LIMIT."""
         instance = Bitlist8(data=[Boolean(True), Boolean(False), Boolean(1), Boolean(0)])
         assert len(instance) == 4
         expected = Bitlist8(data=[Boolean(True), Boolean(False), Boolean(True), Boolean(False)])
         assert instance == expected
 
+    def test_instantiation_from_generator(self) -> None:
+        """Variable-length type materializes a generator into a list before validation."""
+        bits_gen = (Boolean(b) for b in [True, False, True])
+        instance = Bitlist8(data=bits_gen)  # type: ignore[arg-type]
+        assert len(instance) == 3
+
+    @pytest.mark.parametrize(
+        "non_iterable, type_name",
+        [
+            (42, "int"),
+            (None, "NoneType"),
+            (1.5, "float"),
+        ],
+    )
+    def test_instantiation_from_non_iterable_raises(
+        self, non_iterable: Any, type_name: str
+    ) -> None:
+        """Non-iterable input raises SSZTypeError naming the offending type."""
+        with pytest.raises(
+            (SSZTypeError, ValidationError),
+            match=re.escape(f"Expected iterable, got {type_name}"),
+        ):
+            Bitlist8(data=non_iterable)
+
+    @pytest.mark.parametrize("rejected", ["0101", b"\x00\x01"])
+    def test_instantiation_from_str_or_bytes_raises(self, rejected: Any) -> None:
+        """str and bytes are iterable but explicitly rejected — their elements are not booleans."""
+        type_name = type(rejected).__name__
+        with pytest.raises(
+            (SSZTypeError, ValidationError),
+            match=re.escape(f"Expected iterable, got {type_name}"),
+        ):
+            Bitlist8(data=rejected)
+
     def test_instantiation_over_limit_raises_error(self) -> None:
-        """Tests that providing more items than the limit during instantiation fails."""
+        """Input exceeding LIMIT raises with the exact size in the message."""
 
         class Bitlist4(BaseBitlist):
             LIMIT = 4
 
-        with pytest.raises(ValueOrValidationError):
+        with pytest.raises(
+            ValueOrValidationError,
+            match=re.escape("Bitlist4 exceeds limit of 4, got 5"),
+        ):
             Bitlist4(data=[Boolean(b) for b in [True, False, True, False, True]])
 
     def test_pydantic_validation_accepts_valid_list(self) -> None:
-        """Tests that Pydantic validation correctly accepts a valid list of booleans."""
+        """Pydantic validation accepts a valid list of booleans."""
         bits = [Boolean(True), Boolean(False), Boolean(True), Boolean(False)]
         instance = Bitlist8Model(value={"data": bits})  # type: ignore[arg-type]
         assert isinstance(instance.value, Bitlist8)
         assert len(instance.value) == 4
 
-    @pytest.mark.parametrize(
-        "invalid_value",
-        [
-            {"data": [Boolean(True)] * 9},  # Too long
-        ],
-    )
-    def test_pydantic_validation_rejects_invalid_values(self, invalid_value: Any) -> None:
-        """Tests that Pydantic validation rejects lists that exceed the limit."""
+    def test_pydantic_validation_rejects_oversized_list(self) -> None:
+        """Pydantic validation rejects lists exceeding the limit."""
+        invalid_value = {"data": [Boolean(True)] * 9}
         with pytest.raises(ValueOrValidationError):
-            Bitlist8Model(value=invalid_value)
+            Bitlist8Model(value=invalid_value)  # type: ignore[arg-type]
+
+    def test_get_item_int(self) -> None:
+        """Indexing by int returns the Boolean at that position."""
+        bitlist = Bitlist8(data=[Boolean(True), Boolean(False), Boolean(True)])
+        assert bitlist[0] == Boolean(True)
+        assert bitlist[1] == Boolean(False)
+        assert bitlist[2] == Boolean(True)
+
+    def test_get_item_slice(self) -> None:
+        """Indexing by slice returns a list of Booleans."""
+        bitlist = Bitlist8(data=[Boolean(True), Boolean(False), Boolean(True), Boolean(False)])
+        result = bitlist[1:3]
+        assert result == [Boolean(False), Boolean(True)]
+        assert isinstance(result, list)
 
     def test_add_with_list(self) -> None:
-        """Tests concatenating a Bitlist with a regular list."""
+        """Concatenating a Bitlist with a list returns a new instance."""
         bitlist = Bitlist8(data=[Boolean(True), Boolean(False), Boolean(True)])
         result = bitlist + [Boolean(False), Boolean(True)]
         assert len(result) == 5
@@ -180,7 +240,7 @@ class TestBitlist:
         assert isinstance(result, Bitlist8)
 
     def test_add_with_bitlist(self) -> None:
-        """Tests concatenating two Bitlists of the same type."""
+        """Concatenating two Bitlists of the same type returns a new instance."""
         bitlist1 = Bitlist8(data=[Boolean(True), Boolean(False)])
         bitlist2 = Bitlist8(data=[Boolean(True), Boolean(True)])
         result = bitlist1 + bitlist2
@@ -193,140 +253,53 @@ class TestBitlist:
         ]
         assert isinstance(result, Bitlist8)
 
+    def test_add_with_unsupported_type_raises(self) -> None:
+        """Adding an unsupported type returns NotImplemented and Python raises TypeError."""
+        bitlist = Bitlist8(data=[Boolean(True)])
+        with pytest.raises(TypeError):
+            _ = bitlist + 42  # type: ignore[operator]
+
     def test_add_exceeding_limit_raises_error(self) -> None:
-        """Tests that concatenating beyond the limit raises an error."""
+        """Concatenation beyond LIMIT raises with the exact size in the message."""
 
         class Bitlist4(BaseBitlist):
             LIMIT = 4
 
         bitlist = Bitlist4(data=[Boolean(True), Boolean(False), Boolean(True)])
-        with pytest.raises(ValueOrValidationError):
-            bitlist + [Boolean(False), Boolean(True)]
-
-
-class TestBitfieldSerialization:
-    """Tests the `encode_bytes` and `decode_bytes` methods for bitfields."""
-
-    @pytest.mark.parametrize(
-        "length, value, expected_hex",
-        [
-            (8, (True, True, False, True, False, True, False, False), "2b"),
-            (4, (False, True, False, True), "0a"),
-            (3, (False, True, False), "02"),
-            (10, (1, False, True, False, False, False, True, True, False, True), "c502"),
-        ],
-    )
-    def test_bitvector_serialization_deserialization(
-        self, length: int, value: tuple[bool, ...], expected_hex: str
-    ) -> None:
-        """Tests the round trip of serializing and deserializing for Bitvector."""
-
-        class TestBitvector(BaseBitvector):
-            LENGTH = length
-
-        bool_value = tuple(Boolean(b) for b in value)
-        instance = TestBitvector(data=bool_value)
-
-        # Test serialization
-        encoded = instance.encode_bytes()
-        assert encoded.hex() == expected_hex
-
-        # Test deserialization
-        decoded = TestBitvector.decode_bytes(encoded)
-        assert decoded == instance
-
-    @pytest.mark.parametrize(
-        "limit, value, expected_hex",
-        [
-            (8, (), "01"),  # Empty list
-            (8, (True, True, False, True, False, True, False, False), "2b01"),
-            (4, (False, True, False, True), "1a"),
-            (3, (False, True, False), "0a"),
-            (16, (True, False, True, False, False, False, True, True, False, True), "c506"),
-        ],
-    )
-    def test_bitlist_serialization_deserialization(
-        self, limit: int, value: tuple[bool, ...], expected_hex: str
-    ) -> None:
-        """Tests the round trip of serializing and deserializing for Bitlist."""
-
-        class TestBitlist(BaseBitlist):
-            LIMIT = limit
-
-        bool_value = tuple(Boolean(b) for b in value)
-        instance = TestBitlist(data=bool_value)
-
-        # Test serialization
-        encoded = instance.encode_bytes()
-        assert encoded.hex() == expected_hex
-
-        # Test deserialization
-        decoded = TestBitlist.decode_bytes(encoded)
-        assert decoded == instance
-
-    def test_bitvector_decode_invalid_length(self) -> None:
-        """Tests that Bitvector.decode_bytes fails for data of the wrong length."""
-
-        class Bitvector8(BaseBitvector):
-            LENGTH = 8
-
-        with pytest.raises(SSZValueError, match="expected 1 bytes, got 2"):
-            Bitvector8.decode_bytes(b"\x01\x02")  # Expects 1 byte, gets 2
-
-    def test_bitlist_decode_invalid_data(self) -> None:
-        """Tests that Bitlist.decode_bytes fails for invalid byte strings."""
-
-        class Bitlist8(BaseBitlist):
-            LIMIT = 8
-
-        with pytest.raises(SSZSerializationError, match="cannot decode empty bytes"):
-            Bitlist8.decode_bytes(b"")
+        with pytest.raises(
+            ValueOrValidationError,
+            match=re.escape("Bitlist4 exceeds limit of 4, got 5"),
+        ):
+            _ = bitlist + [Boolean(False), Boolean(True)]
 
 
 class TestBitfieldSSZ:
-    """Tests the SSZType interface methods for bitfields."""
+    """SSZ interface methods and end-to-end serialization round-trips."""
 
-    def test_bitvector_ssz_properties(self) -> None:
+    def test_bitvector_is_fixed_size(self) -> None:
+        """Bitvector reports fixed-size and computes byte length via ceil(LENGTH / 8)."""
+
         class Bitvector10(BaseBitvector):
             LENGTH = 10
 
         assert Bitvector10.is_fixed_size() is True
-        assert Bitvector10.get_byte_length() == 2  # (10+7)//8
+        assert Bitvector10.get_byte_length() == 2
 
-    def test_bitlist_ssz_properties(self) -> None:
+    def test_bitlist_is_variable_size(self) -> None:
+        """Bitlist reports variable-size and get_byte_length raises."""
+
         class Bitlist10(BaseBitlist):
             LIMIT = 10
 
         assert Bitlist10.is_fixed_size() is False
-        with pytest.raises(SSZTypeError):
+        with pytest.raises(
+            SSZTypeError,
+            match=re.escape("Bitlist10: variable-size bitlist has no fixed byte length"),
+        ):
             Bitlist10.get_byte_length()
 
-    def test_bitvector_deserialize_invalid_scope(self) -> None:
-        class Bitvector8(BaseBitvector):
-            LENGTH = 8
-
-        stream = io.BytesIO(b"\xff")
-        with pytest.raises(SSZSerializationError, match="expected 1 bytes, got 2"):
-            Bitvector8.deserialize(stream, scope=2)
-
-    def test_bitvector_deserialize_premature_end(self) -> None:
-        class Bitvector16(BaseBitvector):
-            LENGTH = 16
-
-        stream = io.BytesIO(b"\xff")  # Only 1 byte, expects 2
-        with pytest.raises(SSZSerializationError, match="expected 2 bytes, got 1"):
-            Bitvector16.deserialize(stream, scope=2)
-
-    def test_bitlist_deserialize_premature_end(self) -> None:
-        class Bitlist16(BaseBitlist):
-            LIMIT = 16
-
-        stream = io.BytesIO(b"\xff")  # Only 1 byte
-        with pytest.raises(SSZSerializationError, match="expected 2 bytes, got 1"):
-            Bitlist16.deserialize(stream, scope=2)  # Scope says to read 2
-
     @pytest.mark.parametrize(
-        "length,value,expected_hex",
+        "length, value, expected_hex",
         [
             (8, (1, 1, 0, 1, 0, 1, 0, 0), "2b"),
             (4, (0, 1, 0, 1), "0a"),
@@ -337,22 +310,23 @@ class TestBitfieldSSZ:
             (513, tuple([1] * 513), ("ff" * 64) + "01"),
         ],
     )
-    def test_bitvector_encode_decode(
+    def test_bitvector_round_trip(
         self, length: int, value: tuple[int, ...], expected_hex: str
     ) -> None:
+        """Bitvector round-trips through encode_bytes, decode_bytes, and stream serialization."""
+
         class TestBitvector(BaseBitvector):
             LENGTH = length
 
         bool_value = tuple(Boolean(b) for b in value)
         instance = TestBitvector(data=bool_value)
+
         encoded = instance.encode_bytes()
         assert encoded.hex() == expected_hex
 
-        # round-trip via classmethod
         decoded = TestBitvector.decode_bytes(encoded)
         assert decoded == instance
 
-        # round-trip via stream serialize/deserialize
         stream = io.BytesIO()
         written = instance.serialize(stream)
         assert written == TestBitvector.get_byte_length()
@@ -361,7 +335,7 @@ class TestBitfieldSSZ:
         assert decoded2 == instance
 
     @pytest.mark.parametrize(
-        "limit,value,expected_hex",
+        "limit, value, expected_hex",
         [
             (8, (), "01"),
             (8, (1, 1, 0, 1, 0, 1, 0, 0), "2b01"),
@@ -373,26 +347,109 @@ class TestBitfieldSSZ:
             (513, tuple([1] * 513), ("ff" * 64) + "03"),
         ],
     )
-    def test_bitlist_encode_decode(
+    def test_bitlist_round_trip(
         self, limit: int, value: tuple[int, ...], expected_hex: str
     ) -> None:
+        """Bitlist round-trips through encode_bytes, decode_bytes, and stream serialization."""
+
         class TestBitlist(BaseBitlist):
             LIMIT = limit
 
         bool_value = tuple(Boolean(b) for b in value)
         instance = TestBitlist(data=bool_value)
+
         encoded = instance.encode_bytes()
         assert encoded.hex() == expected_hex
 
-        # round-trip via classmethod
         decoded = TestBitlist.decode_bytes(encoded)
         assert decoded == instance
 
-        # round-trip via stream serialize/deserialize
         stream = io.BytesIO()
         written = instance.serialize(stream)
-        # variable-size, so we assert the written size matches the encoding length
         assert written == len(encoded)
         stream.seek(0)
         decoded2 = TestBitlist.deserialize(stream, scope=written)
         assert decoded2 == instance
+
+    def test_bitvector_decode_invalid_length(self) -> None:
+        """Bitvector.decode_bytes rejects inputs whose byte count is wrong."""
+
+        class Bitvector8(BaseBitvector):
+            LENGTH = 8
+
+        with pytest.raises(SSZValueError, match=re.escape("Bitvector8: expected 1 bytes, got 2")):
+            Bitvector8.decode_bytes(b"\x01\x02")
+
+    def test_bitvector_deserialize_invalid_scope(self) -> None:
+        """Bitvector.deserialize rejects a scope mismatching the type's byte length."""
+
+        class Bitvector8(BaseBitvector):
+            LENGTH = 8
+
+        stream = io.BytesIO(b"\xff")
+        with pytest.raises(
+            SSZSerializationError, match=re.escape("Bitvector8: expected 1 bytes, got 2")
+        ):
+            Bitvector8.deserialize(stream, scope=2)
+
+    def test_bitvector_deserialize_premature_end(self) -> None:
+        """Bitvector.deserialize rejects a stream that ends before the declared scope."""
+
+        class Bitvector16(BaseBitvector):
+            LENGTH = 16
+
+        stream = io.BytesIO(b"\xff")
+        with pytest.raises(
+            SSZSerializationError, match=re.escape("Bitvector16: expected 2 bytes, got 1")
+        ):
+            Bitvector16.deserialize(stream, scope=2)
+
+    def test_bitlist_decode_empty_bytes(self) -> None:
+        """Bitlist.decode_bytes rejects an empty byte sequence."""
+
+        class Bitlist8(BaseBitlist):
+            LIMIT = 8
+
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("Bitlist8: cannot decode empty bytes"),
+        ):
+            Bitlist8.decode_bytes(b"")
+
+    def test_bitlist_decode_all_zero_bytes(self) -> None:
+        """Bitlist.decode_bytes rejects non-empty input with no 1 bits — no delimiter to locate."""
+
+        class Bitlist8(BaseBitlist):
+            LIMIT = 8
+
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("Bitlist8: no delimiter bit found"),
+        ):
+            Bitlist8.decode_bytes(b"\x00")
+
+    def test_bitlist_decode_exceeds_limit(self) -> None:
+        """Bitlist.decode_bytes rejects encodings whose recovered bit count exceeds LIMIT."""
+
+        class Bitlist8(BaseBitlist):
+            LIMIT = 8
+
+        # Bytes [0xFF, 0xFF, 0x01] mean 16 data bits + delimiter at bit 16 — > LIMIT=8.
+        with pytest.raises(
+            SSZValueError,
+            match=re.escape("Bitlist8 exceeds limit of 8, got 16"),
+        ):
+            Bitlist8.decode_bytes(b"\xff\xff\x01")
+
+    def test_bitlist_deserialize_premature_end(self) -> None:
+        """Bitlist.deserialize rejects a stream that ends before the declared scope."""
+
+        class Bitlist16(BaseBitlist):
+            LIMIT = 16
+
+        stream = io.BytesIO(b"\xff")
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("Bitlist16: expected 2 bytes, got 1"),
+        ):
+            Bitlist16.deserialize(stream, scope=2)


### PR DESCRIPTION
## Summary

Brings the `bitfields.py` test suite to **100% line and branch coverage** (was 90%) and tightens every `pytest.raises` to assert the **complete error message**.

### Coverage gaps filled

| Path | New test |
|------|----------|
| `BaseBitvector._coerce_and_validate` — generator → tuple materialization | `TestBitvector.test_instantiation_from_generator` |
| `BaseBitlist._coerce_and_validate` — generator → list materialization | `TestBitlist.test_instantiation_from_generator` |
| `BaseBitlist._coerce_and_validate` — non-iterable rejection (int/None/float) | `TestBitlist.test_instantiation_from_non_iterable_raises` (parametrized) |
| `BaseBitlist._coerce_and_validate` — str/bytes explicit rejection | `TestBitlist.test_instantiation_from_str_or_bytes_raises` (parametrized) |
| `BaseBitlist.__getitem__` — int and slice branches | `test_get_item_int`, `test_get_item_slice` |
| `BaseBitlist.__add__` — `NotImplemented` for unsupported types | `test_add_with_unsupported_type_raises` |
| `BaseBitlist.decode_bytes` — non-empty all-zero (no delimiter) | `TestBitfieldSSZ.test_bitlist_decode_all_zero_bytes` |
| `BaseBitlist.decode_bytes` — recovered bits exceed LIMIT | `TestBitfieldSSZ.test_bitlist_decode_exceeds_limit` |

### Duplicates removed

`TestBitfieldSerialization` had two parametrized round-trip tests that were strict subsets of the corresponding tests in `TestBitfieldSSZ`. The class is gone; its unique decode-error tests moved into `TestBitfieldSSZ`.

### Full-message matches

Every `pytest.raises(..., match=...)` now asserts the complete error message — via `re.escape(f"...")` for parametrized cases or `re.escape("...")` for static messages. Examples:

```python
match=re.escape("BaseBitvector must define LENGTH")
match=re.escape(f"Bitvector4 requires exactly 4 elements, got {count}")
match=re.escape("Bitlist10: variable-size bitlist has no fixed byte length")
match=re.escape("Bitlist8: no delimiter bit found")
match=re.escape("Bitlist8 exceeds limit of 8, got 16")
```

`ValidationError` wrappers from Pydantic are still permitted in the exception union — `re.search` finds the SSZ message embedded inside the wrapped error.

## Test plan

- [x] `uv run --group lint ruff check`
- [x] `uv run --group lint ruff format --check`
- [x] `uv run --group lint ty check`
- [x] `uv run --group lint codespell`
- [x] `uv lock --check`
- [x] `uv run pytest tests/lean_spec/types/test_bitfields.py` — 52 tests pass
- [x] Coverage: **100%** on `src/lean_spec/types/bitfields.py` (line + branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)