### PR TITLE
refactor(sync): drop _SyncStoreView adapter, make SyncService implement StoreView

### DIFF
--- a/src/lean_spec/subspecs/sync/backfill_sync.py
+++ b/src/lean_spec/subspecs/sync/backfill_sync.py
@@ -55,22 +55,10 @@ logger = logging.getLogger(__name__)
 
 
 class StoreView(Protocol):
-    """
-    Read-only view of forkchoice state used by backfill.
-
-    Used to skip blocks already in the Store and to find the highest known
-    canonical slot for gap detection.
-
-    Decouples backfill from the concrete Store class.
-    Lets tests supply a tiny in-memory implementation.
-    """
+    """Read-only view of forkchoice state used by backfill."""
 
     def has_root(self, root: Bytes32) -> bool:
         """Return True if the block root is present in the Store."""
-        ...
-
-    def finalized_slot(self) -> Slot:
-        """Return the slot of the latest finalized checkpoint."""
         ...
 
     def head_slot(self) -> Slot:

--- a/src/lean_spec/subspecs/sync/service.py
+++ b/src/lean_spec/subspecs/sync/service.py
@@ -66,30 +66,6 @@ from .states import SyncState
 logger = logging.getLogger(__name__)
 
 
-@dataclass(slots=True)
-class _SyncStoreView:
-    """StoreView adapter delegating to the live SyncService.store reference.
-
-    Wraps a getter so updates to ``SyncService.store`` (assigned after each
-    block is processed) are observed by backfill without re-wiring.
-    """
-
-    _get_store: Callable[[], Store]
-
-    def has_root(self, root: Bytes32) -> bool:
-        """Return True if the block root is present in the Store."""
-        return root in self._get_store().blocks
-
-    def finalized_slot(self) -> Slot:
-        """Return the slot of the latest finalized checkpoint."""
-        return self._get_store().latest_finalized.slot
-
-    def head_slot(self) -> Slot:
-        """Return the slot of the current canonical head."""
-        store = self._get_store()
-        return store.blocks[store.head].slot
-
-
 def _ancestor_set(blocks: dict[Bytes32, Block], head: Bytes32) -> set[Bytes32]:
     """Walk parent links from head and collect every reachable block root."""
     seen: set[Bytes32] = set()
@@ -303,14 +279,14 @@ class SyncService:
         """
         # BackfillSync handles fetching missing parent blocks from peers.
         #
-        # It needs network access to request blocks and the cache to store them.
-        # The store view is a thin adapter that always reads the current
-        # store reference, since we replace `self.store` after each block.
+        # SyncService implements the StoreView protocol directly.
+        # Backfill reads `self.store` through us, so the live reference is
+        # always observed even as we reassign it after each block.
         self._backfill = BackfillSync(
             peer_manager=self.peer_manager,
             block_cache=self.block_cache,
             network=self.network,
-            store_view=_SyncStoreView(_get_store=lambda: self.store),
+            store_view=self,
         )
 
         # HeadSync processes incoming gossip blocks and coordinates backfill.
@@ -405,6 +381,14 @@ class SyncService:
     def state(self) -> SyncState:
         """Current sync state."""
         return self._state
+
+    def has_root(self, root: Bytes32) -> bool:
+        """Return True if the block root is present in the current store."""
+        return root in self.store.blocks
+
+    def head_slot(self) -> Slot:
+        """Return the slot of the current canonical head."""
+        return self.store.blocks[self.store.head].slot
 
     def get_progress(self) -> SyncProgress:
         """

--- a/tests/lean_spec/subspecs/sync/test_backfill_sync.py
+++ b/tests/lean_spec/subspecs/sync/test_backfill_sync.py
@@ -28,12 +28,11 @@ class FakeStoreView:
     """In-memory StoreView used to drive backfill tests.
 
     Concrete implementation. Avoids MagicMock so tests fail loudly when
-    fields drift. Tests mutate `known_roots`, `head`, and `finalized` directly.
+    fields drift. Tests mutate `known_roots` and `head` directly.
     """
 
     known_roots: set[Bytes32] = field(default_factory=set)
     head: Slot = field(default_factory=lambda: Slot(0))
-    finalized: Slot = field(default_factory=lambda: Slot(0))
 
     def has_root(self, root: Bytes32) -> bool:
         """Return True if the root has been registered with this view."""
@@ -42,10 +41,6 @@ class FakeStoreView:
     def head_slot(self) -> Slot:
         """Return the head slot stored on this view."""
         return self.head
-
-    def finalized_slot(self) -> Slot:
-        """Return the finalized slot stored on this view."""
-        return self.finalized
 
 
 @pytest.fixture
@@ -376,7 +371,6 @@ class TestBackfillOptimizations:
         parent_root = Bytes32(b"\x01" * 32)
         store_view.known_roots.add(parent_root)
         store_view.head = Slot(10)
-        store_view.finalized = Slot(10)
 
         # Child is received above the head.
         child = make_signed_block(
@@ -406,9 +400,8 @@ class TestBackfillOptimizations:
         Floor is the head slot, not the finalized slot: slots above finalized
         but at or below head are already canonical for us and are not refetched.
         """
-        # Store head is at slot 49, finalized is older at slot 10.
+        # Store head is at slot 49.
         store_view.head = Slot(49)
-        store_view.finalized = Slot(10)
         store_view.known_roots.add(Bytes32.zero())
 
         # Pre-fill the parent in the network at slot 50.


### PR DESCRIPTION
## Summary

`_SyncStoreView` was a dataclass wrapping a lambda wrapping a getter on
`SyncService.store`. Three layers of indirection to read two fields.
`SyncService` can satisfy the `StoreView` protocol structurally with
two short methods, removing the wrapper without growing the call
surface.

**Net: -28 lines, zero behavior change.**

## What changed

### `service.py`
- **Removed** the entire `_SyncStoreView` dataclass.
- **Added** `has_root(root)` and `head_slot()` methods on `SyncService`
  itself. Each is a one-liner reading `self.store`.
- **Changed** the wiring in `_initialize_subservices`:
  `store_view=self` instead of `_SyncStoreView(_get_store=lambda: self.store)`.
  The live store reference is observed because backfill calls back
  through `self` and reads `self.store` on demand.

### `backfill_sync.py`
- **Removed** the `finalized_slot()` method from the `StoreView`
  Protocol. It was declared on the protocol, implemented on the
  removed wrapper and on `FakeStoreView`, and **never called** from
  any production code in `backfill_sync.py`. Pure protocol bloat.
- Reformatted the surviving Protocol docstring.

### `test_backfill_sync.py`
- **Removed** `finalized_slot()` method and the `finalized: Slot`
  field from `FakeStoreView`.
- **Removed** two `store_view.finalized = Slot(10)` dead writes
  (lines 379 and 411). These had no effect on production code or
  assertions — they were leftover setup from when the protocol
  included `finalized_slot`.

## Why `StoreView` stays

The protocol earns its 8 lines:

- **Breaks a real circular dependency.** `service.py` imports
  `BackfillSync` from `backfill_sync.py`. Typing the field as
  `SyncService` would create a cycle. The Protocol sidesteps this.
- **Test seam.** `FakeStoreView` is a 5-line dataclass. Without the
  protocol, tests would need to construct real `Store` instances
  (with `blocks`, `head`, `latest_finalized`, `config`, etc.) just to
  exercise backfill.
- **Documents the contract.** Two methods. A reader of `BackfillSync`
  sees exactly what it needs from forkchoice without grepping.

## Test plan

- [x] `ruff check`, `ruff format --check`, `ty check` all pass
- [x] `pytest tests/lean_spec/subspecs/sync` -> **156 passed**

## Out of scope

The next queued items from the sync-layer review:

- `make_default_block_processor` factory -> method
- `SyncService` marketing-tone docstring (Reactive/Simple/Resilient/Observable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)