### PR TITLE
refactor: modernize batch — @override, single stop signal, struct cleanups

### DIFF
--- a/src/lean_spec/__main__.py
+++ b/src/lean_spec/__main__.py
@@ -657,7 +657,7 @@ async def run_node(
 
     # Run the node.
     logger.info("Starting consensus node...")
-    event_source._running = True
+    event_source._stop_event.clear()
     await node.run()
 
 

--- a/src/lean_spec/subspecs/koalabear/field.py
+++ b/src/lean_spec/subspecs/koalabear/field.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import IO, Final, Self
+from typing import IO, Final, Self, override
 
 from lean_spec.types import SSZType
 
@@ -48,21 +48,25 @@ class Fp(SSZType):
         self.value: int = value % P
 
     @classmethod
+    @override
     def is_fixed_size(cls) -> bool:
         """Fp elements are fixed-size (4 bytes)."""
         return True
 
     @classmethod
+    @override
     def get_byte_length(cls) -> int:
         """Get the byte length of an Fp element."""
         return P_BYTES
 
+    @override
     def serialize(self, stream: IO[bytes]) -> int:
         """Serialize the field element to a binary stream."""
         stream.write(self.value.to_bytes(P_BYTES, byteorder="little"))
         return P_BYTES
 
     @classmethod
+    @override
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
         """Deserialize a field element from a binary stream."""
         if scope != P_BYTES:

--- a/src/lean_spec/subspecs/networking/client/event_source/live.py
+++ b/src/lean_spec/subspecs/networking/client/event_source/live.py
@@ -206,16 +206,13 @@ class LiveNetworkEventSource:
     Used to validate incoming messages belong to the same fork.
     """
 
-    _running: bool = False
-    """Whether the event source is running.
-
-    Controls the main loop and background tasks.
-    """
-
     _stop_event: asyncio.Event = field(default_factory=asyncio.Event)
-    """Set when the event source stops.
+    """Lifecycle signal.
 
-    Lets awaiters wake immediately rather than poll the running flag.
+    Set means "stopped": fresh instances start stopped (the event is
+    forced to the set state in __post_init__) and stay stopped until
+    dial or listen clears it. Awaiters of wait() wake the moment
+    stop() sets it again.
     """
 
     _gossip_handler: GossipHandler = field(init=False)
@@ -258,6 +255,8 @@ class LiveNetworkEventSource:
         self._reqresp_handler = RequestHandler()
         self._reqresp_server = ReqRespServer(handler=self._reqresp_handler)
         self._gossipsub_behavior = GossipsubBehavior(params=GossipsubParameters())
+        # Initial lifecycle: stopped. dial() or listen() clears the event to start.
+        self._stop_event.set()
 
     @classmethod
     async def create(
@@ -377,7 +376,7 @@ class LiveNetworkEventSource:
     async def _forward_gossipsub_events(self) -> None:
         """Forward events from GossipsubBehavior to our event queue."""
         try:
-            while self._running:
+            while not self._stop_event.is_set():
                 event = await self._gossipsub_behavior.get_next_event()
                 if event is None:
                     # Stopped or no event.
@@ -447,7 +446,7 @@ class LiveNetworkEventSource:
         Raises:
             StopAsyncIteration: When no more events will arrive.
         """
-        if not self._running:
+        if self._stop_event.is_set():
             raise StopAsyncIteration
 
         # Race the queue against the stop signal.
@@ -479,10 +478,9 @@ class LiveNetworkEventSource:
         Returns:
             Peer ID on success, None on failure.
         """
-        # Ensure _running is set so background tasks (like _accept_streams)
+        # Clear the stop signal so background tasks (like _accept_streams)
         # can operate. Without this, _accept_streams exits immediately if
         # dial() is called before listen().
-        self._running = True
         self._stop_event.clear()
 
         try:
@@ -565,7 +563,6 @@ class LiveNetworkEventSource:
         Args:
             multiaddr: Address to listen on (e.g., "/ip4/0.0.0.0/udp/9000/quic-v1").
         """
-        self._running = True
         self._stop_event.clear()
 
         if is_quic_multiaddr(multiaddr):
@@ -713,7 +710,6 @@ class LiveNetworkEventSource:
 
     async def stop(self) -> None:
         """Stop the event source and cancel background tasks."""
-        self._running = False
         self._stop_event.set()
 
         # Cancel gossip tasks first (including event forwarding task).
@@ -830,9 +826,9 @@ class LiveNetworkEventSource:
             # Main loop: accept streams until shutdown or disconnection.
             #
             # The loop continues as long as:
-            #   - We haven't been told to stop (_running is True).
+            #   - We haven't been told to stop (stop event is clear).
             #   - The peer is still connected (peer_id in _connections).
-            while self._running and peer_id in self._connections:
+            while not self._stop_event.is_set() and peer_id in self._connections:
                 try:
                     # Accept the next incoming stream.
                     #

--- a/src/lean_spec/subspecs/networking/gossipsub/behavior.py
+++ b/src/lean_spec/subspecs/networking/gossipsub/behavior.py
@@ -223,14 +223,17 @@ class GossipsubBehavior:
     )
     """Queue of events for the application."""
 
-    _running: bool = False
-    """Whether the behavior is running."""
-
     _heartbeat_task: asyncio.Task[None] | None = None
     """Background heartbeat task."""
 
     _stop_event: asyncio.Event = field(default_factory=asyncio.Event)
-    """Event to signal stop to the events generator."""
+    """Lifecycle signal.
+
+    Set means "stopped": fresh instances start stopped (the event is
+    forced to the set state in __post_init__) and stay stopped until
+    start clears it. Awaiters of wait() wake the moment stop sets it
+    again.
+    """
 
     _background_tasks: set[asyncio.Task[None]] = field(default_factory=set)
     """Tracked background tasks for subscribe/unsubscribe broadcasts.
@@ -252,6 +255,8 @@ class GossipsubBehavior:
             mcache_gossip=self.params.mcache_gossip,
         )
         self.seen_cache = SeenCache(ttl_seconds=self.params.seen_ttl_secs)
+        # Initial lifecycle: stopped. start() clears the event to begin running.
+        self._stop_event.set()
 
     def subscribe(self, topic: TopicId) -> None:
         """Subscribe to a topic.
@@ -273,7 +278,7 @@ class GossipsubBehavior:
 
         logger.debug("Subscribed to topic %s", topic)
 
-        if self._running:
+        if not self._stop_event.is_set():
             self._spawn_background_task(self._broadcast_subscription(topic, subscribe=True))
 
     def unsubscribe(self, topic: TopicId) -> None:
@@ -297,24 +302,22 @@ class GossipsubBehavior:
 
         logger.debug("Unsubscribed from topic %s", topic)
 
-        if self._running:
+        if not self._stop_event.is_set():
             self._spawn_background_task(
                 self._broadcast_subscription(topic, subscribe=False, prune_peers=mesh_peers)
             )
 
     async def start(self) -> None:
         """Start the gossipsub behavior (heartbeat loop)."""
-        if self._running:
+        if not self._stop_event.is_set():
             return
 
-        self._running = True
+        self._stop_event.clear()
         self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
         logger.info("[GS %x] GossipsubBehavior started", self._short_id)
 
     async def stop(self) -> None:
         """Stop the gossipsub behavior."""
-        self._running = False
-
         self._stop_event.set()
 
         if self._heartbeat_task:
@@ -512,7 +515,7 @@ class GossipsubBehavior:
 
         Returns None when stopped or no event available.
         """
-        if not self._running:
+        if self._stop_event.is_set():
             return None
 
         # Race the queue against the stop signal.
@@ -754,7 +757,7 @@ class GossipsubBehavior:
         """Background heartbeat for mesh maintenance."""
         interval = self.params.heartbeat_interval_secs
 
-        while self._running:
+        while not self._stop_event.is_set():
             try:
                 await asyncio.sleep(interval)
                 await self._heartbeat()

--- a/src/lean_spec/subspecs/storage/namespaces.py
+++ b/src/lean_spec/subspecs/storage/namespaces.py
@@ -2,155 +2,98 @@
 Database namespace definitions for storage tables.
 
 Defines table names and schema constants for SQLite storage.
-Each namespace represents a logical grouping of related data.
+Each prefix marks a logical grouping of related data.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Final
 
+# Blocks: SSZ root primary key, SSZ-encoded bytes stored directly.
 
-@dataclass(frozen=True, slots=True)
-class BlockNamespace:
-    """
-    Namespace for block storage.
+BLOCKS_TABLE_NAME: Final = "blocks"
+"""Table name for block storage."""
 
-    Blocks are stored by their SSZ root hash.
-    SSZ-encoded bytes are stored directly.
-    """
+BLOCKS_CREATE_TABLE: Final = """
+    CREATE TABLE IF NOT EXISTS blocks (
+        root BLOB PRIMARY KEY,
+        slot INTEGER NOT NULL,
+        data BLOB NOT NULL
+    )
+"""
+"""SQL to create blocks table."""
 
-    TABLE_NAME: str = "blocks"
-    """Table name for block storage."""
+BLOCKS_CREATE_INDEX: Final = """
+    CREATE INDEX IF NOT EXISTS idx_blocks_slot ON blocks(slot)
+"""
+"""SQL to create slot index."""
 
-    CREATE_TABLE: str = """
-        CREATE TABLE IF NOT EXISTS blocks (
-            root BLOB PRIMARY KEY,
-            slot INTEGER NOT NULL,
-            data BLOB NOT NULL
-        )
-    """
-    """SQL to create blocks table."""
+# States: SSZ root primary key, SSZ-encoded bytes stored directly.
 
-    CREATE_INDEX: str = """
-        CREATE INDEX IF NOT EXISTS idx_blocks_slot ON blocks(slot)
-    """
-    """SQL to create slot index."""
+STATES_TABLE_NAME: Final = "states"
+"""Table name for state storage."""
 
+STATES_CREATE_TABLE: Final = """
+    CREATE TABLE IF NOT EXISTS states (
+        root BLOB PRIMARY KEY,
+        slot INTEGER NOT NULL,
+        data BLOB NOT NULL
+    )
+"""
+"""SQL to create states table."""
 
-@dataclass(frozen=True, slots=True)
-class StateNamespace:
-    """
-    Namespace for state storage.
+STATES_CREATE_INDEX: Final = """
+    CREATE INDEX IF NOT EXISTS idx_states_slot ON states(slot)
+"""
+"""SQL to create slot index."""
 
-    States are stored by their SSZ root hash.
-    SSZ-encoded bytes are stored directly.
-    """
+# Checkpoints: key-value table with fixed keys for justified/finalized/head/genesis-time.
 
-    TABLE_NAME: str = "states"
-    """Table name for state storage."""
+CHECKPOINTS_TABLE_NAME: Final = "checkpoints"
+"""Table name for checkpoint storage."""
 
-    CREATE_TABLE: str = """
-        CREATE TABLE IF NOT EXISTS states (
-            root BLOB PRIMARY KEY,
-            slot INTEGER NOT NULL,
-            data BLOB NOT NULL
-        )
-    """
-    """SQL to create states table."""
+CHECKPOINTS_KEY_JUSTIFIED: Final = "justified"
+"""Key for justified checkpoint."""
 
-    CREATE_INDEX: str = """
-        CREATE INDEX IF NOT EXISTS idx_states_slot ON states(slot)
-    """
-    """SQL to create slot index."""
+CHECKPOINTS_KEY_FINALIZED: Final = "finalized"
+"""Key for finalized checkpoint."""
 
+CHECKPOINTS_KEY_HEAD: Final = "head"
+"""Key for head block root."""
 
-@dataclass(frozen=True, slots=True)
-class CheckpointNamespace:
-    """
-    Namespace for checkpoint tracking.
+CHECKPOINTS_KEY_GENESIS_TIME: Final = "genesis_time"
+"""Key for genesis time. Enables self-contained restarts without external config."""
 
-    Stores latest justified and finalized checkpoints.
-    Uses a key-value pattern with fixed keys.
-    """
+CHECKPOINTS_CREATE_TABLE: Final = """
+    CREATE TABLE IF NOT EXISTS checkpoints (
+        key TEXT PRIMARY KEY,
+        data BLOB NOT NULL
+    )
+"""
+"""SQL to create checkpoints table."""
 
-    TABLE_NAME: str = "checkpoints"
-    """Table name for checkpoint storage."""
+# Slot index: slot-to-root mapping for historical queries.
 
-    KEY_JUSTIFIED: str = "justified"
-    """Key for justified checkpoint."""
+SLOT_INDEX_TABLE_NAME: Final = "slot_index"
+"""Table name for slot index."""
 
-    KEY_FINALIZED: str = "finalized"
-    """Key for finalized checkpoint."""
+SLOT_INDEX_CREATE_TABLE: Final = """
+    CREATE TABLE IF NOT EXISTS slot_index (
+        slot INTEGER PRIMARY KEY,
+        root BLOB NOT NULL
+    )
+"""
+"""SQL to create slot index table."""
 
-    KEY_HEAD: str = "head"
-    """Key for head block root."""
+# State root index: state-root-to-block-root mapping for checkpoint sync and API.
 
-    KEY_GENESIS_TIME: str = "genesis_time"
-    """Key for genesis time. Enables self-contained restarts without external config."""
+STATE_ROOT_INDEX_TABLE_NAME: Final = "state_root_index"
+"""Table name for state root index."""
 
-    CREATE_TABLE: str = """
-        CREATE TABLE IF NOT EXISTS checkpoints (
-            key TEXT PRIMARY KEY,
-            data BLOB NOT NULL
-        )
-    """
-    """SQL to create checkpoints table."""
-
-
-@dataclass(frozen=True, slots=True)
-class SlotIndexNamespace:
-    """
-    Namespace for slot-to-root mapping.
-
-    Enables lookup of block by slot number.
-    Used for historical queries.
-    """
-
-    TABLE_NAME: str = "slot_index"
-    """Table name for slot index."""
-
-    CREATE_TABLE: str = """
-        CREATE TABLE IF NOT EXISTS slot_index (
-            slot INTEGER PRIMARY KEY,
-            root BLOB NOT NULL
-        )
-    """
-    """SQL to create slot index table."""
-
-
-@dataclass(frozen=True, slots=True)
-class StateRootIndexNamespace:
-    """
-    Namespace for state root to block root mapping.
-
-    Enables lookup of block root by state root.
-    Needed for checkpoint sync and API queries by state root.
-    """
-
-    TABLE_NAME: str = "state_root_index"
-    """Table name for state root index."""
-
-    CREATE_TABLE: str = """
-        CREATE TABLE IF NOT EXISTS state_root_index (
-            state_root BLOB PRIMARY KEY,
-            block_root BLOB NOT NULL
-        )
-    """
-    """SQL to create state root index table."""
-
-
-BLOCKS: Final = BlockNamespace()
-"""Block storage namespace."""
-
-STATES: Final = StateNamespace()
-"""State storage namespace."""
-
-CHECKPOINTS: Final = CheckpointNamespace()
-"""Checkpoint tracking namespace."""
-
-SLOT_INDEX: Final = SlotIndexNamespace()
-"""Slot-to-root index namespace."""
-
-STATE_ROOT_INDEX: Final = StateRootIndexNamespace()
-"""State root to block root index namespace."""
+STATE_ROOT_INDEX_CREATE_TABLE: Final = """
+    CREATE TABLE IF NOT EXISTS state_root_index (
+        state_root BLOB PRIMARY KEY,
+        block_root BLOB NOT NULL
+    )
+"""
+"""SQL to create state root index table."""

--- a/src/lean_spec/subspecs/storage/sqlite.py
+++ b/src/lean_spec/subspecs/storage/sqlite.py
@@ -31,11 +31,22 @@ from lean_spec.types import Bytes32, Checkpoint, Slot, Uint64
 
 from .exceptions import StorageCorruptionError, StorageReadError, StorageWriteError
 from .namespaces import (
-    BLOCKS,
-    CHECKPOINTS,
-    SLOT_INDEX,
-    STATE_ROOT_INDEX,
-    STATES,
+    BLOCKS_CREATE_INDEX,
+    BLOCKS_CREATE_TABLE,
+    BLOCKS_TABLE_NAME,
+    CHECKPOINTS_CREATE_TABLE,
+    CHECKPOINTS_KEY_FINALIZED,
+    CHECKPOINTS_KEY_GENESIS_TIME,
+    CHECKPOINTS_KEY_HEAD,
+    CHECKPOINTS_KEY_JUSTIFIED,
+    CHECKPOINTS_TABLE_NAME,
+    SLOT_INDEX_CREATE_TABLE,
+    SLOT_INDEX_TABLE_NAME,
+    STATE_ROOT_INDEX_CREATE_TABLE,
+    STATE_ROOT_INDEX_TABLE_NAME,
+    STATES_CREATE_INDEX,
+    STATES_CREATE_TABLE,
+    STATES_TABLE_NAME,
 )
 
 
@@ -97,25 +108,25 @@ class SQLiteDatabase:
         #
         # This matches how consensus clients identify data: by SSZ merkle root.
         # The slot index enables efficient range queries for historical data.
-        cursor.execute(BLOCKS.CREATE_TABLE)
-        cursor.execute(BLOCKS.CREATE_INDEX)
-        cursor.execute(STATES.CREATE_TABLE)
-        cursor.execute(STATES.CREATE_INDEX)
+        cursor.execute(BLOCKS_CREATE_TABLE)
+        cursor.execute(BLOCKS_CREATE_INDEX)
+        cursor.execute(STATES_CREATE_TABLE)
+        cursor.execute(STATES_CREATE_INDEX)
 
         # Checkpoints use a key-value pattern for singleton values.
         #
         # Only one justified and one finalized checkpoint exist at any time.
-        cursor.execute(CHECKPOINTS.CREATE_TABLE)
+        cursor.execute(CHECKPOINTS_CREATE_TABLE)
 
         # Slot index maps slot numbers to block roots.
         #
         # Enables queries like "what block was at slot N?"
-        cursor.execute(SLOT_INDEX.CREATE_TABLE)
+        cursor.execute(SLOT_INDEX_CREATE_TABLE)
 
         # State root index maps state roots to block roots.
         #
         # Needed for checkpoint sync and API endpoints that query by state root.
-        cursor.execute(STATE_ROOT_INDEX.CREATE_TABLE)
+        cursor.execute(STATE_ROOT_INDEX_CREATE_TABLE)
 
         self._conn.commit()
 
@@ -131,7 +142,7 @@ class SQLiteDatabase:
             # The root is the SSZ merkle root of the block.
             # This 32-byte hash uniquely identifies the block content.
             cursor.execute(
-                f"SELECT data FROM {BLOCKS.TABLE_NAME} WHERE root = ?",
+                f"SELECT data FROM {BLOCKS_TABLE_NAME} WHERE root = ?",
                 (bytes(root),),
             )
             row = cursor.fetchone()
@@ -158,7 +169,7 @@ class SQLiteDatabase:
             # The slot column enables efficient historical range queries.
             cursor.execute(
                 f"""
-                INSERT OR REPLACE INTO {BLOCKS.TABLE_NAME} (root, slot, data)
+                INSERT OR REPLACE INTO {BLOCKS_TABLE_NAME} (root, slot, data)
                 VALUES (?, ?, ?)
                 """,
                 (bytes(root), int(block.slot), block.encode_bytes()),
@@ -178,7 +189,7 @@ class SQLiteDatabase:
         try:
             cursor = self._conn.cursor()
             cursor.execute(
-                f"SELECT data FROM {STATES.TABLE_NAME} WHERE root = ?",
+                f"SELECT data FROM {STATES_TABLE_NAME} WHERE root = ?",
                 (bytes(root),),
             )
             row = cursor.fetchone()
@@ -206,7 +217,7 @@ class SQLiteDatabase:
             # storage costs against replay costs for intermediate slots.
             cursor.execute(
                 f"""
-                INSERT OR REPLACE INTO {STATES.TABLE_NAME} (root, slot, data)
+                INSERT OR REPLACE INTO {STATES_TABLE_NAME} (root, slot, data)
                 VALUES (?, ?, ?)
                 """,
                 (bytes(root), int(state.slot), state.encode_bytes()),
@@ -231,8 +242,8 @@ class SQLiteDatabase:
             # This checkpoint may still be reverted if a competing
             # checkpoint gains more support. Not yet final.
             cursor.execute(
-                f"SELECT data FROM {CHECKPOINTS.TABLE_NAME} WHERE key = ?",
-                (CHECKPOINTS.KEY_JUSTIFIED,),
+                f"SELECT data FROM {CHECKPOINTS_TABLE_NAME} WHERE key = ?",
+                (CHECKPOINTS_KEY_JUSTIFIED,),
             )
             row = cursor.fetchone()
         except sqlite3.Error as e:
@@ -252,10 +263,10 @@ class SQLiteDatabase:
             cursor = self._conn.cursor()
             cursor.execute(
                 f"""
-                INSERT OR REPLACE INTO {CHECKPOINTS.TABLE_NAME} (key, data)
+                INSERT OR REPLACE INTO {CHECKPOINTS_TABLE_NAME} (key, data)
                 VALUES (?, ?)
                 """,
-                (CHECKPOINTS.KEY_JUSTIFIED, checkpoint.encode_bytes()),
+                (CHECKPOINTS_KEY_JUSTIFIED, checkpoint.encode_bytes()),
             )
         except sqlite3.Error as e:
             raise StorageWriteError(f"Failed to write justified checkpoint: {e}") from e
@@ -270,8 +281,8 @@ class SQLiteDatabase:
             # Once finalized, all blocks in the checkpoint's chain are permanent.
             # Reorging past finality requires 1/3 validators to be slashed.
             cursor.execute(
-                f"SELECT data FROM {CHECKPOINTS.TABLE_NAME} WHERE key = ?",
-                (CHECKPOINTS.KEY_FINALIZED,),
+                f"SELECT data FROM {CHECKPOINTS_TABLE_NAME} WHERE key = ?",
+                (CHECKPOINTS_KEY_FINALIZED,),
             )
             row = cursor.fetchone()
         except sqlite3.Error as e:
@@ -291,10 +302,10 @@ class SQLiteDatabase:
             cursor = self._conn.cursor()
             cursor.execute(
                 f"""
-                INSERT OR REPLACE INTO {CHECKPOINTS.TABLE_NAME} (key, data)
+                INSERT OR REPLACE INTO {CHECKPOINTS_TABLE_NAME} (key, data)
                 VALUES (?, ?)
                 """,
-                (CHECKPOINTS.KEY_FINALIZED, checkpoint.encode_bytes()),
+                (CHECKPOINTS_KEY_FINALIZED, checkpoint.encode_bytes()),
             )
         except sqlite3.Error as e:
             raise StorageWriteError(f"Failed to write finalized checkpoint: {e}") from e
@@ -315,8 +326,8 @@ class SQLiteDatabase:
             # Fork choice updates this after processing each new block.
             # Stored in the checkpoints table as a special singleton key.
             cursor.execute(
-                f"SELECT data FROM {CHECKPOINTS.TABLE_NAME} WHERE key = ?",
-                (CHECKPOINTS.KEY_HEAD,),
+                f"SELECT data FROM {CHECKPOINTS_TABLE_NAME} WHERE key = ?",
+                (CHECKPOINTS_KEY_HEAD,),
             )
             row = cursor.fetchone()
         except sqlite3.Error as e:
@@ -334,10 +345,10 @@ class SQLiteDatabase:
             cursor = self._conn.cursor()
             cursor.execute(
                 f"""
-                INSERT OR REPLACE INTO {CHECKPOINTS.TABLE_NAME} (key, data)
+                INSERT OR REPLACE INTO {CHECKPOINTS_TABLE_NAME} (key, data)
                 VALUES (?, ?)
                 """,
-                (CHECKPOINTS.KEY_HEAD, bytes(root)),
+                (CHECKPOINTS_KEY_HEAD, bytes(root)),
             )
         except sqlite3.Error as e:
             raise StorageWriteError(f"Failed to write head root: {e}") from e
@@ -359,7 +370,7 @@ class SQLiteDatabase:
             # A slot may have no block (proposer missed their turn).
             # A slot may have had multiple competing blocks (only one is canonical).
             cursor.execute(
-                f"SELECT root FROM {SLOT_INDEX.TABLE_NAME} WHERE slot = ?",
+                f"SELECT root FROM {SLOT_INDEX_TABLE_NAME} WHERE slot = ?",
                 (int(slot),),
             )
             row = cursor.fetchone()
@@ -381,7 +392,7 @@ class SQLiteDatabase:
             # at different times. This always reflects the current canonical chain.
             cursor.execute(
                 f"""
-                INSERT OR REPLACE INTO {SLOT_INDEX.TABLE_NAME} (slot, root)
+                INSERT OR REPLACE INTO {SLOT_INDEX_TABLE_NAME} (slot, root)
                 VALUES (?, ?)
                 """,
                 (int(slot), bytes(root)),
@@ -401,7 +412,7 @@ class SQLiteDatabase:
         try:
             cursor = self._conn.cursor()
             cursor.execute(
-                f"SELECT block_root FROM {STATE_ROOT_INDEX.TABLE_NAME} WHERE state_root = ?",
+                f"SELECT block_root FROM {STATE_ROOT_INDEX_TABLE_NAME} WHERE state_root = ?",
                 (bytes(state_root),),
             )
             row = cursor.fetchone()
@@ -420,7 +431,7 @@ class SQLiteDatabase:
             cursor = self._conn.cursor()
             cursor.execute(
                 f"""
-                INSERT OR REPLACE INTO {STATE_ROOT_INDEX.TABLE_NAME} (state_root, block_root)
+                INSERT OR REPLACE INTO {STATE_ROOT_INDEX_TABLE_NAME} (state_root, block_root)
                 VALUES (?, ?)
                 """,
                 (bytes(state_root), bytes(block_root)),
@@ -441,8 +452,8 @@ class SQLiteDatabase:
         try:
             cursor = self._conn.cursor()
             cursor.execute(
-                f"SELECT data FROM {CHECKPOINTS.TABLE_NAME} WHERE key = ?",
-                (CHECKPOINTS.KEY_GENESIS_TIME,),
+                f"SELECT data FROM {CHECKPOINTS_TABLE_NAME} WHERE key = ?",
+                (CHECKPOINTS_KEY_GENESIS_TIME,),
             )
             row = cursor.fetchone()
         except sqlite3.Error as e:
@@ -460,10 +471,10 @@ class SQLiteDatabase:
             cursor = self._conn.cursor()
             cursor.execute(
                 f"""
-                INSERT OR REPLACE INTO {CHECKPOINTS.TABLE_NAME} (key, data)
+                INSERT OR REPLACE INTO {CHECKPOINTS_TABLE_NAME} (key, data)
                 VALUES (?, ?)
                 """,
-                (CHECKPOINTS.KEY_GENESIS_TIME, int(genesis_time).to_bytes(8, byteorder="little")),
+                (CHECKPOINTS_KEY_GENESIS_TIME, int(genesis_time).to_bytes(8, byteorder="little")),
             )
         except sqlite3.Error as e:
             raise StorageWriteError(f"Failed to write genesis time: {e}") from e
@@ -522,13 +533,13 @@ class SQLiteDatabase:
             # Prune blocks below the threshold, preserving kept roots.
             if keep_bytes:
                 cursor.execute(
-                    f"DELETE FROM {BLOCKS.TABLE_NAME} "
+                    f"DELETE FROM {BLOCKS_TABLE_NAME} "
                     f"WHERE slot < ? AND root NOT IN ({placeholders})",
                     [int(slot), *keep_bytes],
                 )
             else:
                 cursor.execute(
-                    f"DELETE FROM {BLOCKS.TABLE_NAME} WHERE slot < ?",
+                    f"DELETE FROM {BLOCKS_TABLE_NAME} WHERE slot < ?",
                     (int(slot),),
                 )
             total_pruned += cursor.rowcount
@@ -536,20 +547,20 @@ class SQLiteDatabase:
             # Prune states below the threshold, preserving kept roots.
             if keep_bytes:
                 cursor.execute(
-                    f"DELETE FROM {STATES.TABLE_NAME} "
+                    f"DELETE FROM {STATES_TABLE_NAME} "
                     f"WHERE slot < ? AND root NOT IN ({placeholders})",
                     [int(slot), *keep_bytes],
                 )
             else:
                 cursor.execute(
-                    f"DELETE FROM {STATES.TABLE_NAME} WHERE slot < ?",
+                    f"DELETE FROM {STATES_TABLE_NAME} WHERE slot < ?",
                     (int(slot),),
                 )
             total_pruned += cursor.rowcount
 
             # Prune slot index entries below the threshold.
             cursor.execute(
-                f"DELETE FROM {SLOT_INDEX.TABLE_NAME} WHERE slot < ?",
+                f"DELETE FROM {SLOT_INDEX_TABLE_NAME} WHERE slot < ?",
                 (int(slot),),
             )
             total_pruned += cursor.rowcount

--- a/src/lean_spec/subspecs/xmss/constants.py
+++ b/src/lean_spec/subspecs/xmss/constants.py
@@ -20,7 +20,7 @@ from lean_spec.config import LEAN_ENV
 from lean_spec.types import StrictBaseModel, Uint64
 from lean_spec.types.constants import OFFSET_BYTE_LENGTH
 
-from ..koalabear import P_BYTES, Fp, P
+from ..koalabear import P_BYTES, P
 
 
 class XmssConfig(StrictBaseModel):
@@ -158,13 +158,13 @@ TEST_CONFIG: Final = XmssConfig(
 """Lightweight XMSS configuration for fast test execution."""
 
 
-TWEAK_PREFIX_CHAIN: Final = Fp(value=0x00)
+TWEAK_PREFIX_CHAIN: Final[int] = 0x00
 """The unique prefix for tweaks used in Winternitz-style hash chains."""
 
-TWEAK_PREFIX_TREE: Final = Fp(value=0x01)
+TWEAK_PREFIX_TREE: Final[int] = 0x01
 """The unique prefix for tweaks used when hashing Merkle tree nodes."""
 
-TWEAK_PREFIX_MESSAGE: Final = Fp(value=0x02)
+TWEAK_PREFIX_MESSAGE: Final[int] = 0x02
 """The unique prefix for tweaks used in the initial message hashing step."""
 
 PRF_KEY_LENGTH: Final = 32

--- a/src/lean_spec/subspecs/xmss/message_hash.py
+++ b/src/lean_spec/subspecs/xmss/message_hash.py
@@ -80,7 +80,7 @@ class MessageHasher(StrictBaseModel):
         hash input in a structured, domain-separated way.
         """
         # Combine the epoch and the message hash prefix into a single integer.
-        acc = (int(epoch) << 8) | TWEAK_PREFIX_MESSAGE.value
+        acc = (int(epoch) << 8) | TWEAK_PREFIX_MESSAGE
 
         # Decompose the integer into its base-P representation.
         return int_to_base_p(acc, self.config.TWEAK_LEN_FE)

--- a/src/lean_spec/subspecs/xmss/tweak_hash.py
+++ b/src/lean_spec/subspecs/xmss/tweak_hash.py
@@ -24,9 +24,7 @@ unique across the entire scheme, we guarantee that every hash computation is
 **domain-separated**, eliminating the risk of cross-context collisions.
 """
 
-from __future__ import annotations
-
-from pydantic import Field
+from typing import NamedTuple
 
 from lean_spec.types import StrictBaseModel, Uint64
 
@@ -47,7 +45,7 @@ from .types import HashDigestVector, Parameter
 from .utils import int_to_base_p
 
 
-class TreeTweak(StrictBaseModel):
+class TreeTweak(NamedTuple):
     """
     A tweak used for hashing nodes within the Merkle tree.
 
@@ -55,13 +53,14 @@ class TreeTweak(StrictBaseModel):
     Merkle tree has a unique context.
     """
 
-    level: int = Field(
-        ge=0, description="The level (height) in the Merkle tree, where 0 is the leaf level."
-    )
-    index: Uint64 = Field(description="The node's index (from the left) within that level.")
+    level: int
+    """The level (height) in the Merkle tree, where 0 is the leaf level."""
+
+    index: Uint64
+    """The node's index (from the left) within that level."""
 
 
-class ChainTweak(StrictBaseModel):
+class ChainTweak(NamedTuple):
     """
     A tweak used for hashing elements within a WOTS+ hash chain.
 
@@ -69,11 +68,14 @@ class ChainTweak(StrictBaseModel):
     chain is distinct across all epochs.
     """
 
-    epoch: Uint64 = Field(description="The signature epoch.")
-    chain_index: int = Field(
-        ge=0, description="The index of the hash chain (from 0 to DIMENSION-1)."
-    )
-    step: int = Field(ge=0, description="The step number within the chain (from 1 to BASE-1).")
+    epoch: Uint64
+    """The signature epoch."""
+
+    chain_index: int
+    """The index of the hash chain (from 0 to DIMENSION-1)."""
+
+    step: int
+    """The step number within the chain (from 1 to BASE-1)."""
 
 
 class TweakHasher(StrictBaseModel):
@@ -117,15 +119,10 @@ class TweakHasher(StrictBaseModel):
         match tweak:
             case TreeTweak(level=level, index=index):
                 # Packing scheme: (level << 40) | (index << 8) | PREFIX
-                acc = (level << 40) | (int(index) << 8) | TWEAK_PREFIX_TREE.value
+                acc = (level << 40) | (int(index) << 8) | TWEAK_PREFIX_TREE
             case ChainTweak(epoch=epoch, chain_index=chain_index, step=step):
                 # Packing scheme: (epoch << 24) | (chain_index << 16) | (step << 8) | PREFIX
-                acc = (
-                    (int(epoch) << 24)
-                    | (chain_index << 16)
-                    | (step << 8)
-                    | TWEAK_PREFIX_CHAIN.value
-                )
+                acc = (int(epoch) << 24) | (chain_index << 16) | (step << 8) | TWEAK_PREFIX_CHAIN
 
         # Decompose the packed integer `acc` into a list of base-P field elements.
         return int_to_base_p(acc, length)

--- a/tests/interop/helpers/node_runner.py
+++ b/tests/interop/helpers/node_runner.py
@@ -125,7 +125,7 @@ class TestNode:
         """Stop the node gracefully."""
         # Signal the node and event source to stop.
         self.node.stop()
-        self.event_source._running = False
+        self.event_source._stop_event.set()
 
         # Set the stop event on gossipsub to release waiting tasks.
         self.event_source._gossipsub_behavior._stop_event.set()
@@ -341,10 +341,10 @@ class NodeCluster:
 
         # Start listener in background (listen() calls serve_forever() which blocks).
         #
-        # Set _running BEFORE starting the listener to avoid race conditions.
-        # The network service checks _running when iterating over events.
-        # If _running is False, the iteration stops immediately.
-        event_source._running = True
+        # Clear the stop event BEFORE starting the listener to avoid race conditions.
+        # The network service checks the stop event when iterating over events.
+        # If the stop event is set, iteration stops immediately.
+        event_source._stop_event.clear()
 
         listener_task = asyncio.create_task(
             event_source.listen(listen_addr),

--- a/tests/lean_spec/subspecs/networking/client/test_event_source.py
+++ b/tests/lean_spec/subspecs/networking/client/test_event_source.py
@@ -513,18 +513,18 @@ class TestLiveNetworkEventSourceStop:
     """
 
     async def test_stop_sets_running_false(self) -> None:
-        """Stopping clears the running flag."""
+        """Stopping flips the stop event back to set."""
         es = _make_event_source()
-        es._running = True
+        es._stop_event.clear()
 
         await es.stop()
 
-        assert es._running is False
+        assert es._stop_event.is_set()
 
     async def test_stop_cancels_gossip_tasks(self) -> None:
         """Stopping cancels all tracked background tasks."""
         es = _make_event_source()
-        es._running = True
+        es._stop_event.clear()
 
         task = asyncio.create_task(asyncio.sleep(100))
         es._gossip_tasks.add(task)
@@ -536,7 +536,7 @@ class TestLiveNetworkEventSourceStop:
     async def test_stop_clears_task_set(self) -> None:
         """The gossip task set is empty after stopping."""
         es = _make_event_source()
-        es._running = True
+        es._stop_event.clear()
 
         task = asyncio.create_task(asyncio.sleep(100))
         es._gossip_tasks.add(task)
@@ -614,7 +614,7 @@ class TestLiveNetworkEventSourceInit:
     def test_not_running_initially(self) -> None:
         """Event source starts in stopped state."""
         es = _make_event_source()
-        assert es._running is False
+        assert es._stop_event.is_set()
 
     def test_no_connections_initially(self) -> None:
         """No peer connections on construction."""

--- a/tests/lean_spec/subspecs/networking/gossipsub/test_publish.py
+++ b/tests/lean_spec/subspecs/networking/gossipsub/test_publish.py
@@ -108,7 +108,7 @@ class TestBroadcastSubscription:
     async def test_subscribe_sends_subscription_to_all_peers(self) -> None:
         """Subscribing broadcasts a subscription RPC to all peers."""
         behavior, capture = make_behavior(d=2, d_low=1, d_high=4)
-        behavior._running = True
+        behavior._stop_event.clear()
 
         p1 = add_peer(behavior, "peerA", set())
         p2 = add_peer(behavior, "peerB", set())
@@ -126,7 +126,7 @@ class TestBroadcastSubscription:
     async def test_subscribe_grafts_eligible_peers(self) -> None:
         """Subscribing GRAFTs eligible peers into the mesh."""
         behavior, capture = make_behavior(d=2, d_low=1, d_high=4)
-        behavior._running = True
+        behavior._stop_event.clear()
 
         topic = TopicId("graftTopic")
         # These peers are already subscribed to the topic.
@@ -148,7 +148,7 @@ class TestBroadcastSubscription:
     async def test_subscribe_respects_fanout_promotion(self) -> None:
         """When subscribing, fanout peers are promoted and GRAFT fills to D."""
         behavior, capture = make_behavior(d=3, d_low=2, d_high=6)
-        behavior._running = True
+        behavior._stop_event.clear()
 
         topic = TopicId("promoteTopic")
         p1 = add_peer(behavior, "peerA", {topic})
@@ -176,7 +176,7 @@ class TestBroadcastSubscription:
     async def test_unsubscribe_prunes_mesh_peers(self) -> None:
         """Unsubscribing sends PRUNE to former mesh peers."""
         behavior, capture = make_behavior()
-        behavior._running = True
+        behavior._stop_event.clear()
 
         topic = TopicId("pruneTopic")
         behavior.subscribe(topic)

--- a/tests/lean_spec/subspecs/xmss/test_message_hash.py
+++ b/tests/lean_spec/subspecs/xmss/test_message_hash.py
@@ -44,7 +44,7 @@ def test_encode_epoch() -> None:
     # Test specific values from the Rust reference tests.
     test_epochs = [0, 42, 2**32 - 1]
     for epoch in test_epochs:
-        acc = (epoch << 8) | TWEAK_PREFIX_MESSAGE.value
+        acc = (epoch << 8) | TWEAK_PREFIX_MESSAGE
         expected = int_to_base_p(acc, config.TWEAK_LEN_FE)
         assert hasher.encode_epoch(Uint64(epoch)) == expected
 


### PR DESCRIPTION
## Summary

Five modernization items from the audit, bundled. Net **+193 / −239** across 13 files.

| Module | Change |
|---|---|
| `subspecs/koalabear/field.py` | `@override` added to `is_fixed_size`, `get_byte_length`, `serialize`, `deserialize` so the `SSZType` contract is visible at the method site. |
| `subspecs/networking/client/event_source/live.py` + `subspecs/networking/gossipsub/behavior.py` | After PR #743 both files carried `_running` (bool) *and* `_stop_event` (`asyncio.Event`). The event already exposes `is_set`/`wait`/`set`/`clear`, which covers every read and write the bool was doing. Dropped the bool; `not self._stop_event.is_set()` is the "running" predicate. The default factory stays a vanilla `asyncio.Event`; each file's `__post_init__` forces it to set (= stopped) so fresh instances start stopped until `dial`/`listen`/`start` clears it. Updated `__main__.py`, `node_runner.py`, and 6 affected unit tests. |
| `subspecs/storage/namespaces.py` + `sqlite.py` | Five `@dataclass(frozen=True, slots=True)` namespace classes whose only contents were string defaults collapsed to plain `Final[str]` module constants (`BLOCKS_TABLE_NAME`, `BLOCKS_CREATE_TABLE`, `BLOCKS_CREATE_INDEX`, ...). 30+ attribute accesses in `sqlite.py` and its import block rewritten. |
| `subspecs/xmss/tweak_hash.py` | `TreeTweak` and `ChainTweak` were Pydantic `StrictBaseModel` instances used only as packing structs feeding the `match tweak` block. Converted both to `typing.NamedTuple` — the match patterns keep working since `NamedTuple` auto-populates `__match_args__`. The `from __future__ import annotations` line that the audit flagged as R1 (banned in Pydantic-defining files) goes away with the conversion; `TweakHasher` itself stays a `StrictBaseModel`. |
| `subspecs/xmss/constants.py` | `TWEAK_PREFIX_CHAIN`/`TREE`/`MESSAGE` were `Fp(value=0x00..0x02)` wrappers whose every consumer immediately did `.value`. Inlined as plain `Final[int]`; dropped the unused `Fp` import and rewrote three call sites plus one test. |

## Test plan

- [x] `ruff check` — clean.
- [x] `ruff format --check` — clean.
- [x] `ty check` — clean (it caught 12 stale `_running` references in `__main__.py` and tests during iteration; all migrated).
- [x] `pytest` over koalabear, event_source, gossipsub publish, storage, xmss — **205 tests pass**.
- [x] `fill tests/consensus/lstar/fc/test_tick_system.py::test_tick_interval_progression_through_full_slot` — 1 passed in 9.16s (consensus fixture pipeline still threads through after the lifecycle signal change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)