### PR TITLE
refactor(koalabear): drop tests-only Fp.__bytes__

### DIFF
--- a/src/lean_spec/subspecs/koalabear/field.py
+++ b/src/lean_spec/subspecs/koalabear/field.py
@@ -119,14 +119,3 @@ class Fp(SSZType):
     def __repr__(self) -> str:
         """String representation."""
         return f"Fp(value={self.value})"
-
-    def __bytes__(self) -> bytes:
-        """
-        Serialize the field element using Python's bytes protocol.
-
-        This enables `bytes(fp)` to work naturally with field elements.
-
-        Returns:
-            4-byte little-endian representation of the field element.
-        """
-        return self.encode_bytes()

--- a/tests/lean_spec/subspecs/koalabear/test_field.py
+++ b/tests/lean_spec/subspecs/koalabear/test_field.py
@@ -41,37 +41,6 @@ def test_base_field_arithmetic() -> None:
         Fp(value=0).inverse()
 
 
-def test_bytes_protocol() -> None:
-    """Test serialization using Python's bytes protocol."""
-    # Test basic serialization
-    fp = Fp(value=42)
-    data = bytes(fp)
-    assert len(data) == 4  # P_BYTES
-    assert isinstance(data, bytes)
-
-    # Test deserialization
-    recovered = Fp.decode_bytes(data)
-    assert recovered == fp
-
-    # Test round-trip for various values
-    test_values = [0, 1, 42, 1000, P - 1]
-    for value in test_values:
-        fp = Fp(value=value)
-        assert Fp.decode_bytes(bytes(fp)) == fp
-
-    # Test error handling for invalid data length
-    with pytest.raises(ValueError, match="Expected 4 bytes for Fp, got 3"):
-        Fp.decode_bytes(b"\x01\x02\x03")
-
-    with pytest.raises(ValueError, match="Expected 4 bytes for Fp, got 5"):
-        Fp.decode_bytes(b"\x01\x02\x03\x04\x05")
-
-    # Test error handling for values exceeding the modulus
-    invalid_data = P.to_bytes(4, byteorder="little")
-    with pytest.raises(ValueError, match="exceeds field modulus"):
-        Fp.decode_bytes(invalid_data)
-
-
 def test_ssz_type_properties() -> None:
     """Test that Fp correctly implements SSZ type interface."""
     # Test is_fixed_size
@@ -156,13 +125,9 @@ def test_ssz_roundtrip() -> None:
         value = random.randint(0, P - 1)
         fp = Fp(value=value)
 
-        # Test all serialization methods give same result
-        data1 = bytes(fp)
-        data2 = fp.encode_bytes()
-        assert data1 == data2
-
         # Test deserialization works
-        recovered = Fp.decode_bytes(data1)
+        data = fp.encode_bytes()
+        recovered = Fp.decode_bytes(data)
         assert recovered == fp
 
 
@@ -173,8 +138,6 @@ def test_ssz_deterministic() -> None:
     # Serialize multiple times
     data1 = fp.encode_bytes()
     data2 = fp.encode_bytes()
-    data3 = bytes(fp)
 
-    # All should be identical
+    # Both should be identical
     assert data1 == data2
-    assert data1 == data3


### PR DESCRIPTION
## Summary

`Fp.__bytes__` only enabled `bytes(fp)` syntactic sugar used by a handful of test sites. No production code calls it — the canonical SSZ path is `Fp.encode_bytes()`.

- **`src/lean_spec/subspecs/koalabear/field.py`** (−11 lines): `Fp.__bytes__` deleted.
- **`tests/lean_spec/subspecs/koalabear/test_field.py`** (−40 lines net):
  - `test_bytes_protocol` deleted entirely. The `decode_bytes` error paths it exercised (wrong length, exceeds modulus) are already covered by the dedicated `test_ssz_deserialize_wrong_scope`, `test_ssz_deserialize_short_data`, and `test_ssz_deserialize_exceeds_modulus` tests.
  - `test_ssz_roundtrip` and `test_ssz_deterministic` simplified — removed the `bytes(fp)` vs `encode_bytes()` cross-checks, which become meaningless without the dunder. The encode-decode roundtrip and encode determinism are still asserted.

## Test plan

- [x] `ruff check` — clean.
- [x] `uv run pytest tests/lean_spec/subspecs/koalabear/test_field.py` — 11 tests pass.
- [x] `grep -r "bytes(.*Fp\|__bytes__"` across `src/`, `tests/`, `packages/` — no remaining production references to `Fp.__bytes__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)