### PR TITLE
refactor(quic/tls): drop KEY_TYPE_SECP256K1 duplicate, use KeyType.SECP256K1

### DIFF
--- a/src/lean_spec/subspecs/networking/transport/quic/tls.py
+++ b/src/lean_spec/subspecs/networking/transport/quic/tls.py
@@ -31,6 +31,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from ..identity import IdentityKeypair
+from ..peer_id import KeyType
 
 LIBP2P_EXTENSION_OID: Final = x509.ObjectIdentifier("1.3.6.1.4.1.53594.1.1")
 """libp2p TLS extension OID (Protocol Labs assigned)."""
@@ -42,10 +43,6 @@ Prefix for the signed payload.
 The signature proves ownership of the identity key over this specific TLS key.
 Without a prefix, the signature could potentially be replayed in other contexts.
 """
-
-# Key type identifiers matching libp2p protobuf definitions
-KEY_TYPE_SECP256K1: Final = 2
-"""secp256k1 key type in libp2p protobuf."""
 
 
 def generate_libp2p_certificate(
@@ -174,7 +171,7 @@ def _create_extension_payload(
     #   Field 1 (Type): tag=0x08, value=2 (secp256k1)
     #   Field 2 (Data): tag=0x12, length, bytes
     public_key_proto = (
-        bytes([0x08, KEY_TYPE_SECP256K1, 0x12, len(public_key_compressed)]) + public_key_compressed
+        bytes([0x08, KeyType.SECP256K1, 0x12, len(public_key_compressed)]) + public_key_compressed
     )
 
     # Encode as ASN.1 DER SEQUENCE.

--- a/tests/lean_spec/subspecs/networking/transport/quic/test_tls.py
+++ b/tests/lean_spec/subspecs/networking/transport/quic/test_tls.py
@@ -18,8 +18,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from lean_spec.subspecs.networking.transport.identity.keypair import IdentityKeypair
+from lean_spec.subspecs.networking.transport.peer_id import KeyType
 from lean_spec.subspecs.networking.transport.quic.tls import (
-    KEY_TYPE_SECP256K1,
     LIBP2P_EXTENSION_OID,
     SIGNATURE_PREFIX,
     _create_extension_payload,
@@ -59,7 +59,7 @@ class TestConstants:
 
     def test_key_type_secp256k1(self) -> None:
         """Key type 2 matches the libp2p protobuf KeyType enum for secp256k1."""
-        assert KEY_TYPE_SECP256K1 == 2
+        assert KeyType.SECP256K1 == 2
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +229,7 @@ class TestCreateExtensionPayload:
 
         # Protobuf field 1 (Type): varint tag=0x08, value=2 (secp256k1)
         assert public_key_proto[0] == 0x08
-        assert public_key_proto[1] == KEY_TYPE_SECP256K1
+        assert public_key_proto[1] == KeyType.SECP256K1
         # Protobuf field 2 (Data): length-delimited tag=0x12
         assert public_key_proto[2] == 0x12
         key_len = public_key_proto[3]


### PR DESCRIPTION
## Summary

\`KEY_TYPE_SECP256K1: Final = 2\` in \`subspecs/networking/transport/quic/tls.py\` duplicated \`KeyType.SECP256K1\` from \`subspecs/networking/transport/peer_id.py\` (the libp2p crypto.proto KeyType enum). Both encode the same libp2p protobuf key-type code; carrying two names for the same value risks drift if the enum gains entries.

Drops the constant and switches the single production caller (in \`_encode_asn1_signed_key\`) and three test sites to use \`KeyType.SECP256K1\` directly.

## Test plan

- [x] \`uv run --group lint ruff check\` on changed files — clean
- [x] \`uv run --group lint ruff format --check\` — clean
- [x] \`uv run --group lint ty check\` on changed files — clean
- [x] \`uv run pytest tests/lean_spec/subspecs/networking/transport/quic/test_tls.py\` — 32 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)