### PR TITLE
fix(networking): explicit sync for gossipsub outbound stream setup

### DIFF
--- a/src/lean_spec/subspecs/networking/client/event_source/live.py
+++ b/src/lean_spec/subspecs/networking/client/event_source/live.py
@@ -249,6 +249,15 @@ class LiveNetworkEventSource:
     _gossipsub_event_task: asyncio.Task | None = None
     """Background task forwarding gossipsub events to our event queue."""
 
+    _outbound_setup_locks: dict[PeerId, asyncio.Lock] = field(default_factory=dict)
+    """Per-peer lock serialising outbound gossipsub stream setup.
+
+    Two code paths can race to open the outbound stream for the same peer:
+    the dialing path opens it directly after status exchange,
+    and the inbound-stream handler opens it once the peer's reciprocal stream arrives.
+    Without a lock, both paths can pass the has-outbound-stream check before either
+    registers, leaving an orphaned QUIC stream behind."""
+
     def __post_init__(self) -> None:
         """Wire up internal handlers from configuration."""
         self._gossip_handler = GossipHandler(network_name=self._network_name)
@@ -666,33 +675,48 @@ class LiveNetworkEventSource:
         Opens a persistent stream for gossipsub protocol and registers
         the peer with the GossipsubBehavior.
 
+        Idempotent: if an outbound stream is already registered for the peer,
+        returns without opening a new one.
+
         Args:
             peer_id: Peer identifier.
             conn: QuicConnection to use.
         """
-        try:
-            # Open the gossipsub stream.
-            stream = await conn.open_stream(GOSSIPSUB_DEFAULT_PROTOCOL_ID)
-            logger.info(
-                "Opened outbound gossipsub stream_id=%d to %s (expect odd=server-initiated)",
-                stream.stream_id,
-                peer_id,
-            )
+        # Why:
+        # The dialing path and the inbound-stream handler can both reach this
+        # method concurrently for the same peer.
+        # The lock serialises the check-and-open so only one stream is opened.
+        lock = self._outbound_setup_locks.setdefault(peer_id, asyncio.Lock())
+        async with lock:
+            if self._gossipsub_behavior.has_outbound_stream(peer_id):
+                logger.debug(
+                    "Peer %s already has outbound gossipsub stream, skipping setup",
+                    peer_id,
+                )
+                return
+            try:
+                # Open the gossipsub stream.
+                stream = await conn.open_stream(GOSSIPSUB_DEFAULT_PROTOCOL_ID)
+                logger.info(
+                    "Opened outbound gossipsub stream_id=%d to %s (expect odd=server-initiated)",
+                    stream.stream_id,
+                    peer_id,
+                )
 
-            # Wrap in reader/writer for buffered I/O.
-            wrapped_stream = QuicStreamAdapter(stream)
+                # Wrap in reader/writer for buffered I/O.
+                wrapped_stream = QuicStreamAdapter(stream)
 
-            # Add peer to the gossipsub behavior (outbound stream).
-            await self._gossipsub_behavior.add_peer(peer_id, wrapped_stream, inbound=False)
+                # Add peer to the gossipsub behavior (outbound stream).
+                await self._gossipsub_behavior.add_peer(peer_id, wrapped_stream, inbound=False)
 
-            logger.info(
-                "GossipSub outbound stream established with %s (stream_id=%d)",
-                peer_id,
-                stream.stream_id,
-            )
+                logger.info(
+                    "GossipSub outbound stream established with %s (stream_id=%d)",
+                    peer_id,
+                    stream.stream_id,
+                )
 
-        except Exception as e:
-            logger.warning("Failed to setup gossipsub stream with %s: %s", peer_id, e)
+            except Exception as e:
+                logger.warning("Failed to setup gossipsub stream with %s: %s", peer_id, e)
 
     async def disconnect(self, peer_id: PeerId) -> None:
         """
@@ -702,6 +726,7 @@ class LiveNetworkEventSource:
             peer_id: Peer to disconnect.
         """
         conn = self._connections.pop(peer_id, None)
+        self._outbound_setup_locks.pop(peer_id, None)
         if conn is not None:
             self.reqresp_client.unregister_connection(peer_id)
             await conn.close()
@@ -1005,63 +1030,13 @@ class LiveNetworkEventSource:
         # Await directly to ensure peer is registered before setting up outbound.
         await self._gossipsub_behavior.add_peer(peer_id, wrapper, inbound=True)
 
-        # Now that we've received the peer's inbound stream, set up our
-        # outbound stream if we don't have one yet.
+        # Open our reciprocal outbound stream as a background task.
         #
-        # For dialers: The outbound stream was already set up during
-        # the dialing path, so this check prevents a duplicate.
-        #
-        # For listeners: The outbound stream is NOT set up immediately
-        # (to avoid interfering with the dialer's status exchange).
-        # This is where the listener's outbound stream gets created.
-        #
-        # IMPORTANT: We add a small delay before setting up the outbound
-        # stream to allow the dialer to complete their operations first.
-        # This prevents deadlock while still ensuring the outbound stream
-        # is set up quickly enough for mesh formation.
-        if self._gossipsub_behavior.has_outbound_stream(peer_id):
-            logger.info(
-                "Peer %s already has outbound gossipsub stream, skipping setup",
-                peer_id,
-            )
-            return
-
-        gossip_task = asyncio.create_task(self._setup_outbound_gossipsub_after_delay(peer_id, conn))
+        # Idempotent and serialised internally: a concurrent dialing-path
+        # setup for the same peer will not race with this one.
+        gossip_task = asyncio.create_task(self._setup_gossipsub_stream(peer_id, conn))
         self._gossip_tasks.add(gossip_task)
         gossip_task.add_done_callback(self._gossip_tasks.discard)
-
-    async def _setup_outbound_gossipsub_after_delay(
-        self,
-        peer_id: PeerId,
-        conn: QuicConnection,
-    ) -> None:
-        """
-        Open our outbound gossipsub stream after a small delay.
-
-        The delay lets the dialer complete its status exchange first.
-        Re-checks the outbound-stream flag right before opening: the
-        dialer path may have set up the stream while we were sleeping.
-
-        Args:
-            peer_id: Peer to open the outbound stream to.
-            conn: Connection to use.
-        """
-        try:
-            await asyncio.sleep(0.1)  # Small delay to avoid contention
-            # Re-check BEFORE opening a stream. The dialing path
-            # may have set up the outbound stream while we were
-            # sleeping. Opening a duplicate gossipsub stream would
-            # cause the handler to replace its reader with an orphan.
-            if self._gossipsub_behavior.has_outbound_stream(peer_id):
-                logger.info(
-                    "Peer %s already has outbound stream (set by dialer), skipping duplicate setup",
-                    peer_id,
-                )
-                return
-            logger.info("Setting up outbound gossipsub stream for %s", peer_id)
-            await self._setup_gossipsub_stream(peer_id, conn)
-        except Exception as e:
-            logger.warning("setup_outbound_with_delay failed for %s: %s", peer_id, e)
 
     def _handle_reqresp_inbound_stream(
         self,


### PR DESCRIPTION
## Summary

- Two code paths on the dialer side could race to open an outbound gossipsub stream for the same peer: the direct call after status exchange, and the inbound-stream handler after the peer's reciprocal stream arrived. Both could pass the has-outbound-stream check before either registered, leaving an orphaned QUIC stream behind.
- The previous fix was an `await asyncio.sleep(0.1)` in the deferred-setup helper — timing-dependent papering over a TOCTOU race.
- Replaces the sleep with a per-peer `asyncio.Lock` that makes check-and-open atomic. The deferred-setup helper is deleted; the inbound handler now calls the idempotent setup directly. Lock entries are cleared on disconnect to bound memory.

## Why the delay was unnecessary

The two comments around the removed delay claimed it "lets the dialer complete its status exchange first" and "prevents deadlock". Neither is true:

- The dialer opens its outbound gossipsub stream *after* status exchange completes, so when a listener receives an inbound gossipsub stream, the dialer's status is already done.
- Gossipsub mesh formation is heartbeat-driven (1s tick). Opening the reciprocal stream earlier strictly enlarges the GRAFT-eligible set at the next heartbeat, so faster open helps mesh convergence rather than hurts.
- Subscription RPCs sent on first outbound open are idempotent (set add/discard), so concurrent reciprocal subscribes converge to identical state regardless of arrival order.

The delay was, in practice, only serialising against the local TOCTOU race on the dialer side — which the lock now handles deterministically.

## Test plan

- [x] `uv run pytest tests/lean_spec/subspecs/networking/` — 804 passed
- [x] `just check` — ruff check, ruff format, ty check, codespell, mdformat all pass
- [ ] Verify two-node connect on a local devnet still completes mesh handshake without orphaned streams in the QUIC log

🤖 Generated with [Claude Code](https://claude.com/claude-code)