### PR TITLE
refactor(sync): inline make_default_block_processor as method

### DIFF
--- a/src/lean_spec/subspecs/sync/service.py
+++ b/src/lean_spec/subspecs/sync/service.py
@@ -79,39 +79,6 @@ def _ancestor_set(blocks: dict[Bytes32, Block], head: Bytes32) -> set[Bytes32]:
     return seen
 
 
-def make_default_block_processor(
-    spec: LstarSpec,
-) -> Callable[[Store, SignedBlock], Store]:
-    """
-    Build a default block processor bound to the given spec.
-
-    Wraps the pure spec entry point with caller-side fork-choice telemetry.
-    State transition and block processing timings are emitted by the spec
-    itself through the observer, wired at node startup. Everything else
-    here is derived by diffing pre- and post-stores.
-    """
-
-    def default_block_processor(store: Store, block: SignedBlock) -> Store:
-        new_store = spec.on_block(store, block)
-
-        metrics.lean_head_slot.set(new_store.blocks[new_store.head].slot)
-        metrics.lean_safe_target_slot.set(new_store.blocks[new_store.safe_target].slot)
-        metrics.lean_latest_justified_slot.set(new_store.latest_justified.slot)
-        metrics.lean_latest_finalized_slot.set(new_store.latest_finalized.slot)
-
-        if new_store.head != store.head:
-            depth = len(
-                _ancestor_set(new_store.blocks, store.head)
-                - _ancestor_set(new_store.blocks, new_store.head)
-            )
-            metrics.lean_fork_choice_reorgs_total.inc()
-            metrics.lean_fork_choice_reorg_depth.observe(depth)
-
-        return new_store
-
-    return default_block_processor
-
-
 async def _noop_publish_agg(signed_attestation: SignedAggregatedAttestation) -> None:
     """No-op default for aggregated attestation publishing."""
 
@@ -257,11 +224,11 @@ class SyncService:
 
     def __post_init__(self) -> None:
         """Initialize sync components."""
-        # Bind the default processor to the injected spec when no override is provided.
+        # Bind the default processor when no override is provided.
         #
         # Tests pass an explicit processor and skip this path.
         if self.process_block is None:
-            self.process_block = make_default_block_processor(self.spec)
+            self.process_block = self._default_process_block
 
         self._init_components()
 
@@ -297,6 +264,31 @@ class SyncService:
             backfill=self._backfill,
             process_block=self._process_block_wrapper,
         )
+
+    def _default_process_block(self, store: Store, block: SignedBlock) -> Store:
+        """Run the spec's block processor and emit forkchoice telemetry.
+
+        Wraps the pure spec entry point with caller-side metrics.
+        State transition and block processing timings are emitted by the spec
+        itself through the observer, wired at node startup.
+        Everything below is derived by diffing pre- and post-stores.
+        """
+        new_store = self.spec.on_block(store, block)
+
+        metrics.lean_head_slot.set(new_store.blocks[new_store.head].slot)
+        metrics.lean_safe_target_slot.set(new_store.blocks[new_store.safe_target].slot)
+        metrics.lean_latest_justified_slot.set(new_store.latest_justified.slot)
+        metrics.lean_latest_finalized_slot.set(new_store.latest_finalized.slot)
+
+        if new_store.head != store.head:
+            depth = len(
+                _ancestor_set(new_store.blocks, store.head)
+                - _ancestor_set(new_store.blocks, new_store.head)
+            )
+            metrics.lean_fork_choice_reorgs_total.inc()
+            metrics.lean_fork_choice_reorg_depth.observe(depth)
+
+        return new_store
 
     def _process_block_wrapper(
         self,


### PR DESCRIPTION
## Summary

The `make_default_block_processor(spec)` factory existed only to
capture `spec` in a closure for the `SyncService.process_block`
field. `SyncService` already has `self.spec`, so the closure is
unnecessary indirection. Inlines the body as
`_default_process_block(self, store, block)` and binds it as the
default in `__post_init__`.

**Net: -8 lines, zero behavior change, no test updates needed.**

## What changed

### `service.py`

**Removed** the module-level `make_default_block_processor` factory
(~32 lines with docstring).

**Added** `_default_process_block` method on `SyncService` (~22
lines, same body). Reads `self.spec` directly instead of a
captured closure variable.

**Updated** `__post_init__`:
```python
# before
self.process_block = make_default_block_processor(self.spec)

# after
self.process_block = self._default_process_block
```

## What stayed the same

- **The `process_block: Callable | None` field stays.** It is a
  real test-injection point used by two paths in the test suite:
  - `create_mock_sync_service` passes
    `lambda s, b: s.on_block(b)` so tests run against
    `MockForkchoiceStore.on_block` rather than a real spec.
  - `_persist_process_block(...)` in `TestBlockPersistence`
    substitutes a custom processor that exercises the
    database-persistence wrapper without needing a real spec or
    state transition.
- **Behavior is identical.** Same metrics emitted, same reorg-depth
  computation, same `_process_block_wrapper` flow.
- **No test changes** — the injection contract is unchanged.

## Correction on the original estimate

The earlier scan claimed "every call site uses the default" — that
was wrong. Tests genuinely override `process_block`. The factory
itself is still worth removing (a closure capturing `self.spec` when
the method has `self` is pure indirection), but the metrics body has
to live somewhere, so savings are modest (~8 lines instead of ~30).

The architectural win is small but real: `_default_process_block`
and `_process_block_wrapper` now sit next to each other on
`SyncService`, both reading `self.spec` and `self.database`. One
indirection layer fewer for a reader tracing the block-processing
path.

## Test plan

- [x] `ruff check`, `ruff format --check`, `ty check` all pass
- [x] `pytest tests/lean_spec/subspecs/sync` -> **156 passed**

## Out of scope

The last queued item from the sync-layer review:

- `SyncService` marketing-tone docstring rewrite (Reactive/Simple/Resilient/Observable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)