### PR TITLE
refactor(networking): event-driven wakeups, drop running-flag polling

### DIFF
--- a/src/lean_spec/subspecs/networking/client/event_source/live.py
+++ b/src/lean_spec/subspecs/networking/client/event_source/live.py
@@ -211,6 +211,12 @@ class LiveNetworkEventSource:
     Controls the main loop and background tasks.
     """
 
+    _stop_event: asyncio.Event = field(default_factory=asyncio.Event)
+    """Set when the event source stops.
+
+    Lets awaiters wake immediately rather than poll the running flag.
+    """
+
     _gossip_handler: GossipHandler = field(init=False)
     """Handler for decoding incoming gossip messages.
 
@@ -440,14 +446,24 @@ class LiveNetworkEventSource:
         Raises:
             StopAsyncIteration: When no more events will arrive.
         """
-        while self._running:
-            try:
-                return await asyncio.wait_for(self._events.get(), timeout=0.5)
-            except asyncio.TimeoutError:
-                # Check running flag and loop.
-                continue
+        if not self._running:
+            raise StopAsyncIteration
 
-        raise StopAsyncIteration
+        # Race the queue against the stop signal.
+        # Whichever wins decides whether to return an event or end iteration.
+        get_task = asyncio.create_task(self._events.get())
+        stop_task = asyncio.create_task(self._stop_event.wait())
+        try:
+            done, _ = await asyncio.wait(
+                {get_task, stop_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if get_task in done:
+                return get_task.result()
+            raise StopAsyncIteration
+        finally:
+            get_task.cancel()
+            stop_task.cancel()
 
     async def dial(self, multiaddr: str) -> PeerId | None:
         """
@@ -466,6 +482,7 @@ class LiveNetworkEventSource:
         # can operate. Without this, _accept_streams exits immediately if
         # dial() is called before listen().
         self._running = True
+        self._stop_event.clear()
 
         try:
             # Detect transport type and connect accordingly.
@@ -548,6 +565,7 @@ class LiveNetworkEventSource:
             multiaddr: Address to listen on (e.g., "/ip4/0.0.0.0/udp/9000/quic-v1").
         """
         self._running = True
+        self._stop_event.clear()
 
         if is_quic_multiaddr(multiaddr):
             await self._listen_quic(multiaddr)
@@ -695,6 +713,7 @@ class LiveNetworkEventSource:
     async def stop(self) -> None:
         """Stop the event source and cancel background tasks."""
         self._running = False
+        self._stop_event.set()
 
         # Cancel gossip tasks first (including event forwarding task).
         # This must happen BEFORE stopping gossipsub behavior to avoid

--- a/src/lean_spec/subspecs/networking/gossipsub/behavior.py
+++ b/src/lean_spec/subspecs/networking/gossipsub/behavior.py
@@ -515,42 +515,21 @@ class GossipsubBehavior:
         if not self._running:
             return None
 
+        # Race the queue against the stop signal.
+        # Whichever wins decides whether to return an event or signal shutdown.
         queue_task = asyncio.create_task(self._event_queue.get())
         stop_task = asyncio.create_task(self._stop_event.wait())
-
         try:
-            done, pending = await asyncio.wait(
-                [queue_task, stop_task],
+            done, _ = await asyncio.wait(
+                {queue_task, stop_task},
                 return_when=asyncio.FIRST_COMPLETED,
             )
-
-            for task in pending:
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
-
-            if stop_task in done:
-                return None
-
             if queue_task in done:
                 return queue_task.result()
-
             return None
-
-        except asyncio.CancelledError:
+        finally:
             queue_task.cancel()
             stop_task.cancel()
-            try:
-                await queue_task
-            except asyncio.CancelledError:
-                pass
-            try:
-                await stop_task
-            except asyncio.CancelledError:
-                pass
-            return None
 
     async def _handle_rpc(self, peer_id: PeerId, rpc: RPC) -> None:
         """Dispatch an incoming RPC to the appropriate handlers."""


### PR DESCRIPTION
## Summary

Two related cleanups to async wakeup patterns in the networking subspec.

### `client/event_source/live.py` — real fix (was polling)

`__anext__` polled the running flag every 500ms via `asyncio.wait_for(..., timeout=0.5)` + `TimeoutError` + `continue`. Replaced with a single `asyncio.wait(..., FIRST_COMPLETED)` race between the event queue and a new `_stop_event: asyncio.Event` field. Stop is now observed with no latency instead of up to 500ms.

- Added `_stop_event` field.
- `dial()` and `listen()` call `_stop_event.clear()` next to each `_running = True` so restart still works.
- `stop()` calls `_stop_event.set()` next to `_running = False` so any waiter wakes immediately.

### `gossipsub/behavior.py` — cleanup, not bug fix

`get_next_event` already raced the queue against a stop event, but the body manually cancelled and awaited each pending task and duplicated the cancellation handling in an outer `except` block. Collapsed to a single try/finally cancel pattern (~46 lines → ~24 lines).

**Behavioural note:** the original swallowed `asyncio.CancelledError` and returned `None`. The new version lets cancellation propagate (the asyncio convention). The sole caller (`_forward_gossipsub_events` in `live.py:387`) wraps the call in `except asyncio.CancelledError: pass`, so it already handles propagation correctly.

## Test plan

- [x] `ruff check` — clean on both files.
- [x] `uv run pytest tests/lean_spec/subspecs/networking/client/test_event_source.py tests/lean_spec/subspecs/networking/gossipsub/` — 215 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)