### PR TITLE
refactor: PEP 695 generic syntax for SSZ collections and Store

### DIFF
--- a/src/lean_spec/forks/lstar/store.py
+++ b/src/lean_spec/forks/lstar/store.py
@@ -4,9 +4,9 @@ Forkchoice store for tracking chain state and attestations.
 The Store tracks all information required for the LMD GHOST forkchoice algorithm.
 """
 
-__all__ = ["AttestationSignatureEntry", "BlockT", "StateT", "Store"]
+__all__ = ["AttestationSignatureEntry", "Store"]
 
-from typing import Generic, NamedTuple, TypeVar
+from typing import NamedTuple
 
 from pydantic import Field
 
@@ -21,12 +21,6 @@ from lean_spec.types import Bytes32, Checkpoint, ValidatorIndex
 from lean_spec.types.base import StrictBaseModel
 from lean_spec.types.container import Container
 
-StateT = TypeVar("StateT", bound=Container)
-"""Per-fork post-state type tracked alongside each known block."""
-
-BlockT = TypeVar("BlockT", bound=Container)
-"""Per-fork block type stored in the forkchoice view."""
-
 
 class AttestationSignatureEntry(NamedTuple):
     """
@@ -40,7 +34,7 @@ class AttestationSignatureEntry(NamedTuple):
     signature: Signature
 
 
-class Store(StrictBaseModel, Generic[StateT, BlockT]):
+class Store[StateT: Container, BlockT: Container](StrictBaseModel):
     """
     Forkchoice store tracking chain state and validator attestations.
 

--- a/src/lean_spec/types/collections.py
+++ b/src/lean_spec/types/collections.py
@@ -8,10 +8,8 @@ from typing import (
     IO,
     Any,
     ClassVar,
-    Generic,
     Protocol,
     Self,
-    TypeVar,
     cast,
     overload,
     override,
@@ -36,14 +34,6 @@ class IntFieldElement(Protocol):
     """
 
     value: int
-
-
-T = TypeVar("T", bound=SSZType)
-"""Generic type parameter for SSZ collection elements.
-
-Bound to SSZType to ensure elements are valid SSZ types.
-Enables type checkers to infer correct return types for indexed access.
-"""
 
 
 def _extract_element_type_from_generic(cls: type, origin_class: type) -> type[SSZType] | None:
@@ -94,7 +84,7 @@ def _validate_offsets(offsets: list[int], scope: int, type_name: str) -> None:
         )
 
 
-class SSZVector(SSZModel, Generic[T]):
+class SSZVector[T: SSZType](SSZModel):
     """Fixed-length, immutable SSZ sequence.
 
     Contains exactly LENGTH elements of type ELEMENT_TYPE.
@@ -260,7 +250,7 @@ class SSZVector(SSZModel, Generic[T]):
         return list(self.data)
 
 
-class SSZList(SSZModel, Generic[T]):
+class SSZList[T: SSZType](SSZModel):
     """Variable-length SSZ sequence with a maximum capacity.
 
     Contains between 0 and LIMIT elements of type ELEMENT_TYPE.


### PR DESCRIPTION
## Summary

Convert `SSZVector`, `SSZList`, and `lstar.Store` to PEP 695 generic syntax. The bounds now live inline in the class header, dropping three module-level `TypeVar` blocks and the `Generic` and `TypeVar` imports across two files.

- `types/collections.py`: `class SSZVector[T: SSZType](SSZModel)` and `class SSZList[T: SSZType](SSZModel)`.
- `forks/lstar/store.py`: `class Store[StateT: Container, BlockT: Container](StrictBaseModel)`. `StateT` and `BlockT` are now class-scoped, so they also leave `__all__` (confirmed unused outside the file).

Pydantic 2.12 emits identical `__pydantic_generic_metadata__` under both syntaxes, so the element-type recovery helper in `collections.py` keeps working unchanged. Verified with a probe before editing.

## Test plan

- [x] `ruff check src/lean_spec/types/collections.py src/lean_spec/forks/lstar/store.py` — clean.
- [x] Pydantic metadata probe: parameterised PEP 695 subclass produces the same `{'origin': ..., 'args': (...), 'parameters': ()}` shape as old-style `Generic[T]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)