### PR TITLE
fix(forkchoice): correct LMD-GHOST orphan-skip, tighten checkpoint advance, assert start_root

### DIFF
--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -1287,14 +1287,14 @@ class LstarSpec(ForkProtocol):
 
             # Propagate checkpoint advances from the post-state.
             #
-            # Keep the checkpoint with the higher slot.
-            # On slot ties, prefer the store's own checkpoint.
+            # A candidate replaces the store's checkpoint only when its slot is strictly higher.
+            # On slot ties the store's view stays authoritative.
             #
-            # The store's checkpoint is pinned to the anchor at init and only
-            # moves forward via real justification/finalization events.
-            # On ties the store's view is authoritative.
-            latest_justified = max(store.latest_justified, post_state.latest_justified)
-            latest_finalized = max(store.latest_finalized, post_state.latest_finalized)
+            # Why: the store's checkpoint is pinned at init.
+            # It advances only on real justification or finalization events.
+            # An incoming tie must not silently swap roots.
+            latest_justified = store.latest_justified.advance_to(post_state.latest_justified)
+            latest_finalized = store.latest_finalized.advance_to(post_state.latest_finalized)
 
             store = store.model_copy(
                 update={
@@ -1416,6 +1416,10 @@ class LstarSpec(ForkProtocol):
         When two branches have equal weight, the one with the lexicographically
         larger hash is chosen to break ties.
         """
+        # Invariant: the anchor must be a block the store already knows.
+        # A loud failure here beats a cryptic missing-key error deep in the weight loop.
+        assert start_root in store.blocks, f"start_root {start_root.hex()} not in store.blocks"
+
         # Remember the slot of the anchor once and reuse it during the walk.
         #
         # This avoids repeated lookups inside the inner loop.
@@ -1439,17 +1443,15 @@ class LstarSpec(ForkProtocol):
                 weights[current_root] += 1
                 current_root = store.blocks[current_root].parent_root
 
-        # Build the adjacency tree (parent -> children).
+        # Build the parent -> children adjacency.
         #
-        # We use a defaultdict to avoid checking if keys exist.
+        # Genesis blocks land in the bucket keyed by the zero hash.
+        # That bucket is never consulted.
+        # The walk anchors at the latest justified root and only descends.
         children_map: dict[Bytes32, list[Bytes32]] = defaultdict(list)
 
         for root, block in store.blocks.items():
-            # 1. Structural check: skip blocks without parents (e.g., purely genesis/orphans)
-            if not block.parent_root:
-                continue
-
-            # 2. Heuristic check: prune branches early if they lack sufficient weight
+            # Prune low-weight branches early when a threshold is set.
             if min_score > 0 and weights[root] < min_score:
                 continue
 
@@ -1948,10 +1950,12 @@ class LstarSpec(ForkProtocol):
         # Update checkpoints from post-state.
         #
         # Locally produced blocks bypass normal block processing.
-        # We must manually propagate any checkpoint advances.
-        # Higher slots indicate more recent justified/finalized states.
-        latest_justified = max(final_post_state.latest_justified, store.latest_justified)
-        latest_finalized = max(final_post_state.latest_finalized, store.latest_finalized)
+        # Checkpoint advances must be propagated manually here.
+        #
+        # Tie semantics mirror the block-import path.
+        # A candidate needs a strictly higher slot to replace the store's view.
+        latest_justified = store.latest_justified.advance_to(final_post_state.latest_justified)
+        latest_finalized = store.latest_finalized.advance_to(final_post_state.latest_finalized)
 
         # Persist block and state immutably.
         new_store = store.model_copy(

--- a/src/lean_spec/types/checkpoint.py
+++ b/src/lean_spec/types/checkpoint.py
@@ -1,9 +1,11 @@
 """
-Checkpoint Container.
+Checkpoint container.
 
-A checkpoint marks a specific moment in the chain. It combines a block
-identifier with a slot number. Checkpoints are used for justification and
-finalization.
+A checkpoint marks a specific moment in the chain.
+
+It combines a block identifier with a slot number.
+
+Checkpoints are used for justification and finalization.
 """
 
 from lean_spec.types.byte_arrays import Bytes32

--- a/src/lean_spec/types/checkpoint.py
+++ b/src/lean_spec/types/checkpoint.py
@@ -27,3 +27,13 @@ class Checkpoint(Container):
             return NotImplemented
         # Slot drives the order; equal slots leave the pair incomparable.
         return self.slot < other.slot
+
+    def advance_to(self, candidate: "Checkpoint") -> "Checkpoint":
+        """
+        Return the later of two checkpoints, keeping self on a slot tie.
+
+        Forward-only progression for justified and finalized checkpoints.
+
+        The candidate replaces the receiver only when its slot is strictly higher.
+        """
+        return candidate if candidate.slot > self.slot else self

--- a/tests/lean_spec/forks/lstar/forkchoice/test_compute_block_weights.py
+++ b/tests/lean_spec/forks/lstar/forkchoice/test_compute_block_weights.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lean_spec.forks.lstar import Store
 from lean_spec.forks.lstar.containers.attestation import AttestationData
 from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.xmss.aggregation import AggregatedSignatureProof
-from lean_spec.types import Checkpoint, Slot, ValidatorIndex, ValidatorIndices
+from lean_spec.types import Bytes32, Checkpoint, Slot, ValidatorIndex, ValidatorIndices
 from lean_spec.types.byte_arrays import ByteListMiB
 from tests.lean_spec.helpers import make_bytes32, make_signed_block
 
@@ -125,3 +127,15 @@ def test_multiple_attestations_accumulate(spec: LstarSpec, base_store: Store) ->
 
     # Both validators contribute weight to block1
     assert weights == {block1_root: 2}
+
+
+def test_compute_lmd_ghost_head_rejects_unknown_start_root(
+    spec: LstarSpec, base_store: Store
+) -> None:
+    """An anchor missing from the store fails the head-walk invariant loudly."""
+    # A 32-byte root that is guaranteed not to be in the store.
+    unknown_root = Bytes32(b"\xee" * 32)
+    assert unknown_root not in base_store.blocks
+
+    with pytest.raises(AssertionError, match="not in store.blocks"):
+        spec._compute_lmd_ghost_head(base_store, start_root=unknown_root, attestations={})

--- a/tests/lean_spec/forks/lstar/forkchoice/test_validator.py
+++ b/tests/lean_spec/forks/lstar/forkchoice/test_validator.py
@@ -407,7 +407,10 @@ class TestValidatorErrorHandling:
             validator_id=TEST_VALIDATOR_ID,
         )
 
-        with pytest.raises(KeyError):  # Missing head in get_proposal_head
+        # The forkchoice head walk asserts that the justified root is known.
+        # Calling produce_block on a store whose latest_justified.root is
+        # missing from blocks must fail loudly with that invariant message.
+        with pytest.raises(AssertionError, match="not in store.blocks"):
             spec.produce_block_with_signatures(store, Slot(1), ValidatorIndex(1))
 
     def test_validator_operations_invalid_parameters(

--- a/tests/lean_spec/subspecs/containers/test_checkpoint.py
+++ b/tests/lean_spec/subspecs/containers/test_checkpoint.py
@@ -66,3 +66,32 @@ def test_max_keeps_first_argument_on_slot_tie() -> None:
     b = Checkpoint(root=ROOT_B, slot=Slot(5))
     assert max(a, b) == a
     assert max(b, a) == b
+
+
+def test_advance_to_returns_candidate_on_higher_slot() -> None:
+    """A candidate at a strictly higher slot replaces the receiver."""
+    current = Checkpoint(root=ROOT_A, slot=Slot(3))
+    candidate = Checkpoint(root=ROOT_B, slot=Slot(4))
+    assert current.advance_to(candidate) == candidate
+
+
+def test_advance_to_keeps_self_on_lower_slot() -> None:
+    """A candidate at a lower slot is ignored."""
+    current = Checkpoint(root=ROOT_A, slot=Slot(4))
+    candidate = Checkpoint(root=ROOT_B, slot=Slot(3))
+    assert current.advance_to(candidate) == current
+
+
+def test_advance_to_keeps_self_on_slot_tie() -> None:
+    """On a slot tie the receiver wins regardless of root."""
+    current = Checkpoint(root=ROOT_A, slot=Slot(7))
+    candidate = Checkpoint(root=ROOT_B, slot=Slot(7))
+    assert current.advance_to(candidate) == current
+    # Symmetric: the receiver of the call always wins on a tie.
+    assert candidate.advance_to(current) == candidate
+
+
+def test_advance_to_is_idempotent() -> None:
+    """Calling against the same checkpoint returns the receiver unchanged."""
+    cp = Checkpoint(root=ROOT_A, slot=Slot(2))
+    assert cp.advance_to(cp) == cp


### PR DESCRIPTION
## Summary

Three correctness fixes surfaced by the consensus-researcher review.

- Removes a dead orphan-skip branch in LMD-GHOST whose comment lied about
  its behavior.
- Centralizes checkpoint advance semantics in `Checkpoint.advance_to`,
  resolving an inconsistency where `on_block` and `build_block` had
  opposite tie semantics because of different `max()` argument orders.
- Adds an invariant assert at the head walk so a bad anchor fails loudly
  with a useful message instead of a `KeyError` deep in the weight loop.

Behavior on the hot path is preserved. The only intentional semantic
change is at `build_block` on slot ties: the store now wins consistently
with the documented intent at `on_block`.

## What was wrong

### 1. Dead orphan-skip in `_compute_lmd_ghost_head`

```python
if not block.parent_root:
    continue  # skip blocks without parents (e.g., purely genesis/orphans)
```

`block.parent_root` is `Bytes32` — always 32 bytes, so `bool(parent_root)`
is always `True`. The branch never fired. Genesis blocks landed in
`children_map[Bytes32.zero()]` instead of being skipped. The bucket was
never consulted because the walk anchors at the justified root and only
descends, so the bug was silent. The filter is removed and the comment
now explains why genesis cannot pollute the walk.

### 2. Inconsistent tie semantics across `max()` call sites

```python
# on_block:    "On slot ties, prefer the store's own checkpoint" (documented)
max(store.latest_justified, post_state.latest_justified)

# build_block: same docstring, opposite argument order, opposite behavior
max(final_post_state.latest_justified, store.latest_justified)
```

Slot-only `__lt__` plus `max()` means tie behavior depends on argument
order. The two sites had **opposite** orders. The fix introduces
`Checkpoint.advance_to(candidate)` which encodes the documented "receiver
wins on tie" rule in the type. Both call sites now read:
`store.latest_*.advance_to(post_state.latest_*)`.

### 3. Missing invariant on `_compute_lmd_ghost_head`

Both callers pass `store.latest_justified.root` which is always a known
block. A future misuse would have produced a cryptic `KeyError` deep in
the weight loop. A one-line assert states the invariant up front.

## Test plan

- [x] New unit tests for `Checkpoint.advance_to` covering higher slot,
      lower slot, slot tie, and idempotence
- [x] New unit test for `_compute_lmd_ghost_head` rejecting an unknown
      anchor
- [x] Existing `test_produce_block_missing_parent_state` updated to
      expect the clearer `AssertionError`
- [x] All 100 tests in `tests/lean_spec/subspecs/containers/test_checkpoint.py`
      and `tests/lean_spec/forks/lstar/forkchoice/` pass
- [x] `ruff check`, `ruff format --check`, `ty check` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)