### PR TITLE
refactor(lstar): use math.ceil for 2/3 supermajority threshold

### DIFF
--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -1,5 +1,6 @@
 """Lstar fork — identity and construction facade."""
 
+import math
 from collections import defaultdict
 from collections.abc import Iterable, Sequence, Set as AbstractSet
 from typing import Any, ClassVar
@@ -1570,9 +1571,9 @@ class LstarSpec(ForkProtocol):
         # Compute the 2/3 supermajority threshold.
         #
         # A block needs at least this many attestation votes to be "safe".
-        # The ceiling division (negation trick) ensures we round UP.
+        # The threshold is rounded UP so a strict majority is required.
         # For example, 100 validators => threshold is 67, not 66.
-        min_target_score = -(-num_validators * 2 // 3)
+        min_target_score = math.ceil(int(num_validators) * 2 / 3)
 
         # Unpack "new" payloads into a flat validator -> vote mapping.
         # "Known" is excluded by design.


### PR DESCRIPTION
## Summary

- Replace the `-(-num_validators * 2 // 3)` ceiling-division trick with `math.ceil(int(num_validators) * 2 / 3)`.
- The negation trick required the reader to recognise that flooring on a negated value yields a ceiling; `math.ceil` expresses the intent directly.
- The `int()` cast keeps the multiplication out of the `Uint64.__mul__` overload that rejects plain-int operands, and validator counts are capped well within float precision.

## Test plan

- [x] `ruff check src/lean_spec/forks/lstar/spec.py` — clean.
- [x] Equivalence verified across `n ∈ {0, 1, 2, 3, 99, 100, 101, 4096, 8192, 99999}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)