### PR TITLE
fix(ssz): correct JustificationValidators LIMIT formula in rule doc

### DIFF
--- a/.claude/rules/ssz-patterns.md
+++ b/.claude/rules/ssz-patterns.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "src/lean_spec/subspecs/containers/**/*.py"
+  - "src/lean_spec/forks/*/containers/**/*.py"
   - "src/lean_spec/types/**/*.py"
 ---
 
@@ -36,7 +36,7 @@ When creating SSZ types, follow these established patterns:
 Containers should be organized into modules with clear separation:
 
 ```
-src/lean_spec/subspecs/containers/
+src/lean_spec/forks/<fork>/containers/
 ├── state/
 │   ├── __init__.py      # Exports State and related types
 │   ├── state.py         # Main State container class
@@ -61,11 +61,15 @@ src/lean_spec/subspecs/containers/
 
 ```python
 # In state/types.py
-HISTORICAL_ROOTS_LIMIT = 262144
+HISTORICAL_ROOTS_LIMIT = 262144   # 2**18 tracked roots
+VALIDATOR_REGISTRY_LIMIT = 4096   # 2**12 registered validators
 
 class JustificationValidators(BaseBitlist):
-    """Bitlist for tracking validator justifications."""
-    LIMIT = HISTORICAL_ROOTS_LIMIT * HISTORICAL_ROOTS_LIMIT
+    """Per-root validator vote bitfields, concatenated into one flat bitlist."""
+    # Worst-case size: one bit per (tracked root, registered validator) pair.
+    # Any larger LIMIT inflates the bitlist's merkle depth and changes the
+    # state root for identical data, so this product is consensus-critical.
+    LIMIT = HISTORICAL_ROOTS_LIMIT * VALIDATOR_REGISTRY_LIMIT
 
 # In block/types.py
 class Attestations(SSZList):

--- a/src/lean_spec/forks/lstar/containers/state/types.py
+++ b/src/lean_spec/forks/lstar/containers/state/types.py
@@ -162,6 +162,13 @@ class JustifiedSlots(BaseBitlist):
 
 
 class JustificationValidators(BaseBitlist):
-    """Bitlist for tracking validator justifications per historical root."""
+    """Per-root validator vote bitfields, concatenated into one flat bitlist.
+
+    Each tracked root contributes one bit per registered validator.
+    The cap is the maximum tracked roots times the validator registry limit.
+
+    Why this product: a larger cap inflates the bitlist's merkle tree depth.
+    That changes the state root for identical data, so this limit is consensus-critical.
+    """
 
     LIMIT = int(HISTORICAL_ROOTS_LIMIT) * int(VALIDATOR_REGISTRY_LIMIT)


### PR DESCRIPTION
## Summary

The SSZ-patterns rule doc showed `LIMIT = HISTORICAL_ROOTS_LIMIT *
HISTORICAL_ROOTS_LIMIT` for the `JustificationValidators` example, but
the type stores one bit per **(tracked root, registered validator)**
pair. The second factor must be the validator registry limit. The
code (`state/types.py:167`) already uses the correct product — only
the rule doc was wrong.

## Why it matters

`BaseBitlist.LIMIT` directly controls merkleization depth:

| Source | Formula | Value (bits) | Chunk count | Tree depth |
|---|---|---|---|---|
| Code | `2^18 * 2^12` | `2^30` | `2^22` | 22 |
| Rule doc (was) | `2^18 * 2^18` | `2^36` | `2^28` | 28 |

A second-client implementer treating `.claude/rules/ssz-patterns.md`
as canonical would compute a different `hash_tree_root` for the same
state field. Different state roots → different block roots → silent
consensus divergence on the first network exchange. Exactly the kind
of doc/code drift this rule file is meant to prevent.

## Changes

- **`.claude/rules/ssz-patterns.md`** — fix the formula in the example
  and add an inline rationale block explaining why the product matters
  (consensus-critical merkle depth). Also define `VALIDATOR_REGISTRY_LIMIT`
  alongside `HISTORICAL_ROOTS_LIMIT` so the math is self-contained.
- **`.claude/rules/ssz-patterns.md`** — update the frontmatter path
  glob and the architecture diagram to reflect that containers moved
  to `forks/<fork>/containers/` in the recent refactor.
- **`state/types.py`** — expand the one-line docstring on
  `JustificationValidators` to document the layout and the
  consensus-critical nature of the `LIMIT` product. One sentence per
  line per the documentation rules.

## Test plan

- [x] `ruff check`, `ruff format --check`, `ty check` pass
- [x] 104/104 tests in `tests/lean_spec/forks/lstar/state` and
      `tests/lean_spec/forks/lstar/forkchoice` pass
- [x] No code-level value changed — the code was already correct, only
      the doc was wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)