### PR TITLE
docs(slot): trim module header to a single descriptive line

### DIFF
--- a/src/lean_spec/types/slot.py
+++ b/src/lean_spec/types/slot.py
@@ -1,10 +1,4 @@
-"""Slot type — fork-stable consensus-time index.
-
-A slot is the smallest unit of consensus time. The numeric type and the
-justifiability rule are stable across the leanSpec fork chain; later forks
-that change the rule should override the relevant fork-class methods rather
-than fork the type itself.
-"""
+"""Slot type: the smallest unit of consensus time."""
 
 import math
 from typing import Final


### PR DESCRIPTION
## Summary

- Drop the fork-stability paragraph from the module header — that intent belongs to design notes, not the file's opening docstring.
- Keep a single-line description that matches the bar set for other types of similar scope.

## Test plan

- [x] `just check` — ruff, format, ty, codespell, mdformat all pass