### PR TITLE
lstar/aggregate: skip trivial 1-raw-sig + 0-children case

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -523,7 +523,7 @@ class BlockSpec(CamelModel):
         # Aggregation runs on a local clone: gossip pools mutate here, but the
         # caller's gossip-signature view must not be consumed by this simulated
         # build. Only the freshly aggregated Type-1 payloads propagate back.
-        aggregation_store, _ = spec.aggregate(store)
+        aggregation_store, _ = spec.aggregate(store, skip_trivial_inputs=False)
         merged_store = spec.accept_new_attestations(aggregation_store)
 
         # Build the block through the spec's State.build_block().

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -1603,12 +1603,26 @@ class LstarSpec(ForkProtocol):
         # The head and attestation pools remain unchanged.
         return store.model_copy(update={"safe_target": safe_target})
 
-    def aggregate(self, store: LstarStore) -> tuple[LstarStore, list[SignedAggregatedAttestation]]:
+    def aggregate(
+        self,
+        store: LstarStore,
+        *,
+        skip_trivial_inputs: bool = True,
+    ) -> tuple[LstarStore, list[SignedAggregatedAttestation]]:
         """Turn raw validator votes into compact aggregated attestations.
 
         Validators cast individual signatures over gossip. Before those
         votes can influence fork choice or be included in a block, they
         must be combined into compact cryptographic proofs.
+
+        ``skip_trivial_inputs`` (default ``True``) is an **aggregator-role**
+        policy: when set, the ``1 raw + 0 children`` shape is skipped because
+        a single-validator "aggregate" carries no consensus signal beyond the
+        raw gossip sig already on the network (see issue #747). Interval-2
+        aggregator ticks use the default. Block-building callers that must
+        fold every chosen ``att_data`` into ``latest_known_aggregated_payloads``
+        (including lone gossip sigs) pass ``skip_trivial_inputs=False`` —
+        see ``BlockSpec`` in the consensus-testing filler.
 
         The store holds three pools of attestation evidence:
 
@@ -1676,29 +1690,17 @@ class LstarSpec(ForkProtocol):
                 if e.validator_id not in covered
             ]
 
-            # Skip cases where running the prover provides no consensus value:
-            #
+            # Always skip cases where there is nothing to aggregate:
             #   - 0 raw + 0 children: nothing to aggregate.
-            #   - 0 raw + 1 child:    a lone child proof is already a valid
-            #                         proof; nothing to do.
-            #   - 1 raw + 0 children: a single-validator "aggregate" carries
-            #                         no information the raw gossip sig
-            #                         doesn't already carry — the sig is on
-            #                         the per-subnet `attestation_signatures`
-            #                         gossip topic at sign time, so any peer
-            #                         aggregator can fold it in as a raw
-            #                         entry next round. The recursive STARK
-            #                         prover is constant-cost in input size,
-            #                         so building a 1-validator proof spends
-            #                         the full prover budget for zero
-            #                         consensus signal. The unconsumed gossip
-            #                         sig stays in `store.attestation_signatures`
-            #                         (see bookkeeping below) and gets folded
-            #                         in by a future round once another sig
-            #                         or a child shows up.
-            if not child_proofs and len(raw_entries) <= 1:
-                continue
+            #   - 0 raw + 1 child:    a lone child proof is already valid.
             if not raw_entries and len(child_proofs) < 2:
+                continue
+
+            # Aggregator-role optimization (``skip_trivial_inputs=True``, the
+            # default): skip ``1 raw + 0 children``. Block-building callers
+            # pass ``skip_trivial_inputs=False`` so every gossip sig they
+            # seeded is folded into ``latest_known_aggregated_payloads``.
+            if skip_trivial_inputs and not child_proofs and len(raw_entries) <= 1:
                 continue
 
             # Encode raw signers as a compact bitfield when present.

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -1676,10 +1676,28 @@ class LstarSpec(ForkProtocol):
                 if e.validator_id not in covered
             ]
 
-            # The aggregation layer enforces a minimum: either at least one
-            # raw signature, or at least two child proofs to merge.
+            # Skip cases where running the prover provides no consensus value:
             #
-            # A lone child proof is already a valid proof — nothing to do.
+            #   - 0 raw + 0 children: nothing to aggregate.
+            #   - 0 raw + 1 child:    a lone child proof is already a valid
+            #                         proof; nothing to do.
+            #   - 1 raw + 0 children: a single-validator "aggregate" carries
+            #                         no information the raw gossip sig
+            #                         doesn't already carry — the sig is on
+            #                         the per-subnet `attestation_signatures`
+            #                         gossip topic at sign time, so any peer
+            #                         aggregator can fold it in as a raw
+            #                         entry next round. The recursive STARK
+            #                         prover is constant-cost in input size,
+            #                         so building a 1-validator proof spends
+            #                         the full prover budget for zero
+            #                         consensus signal. The unconsumed gossip
+            #                         sig stays in `store.attestation_signatures`
+            #                         (see bookkeeping below) and gets folded
+            #                         in by a future round once another sig
+            #                         or a child shows up.
+            if not child_proofs and len(raw_entries) <= 1:
+                continue
             if not raw_entries and len(child_proofs) < 2:
                 continue
 

--- a/tests/lean_spec/forks/lstar/forkchoice/test_store_attestations.py
+++ b/tests/lean_spec/forks/lstar/forkchoice/test_store_attestations.py
@@ -593,12 +593,33 @@ class TestAggregateCommitteeSignatures:
             source=att_data_1.source,
         )
 
-        # Validators 1 attests to data_1, validator 2 attests to data_2
-        sig_1 = key_manager.sign_attestation_data(ValidatorIndex(1), att_data_1)
-        sig_2 = key_manager.sign_attestation_data(ValidatorIndex(2), att_data_2)
+        # Validators 1, 3 attest to data_1; validators 2, 0 attest to data_2.
+        # Two distinct sigs per att_data is the minimum non-trivial shape:
+        # `aggregate()` skips the `1 raw + 0 children` case (a single-validator
+        # "aggregate" carries no information the raw gossip sig doesn't
+        # already carry), so this test must seed at least two raw sigs per
+        # `att_data` for the per-data grouping it is asserting.
         attestation_signatures = {
-            att_data_1: {AttestationSignatureEntry(ValidatorIndex(1), sig_1)},
-            att_data_2: {AttestationSignatureEntry(ValidatorIndex(2), sig_2)},
+            att_data_1: {
+                AttestationSignatureEntry(
+                    ValidatorIndex(1),
+                    key_manager.sign_attestation_data(ValidatorIndex(1), att_data_1),
+                ),
+                AttestationSignatureEntry(
+                    ValidatorIndex(3),
+                    key_manager.sign_attestation_data(ValidatorIndex(3), att_data_1),
+                ),
+            },
+            att_data_2: {
+                AttestationSignatureEntry(
+                    ValidatorIndex(2),
+                    key_manager.sign_attestation_data(ValidatorIndex(2), att_data_2),
+                ),
+                AttestationSignatureEntry(
+                    ValidatorIndex(0),
+                    key_manager.sign_attestation_data(ValidatorIndex(0), att_data_2),
+                ),
+            },
         }
 
         store = base_store.model_copy(

--- a/tests/lean_spec/forks/lstar/state/test_state_aggregation.py
+++ b/tests/lean_spec/forks/lstar/state/test_state_aggregation.py
@@ -141,6 +141,41 @@ def test_aggregate_with_empty_attestation_signatures(
     assert results == []
 
 
+def test_aggregate_skips_single_gossip_sig_with_no_children(
+    container_key_manager: XmssKeyManager,
+    spec: LstarSpec,
+) -> None:
+    """Trivial 1 raw sig + 0 children case: aggregate returns nothing.
+
+    A single-validator "aggregate" carries no information the raw gossip
+    sig doesn't already carry — the sig is on the per-subnet
+    `attestation_signatures` gossip topic at sign time, so any peer
+    aggregator can fold it in as a raw entry next round. The recursive
+    STARK prover is constant-cost in input size, so building a
+    1-validator proof spends the full prover budget for zero consensus
+    signal. The unconsumed gossip sig must remain in
+    `store.attestation_signatures` so it is folded in by a future round
+    once another sig or a child shows up.
+    """
+    store = make_store(num_validators=2, key_manager=container_key_manager)
+    source = Checkpoint(root=make_bytes32(1), slot=Slot(0))
+    att_data = make_attestation_data_simple(
+        Slot(2), make_bytes32(3), make_bytes32(4), source=source
+    )
+    sig_entry = AttestationSignatureEntry(
+        ValidatorIndex(0),
+        container_key_manager.sign_attestation_data(ValidatorIndex(0), att_data),
+    )
+    attestation_signatures = {att_data: {sig_entry}}
+
+    store = store.model_copy(update={"attestation_signatures": attestation_signatures})
+    updated_store, results = spec.aggregate(store)
+
+    assert results == []
+    # The lone sig must survive untouched for a later, non-trivial pass.
+    assert updated_store.attestation_signatures == attestation_signatures
+
+
 def test_aggregated_signatures_with_multiple_data_groups(
     container_key_manager: XmssKeyManager,
     spec: LstarSpec,


### PR DESCRIPTION
Closes #747.

## Summary

Extend the early-skip predicate in `lstar/spec.py:aggregate()`:

```python
# Skip cases where running the prover provides no consensus value:
#   - 0 raw + 0 children: nothing to aggregate.
#   - 0 raw + 1 child:    a lone child proof is already a valid proof.
#   - 1 raw + 0 children: a single-validator "aggregate" carries no
#                         information the raw gossip sig doesn't already
#                         carry — the sig is already on the gossip topic.
if not child_proofs and len(raw_entries) <= 1:
    continue
if not raw_entries and len(child_proofs) < 2:
    continue
```

## Why

A 1-validator aggregate can't move ⅔ quorum and the raw XMSS sig is already on the per-subnet `attestation_signatures` gossip topic at sign time, so any peer aggregator can fold it in as a raw entry next round. The recursive STARK prover is roughly constant-cost in input size — building a 1-validator proof costs the same as a 32-validator one.

On the multi-client devnet, two zeam aggregators sat in this case for 100% of slots over 10 minutes, spending ~10.8 s of FFI per worker run on single-validator proofs and dropping ~50% of slot triggers as `in_flight`. Full numbers in [blockblaz/zeam#907](https://github.com/blockblaz/zeam/issues/907).

## Correctness

- Wire format and verifier unchanged.
- The lone gossip sig stays in `store.attestation_signatures` because the existing bookkeeping only prunes sigs whose `att_data` produced an aggregate. A future round folds it in once another sig or a child shows up.
- Same end-state coverage as before, much cheaper to get there.

## Tests

- New: `test_aggregate_skips_single_gossip_sig_with_no_children` — asserts no aggregation is produced for the 1-sig + 0-children case and that the sig survives in the store.
- Updated: `test_multiple_attestation_data_grouped_separately` — seeded with two raw sigs per `att_data` so each group is non-trivial. The test's intent (two distinct `AttestationData` → two distinct proofs) is preserved.

`uv run pytest tests/lean_spec/forks/lstar/state tests/lean_spec/forks/lstar/forkchoice` → 47 passed.

## Related

- [blockblaz/zeam#907](https://github.com/blockblaz/zeam/issues/907) — devnet investigation
- [blockblaz/zeam#908](https://github.com/blockblaz/zeam/pull/908) — zeam-side fast path. Becomes spec-compliant once this lands.