### PR TITLE
refactor(poseidon1): build circulant MDS via np.roll

### DIFF
--- a/src/lean_spec/subspecs/poseidon1/permutation.py
+++ b/src/lean_spec/subspecs/poseidon1/permutation.py
@@ -30,12 +30,10 @@ def _build_circulant_mds(first_row: list[int], n: int, p: int) -> NDArray[np.int
 
     A circulant matrix C defined by first row [r0, r1, ..., rn-1]:
     C[i][j] = r[(j - i) mod n]
+
+    Row i is the first row rolled right by i positions.
     """
-    matrix = np.zeros((n, n), dtype=np.int64)
-    for i in range(n):
-        for j in range(n):
-            matrix[i][j] = first_row[(j - i) % n] % p
-    return matrix
+    return np.array([np.roll(first_row, i) for i in range(n)], dtype=np.int64) % p
 
 
 @njit(cache=True)


### PR DESCRIPTION
## Summary

- Replace the nested Python loop in `_build_circulant_mds` with a single numpy comprehension: row `i` of a circulant matrix is just the first row rolled right by `i` positions.
- Modulo reduction is applied once on the assembled matrix instead of per element.
- Added one sentence to the docstring explaining the row-i = first-row-rolled-by-i identity.

## Test plan

- [x] Element-wise equality check against the original implementation for the width-16 spec row, the width-24 spec row, and a value crossing the modulus.
- [x] `uv run pytest tests/ -k poseidon1` — 8 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)