### PR TITLE
refactor: drop dead aggregate_subnet_ids plumbing through services

### DIFF
--- a/src/lean_spec/__main__.py
+++ b/src/lean_spec/__main__.py
@@ -162,7 +162,6 @@ def _init_from_genesis(
     fork: ForkProtocol,
     validator_registry: ValidatorRegistry | None = None,
     is_aggregator: bool = False,
-    aggregate_subnet_ids: tuple[SubnetId, ...] = (),
     api_port: int | None = None,
 ) -> Node:
     """
@@ -174,8 +173,6 @@ def _init_from_genesis(
         fork: Fork specification for state/store construction.
         validator_registry: Optional registry with validator secret keys.
         is_aggregator: Enable aggregator mode for attestation aggregation.
-        aggregate_subnet_ids: Additional subnets to subscribe and aggregate from.
-            Only effective when is_aggregator is also True.
         api_port: Port for API server and /metrics. None disables the API.
 
     Returns:
@@ -200,7 +197,6 @@ def _init_from_genesis(
         validator_registry=validator_registry,
         network_name=fork.GOSSIP_DIGEST,
         is_aggregator=is_aggregator,
-        aggregate_subnet_ids=aggregate_subnet_ids,
         api_config=ApiServerConfig(port=api_port) if api_port is not None else None,
     )
 
@@ -215,7 +211,6 @@ async def _init_from_checkpoint(
     fork: ForkProtocol,
     validator_registry: ValidatorRegistry | None = None,
     is_aggregator: bool = False,
-    aggregate_subnet_ids: tuple[SubnetId, ...] = (),
     api_port: int | None = None,
 ) -> Node | None:
     """
@@ -245,8 +240,6 @@ async def _init_from_checkpoint(
         fork: Fork specification for state/store construction.
         validator_registry: Optional registry with validator secret keys.
         is_aggregator: Enable aggregator mode for attestation aggregation.
-        aggregate_subnet_ids: Additional subnets to subscribe and aggregate from.
-            Only effective when is_aggregator is also True.
         api_port: Port for API server and /metrics. None disables the API.
 
     Returns:
@@ -316,7 +309,6 @@ async def _init_from_checkpoint(
             validator_registry=validator_registry,
             network_name=fork.GOSSIP_DIGEST,
             is_aggregator=is_aggregator,
-            aggregate_subnet_ids=aggregate_subnet_ids,
             api_config=ApiServerConfig(port=api_port) if api_port is not None else None,
         )
 
@@ -574,7 +566,6 @@ async def run_node(
             fork=fork,
             validator_registry=validator_registry,
             is_aggregator=is_aggregator,
-            aggregate_subnet_ids=aggregate_subnet_ids,
             api_port=api_port_int,
         )
         if node is None:
@@ -590,7 +581,6 @@ async def run_node(
             fork=fork,
             validator_registry=validator_registry,
             is_aggregator=is_aggregator,
-            aggregate_subnet_ids=aggregate_subnet_ids,
             api_port=api_port_int,
         )
 

--- a/src/lean_spec/subspecs/networking/service/service.py
+++ b/src/lean_spec/subspecs/networking/service/service.py
@@ -76,9 +76,6 @@ class NetworkService:
     is_aggregator: bool = field(default=False)
     """Whether this node functions as an aggregator."""
 
-    aggregate_subnet_ids: tuple[SubnetId, ...] = field(default_factory=tuple)
-    """Explicit attestation subnets to subscribe and aggregate from (requires is_aggregator)."""
-
     _running: bool = field(default=False, repr=False)
     """Whether the event loop is running."""
 

--- a/src/lean_spec/subspecs/node/node.py
+++ b/src/lean_spec/subspecs/node/node.py
@@ -42,7 +42,7 @@ from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.storage import Database, SQLiteDatabase
 from lean_spec.subspecs.sync import BlockCache, NetworkRequester, PeerManager, SyncService
 from lean_spec.subspecs.validator import ValidatorRegistry, ValidatorService
-from lean_spec.types import Bytes32, Slot, SubnetId, Uint64, ValidatorIndex
+from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
 
 logger = logging.getLogger(__name__)
 
@@ -130,17 +130,6 @@ class NodeConfig:
     NetworkService. The flag can be toggled at runtime via the admin API
     (see AggregatorController). Runtime toggles do not persist across
     restarts and do not update the local ENR or subnet subscriptions.
-    """
-
-    aggregate_subnet_ids: tuple[SubnetId, ...] = field(default_factory=tuple)
-    """
-    Additional attestation subnets to subscribe to and aggregate from.
-
-    When set, the node subscribes to these subnets at the p2p layer in
-    addition to validator-derived subnets. Effective only when is_aggregator
-    is True — only aggregators import gossip attestations into forkchoice.
-
-    Additive to the validator-derived subnet.
     """
 
 
@@ -280,7 +269,6 @@ class Node:
             spec=fork,
             database=database,
             is_aggregator=config.is_aggregator,
-            aggregate_subnet_ids=config.aggregate_subnet_ids,
             genesis_start=True,
         )
 
@@ -290,7 +278,6 @@ class Node:
             event_source=config.event_source,
             network_name=config.network_name,
             is_aggregator=config.is_aggregator,
-            aggregate_subnet_ids=config.aggregate_subnet_ids,
         )
 
         # Wire up aggregated attestation publishing.

--- a/src/lean_spec/subspecs/sync/service.py
+++ b/src/lean_spec/subspecs/sync/service.py
@@ -32,7 +32,7 @@ from lean_spec.subspecs.xmss.aggregation import (
     TypeTwoMultiSignature,
 )
 from lean_spec.subspecs.xmss.containers import PublicKey
-from lean_spec.types import Bytes32, Slot, SubnetId
+from lean_spec.types import Bytes32, Slot
 from lean_spec.types.exceptions import SSZError
 
 from .backfill_sync import BackfillSync, NetworkRequester
@@ -76,13 +76,6 @@ class SyncService:
 
     is_aggregator: bool = field(default=False)
     """Whether this node functions as an aggregator."""
-
-    aggregate_subnet_ids: tuple[SubnetId, ...] = field(default_factory=tuple)
-    """
-    Extra subnets the aggregator subscribes to on top of its validator-derived one.
-
-    Ignored on non-aggregator nodes, which never import gossip attestations.
-    """
 
     publish_aggregated_attestation: Callable[
         [SignedAggregatedAttestation], Coroutine[None, None, None]

--- a/tests/lean_spec/subspecs/networking/service/test_service.py
+++ b/tests/lean_spec/subspecs/networking/service/test_service.py
@@ -478,25 +478,13 @@ class TestNetworkServiceInit:
         )
         assert svc.is_aggregator is False
 
-    def test_default_aggregate_subnet_ids(self, peer_id: PeerId) -> None:
-        """aggregate_subnet_ids defaults to an empty tuple."""
-        source = MockEventSource(events=[])
-        sync_service = create_mock_sync_service(peer_id)
-        svc = NetworkService(
-            sync_service=sync_service,
-            event_source=source,
-        )
-        assert svc.aggregate_subnet_ids == ()
-
-    def test_custom_aggregator_fields(self, peer_id: PeerId) -> None:
-        """Constructor accepts is_aggregator and aggregate_subnet_ids."""
+    def test_custom_is_aggregator(self, peer_id: PeerId) -> None:
+        """Constructor accepts is_aggregator."""
         source = MockEventSource(events=[])
         sync_service = create_mock_sync_service(peer_id)
         svc = NetworkService(
             sync_service=sync_service,
             event_source=source,
             is_aggregator=True,
-            aggregate_subnet_ids=(SubnetId(0), SubnetId(3)),
         )
         assert svc.is_aggregator is True
-        assert svc.aggregate_subnet_ids == (SubnetId(0), SubnetId(3))


### PR DESCRIPTION
## Summary

\`aggregate_subnet_ids\` is parsed from the CLI and legitimately used in \`__main__.run_node\` to compute \`subscription_subnets\` (line 533 after this PR). However, it was also threaded through:

- \`_init_from_genesis\` / \`_init_from_checkpoint\` parameters
- \`NodeConfig\` field
- Passed to \`SyncService\` and \`NetworkService\` constructors as fields
- \`SyncService.aggregate_subnet_ids\` and \`NetworkService.aggregate_subnet_ids\` are **never read** anywhere on \`self\`

This PR removes the dead plumbing while keeping the CLI flag and the subscription read intact.

## What changed

- Drops the field from \`SyncService\`, \`NetworkService\`, and \`NodeConfig\`
- Drops the parameter from \`_init_from_genesis\` and \`_init_from_checkpoint\`
- Drops the \`Node.from_genesis\` pass-through to both services
- Updates the two networking-service tests that asserted on the dead field
- The audit's other Section 2 item (\`BaseUint.to_bytes\` override) was already dropped in PR #750 — no action needed.

## Diff size

5 files, +4 / -49.

## Test plan

- [x] \`uv run --group lint ruff check\` — clean
- [x] \`uv run --group lint ruff format --check\` — clean
- [x] \`uv run --group lint ty check src/ tests/\` — clean
- [x] \`uv run pytest tests/lean_spec/subspecs/{sync,networking/service,node}/ tests/lean_spec/test_cli.py\` — 229 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)