### PR TITLE
refactor(types): drop unused Checkpoint.__lt__

### DIFF
--- a/src/lean_spec/types/checkpoint.py
+++ b/src/lean_spec/types/checkpoint.py
@@ -22,14 +22,6 @@ class Checkpoint(Container):
     slot: Slot
     """The slot number of the checkpoint's block."""
 
-    def __lt__(self, other: "Checkpoint") -> bool:
-        """Order checkpoints by slot."""
-        # Foreign types: defer to Python's reflected fallback.
-        if not isinstance(other, Checkpoint):
-            return NotImplemented
-        # Slot drives the order; equal slots leave the pair incomparable.
-        return self.slot < other.slot
-
     def advance_to(self, candidate: "Checkpoint") -> "Checkpoint":
         """
         Return the later of two checkpoints, keeping self on a slot tie.

--- a/tests/lean_spec/subspecs/containers/test_checkpoint.py
+++ b/tests/lean_spec/subspecs/containers/test_checkpoint.py
@@ -1,71 +1,12 @@
-"""Unit tests for Checkpoint ordering."""
+"""Unit tests for advancing checkpoints by slot."""
 
 from __future__ import annotations
 
-import pytest
-
 from lean_spec.types import Bytes32, Checkpoint, Slot
 
-# Two distinct roots to verify ordering ignores root content.
+# Two distinct roots to verify slot drives the choice, not root content.
 ROOT_A = Bytes32(b"\xa0" * 32)
 ROOT_B = Bytes32(b"\xb0" * 32)
-
-
-def test_lt_returns_true_for_lower_slot() -> None:
-    """Lower slot is less than higher slot."""
-    low = Checkpoint(root=ROOT_A, slot=Slot(1))
-    high = Checkpoint(root=ROOT_A, slot=Slot(2))
-    assert (low < high) is True
-
-
-def test_lt_returns_false_for_higher_slot() -> None:
-    """Higher slot is not less than lower slot."""
-    low = Checkpoint(root=ROOT_A, slot=Slot(1))
-    high = Checkpoint(root=ROOT_A, slot=Slot(2))
-    assert (high < low) is False
-
-
-def test_lt_returns_false_for_equal_slots_with_different_roots() -> None:
-    """Equal slots are incomparable regardless of root."""
-    a = Checkpoint(root=ROOT_A, slot=Slot(7))
-    b = Checkpoint(root=ROOT_B, slot=Slot(7))
-    assert (a < b) is False
-    assert (b < a) is False
-
-
-def test_lt_returns_false_for_identical_checkpoint() -> None:
-    """Checkpoint is never less than itself."""
-    cp = Checkpoint(root=ROOT_A, slot=Slot(3))
-    assert (cp < cp) is False
-
-
-def test_lt_returns_not_implemented_for_non_checkpoint() -> None:
-    """Direct dunder call returns NotImplemented for foreign types."""
-    cp = Checkpoint(root=ROOT_A, slot=Slot(1))
-    assert cp.__lt__(42) is NotImplemented  # type: ignore[arg-type]
-
-
-def test_lt_raises_typeerror_when_compared_with_non_checkpoint() -> None:
-    """Operator < raises TypeError after the reflected fallback fails."""
-    cp = Checkpoint(root=ROOT_A, slot=Slot(1))
-    with pytest.raises(TypeError):
-        _ = cp < 42  # type: ignore[operator]
-
-
-def test_max_returns_higher_slot_regardless_of_argument_order() -> None:
-    """max selects the higher-slot checkpoint regardless of argument order."""
-    low = Checkpoint(root=ROOT_A, slot=Slot(1))
-    high = Checkpoint(root=ROOT_B, slot=Slot(2))
-    assert max(low, high) == high
-    assert max(high, low) == high
-
-
-def test_max_keeps_first_argument_on_slot_tie() -> None:
-    """max returns the first argument on slot ties."""
-    a = Checkpoint(root=ROOT_A, slot=Slot(5))
-    b = Checkpoint(root=ROOT_B, slot=Slot(5))
-    assert max(a, b) == a
-    assert max(b, a) == b
 
 
 def test_advance_to_returns_candidate_on_higher_slot() -> None:


### PR DESCRIPTION
## Summary

`Checkpoint.__lt__` had no production caller. The forward-progress helper `advance_to` compares slots directly through `Slot`'s comparator (`candidate.slot > self.slot`) — never ordering `Checkpoint` against `Checkpoint`.

- **`src/lean_spec/types/checkpoint.py`** (−8): `__lt__` deleted.
- **`tests/lean_spec/subspecs/containers/test_checkpoint.py`** (−63 / +2):
  - Six `__lt__` tests retired (only exercised the deleted dunder).
  - Two `max(low, high)` tests retired (only worked because `__lt__` was defined; `max`/`min` on `Checkpoint` stop making sense without the comparator).
  - Four `advance_to` tests kept.
  - Unused `pytest` import dropped.
  - File docstring reworded from "Checkpoint ordering" to "advancing checkpoints by slot" since ordering is no longer tested here.

## Test plan

- [x] `ruff check src/lean_spec/types/checkpoint.py tests/lean_spec/subspecs/containers/test_checkpoint.py` — clean.
- [x] `grep` across `src/`, `tests/`, `packages/` — no remaining references to `Checkpoint.__lt__` or to ordering `Checkpoint` instances against each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)