### PR TITLE
test framework: close download tempfile before extracting tarball

### DIFF
--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -715,29 +715,34 @@ def download_keys(scheme: str) -> None:
 
     print(f"Downloading {scheme} keys from {url}...")
 
-    # Download to a temporary file to avoid partial-write corruption.
-    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp_file:
-        tmp_path = Path(tmp_file.name)
-        try:
-            # Stream the response directly into the temp file.
-            with urllib.request.urlopen(url) as response:
-                shutil.copyfileobj(response, tmp_file)
+    # Reserve a temp path; we open it explicitly below so the writer can close
+    # before the reader opens.
+    tmp_fd, tmp_name = tempfile.mkstemp(suffix=".tar.gz")
+    os.close(tmp_fd)
+    tmp_path = Path(tmp_name)
 
-            # Remove any existing keys for this scheme before extracting.
-            target_dir = base_dir / f"{scheme}_scheme"
-            if target_dir.exists():
-                shutil.rmtree(target_dir)
-            base_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        # Close the writer before opening the reader.
+        # Otherwise Python's userspace buffer can withhold the tail of the gzip stream.
+        # That produces a near-end decompression failure that looks like a truncated download.
+        with urllib.request.urlopen(url) as response, tmp_path.open("wb") as out:
+            shutil.copyfileobj(response, out)
 
-            # Extract the archive into the base directory.
-            # The archive root is the scheme directory itself.
-            with tarfile.open(tmp_path, "r:gz") as tar:
-                tar.extractall(path=base_dir, filter="data")
+        # Remove any existing keys for this scheme before extracting.
+        target_dir = base_dir / f"{scheme}_scheme"
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        base_dir.mkdir(parents=True, exist_ok=True)
 
-            print(f"Extracted {scheme} keys to {target_dir}/")
-        finally:
-            # Always clean up the temporary download file.
-            tmp_path.unlink(missing_ok=True)
+        # Extract the archive into the base directory.
+        # The archive root is the scheme directory itself.
+        with tarfile.open(tmp_path, "r:gz") as tar:
+            tar.extractall(path=base_dir, filter="data")
+
+        print(f"Extracted {scheme} keys to {target_dir}/")
+    finally:
+        # Always clean up the temporary download file.
+        tmp_path.unlink(missing_ok=True)
 
     print("Download complete!")
 


### PR DESCRIPTION
## 🗒️ Description

Prod key extraction on latest main branch [is failing](https://github.com/leanEthereum/leanSpec/actions/runs/26214049841/job/77135357943) because the previous flow held the temp file open while tarfile reopened the same path with a separate file descriptor. So there's chance that the tar file content was not fully written before it's being decompressed.

The new code closes the temp-file write context before opening it again for reading, so the kernel sees the full tarball on disk.
