### PR TITLE
refactor: drop from __future__ import annotations in Pydantic-defining files

### DIFF
--- a/src/lean_spec/forks/lstar/containers/attestation/attestation.py
+++ b/src/lean_spec/forks/lstar/containers/attestation/attestation.py
@@ -11,8 +11,6 @@ Each attestation specifies:
 Attestations can be aggregated by common data to save space and bandwidth.
 """
 
-from __future__ import annotations
-
 from lean_spec.subspecs.xmss.aggregation import TypeOneMultiSignature
 from lean_spec.subspecs.xmss.containers import Signature
 from lean_spec.types import AggregationBits, Checkpoint, Container, Slot, ValidatorIndex

--- a/src/lean_spec/forks/lstar/containers/block/types.py
+++ b/src/lean_spec/forks/lstar/containers/block/types.py
@@ -1,7 +1,5 @@
 """Block-specific SSZ types for the Lean Ethereum consensus specification."""
 
-from __future__ import annotations
-
 from lean_spec.subspecs.chain.config import VALIDATOR_REGISTRY_LIMIT
 from lean_spec.types import SSZList
 

--- a/src/lean_spec/forks/lstar/containers/state/state.py
+++ b/src/lean_spec/forks/lstar/containers/state/state.py
@@ -1,7 +1,5 @@
 """State Container for the Lean Ethereum consensus specification."""
 
-from __future__ import annotations
-
 from lean_spec.forks.lstar.containers.block import BlockHeader
 from lean_spec.forks.lstar.containers.config import Config
 from lean_spec.forks.lstar.containers.state.types import (

--- a/src/lean_spec/forks/lstar/containers/state/types.py
+++ b/src/lean_spec/forks/lstar/containers/state/types.py
@@ -1,6 +1,6 @@
 """State-specific SSZ types for the Lean Ethereum consensus specification."""
 
-from __future__ import annotations
+from typing import Self
 
 from lean_spec.subspecs.chain.config import HISTORICAL_ROOTS_LIMIT, VALIDATOR_REGISTRY_LIMIT
 from lean_spec.types import Boolean, Bytes32, Slot, SSZList
@@ -67,7 +67,7 @@ class JustifiedSlots(BaseBitlist):
         finalized_slot: Slot,
         target_slot: Slot,
         value: Boolean,
-    ) -> JustifiedSlots:
+    ) -> Self:
         """
         Return a new bitfield with the justification status updated.
 
@@ -112,7 +112,7 @@ class JustifiedSlots(BaseBitlist):
 
         return self.model_copy(update={"data": new_data})
 
-    def extend_to_slot(self, finalized_slot: Slot, target_slot: Slot) -> JustifiedSlots:
+    def extend_to_slot(self, finalized_slot: Slot, target_slot: Slot) -> Self:
         """
         Extend the tracking capacity to cover a new target slot.
 
@@ -147,7 +147,7 @@ class JustifiedSlots(BaseBitlist):
         # We extend the existing data with False values to bridge the gap.
         return self.model_copy(update={"data": list(self.data) + [Boolean(False)] * gap_size})
 
-    def shift_window(self, delta: int) -> JustifiedSlots:
+    def shift_window(self, delta: int) -> Self:
         """
         Advance the tracking window by dropping slots that became finalized.
 

--- a/src/lean_spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/forks/lstar/containers/validator.py
@@ -1,7 +1,5 @@
 """Validator container for the Lean Ethereum consensus specification."""
 
-from __future__ import annotations
-
 from lean_spec.subspecs.chain.config import VALIDATOR_REGISTRY_LIMIT
 from lean_spec.subspecs.xmss.containers import PublicKey
 from lean_spec.types import Bytes52, Container, SSZList, ValidatorIndex

--- a/src/lean_spec/subspecs/xmss/rand.py
+++ b/src/lean_spec/subspecs/xmss/rand.py
@@ -1,7 +1,5 @@
 """Random data generator for the XMSS signature scheme."""
 
-from __future__ import annotations
-
 import secrets
 
 from lean_spec.types import StrictBaseModel


### PR DESCRIPTION
## Summary

CLAUDE.md rule R1 bans `from __future__ import annotations` in files that define Pydantic Container or SSZModel classes, because lazy-string annotations break Pydantic's forward-reference resolution. Six audit-flagged files still carried it.

- `forks/lstar/containers/validator.py`
- `forks/lstar/containers/state/types.py` — small adjustment alongside the drop: three classmethod-like helpers on `JustifiedSlots` returned the class by name (`-> JustifiedSlots`). Without future annotations the bare name is undefined at signature evaluation, so they switch to `typing.Self`, which reads cleaner anyway for self-referential factories.
- `forks/lstar/containers/state/state.py`
- `forks/lstar/containers/attestation/attestation.py`
- `forks/lstar/containers/block/types.py`
- `subspecs/xmss/rand.py`

## Items deliberately skipped

- **R2** (`Store = LstarStore` alias in `forks/__init__.py`) — the audit framed it as a backwards-compat shim, but per leanEthereum/leanSpec#686 the alias is the **public generic name** that lets subspecs (`sync/`, `api/`, `node/`, ...) reference "the current fork's Store" without importing `forks.lstar.*`. Dropping it would couple subspecs to the concrete fork and defeat the multi-fork architecture.
- **R3** (QUIC random peer-id anti-pattern in `transport/quic/connection.py`) — needs real libp2p TLS extension parsing (X.509 extension OID `1.3.6.1.4.1.53594.1.1`, signature verification over the TLS public key, PeerId derivation). Affects both client and server paths and belongs in its own focused PR.

## Test plan

- [x] `ruff check`, `ruff format --check`, `ty check` — all clean.
- [x] `uv run pytest tests/lean_spec/forks/ tests/lean_spec/subspecs/sync/ tests/lean_spec/subspecs/api/ tests/lean_spec/subspecs/node/ tests/lean_spec/subspecs/xmss/` — 455 tests pass.
- [x] `uv run fill tests/consensus/lstar/fc/test_tick_system.py::test_tick_interval_progression_through_full_slot --fork=Lstar` — 1 passed in 9.25s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)