### PR TITLE
refactor: drop from __future__ import annotations in Pydantic-defining files

### DIFF
--- a/src/lean_spec/subspecs/xmss/aggregation.py
+++ b/src/lean_spec/subspecs/xmss/aggregation.py
@@ -7,8 +7,6 @@ Two proof shapes:
 - Type-2: a merge of N Type-1 proofs over distinct messages.
 """
 
-from __future__ import annotations
-
 from collections.abc import Sequence
 
 from lean_multisig_py import (
@@ -67,8 +65,8 @@ class TypeOneMultiSignature(Container):
 
     @staticmethod
     def select_greedily(
-        *proof_sets: set[TypeOneMultiSignature] | None,
-    ) -> tuple[list[TypeOneMultiSignature], set[ValidatorIndex]]:
+        *proof_sets: set["TypeOneMultiSignature"] | None,
+    ) -> tuple[list["TypeOneMultiSignature"], set[ValidatorIndex]]:
         """Greedy set-cover over Type-1 proofs to maximise validator coverage.
 
         Repeatedly selects the proof covering the most uncovered validators
@@ -102,13 +100,13 @@ class TypeOneMultiSignature(Container):
 
     @staticmethod
     def aggregate(
-        children: Sequence[tuple[TypeOneMultiSignature, Sequence[PublicKey]]],
+        children: Sequence[tuple["TypeOneMultiSignature", Sequence[PublicKey]]],
         raw_xmss: Sequence[tuple[PublicKey, Signature]],
         xmss_participants: AggregationBits | None,
         message: Bytes32,
         slot: Slot,
         mode: LeanEnvMode | None = None,
-    ) -> TypeOneMultiSignature:
+    ) -> "TypeOneMultiSignature":
         """Aggregate raw XMSS signatures and child Type-1 proofs into one Type-1 proof.
 
         Proof bytes are stored in compact no-pubkeys form. Participant identity is
@@ -224,7 +222,7 @@ class TypeTwoMultiSignature(Container):
         parts: Sequence[TypeOneMultiSignature],
         public_keys_per_part: Sequence[Sequence[PublicKey]] | None = None,
         mode: LeanEnvMode | None = None,
-    ) -> TypeTwoMultiSignature:
+    ) -> "TypeTwoMultiSignature":
         """Merge several Type-1 proofs (each over a distinct message) into one Type-2 proof.
 
         The returned Type-2 proof bytes are stored in compact no-pubkeys form.

--- a/src/lean_spec/subspecs/xmss/containers.py
+++ b/src/lean_spec/subspecs/xmss/containers.py
@@ -1,7 +1,5 @@
 """Generalized XMSS containers."""
 
-from __future__ import annotations
-
 from typing import override
 
 from pydantic import field_serializer, field_validator, model_serializer

--- a/src/lean_spec/subspecs/xmss/subtree.py
+++ b/src/lean_spec/subspecs/xmss/subtree.py
@@ -5,7 +5,7 @@ This module contains the `HashSubTree` type and its associated construction meth
 implementing the memory-efficient top-bottom tree traversal approach.
 """
 
-from __future__ import annotations
+from typing import Self
 
 from lean_spec.types import Uint64
 from lean_spec.types.container import Container
@@ -103,7 +103,7 @@ class HashSubTree(Container):
         start_index: Uint64,
         parameter: Parameter,
         lowest_layer_nodes: list[HashDigestVector],
-    ) -> HashSubTree:
+    ) -> Self:
         """
         Builds a new sparse Merkle subtree starting from a specified layer.
 
@@ -187,7 +187,7 @@ class HashSubTree(Container):
         start_bottom_tree_index: Uint64,
         parameter: Parameter,
         bottom_tree_roots: list[HashDigestVector],
-    ) -> HashSubTree:
+    ) -> Self:
         """
         Constructs a top tree from the roots of bottom trees.
 
@@ -243,7 +243,7 @@ class HashSubTree(Container):
         bottom_tree_index: Uint64,
         parameter: Parameter,
         leaves: list[HashDigestVector],
-    ) -> HashSubTree:
+    ) -> Self:
         """
         Constructs a single bottom tree from leaf hashes.
 
@@ -327,7 +327,7 @@ class HashSubTree(Container):
         prf_key: PRFKey,
         bottom_tree_index: Uint64,
         parameter: Parameter,
-    ) -> HashSubTree:
+    ) -> Self:
         """
         Generates a single bottom tree on-demand from the PRF key.
 

--- a/src/lean_spec/types/bitfields.py
+++ b/src/lean_spec/types/bitfields.py
@@ -12,8 +12,6 @@ Both flavors pack bits little-endian within each byte.
 Bit i of the input lands in byte i // 8 at position i % 8.
 """
 
-from __future__ import annotations
-
 import math
 from collections.abc import Sequence
 from typing import (

--- a/src/lean_spec/types/byte_arrays.py
+++ b/src/lean_spec/types/byte_arrays.py
@@ -11,8 +11,6 @@ Two flavors are defined by the SSZ spec:
 Both flavors serialize as the raw bytes themselves — no length prefix, no delimiter.
 """
 
-from __future__ import annotations
-
 from collections.abc import Iterable
 from typing import IO, Any, ClassVar, Self, override
 

--- a/src/lean_spec/types/collections.py
+++ b/src/lean_spec/types/collections.py
@@ -1,7 +1,5 @@
 """Vector and List Type Specifications."""
 
-from __future__ import annotations
-
 import io
 from collections.abc import Iterator, Sequence
 from typing import (

--- a/src/lean_spec/types/container.py
+++ b/src/lean_spec/types/container.py
@@ -7,8 +7,6 @@ Containers are the primary way to define structured data in
 Ethereum's serialization format.
 """
 
-from __future__ import annotations
-
 from typing import IO, Any, Self, override
 
 from .constants import OFFSET_BYTE_LENGTH

--- a/src/lean_spec/types/ssz_base.py
+++ b/src/lean_spec/types/ssz_base.py
@@ -1,7 +1,5 @@
 """Base classes and interfaces for all SSZ types."""
 
-from __future__ import annotations
-
 import io
 from abc import ABC, abstractmethod
 from collections.abc import Sequence


### PR DESCRIPTION
## Summary

CLAUDE.md rule R1 bans `from __future__ import annotations` in files that define Pydantic Container or SSZModel classes, because lazy-string annotations break Pydantic's forward-reference resolution. Eight audit-flagged files still carried it; this PR removes it from all of them.

### Forward-reference fixes (annotations now evaluate eagerly)

- **`subspecs/xmss/subtree.py`** — four classmethod constructors that returned `HashSubTree` now return `Self` (added `from typing import Self`). The methods are pure classmethod factories on the class itself, so `Self` reads cleaner than quoting.
- **`subspecs/xmss/aggregation.py`** — five forward references to `TypeOneMultiSignature` and `TypeTwoMultiSignature` inside their own class bodies became quoted strings (`"TypeOneMultiSignature"`, `"TypeTwoMultiSignature"`), since the class isn't bound at the point the signatures are evaluated.

### Files whose future import alone was redundant

`types/byte_arrays.py`, `types/bitfields.py`, `types/collections.py`, `types/ssz_base.py`, `types/container.py`, `subspecs/xmss/containers.py` — no forward-reference fixes needed.

### Audit "Plus check" list

`participation.py`, `validator.py`, `checkpoint.py` did not actually carry the future import. No change needed there.

## Test plan

- [x] `ruff check src/lean_spec/types/ src/lean_spec/subspecs/xmss/` — clean.
- [x] `uv run pytest tests/lean_spec/types/ tests/lean_spec/subspecs/xmss/` — 1056 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)