### PR TITLE
refactor(xmss/prf): drop redundant message length check

### DIFF
--- a/src/lean_spec/subspecs/xmss/prf.py
+++ b/src/lean_spec/subspecs/xmss/prf.py
@@ -184,12 +184,6 @@ class Prf(StrictBaseModel):
         """
         config = self.config
 
-        # Validate message length
-        if len(message) != config.MESSAGE_LENGTH:
-            raise ValueError(
-                f"Message must be exactly {config.MESSAGE_LENGTH} bytes, got {len(message)}"
-            )
-
         # Construct input: DOMAIN_SEP || 0x01 || key || epoch || message || counter
         input_data = (
             PRF_DOMAIN_SEP


### PR DESCRIPTION
## Summary

- `get_randomness` takes `message: Bytes32`, which enforces a 32-byte payload at construction time.
- `MESSAGE_LENGTH` is `32` in every production and test config, so the runtime `len(message) != config.MESSAGE_LENGTH` branch could never fire from the single internal call site (`xmss/interface.py:285`).
- No test pinned the removed error message.

## Test plan

- [x] `uv run pytest tests/lean_spec/subspecs/xmss/` — 107 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)