### PR TITLE
refactor(types/uint): polish base uint type

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
@@ -13,7 +13,7 @@ from lean_spec.subspecs.chain.config import (
     MILLISECONDS_PER_INTERVAL,
     SECONDS_PER_SLOT,
 )
-from lean_spec.types import Uint64
+from lean_spec.types import Slot, Uint64
 
 from .base import BaseConsensusFixture
 
@@ -72,7 +72,7 @@ class SlotClockTest(BaseConsensusFixture):
 
     def _make_from_slot(self) -> dict[str, Any]:
         """Convert slot number to interval at that slot's start."""
-        slot = Uint64(self.input["slot"])
+        slot = Slot(self.input["slot"])
         interval = Interval.from_slot(slot)
         return {"interval": int(interval)}
 

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -6,8 +6,9 @@ from lean_spec.forks.lstar.containers import AttestationData
 from lean_spec.forks.lstar.containers.block.block import Block
 from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.forks.lstar.store import Store
+from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.ssz import hash_tree_root
-from lean_spec.types import ZERO_HASH, Bytes32, CamelModel, Slot, Uint64, ValidatorIndex
+from lean_spec.types import ZERO_HASH, Bytes32, CamelModel, Slot, ValidatorIndex
 
 from .utils import resolve_block_root
 
@@ -123,7 +124,7 @@ class StoreChecks(CamelModel):
     This allows tests to focus on the properties they care about.
     """
 
-    time: Uint64 | None = None
+    time: Interval | None = None
     """Expected store time (in intervals since genesis)."""
 
     head_slot: Slot | None = None

--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -1092,7 +1092,8 @@ class LstarSpec(ForkProtocol):
         # let an adversary pre-publish next-slot aggregates ahead of any
         # honest validator.
         attestation_start_interval = Interval.from_slot(data.slot)
-        assert attestation_start_interval <= store.time + GOSSIP_DISPARITY_INTERVALS, (
+        gossip_disparity = Interval(int(GOSSIP_DISPARITY_INTERVALS))
+        assert attestation_start_interval <= store.time + gossip_disparity, (
             "Attestation too far in future"
         )
 
@@ -1761,7 +1762,7 @@ class LstarSpec(ForkProtocol):
         """
         # Advance time by one interval
         store = store.model_copy(update={"time": store.time + Interval(1)})
-        current_interval = store.time % INTERVALS_PER_SLOT
+        current_interval = Interval(int(store.time) % int(INTERVALS_PER_SLOT))
         new_aggregates: list[SignedAggregatedAttestation] = []
 
         if current_interval == Interval(0) and has_proposal:

--- a/src/lean_spec/subspecs/chain/clock.py
+++ b/src/lean_spec/subspecs/chain/clock.py
@@ -53,7 +53,7 @@ class Interval(Uint64):
         return cls(delta_ms // MILLISECONDS_PER_INTERVAL)
 
     @classmethod
-    def from_slot(cls, slot: Uint64) -> Interval:
+    def from_slot(cls, slot: Slot) -> Interval:
         """
         Convert a slot number to the interval at that slot's start.
 
@@ -67,7 +67,10 @@ class Interval(Uint64):
             Interval count at the start of the given slot.
         """
         # Slot boundaries fall on exact multiples of the interval count.
-        return cls(slot * INTERVALS_PER_SLOT)
+        # The newtype and the constant are distinct types under the strict rule.
+        # The math runs on plain ints.
+        # The result is wrapped explicitly before returning.
+        return cls(int(slot) * int(INTERVALS_PER_SLOT))
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/lean_spec/subspecs/chain/clock.py
+++ b/src/lean_spec/subspecs/chain/clock.py
@@ -67,9 +67,6 @@ class Interval(Uint64):
             Interval count at the start of the given slot.
         """
         # Slot boundaries fall on exact multiples of the interval count.
-        # The newtype and the constant are distinct types under the strict rule.
-        # The math runs on plain ints.
-        # The result is wrapped explicitly before returning.
         return cls(int(slot) * int(INTERVALS_PER_SLOT))
 
 

--- a/src/lean_spec/subspecs/chain/service.py
+++ b/src/lean_spec/subspecs/chain/service.py
@@ -29,7 +29,6 @@ from dataclasses import dataclass, field
 from lean_spec.forks import LstarSpec, SignedAggregatedAttestation
 from lean_spec.subspecs.chain.config import INTERVALS_PER_SLOT
 from lean_spec.subspecs.sync import SyncService
-from lean_spec.types import Uint64
 
 from .clock import Interval, SlotClock
 
@@ -167,9 +166,10 @@ class ChainService:
         # Jump to the last full slot boundary before the target.
         # The final slot's worth of intervals still runs normally so that
         # aggregation, safe target, and attestation acceptance happen.
+        intervals_per_slot = Interval(int(INTERVALS_PER_SLOT))
         gap = target_interval - store.time
-        if gap > INTERVALS_PER_SLOT:
-            skip_to = Uint64(target_interval - INTERVALS_PER_SLOT)
+        if gap > intervals_per_slot:
+            skip_to = target_interval - intervals_per_slot
             store = store.model_copy(update={"time": skip_to})
             self.sync_service.store = store
 

--- a/src/lean_spec/subspecs/validator/service.py
+++ b/src/lean_spec/subspecs/validator/service.py
@@ -165,7 +165,7 @@ class ValidatorService:
                 my_indices,
             )
 
-            if interval == Uint64(0):
+            if interval == Interval(0):
                 # Block production interval.
                 #
                 # Check if any of our validators is the proposer.
@@ -204,7 +204,7 @@ class ValidatorService:
             # Why split eligibility from the sync gate: the skip counter
             # must only tick on real misses, never on wrong-interval
             # iterations.
-            needs_attestation = interval >= Uint64(1) and slot not in self._attested_slots
+            needs_attestation = interval >= Interval(1) and slot not in self._attested_slots
             if needs_attestation:
                 logger.debug(
                     "ValidatorService: producing attestations for slot %d (interval %d)",

--- a/src/lean_spec/subspecs/xmss/interface.py
+++ b/src/lean_spec/subspecs/xmss/interface.py
@@ -117,7 +117,7 @@ class GeneralizedXmssScheme(StrictBaseModel):
         config = self.config
 
         # Ensure the requested activation range is within the scheme's total supported lifetime.
-        if activation_slot + num_active_slots > config.LIFETIME:
+        if int(activation_slot) + int(num_active_slots) > int(config.LIFETIME):
             raise ValueError("Activation range exceeds the key's lifetime.")
 
         # Generate the random public parameter `P` and the master PRF key.
@@ -330,7 +330,7 @@ class GeneralizedXmssScheme(StrictBaseModel):
         bottom_tree = sk.left_bottom_tree if slot_int < boundary else sk.right_bottom_tree
 
         # Generate the combined authentication path
-        path = combined_path(sk.top_tree, bottom_tree, slot)
+        path = combined_path(sk.top_tree, bottom_tree, Uint64(int(slot)))
 
         # Assemble and return the final signature, which contains:
         # - The OTS,
@@ -385,7 +385,7 @@ class GeneralizedXmssScheme(StrictBaseModel):
         #
         # Return False instead of raising to avoid panic on invalid signatures.
         # The slot is attacker-controlled input.
-        if slot >= self.config.LIFETIME:
+        if int(slot) >= int(self.config.LIFETIME):
             return False
 
         # Re-encode the message using the randomness `rho` from the signature.

--- a/src/lean_spec/types/uint.py
+++ b/src/lean_spec/types/uint.py
@@ -337,13 +337,15 @@ class BaseUint(int, SSZType):
 
     def __eq__(self, other: object) -> bool:
         """Handle the equality operator (`==`)."""
-        if not isinstance(other, BaseUint):
+        # Two values of different widths must not compare equal.
+        if type(other) is not type(self):
             self._raise_type_error(other, "==")
         return super().__eq__(other)
 
     def __ne__(self, other: object) -> bool:
         """Handle the inequality operator (`!=`)."""
-        if not isinstance(other, BaseUint):
+        # Two values of different widths must not compare equal.
+        if type(other) is not type(self):
             self._raise_type_error(other, "!=")
         return super().__ne__(other)
 

--- a/src/lean_spec/types/uint.py
+++ b/src/lean_spec/types/uint.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import IO, Any, ClassVar, NoReturn, Self, SupportsInt, override
+from typing import IO, Any, ClassVar, NoReturn, Self, SupportsInt, overload, override
 
 from pydantic.annotated_handlers import GetCoreSchemaHandler
 from pydantic_core import core_schema
@@ -12,7 +12,7 @@ from .ssz_base import SSZType
 
 
 class BaseUint(int, SSZType):
-    """A base class for custom unsigned integer types that inherits from `int`."""
+    """Base class for fixed-width unsigned integer types."""
 
     __slots__ = ()
 
@@ -188,106 +188,109 @@ class BaseUint(int, SSZType):
             f"'{type(self).__name__}' and '{type(other).__name__}'"
         )
 
-    def _validate_int_operand(self, other: Any, op_symbol: str) -> None:
-        """Helper to ensure an operand is a true integer, not a bool."""
-        if not isinstance(other, int) or isinstance(other, bool):
-            raise TypeError(
-                f"Unsupported operand type for {op_symbol}: "
-                f"expected 'int' but got '{type(other).__name__}'"
-            )
-
     def __add__(self, other: Any) -> Self:
         """Handle the addition operator (`+`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "+")
         return type(self)(super().__add__(other))
 
     def __radd__(self, other: Any) -> Self:
         """Handle the reverse addition operator (`+`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "+")
         return type(self)(int(other) + int(self))
 
     def __sub__(self, other: Any) -> Self:
         """Handle the subtraction operator (`-`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "-")
         return type(self)(super().__sub__(other))
 
     def __rsub__(self, other: Any) -> Self:
         """Handle the reverse subtraction operator (`-`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "-")
         return type(self)(int(other) - int(self))
 
     def __mul__(self, other: Any) -> Self:
         """Handle the multiplication operator (`*`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "*")
         return type(self)(super().__mul__(other))
 
     def __rmul__(self, other: Any) -> Self:
         """Handle the reverse multiplication operator (`*`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "*")
         return type(self)(int(other) * int(self))
 
     def __floordiv__(self, other: Any) -> Self:
         """Handle the floor division operator (`//`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "//")
         return type(self)(super().__floordiv__(other))
 
     def __rfloordiv__(self, other: Any) -> Self:
         """Handle the reverse floor division operator (`//`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "//")
         return type(self)(int(other) // int(self))
 
     def __mod__(self, other: Any) -> Self:
         """Handle the modulo operator (`%`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "%")
         return type(self)(super().__mod__(other))
 
     def __rmod__(self, other: Any) -> Self:
         """Handle the reverse modulo operator (`%`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "%")
         return type(self)(int(other) % int(self))
 
-    def __pow__(self, exponent: Any, modulo: Any | None = None) -> Any:  # type: ignore[override]
+    @overload
+    def __pow__(self, value: int, mod: None = None, /) -> Self: ...
+    @overload
+    def __pow__(self, value: int, mod: int, /) -> Self: ...
+    # The parent declaration uses two stub overloads with different return types.
+    #
+    # Narrowing both to a single subtype is safe by Liskov substitution.
+    # The strict overload-match check rejects it regardless.
+    def __pow__(self, value: int, mod: int | None = None, /) -> Self:  # ty: ignore[invalid-method-override]
         """Handle the exponentiation operator (`**`) and `pow(self, exp, mod)`."""
-        self._validate_int_operand(exponent, "** or pow()")
-        if modulo is not None:
-            self._validate_int_operand(modulo, "** or pow()")
-
-        result = pow(int(self), int(exponent), int(modulo) if modulo is not None else None)
+        if type(value) is not type(self):
+            self._raise_type_error(value, "**")
+        if mod is not None and type(mod) is not type(self):
+            self._raise_type_error(mod, "**")
+        result = pow(int(self), int(value), int(mod) if mod is not None else None)
         return type(self)(result)
 
-    def __rpow__(self, base: Any) -> Any:  # type: ignore[override]
-        """Handle the reverse exponentiation operator (`**`)."""
-        self._validate_int_operand(base, "**")
-        result = pow(int(base), int(self))
+    def __rpow__(self, base: int, modulo: int | None = None, /) -> Self:
+        """Handle the reverse exponentiation operator and three-argument pow."""
+        if type(base) is not type(self):
+            self._raise_type_error(base, "**")
+        if modulo is not None and type(modulo) is not type(self):
+            self._raise_type_error(modulo, "**")
+        result = pow(int(base), int(self), int(modulo) if modulo is not None else None)
         return type(self)(result)
 
     def __divmod__(self, other: Any) -> tuple[Self, Self]:
         """Handle `divmod(self, other)`."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "divmod")
         q, r = super().__divmod__(other)
         return type(self)(q), type(self)(r)
 
     def __rdivmod__(self, other: Any) -> tuple[Self, Self]:
         """Handle `divmod(other, self)`."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "divmod")
         q, r = super().__rdivmod__(other)
         return type(self)(q), type(self)(r)
 
     def __and__(self, other: Any) -> Self:
         """Handle the bitwise AND operator (`&`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "&")
         return type(self)(super().__and__(other))
 
@@ -297,7 +300,7 @@ class BaseUint(int, SSZType):
 
     def __or__(self, other: Any) -> Self:
         """Handle the bitwise OR operator (`|`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "|")
         return type(self)(super().__or__(other))
 
@@ -307,7 +310,7 @@ class BaseUint(int, SSZType):
 
     def __xor__(self, other: Any) -> Self:
         """Handle the bitwise XOR operator (`^`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "^")
         return type(self)(super().__xor__(other))
 
@@ -317,59 +320,61 @@ class BaseUint(int, SSZType):
 
     def __lshift__(self, other: Any) -> Self:
         """Handle the left bit-shift operator (`<<`)."""
-        self._validate_int_operand(other, "<<")
+        if type(other) is not type(self):
+            self._raise_type_error(other, "<<")
         return type(self)(super().__lshift__(other))
 
     def __rlshift__(self, other: Any) -> Self:
         """Handle the reverse left bit-shift operator (`<<`)."""
-        self._validate_int_operand(other, "<<")
+        if type(other) is not type(self):
+            self._raise_type_error(other, "<<")
         return type(self)(int(other) << int(self))
 
     def __rshift__(self, other: Any) -> Self:
         """Handle the right bit-shift operator (`>>`)."""
-        self._validate_int_operand(other, ">>")
+        if type(other) is not type(self):
+            self._raise_type_error(other, ">>")
         return type(self)(super().__rshift__(other))
 
     def __rrshift__(self, other: Any) -> Self:
         """Handle the reverse right bit-shift operator (`>>`)."""
-        self._validate_int_operand(other, ">>")
+        if type(other) is not type(self):
+            self._raise_type_error(other, ">>")
         return type(self)(int(other) >> int(self))
 
     def __eq__(self, other: object) -> bool:
         """Handle the equality operator (`==`)."""
-        # Two values of different widths must not compare equal.
         if type(other) is not type(self):
             self._raise_type_error(other, "==")
         return super().__eq__(other)
 
     def __ne__(self, other: object) -> bool:
         """Handle the inequality operator (`!=`)."""
-        # Two values of different widths must not compare equal.
         if type(other) is not type(self):
             self._raise_type_error(other, "!=")
         return super().__ne__(other)
 
     def __lt__(self, other: Any) -> bool:
         """Handle the less-than operator (`<`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "<")
         return super().__lt__(other)
 
     def __le__(self, other: Any) -> bool:
         """Handle the less-than-or-equal-to operator (`<=`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, "<=")
         return super().__le__(other)
 
     def __gt__(self, other: Any) -> bool:
         """Handle the greater-than operator (`>`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, ">")
         return super().__gt__(other)
 
     def __ge__(self, other: Any) -> bool:
         """Handle the greater-than-or-equal-to operator (`>=`)."""
-        if not isinstance(other, BaseUint):
+        if type(other) is not type(self):
             self._raise_type_error(other, ">=")
         return super().__ge__(other)
 

--- a/src/lean_spec/types/uint.py
+++ b/src/lean_spec/types/uint.py
@@ -20,14 +20,13 @@ class BaseUint(int, SSZType):
     """The number of bits in the integer (overridden by subclasses)."""
 
     def __new__(cls, value: SupportsInt) -> Self:
-        """
-        Create and validate a new Uint instance.
+        """Create and range-check a new instance.
 
         Raises:
-            SSZTypeError: If `value` is not an int (rejects bool, string, float).
-            SSZValueError: If `value` is outside the allowed range [0, 2**BITS - 1].
+            SSZTypeError: If value is not an int. Bool, string, and float are rejected.
+            SSZValueError: If value is outside [0, 2**BITS - 1].
         """
-        # We should accept only ints.
+        # Bool subclasses int, so reject it explicitly before the value check.
         if not isinstance(value, int) or isinstance(value, bool):
             raise SSZTypeError(f"Expected int, got {type(value).__name__}")
 
@@ -41,23 +40,18 @@ class BaseUint(int, SSZType):
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
-        """
-        Hook into Pydantic's validation system.
-
-        This schema defines how to handle the custom Uint type:
-        1. If the input is already an instance of the class, accept it.
-        2. Otherwise, validate the input as an integer within the defined bit range
-            and then instantiate the class.
-        3. For serialization (e.g., to JSON), convert the instance to a plain int.
-        """
-        # Validator that takes an integer and returns an instance of the class.
+        """Hook into Pydantic's validation system."""
+        # A plain validator wraps a pre-validated int into a typed instance.
         from_int_validator = core_schema.no_info_plain_validator_function(cls)
-
-        # Schema that first validates the input as an int, then calls our validator.
+        # Strict int validation enforces the unsigned range before construction.
+        #
+        # The lt bound is exclusive, so a value equal to 2**BITS is rejected.
         python_schema = core_schema.chain_schema(
             [core_schema.int_schema(ge=0, lt=2**cls.BITS, strict=True), from_int_validator]
         )
-
+        # Existing instances bypass validation.
+        #
+        # Raw values flow through the strict chain instead.
         return core_schema.union_schema(
             [
                 # Case 1: The value is already the correct type.
@@ -65,56 +59,34 @@ class BaseUint(int, SSZType):
                 # Case 2: The value needs to be parsed and validated.
                 python_schema,
             ],
+            # Round-trip to JSON drops the subtype back to a plain int.
             serialization=core_schema.plain_serializer_function_ser_schema(int),
         )
 
     @classmethod
     @override
     def is_fixed_size(cls) -> bool:
-        """
-        Determine if this is a fixed-size type.
-
-        Returns:
-            bool: True, as all Uint types are fixed-size.
-        """
+        """All unsigned integer types are fixed-size."""
         return True
 
     @classmethod
     @override
     def get_byte_length(cls) -> int:
-        """
-        Get the number of bytes for this Uint type.
-
-        Returns:
-            int: The byte length of the integer.
-        """
+        """Byte length derived from the bit width."""
         return cls.BITS // 8
 
     @override
     def encode_bytes(self) -> bytes:
-        """
-        Serializes the Uint to its little-endian byte representation.
-
-        Returns:
-            bytes: The SSZ serialized bytes.
-        """
-        # The `to_bytes` method from `int` is used directly.
+        """Serialize to little-endian bytes."""
         return self.to_bytes(length=self.get_byte_length(), byteorder="little")
 
     @classmethod
     @override
     def decode_bytes(cls, data: bytes) -> Self:
-        """
-        Deserializes a byte string into a Uint instance.
-
-        Args:
-            data (bytes): The SSZ byte string to deserialize.
+        """Deserialize from little-endian bytes.
 
         Raises:
-            SSZDecodeError: If the byte string has an incorrect length.
-
-        Returns:
-            Self: A new instance of the Uint class.
+            SSZSerializationError: If the byte string has the wrong length.
         """
         # Ensure the input data has the correct number of bytes.
         expected_length = cls.get_byte_length()
@@ -122,21 +94,11 @@ class BaseUint(int, SSZType):
             raise SSZSerializationError(
                 f"{cls.__name__}: expected {expected_length} bytes, got {len(data)}"
             )
-        # The `from_bytes` class method from `int` is used to convert the data.
         return cls(int.from_bytes(data, "little"))
 
     @override
     def serialize(self, stream: IO[bytes]) -> int:
-        """
-        Serializes the Uint and writes it to a binary stream.
-
-        Args:
-            stream (IO[bytes]): The stream to write the serialized data to.
-
-        Returns:
-            int: The number of bytes written.
-        """
-        # Get the serialized bytes.
+        """Write little-endian bytes to a stream and return the count written."""
         encoded_data = self.encode_bytes()
         # Write the data to the stream.
         stream.write(encoded_data)
@@ -146,21 +108,11 @@ class BaseUint(int, SSZType):
     @classmethod
     @override
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
-        """
-        Deserializes a Uint from a binary stream within a given scope.
-
-        Args:
-            stream (IO[bytes]): The stream to read from.
-            scope (int): The number of bytes available to read for this object.
+        """Read little-endian bytes from a stream within a fixed scope.
 
         Raises:
-            SSZDecodeError: If the scope does not match the type's byte length.
-            SSZStreamError: If the stream ends prematurely.
-
-        Returns:
-            Self: A new instance of the Uint class.
+            SSZSerializationError: If the scope mismatches, or the stream ends early.
         """
-        # For a fixed-size type, the scope must exactly match the byte length.
         byte_length = cls.get_byte_length()
         if scope != byte_length:
             raise SSZSerializationError(
@@ -189,61 +141,61 @@ class BaseUint(int, SSZType):
         )
 
     def __add__(self, other: Any) -> Self:
-        """Handle the addition operator (`+`)."""
+        """Forward addition."""
         if type(other) is not type(self):
             self._raise_type_error(other, "+")
         return type(self)(super().__add__(other))
 
     def __radd__(self, other: Any) -> Self:
-        """Handle the reverse addition operator (`+`)."""
+        """Reverse addition."""
         if type(other) is not type(self):
             self._raise_type_error(other, "+")
         return type(self)(int(other) + int(self))
 
     def __sub__(self, other: Any) -> Self:
-        """Handle the subtraction operator (`-`)."""
+        """Forward subtraction."""
         if type(other) is not type(self):
             self._raise_type_error(other, "-")
         return type(self)(super().__sub__(other))
 
     def __rsub__(self, other: Any) -> Self:
-        """Handle the reverse subtraction operator (`-`)."""
+        """Reverse subtraction."""
         if type(other) is not type(self):
             self._raise_type_error(other, "-")
         return type(self)(int(other) - int(self))
 
     def __mul__(self, other: Any) -> Self:
-        """Handle the multiplication operator (`*`)."""
+        """Forward multiplication."""
         if type(other) is not type(self):
             self._raise_type_error(other, "*")
         return type(self)(super().__mul__(other))
 
     def __rmul__(self, other: Any) -> Self:
-        """Handle the reverse multiplication operator (`*`)."""
+        """Reverse multiplication."""
         if type(other) is not type(self):
             self._raise_type_error(other, "*")
         return type(self)(int(other) * int(self))
 
     def __floordiv__(self, other: Any) -> Self:
-        """Handle the floor division operator (`//`)."""
+        """Forward floor division."""
         if type(other) is not type(self):
             self._raise_type_error(other, "//")
         return type(self)(super().__floordiv__(other))
 
     def __rfloordiv__(self, other: Any) -> Self:
-        """Handle the reverse floor division operator (`//`)."""
+        """Reverse floor division."""
         if type(other) is not type(self):
             self._raise_type_error(other, "//")
         return type(self)(int(other) // int(self))
 
     def __mod__(self, other: Any) -> Self:
-        """Handle the modulo operator (`%`)."""
+        """Forward modulo."""
         if type(other) is not type(self):
             self._raise_type_error(other, "%")
         return type(self)(super().__mod__(other))
 
     def __rmod__(self, other: Any) -> Self:
-        """Handle the reverse modulo operator (`%`)."""
+        """Reverse modulo."""
         if type(other) is not type(self):
             self._raise_type_error(other, "%")
         return type(self)(int(other) % int(self))
@@ -257,7 +209,7 @@ class BaseUint(int, SSZType):
     # Narrowing both to a single subtype is safe by Liskov substitution.
     # The strict overload-match check rejects it regardless.
     def __pow__(self, value: int, mod: int | None = None, /) -> Self:  # ty: ignore[invalid-method-override]
-        """Handle the exponentiation operator (`**`) and `pow(self, exp, mod)`."""
+        """Forward exponentiation and three-argument pow."""
         if type(value) is not type(self):
             self._raise_type_error(value, "**")
         if mod is not None and type(mod) is not type(self):
@@ -266,7 +218,7 @@ class BaseUint(int, SSZType):
         return type(self)(result)
 
     def __rpow__(self, base: int, modulo: int | None = None, /) -> Self:
-        """Handle the reverse exponentiation operator and three-argument pow."""
+        """Reverse exponentiation and three-argument pow."""
         if type(base) is not type(self):
             self._raise_type_error(base, "**")
         if modulo is not None and type(modulo) is not type(self):
@@ -275,123 +227,123 @@ class BaseUint(int, SSZType):
         return type(self)(result)
 
     def __divmod__(self, other: Any) -> tuple[Self, Self]:
-        """Handle `divmod(self, other)`."""
+        """Forward divmod."""
         if type(other) is not type(self):
             self._raise_type_error(other, "divmod")
         q, r = super().__divmod__(other)
         return type(self)(q), type(self)(r)
 
     def __rdivmod__(self, other: Any) -> tuple[Self, Self]:
-        """Handle `divmod(other, self)`."""
+        """Reverse divmod."""
         if type(other) is not type(self):
             self._raise_type_error(other, "divmod")
         q, r = super().__rdivmod__(other)
         return type(self)(q), type(self)(r)
 
     def __and__(self, other: Any) -> Self:
-        """Handle the bitwise AND operator (`&`)."""
+        """Forward bitwise AND."""
         if type(other) is not type(self):
             self._raise_type_error(other, "&")
         return type(self)(super().__and__(other))
 
     def __rand__(self, other: Any) -> Self:
-        """Handle the reverse bitwise AND operator (`&`)."""
+        """Reverse bitwise AND."""
         return self.__and__(other)
 
     def __or__(self, other: Any) -> Self:
-        """Handle the bitwise OR operator (`|`)."""
+        """Forward bitwise OR."""
         if type(other) is not type(self):
             self._raise_type_error(other, "|")
         return type(self)(super().__or__(other))
 
     def __ror__(self, other: Any) -> Self:
-        """Handle the reverse bitwise OR operator (`|`)."""
+        """Reverse bitwise OR."""
         return self.__or__(other)
 
     def __xor__(self, other: Any) -> Self:
-        """Handle the bitwise XOR operator (`^`)."""
+        """Forward bitwise XOR."""
         if type(other) is not type(self):
             self._raise_type_error(other, "^")
         return type(self)(super().__xor__(other))
 
     def __rxor__(self, other: Any) -> Self:
-        """Handle the reverse bitwise XOR operator (`^`)."""
+        """Reverse bitwise XOR."""
         return self.__xor__(other)
 
     def __lshift__(self, other: Any) -> Self:
-        """Handle the left bit-shift operator (`<<`)."""
+        """Forward left bit-shift."""
         if type(other) is not type(self):
             self._raise_type_error(other, "<<")
         return type(self)(super().__lshift__(other))
 
     def __rlshift__(self, other: Any) -> Self:
-        """Handle the reverse left bit-shift operator (`<<`)."""
+        """Reverse left bit-shift."""
         if type(other) is not type(self):
             self._raise_type_error(other, "<<")
         return type(self)(int(other) << int(self))
 
     def __rshift__(self, other: Any) -> Self:
-        """Handle the right bit-shift operator (`>>`)."""
+        """Forward right bit-shift."""
         if type(other) is not type(self):
             self._raise_type_error(other, ">>")
         return type(self)(super().__rshift__(other))
 
     def __rrshift__(self, other: Any) -> Self:
-        """Handle the reverse right bit-shift operator (`>>`)."""
+        """Reverse right bit-shift."""
         if type(other) is not type(self):
             self._raise_type_error(other, ">>")
         return type(self)(int(other) >> int(self))
 
     def __eq__(self, other: object) -> bool:
-        """Handle the equality operator (`==`)."""
+        """Equality."""
         if type(other) is not type(self):
             self._raise_type_error(other, "==")
         return super().__eq__(other)
 
     def __ne__(self, other: object) -> bool:
-        """Handle the inequality operator (`!=`)."""
+        """Inequality."""
         if type(other) is not type(self):
             self._raise_type_error(other, "!=")
         return super().__ne__(other)
 
     def __lt__(self, other: Any) -> bool:
-        """Handle the less-than operator (`<`)."""
+        """Less-than."""
         if type(other) is not type(self):
             self._raise_type_error(other, "<")
         return super().__lt__(other)
 
     def __le__(self, other: Any) -> bool:
-        """Handle the less-than-or-equal-to operator (`<=`)."""
+        """Less-than-or-equal."""
         if type(other) is not type(self):
             self._raise_type_error(other, "<=")
         return super().__le__(other)
 
     def __gt__(self, other: Any) -> bool:
-        """Handle the greater-than operator (`>`)."""
+        """Greater-than."""
         if type(other) is not type(self):
             self._raise_type_error(other, ">")
         return super().__gt__(other)
 
     def __ge__(self, other: Any) -> bool:
-        """Handle the greater-than-or-equal-to operator (`>=`)."""
+        """Greater-than-or-equal."""
         if type(other) is not type(self):
             self._raise_type_error(other, ">=")
         return super().__ge__(other)
 
     def __repr__(self) -> str:
-        """Return the official string representation of the object."""
+        """Official representation includes the subtype name."""
         return f"{type(self).__name__}({int(self)})"
 
     def __str__(self) -> str:
-        """Return the informal, user-friendly string representation."""
+        """Informal representation matches the underlying value."""
         return str(int(self))
 
     def __hash__(self) -> int:
-        """Return a hash distinct from raw int."""
+        """Hash mixes in the concrete subtype so distinct widths never collide."""
         return hash((type(self), int(self)))
 
     def __index__(self) -> int:
-        """Return self as an integer for use in slicing and indexing."""
+        """Return a plain integer for slicing and indexing."""
         return int(self)
 
 

--- a/tests/consensus/lstar/fc/test_checkpoint_sync.py
+++ b/tests/consensus/lstar/fc/test_checkpoint_sync.py
@@ -11,9 +11,10 @@ from consensus_testing import (
     build_anchor,
 )
 
+from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import INTERVALS_PER_SLOT, SECONDS_PER_SLOT
 from lean_spec.subspecs.ssz.hash import hash_tree_root
-from lean_spec.types import Bytes32, Slot, Uint64, ValidatorIndex
+from lean_spec.types import Bytes32, Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 
@@ -63,7 +64,7 @@ def test_store_init_from_non_genesis_anchor(
 
     # Derive the expected store.time from the anchor slot.
     # The store clock is in intervals since genesis, not seconds.
-    anchor_time_intervals = Uint64(int(ANCHOR_SLOT) * int(INTERVALS_PER_SLOT))
+    anchor_time_intervals = Interval(int(ANCHOR_SLOT) * int(INTERVALS_PER_SLOT))
 
     fork_choice_test(
         anchor_state=anchor_state,

--- a/tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py
@@ -18,7 +18,7 @@ from lean_spec.types import Bytes32, Slot, ValidatorIndex
 pytestmark = pytest.mark.valid_until("Lstar")
 
 
-SLOT_3_BOUNDARY_INTERVAL = int(Interval.from_slot(Slot(3)) - GOSSIP_DISPARITY_INTERVALS)
+SLOT_3_BOUNDARY_INTERVAL = int(Interval.from_slot(Slot(3))) - int(GOSSIP_DISPARITY_INTERVALS)
 """Latest local interval that still admits a slot-3 aggregate."""
 
 SLOT_3_JUST_BEYOND_BOUNDARY_INTERVAL = SLOT_3_BOUNDARY_INTERVAL - 1

--- a/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
@@ -18,7 +18,7 @@ from lean_spec.types import Bytes32, Slot, ValidatorIndex
 pytestmark = pytest.mark.valid_until("Lstar")
 
 
-SLOT_3_BOUNDARY_INTERVAL = int(Interval.from_slot(Slot(3)) - GOSSIP_DISPARITY_INTERVALS)
+SLOT_3_BOUNDARY_INTERVAL = int(Interval.from_slot(Slot(3))) - int(GOSSIP_DISPARITY_INTERVALS)
 """Latest local interval that still admits a slot-3 vote."""
 
 SLOT_3_JUST_BEYOND_BOUNDARY_INTERVAL = SLOT_3_BOUNDARY_INTERVAL - 1

--- a/tests/consensus/lstar/fc/test_tick_system.py
+++ b/tests/consensus/lstar/fc/test_tick_system.py
@@ -12,7 +12,8 @@ from consensus_testing import (
     TickStep,
 )
 
-from lean_spec.types import Slot, Uint64, ValidatorIndex
+from lean_spec.subspecs.chain.clock import Interval
+from lean_spec.types import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 
@@ -59,7 +60,7 @@ def test_tick_interval_progression_through_full_slot(
             TickStep(
                 time=12,
                 checks=StoreChecks(
-                    time=Uint64(15),
+                    time=Interval(15),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                 ),
@@ -69,7 +70,7 @@ def test_tick_interval_progression_through_full_slot(
             TickStep(
                 time=13,
                 checks=StoreChecks(
-                    time=Uint64(16),
+                    time=Interval(16),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                 ),
@@ -80,7 +81,7 @@ def test_tick_interval_progression_through_full_slot(
             TickStep(
                 time=14,
                 checks=StoreChecks(
-                    time=Uint64(17),
+                    time=Interval(17),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                 ),
@@ -125,7 +126,7 @@ def test_tick_interval_progression_through_full_slot(
             TickStep(
                 time=15,
                 checks=StoreChecks(
-                    time=Uint64(18),
+                    time=Interval(18),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                     safe_target_slot=Slot(2),
@@ -145,7 +146,7 @@ def test_tick_interval_progression_through_full_slot(
             TickStep(
                 time=16,
                 checks=StoreChecks(
-                    time=Uint64(20),
+                    time=Interval(20),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                     safe_target_slot=Slot(2),
@@ -178,7 +179,7 @@ def test_on_tick_advances_across_multiple_empty_slots(
             TickStep(
                 time=8,
                 checks=StoreChecks(
-                    time=Uint64(10),
+                    time=Interval(10),
                     head_slot=Slot(1),
                     head_root_label="block_1",
                 ),
@@ -187,7 +188,7 @@ def test_on_tick_advances_across_multiple_empty_slots(
             TickStep(
                 time=12,
                 checks=StoreChecks(
-                    time=Uint64(15),
+                    time=Interval(15),
                     head_slot=Slot(1),
                     head_root_label="block_1",
                 ),
@@ -196,7 +197,7 @@ def test_on_tick_advances_across_multiple_empty_slots(
             TickStep(
                 time=16,
                 checks=StoreChecks(
-                    time=Uint64(20),
+                    time=Interval(20),
                     head_slot=Slot(1),
                     head_root_label="block_1",
                 ),
@@ -240,7 +241,7 @@ def test_tick_interval_0_skips_acceptance_when_not_proposer(
             TickStep(
                 interval=14,
                 checks=StoreChecks(
-                    time=Uint64(14),
+                    time=Interval(14),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                 ),
@@ -274,7 +275,7 @@ def test_tick_interval_0_skips_acceptance_when_not_proposer(
             TickStep(
                 interval=15,
                 checks=StoreChecks(
-                    time=Uint64(15),
+                    time=Interval(15),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                     attestation_checks=[
@@ -293,7 +294,7 @@ def test_tick_interval_0_skips_acceptance_when_not_proposer(
             TickStep(
                 interval=19,
                 checks=StoreChecks(
-                    time=Uint64(19),
+                    time=Interval(19),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                 ),
@@ -330,7 +331,7 @@ def test_tick_interval_0_skips_acceptance_when_not_proposer(
                 interval=20,
                 has_proposal=True,
                 checks=StoreChecks(
-                    time=Uint64(20),
+                    time=Interval(20),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                     attestation_checks=[
@@ -349,7 +350,7 @@ def test_tick_interval_0_skips_acceptance_when_not_proposer(
             TickStep(
                 interval=28,
                 checks=StoreChecks(
-                    time=Uint64(28),
+                    time=Interval(28),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                 ),
@@ -379,7 +380,7 @@ def test_tick_interval_0_skips_acceptance_when_not_proposer(
             TickStep(
                 interval=29,
                 checks=StoreChecks(
-                    time=Uint64(29),
+                    time=Interval(29),
                     head_slot=Slot(2),
                     head_root_label="block_2",
                     attestation_checks=[

--- a/tests/lean_spec/forks/lstar/forkchoice/conftest.py
+++ b/tests/lean_spec/forks/lstar/forkchoice/conftest.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import pytest
 
 from lean_spec.forks.lstar import Store
-from lean_spec.types import Uint64
+from lean_spec.subspecs.chain.clock import Interval
 from tests.lean_spec.helpers import TEST_VALIDATOR_ID, make_store
 
 
@@ -23,4 +23,4 @@ def pruning_store() -> Store:
 def sample_store(store_factory):
     """Store with 8 validators, genesis_time=1000, time=100."""
     store = store_factory(num_validators=8, genesis_time=1000)
-    return store.model_copy(update={"time": Uint64(100)})
+    return store.model_copy(update={"time": Interval(100)})

--- a/tests/lean_spec/forks/lstar/forkchoice/test_attestation_target.py
+++ b/tests/lean_spec/forks/lstar/forkchoice/test_attestation_target.py
@@ -82,7 +82,7 @@ class TestGetAttestationTarget:
         target_slot = target.slot
 
         # The target should be at most JUSTIFICATION_LOOKBACK_SLOTS behind head
-        assert target_slot >= head_slot - JUSTIFICATION_LOOKBACK_SLOTS
+        assert int(target_slot) >= int(head_slot) - int(JUSTIFICATION_LOOKBACK_SLOTS)
 
     def test_attestation_target_respects_justifiable_slots(
         self,
@@ -505,7 +505,7 @@ class TestAttestationTargetEdgeCases:
         head_slot = store.blocks[store.head].slot
 
         # Target should not be more than JUSTIFICATION_LOOKBACK_SLOTS behind head
-        assert target.slot >= head_slot - JUSTIFICATION_LOOKBACK_SLOTS
+        assert int(target.slot) >= int(head_slot) - int(JUSTIFICATION_LOOKBACK_SLOTS)
 
 
 class TestIntegrationScenarios:

--- a/tests/lean_spec/forks/lstar/forkchoice/test_store_attestations.py
+++ b/tests/lean_spec/forks/lstar/forkchoice/test_store_attestations.py
@@ -21,7 +21,6 @@ from lean_spec.types import (
     Bytes32,
     Checkpoint,
     Slot,
-    Uint64,
     ValidatorIndex,
     ValidatorIndices,
 )
@@ -643,7 +642,7 @@ class TestTickIntervalAggregation:
         # Set time to interval 1 (so next tick goes to interval 2)
         # time % INTERVALS_PER_SLOT determines current interval
         # We want to end up at interval 2 after tick
-        store = store.model_copy(update={"time": Uint64(1)})
+        store = store.model_copy(update={"time": Interval(1)})
 
         # Tick to interval 2 as aggregator
         updated_store, _ = spec.tick_interval(store, has_proposal=False, is_aggregator=True)
@@ -671,7 +670,7 @@ class TestTickIntervalAggregation:
         )
 
         # Set time to interval 1
-        store = store.model_copy(update={"time": Uint64(1)})
+        store = store.model_copy(update={"time": Interval(1)})
 
         # Tick to interval 2 as NON-aggregator
         updated_store, _ = spec.tick_interval(store, has_proposal=False, is_aggregator=False)
@@ -707,7 +706,7 @@ class TestTickIntervalAggregation:
             # So we need time+1 % 5 == target_interval
             # Therefore time = target_interval - 1 (mod 5)
             pre_tick_time = (target_interval - 1) % int(INTERVALS_PER_SLOT)
-            test_store = store.model_copy(update={"time": Uint64(pre_tick_time)})
+            test_store = store.model_copy(update={"time": Interval(pre_tick_time)})
 
             updated_store, _ = spec.tick_interval(
                 test_store, has_proposal=False, is_aggregator=True
@@ -731,15 +730,15 @@ class TestTickIntervalAggregation:
         )
 
         # Set time to interval 4 (so next tick wraps to interval 0)
-        store = store.model_copy(update={"time": Uint64(4)})
+        store = store.model_copy(update={"time": Interval(4)})
 
         # Tick to interval 0 with proposal
         updated_store, _ = spec.tick_interval(store, has_proposal=True, is_aggregator=True)
 
         # Verify time advanced
-        assert updated_store.time == Uint64(5)
+        assert updated_store.time == Interval(5)
         # Interval should now be 0
-        assert updated_store.time % INTERVALS_PER_SLOT == Uint64(0)
+        assert Interval(int(updated_store.time) % int(INTERVALS_PER_SLOT)) == Interval(0)
 
 
 class TestEndToEndAggregationFlow:
@@ -796,7 +795,7 @@ class TestEndToEndAggregationFlow:
             assert vid in stored_validators, f"Signature for {vid} should be stored"
 
         # Step 2: Advance to interval 2 (aggregation interval)
-        store = store.model_copy(update={"time": Uint64(1)})
+        store = store.model_copy(update={"time": Interval(1)})
         store, _ = spec.tick_interval(store, has_proposal=False, is_aggregator=True)
 
         # Step 3: Verify aggregated proofs were created

--- a/tests/lean_spec/forks/lstar/forkchoice/test_time_management.py
+++ b/tests/lean_spec/forks/lstar/forkchoice/test_time_management.py
@@ -107,7 +107,7 @@ class TestIntervalTicking:
         sample_store, _ = spec.tick_interval(sample_store, has_proposal=False)
 
         # Time should advance by one interval
-        assert sample_store.time == initial_time + Uint64(1)
+        assert sample_store.time == initial_time + Interval(1)
 
     def test_tick_interval_with_proposal(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test interval ticking with proposal."""
@@ -116,7 +116,7 @@ class TestIntervalTicking:
         sample_store, _ = spec.tick_interval(sample_store, has_proposal=True)
 
         # Time should advance
-        assert sample_store.time == initial_time + Uint64(1)
+        assert sample_store.time == initial_time + Interval(1)
 
     def test_tick_interval_sequence(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test sequence of interval ticks."""
@@ -127,21 +127,21 @@ class TestIntervalTicking:
             sample_store, _ = spec.tick_interval(sample_store, has_proposal=(i % 2 == 0))
 
         # Should have advanced by 5 intervals
-        assert sample_store.time == initial_time + Uint64(5)
+        assert sample_store.time == initial_time + Interval(5)
 
     def test_tick_interval_actions_by_phase(self, sample_store: Store, spec: LstarSpec) -> None:
         """Test different actions performed based on interval phase."""
         # Reset store to known state
-        initial_time = Uint64(0)
+        initial_time = Interval(0)
         object.__setattr__(sample_store, "time", initial_time)
 
         # Tick through a complete slot cycle
-        for interval in range(INTERVALS_PER_SLOT):
+        for interval in range(int(INTERVALS_PER_SLOT)):
             has_proposal = interval == 0  # Proposal only in first interval
             sample_store, _ = spec.tick_interval(sample_store, has_proposal=has_proposal)
 
-            current_interval = sample_store.time % INTERVALS_PER_SLOT
-            expected_interval = Uint64((interval + 1)) % INTERVALS_PER_SLOT
+            current_interval = Interval(int(sample_store.time) % int(INTERVALS_PER_SLOT))
+            expected_interval = Interval((interval + 1) % int(INTERVALS_PER_SLOT))
             assert current_interval == expected_interval
 
 

--- a/tests/lean_spec/forks/lstar/forkchoice/test_validate_attestation.py
+++ b/tests/lean_spec/forks/lstar/forkchoice/test_validate_attestation.py
@@ -22,13 +22,13 @@ ATTESTATION_SLOT = Slot(2)
 ATTESTATION_START_INTERVAL = Interval.from_slot(ATTESTATION_SLOT)
 """First interval at which ATTESTATION_SLOT begins."""
 
-DISPARITY_BOUNDARY_INTERVAL = ATTESTATION_START_INTERVAL - GOSSIP_DISPARITY_INTERVALS
+DISPARITY_BOUNDARY_INTERVAL = ATTESTATION_START_INTERVAL - Interval(int(GOSSIP_DISPARITY_INTERVALS))
 """Latest local interval that still admits the attestation."""
 
 JUST_BEYOND_DISPARITY_BOUNDARY_INTERVAL = DISPARITY_BOUNDARY_INTERVAL - Interval(1)
 """First local interval that rejects the attestation."""
 
-ONE_FULL_SLOT_BEHIND_INTERVAL = ATTESTATION_START_INTERVAL - INTERVALS_PER_SLOT
+ONE_FULL_SLOT_BEHIND_INTERVAL = ATTESTATION_START_INTERVAL - Interval(int(INTERVALS_PER_SLOT))
 """Local interval one full slot behind the attestation's slot start."""
 
 
@@ -248,7 +248,7 @@ class TestValidateAttestationTimeCheck:
         store, data = self._build_two_block_chain(spec, observer_store)
 
         # Place the local clock several slots ahead.
-        far_future = ATTESTATION_START_INTERVAL + INTERVALS_PER_SLOT * Interval(10)
+        far_future = ATTESTATION_START_INTERVAL + Interval(int(INTERVALS_PER_SLOT) * 10)
         store = store.model_copy(update={"time": far_future})
         spec.validate_attestation(store, data)
 

--- a/tests/lean_spec/subspecs/chain/test_clock.py
+++ b/tests/lean_spec/subspecs/chain/test_clock.py
@@ -82,34 +82,34 @@ class TestIntervalFromSlot:
 
     def test_slot_zero(self) -> None:
         """Slot 0 maps to interval 0."""
-        assert Interval.from_slot(Uint64(0)) == Interval(0)
+        assert Interval.from_slot(Slot(0)) == Interval(0)
 
     def test_slot_one(self) -> None:
         """Slot 1 maps to interval equal to INTERVALS_PER_SLOT."""
-        assert Interval.from_slot(Uint64(1)) == Interval(INTERVALS_PER_SLOT)
+        assert Interval.from_slot(Slot(1)) == Interval(INTERVALS_PER_SLOT)
 
     def test_slot_three(self) -> None:
         """Slot 3 maps to interval 3 * INTERVALS_PER_SLOT."""
-        assert Interval.from_slot(Uint64(3)) == Interval(Uint64(3) * INTERVALS_PER_SLOT)
+        assert Interval.from_slot(Slot(3)) == Interval(3 * int(INTERVALS_PER_SLOT))
 
     def test_multiple_slots(self) -> None:
         """Each slot N maps to interval N * INTERVALS_PER_SLOT."""
         for n in range(10):
-            slot = Uint64(n)
-            assert Interval.from_slot(slot) == Interval(slot * INTERVALS_PER_SLOT)
+            slot = Slot(n)
+            assert Interval.from_slot(slot) == Interval(int(slot) * int(INTERVALS_PER_SLOT))
 
     def test_return_type_is_interval(self) -> None:
         """Return value is an Interval instance, not a plain Uint64."""
-        result = Interval.from_slot(Uint64(2))
+        result = Interval.from_slot(Slot(2))
         assert isinstance(result, Interval)
 
     def test_consistent_with_from_unix_time(self) -> None:
         """from_slot(N) equals from_unix_time at genesis + N * SECONDS_PER_SLOT."""
         for n in range(5):
-            slot = Uint64(n)
+            slot = Slot(n)
             from_slot_result = Interval.from_slot(slot)
             from_unix_result = Interval.from_unix_time(
-                GENESIS_TIME + slot * SECONDS_PER_SLOT, GENESIS_TIME
+                GENESIS_TIME + Uint64(int(slot) * int(SECONDS_PER_SLOT)), GENESIS_TIME
             )
             assert from_slot_result == from_unix_result
 

--- a/tests/lean_spec/subspecs/chain/test_service.py
+++ b/tests/lean_spec/subspecs/chain/test_service.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from lean_spec.forks.lstar.containers.attestation.attestation import SignedAggregatedAttestation
 from lean_spec.subspecs.chain import SlotClock
+from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.subspecs.chain.service import ChainService
 from lean_spec.types import ZERO_HASH, Bytes32, Slot, Uint64
@@ -24,8 +25,8 @@ class MockCheckpoint:
 class MockStore:
     """Mock store that tracks tick_interval calls."""
 
-    time: Uint64 = field(default_factory=lambda: Uint64(0))
-    tick_calls: list[tuple[Uint64, bool]] = field(default_factory=list)
+    time: Interval = field(default_factory=lambda: Interval(0))
+    tick_calls: list[tuple[Interval, bool]] = field(default_factory=list)
     head: Bytes32 = field(default_factory=lambda: ZERO_HASH)
     latest_finalized: MockCheckpoint = field(default_factory=MockCheckpoint)
 
@@ -33,7 +34,7 @@ class MockStore:
         self, has_proposal: bool, is_aggregator: bool = False
     ) -> tuple[MockStore, list]:
         """Record the tick call, advance time by one interval, and return a new store."""
-        new_time = self.time + Uint64(1)
+        new_time = self.time + Interval(1)
         new_store = MockStore(
             time=new_time,
             tick_calls=[*self.tick_calls, (new_time, has_proposal)],
@@ -266,7 +267,7 @@ class TestStoreTicking:
 
         # Initial tick handles all 5 intervals (0→1, 1→2, ..., 4→5).
         # Main loop recognizes the interval was handled and waits.
-        expected_ticks = [(Uint64(i), False) for i in range(1, 6)]
+        expected_ticks = [(Interval(i), False) for i in range(1, 6)]
         assert sync_service.store.tick_calls == expected_ticks
 
     async def test_has_proposal_always_false(self) -> None:
@@ -333,7 +334,7 @@ class TestStoreTicking:
         assert sync_service.store is not initial_store
 
         # Initial tick handles all 5 intervals.
-        assert sync_service.store.time == Uint64(5)
+        assert sync_service.store.time == Interval(5)
 
 
 class TestMultipleIntervals:
@@ -382,10 +383,10 @@ class TestMultipleIntervals:
         # Initial tick at interval 1, then main loop ticks at 2, 3, 4.
         # Each _tick_to call ticks exactly one interval (gap=1 each time).
         assert sync_service.store.tick_calls == [
-            (Uint64(1), False),
-            (Uint64(2), False),
-            (Uint64(3), False),
-            (Uint64(4), False),
+            (Interval(1), False),
+            (Interval(2), False),
+            (Interval(3), False),
+            (Interval(4), False),
         ]
 
 
@@ -442,7 +443,7 @@ class TestInitialTick:
 
         # Store should have been replaced and ticked through all 5 intervals.
         assert sync_service.store is not initial_store
-        assert sync_service.store.time == Uint64(5)
+        assert sync_service.store.time == Interval(5)
         assert len(sync_service.store.tick_calls) == 5
 
     async def test_initial_tick_at_exact_genesis(self) -> None:
@@ -466,7 +467,7 @@ class TestInitialTick:
         await chain_service._initial_tick()
 
         # At interval 0, no ticks needed (store already at time=0).
-        assert sync_service.store.time == Uint64(0)
+        assert sync_service.store.time == Interval(0)
         assert sync_service.store.tick_calls == []
 
     async def test_initial_tick_skips_stale_intervals(self) -> None:
@@ -493,10 +494,10 @@ class TestInitialTick:
 
         # Gap=20 > INTERVALS_PER_SLOT(5), so skip to interval 15.
         # Only last 5 intervals are ticked (15→16, ..., 19→20).
-        assert sync_service.store.time == Uint64(20)
+        assert sync_service.store.time == Interval(20)
         assert len(sync_service.store.tick_calls) == 5
-        assert sync_service.store.tick_calls[0] == (Uint64(16), False)
-        assert sync_service.store.tick_calls[-1] == (Uint64(20), False)
+        assert sync_service.store.tick_calls[0] == (Interval(16), False)
+        assert sync_service.store.tick_calls[-1] == (Interval(20), False)
 
 
 class TestIntervalTracking:
@@ -538,7 +539,7 @@ class TestIntervalTracking:
 
         # Only the initial tick happens (one interval: 0→1).
         # The interval tracking prevents redundant ticks for the same interval.
-        assert sync_service.store.tick_calls == [(Uint64(1), False)]
+        assert sync_service.store.tick_calls == [(Interval(1), False)]
 
 
 class TestEdgeCases:
@@ -568,7 +569,7 @@ class TestEdgeCases:
             await chain_service.run()
 
         # Initial tick advances through 5 intervals.
-        assert sync_service.store.time == Uint64(5)
+        assert sync_service.store.time == Interval(5)
         assert len(sync_service.store.tick_calls) == 5
 
     async def test_large_genesis_time(self) -> None:
@@ -598,7 +599,7 @@ class TestEdgeCases:
 
         # Gap=100 > INTERVALS_PER_SLOT(5), so stale intervals are skipped.
         # Only the last 5 intervals are ticked (96→97, ..., 99→100).
-        assert sync_service.store.time == Uint64(100)
+        assert sync_service.store.time == Interval(100)
         assert len(sync_service.store.tick_calls) == 5
 
     async def test_stop_during_sleep(self) -> None:
@@ -631,4 +632,4 @@ class TestEdgeCases:
 
         # Initial tick handles all 5 intervals even though stop is called
         # during the yield sleeps (stop only checked in main loop).
-        assert sync_service.store.time == Uint64(5)
+        assert sync_service.store.time == Interval(5)

--- a/tests/lean_spec/subspecs/genesis/test_config.py
+++ b/tests/lean_spec/subspecs/genesis/test_config.py
@@ -9,7 +9,7 @@ import yaml
 from pydantic import ValidationError
 
 from lean_spec.subspecs.genesis import GenesisConfig
-from lean_spec.types import Bytes52, SSZValueError, Uint64
+from lean_spec.types import Bytes52, SSZValueError, Uint64, ValidatorIndex
 
 
 def _load(content: str) -> GenesisConfig:
@@ -107,7 +107,7 @@ class TestGenesisConfigValidators:
         assert len(validators.data) == 3
 
         for i, validator in enumerate(validators.data):
-            assert validator.index == Uint64(i)
+            assert validator.index == ValidatorIndex(i)
             assert validator.attestation_pubkey == config.genesis_validators[i].attestation_pubkey
             assert validator.proposal_pubkey == config.genesis_validators[i].proposal_pubkey
 

--- a/tests/lean_spec/subspecs/networking/enr/test_enr.py
+++ b/tests/lean_spec/subspecs/networking/enr/test_enr.py
@@ -66,7 +66,7 @@ class TestOfficialEIP778Vector:
     def test_official_enr_sequence_number(self) -> None:
         """Official ENR has sequence number 1."""
         enr = ENR.from_string(OFFICIAL_ENR_STRING)
-        assert enr.seq == Uint64(OFFICIAL_SEQ)
+        assert enr.seq == SeqNumber(OFFICIAL_SEQ)
 
     def test_official_enr_identity_scheme(self) -> None:
         """Official ENR uses "v4" identity scheme."""
@@ -245,7 +245,7 @@ class TestRLPStructureValidation:
         b64_content = base64.urlsafe_b64encode(rlp_data).decode("utf-8").rstrip("=")
 
         enr = ENR.from_string(f"enr:{b64_content}")
-        assert enr.seq == Uint64(1)
+        assert enr.seq == SeqNumber(1)
         assert enr.identity_scheme == "v4"
 
 
@@ -607,7 +607,7 @@ class TestEdgeCases:
         b64_content = base64.urlsafe_b64encode(rlp_data).decode("utf-8").rstrip("=")
 
         enr = ENR.from_string(f"enr:{b64_content}")
-        assert enr.seq == Uint64(0)
+        assert enr.seq == SeqNumber(0)
 
     def test_large_sequence_number(self) -> None:
         """ENR with large sequence number parses correctly."""
@@ -625,7 +625,7 @@ class TestEdgeCases:
         b64_content = base64.urlsafe_b64encode(rlp_data).decode("utf-8").rstrip("=")
 
         enr = ENR.from_string(f"enr:{b64_content}")
-        assert enr.seq == Uint64(2**32)
+        assert enr.seq == SeqNumber(2**32)
 
 
 class TestENRConstants:
@@ -906,7 +906,7 @@ class TestRoundTripSerialization:
         enr1 = ENR.from_string(f"enr:{b64}")
         enr2 = ENR.from_string(enr1.to_string())
 
-        assert enr1.seq == enr2.seq == Uint64(0x42)
+        assert enr1.seq == enr2.seq == SeqNumber(0x42)
         assert enr1.ip4 == enr2.ip4 == "192.168.1.1"
         assert enr1.udp_port == enr2.udp_port == Port(9000)
         assert enr1.identity_scheme == enr2.identity_scheme == "v4"

--- a/tests/lean_spec/subspecs/networking/test_network_service.py
+++ b/tests/lean_spec/subspecs/networking/test_network_service.py
@@ -20,7 +20,7 @@ from lean_spec.subspecs.networking.service import (
 )
 from lean_spec.subspecs.ssz.hash import hash_tree_root
 from lean_spec.subspecs.sync.states import SyncState
-from lean_spec.types import Bytes32, Checkpoint, Slot, Uint64, ValidatorIndex
+from lean_spec.types import Bytes32, Checkpoint, Slot, ValidatorIndex
 from tests.lean_spec.helpers import (
     MockEventSource,
     MockForkchoiceStore,
@@ -197,7 +197,7 @@ class TestAttestationRoutingToForkchoice:
         # Verify attestation was passed to store
         updated_store = cast(MockForkchoiceStore, sync_service.store)
         assert len(updated_store._attestations_received) == initial_count + 1
-        assert updated_store._attestations_received[-1].validator_id == Uint64(42)
+        assert updated_store._attestations_received[-1].validator_id == ValidatorIndex(42)
 
     async def test_attestation_ignored_in_idle_state(
         self,

--- a/tests/lean_spec/subspecs/node/test_node.py
+++ b/tests/lean_spec/subspecs/node/test_node.py
@@ -27,6 +27,7 @@ from lean_spec.forks.lstar.containers.state.types import (
 )
 from lean_spec.forks.lstar.spec import LstarSpec
 from lean_spec.subspecs.api import ApiServerConfig
+from lean_spec.subspecs.chain.clock import Interval
 from lean_spec.subspecs.chain.config import (
     ATTESTATION_COMMITTEE_COUNT,
     HISTORICAL_ROOTS_LIMIT,
@@ -242,9 +243,9 @@ class TestDatabaseLoading:
         assert store is not None
 
         # Wall clock: 100s * 5 intervals / 4 seconds = 125 intervals.
-        expected_wall = Uint64(100) * INTERVALS_PER_SLOT // SECONDS_PER_SLOT
+        expected_wall = Interval(100 * int(INTERVALS_PER_SLOT) // int(SECONDS_PER_SLOT))
         # Block-based: slot 10 * 5 = 50 intervals.
-        expected_block = test_slot * INTERVALS_PER_SLOT
+        expected_block = Interval(int(test_slot) * int(INTERVALS_PER_SLOT))
         assert expected_wall > expected_block
         assert store.time == expected_wall
 
@@ -265,7 +266,7 @@ class TestDatabaseLoading:
         assert store is not None
 
         # Block-based: slot 100 * 5 = 500 intervals.
-        expected_block = test_slot * INTERVALS_PER_SLOT
+        expected_block = Interval(int(test_slot) * int(INTERVALS_PER_SLOT))
         assert store.time == expected_block
 
 
@@ -409,7 +410,7 @@ class TestDatabaseGenesisTimeFallback:
 
         # Same math as test_successful_load_uses_wall_clock_time:
         # wall clock 100s * 5 intervals / 4 seconds = 125 intervals.
-        expected_wall = Uint64(100) * INTERVALS_PER_SLOT // SECONDS_PER_SLOT
+        expected_wall = Interval(100 * int(INTERVALS_PER_SLOT) // int(SECONDS_PER_SLOT))
         assert store.time == expected_wall
 
     def test_zero_genesis_time_when_database_returns_none(self) -> None:
@@ -427,8 +428,8 @@ class TestDatabaseGenesisTimeFallback:
 
         assert store is not None
         # With genesis_time=0, wall clock = 200s * INTERVALS_PER_SLOT / SECONDS_PER_SLOT
-        expected_wall = Uint64(200) * INTERVALS_PER_SLOT // SECONDS_PER_SLOT
-        expected_block = test_slot * INTERVALS_PER_SLOT
+        expected_wall = Interval(200 * int(INTERVALS_PER_SLOT) // int(SECONDS_PER_SLOT))
+        expected_block = Interval(int(test_slot) * int(INTERVALS_PER_SLOT))
         assert store.time == max(expected_wall, expected_block)
 
 

--- a/tests/lean_spec/types/test_uint.py
+++ b/tests/lean_spec/types/test_uint.py
@@ -149,10 +149,10 @@ def test_arithmetic_operators(uint_class: Type[BaseUint]) -> None:
     assert a % b == uint_class(a_val % b_val)
 
     # Exponentiation
-    assert uint_class(b_val) ** 4 == uint_class(b_val**4)
+    assert uint_class(b_val) ** uint_class(4) == uint_class(b_val**4)
     if uint_class.BITS <= 16:  # Pow gets too big quickly
         with pytest.raises(SSZValueError):
-            _ = a ** int(b)
+            _ = a**b
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -205,8 +205,8 @@ def test_bitwise_operators(uint_class: Type[BaseUint]) -> None:
     assert a & b == uint_class(0b1000)
     assert a | b == uint_class(0b1110)
     assert a ^ b == uint_class(0b0110)
-    assert a << 2 == uint_class(0b110000)
-    assert a >> 2 == uint_class(0b11)
+    assert a << uint_class(2) == uint_class(0b110000)
+    assert a >> uint_class(2) == uint_class(0b11)
 
     with pytest.raises(TypeError):
         _ = a & 1
@@ -214,6 +214,10 @@ def test_bitwise_operators(uint_class: Type[BaseUint]) -> None:
         _ = a | 1
     with pytest.raises(TypeError):
         _ = a ^ 1
+    with pytest.raises(TypeError):
+        _ = a << 1
+    with pytest.raises(TypeError):
+        _ = a >> 1
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -487,15 +491,9 @@ class TestPowAndRpow:
     def test_pow_with_modulo(self, uint_class: Type[BaseUint]) -> None:
         """Three-argument pow(base, exp, mod) validates the modulo and returns correct result."""
         # pow(2, 10, 100) == 1024 % 100 == 24
-        result = pow(uint_class(2), 10, 100)
+        result = pow(uint_class(2), uint_class(10), uint_class(100))
         assert result == uint_class(24)
         assert isinstance(result, uint_class)
-
-    @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
-    def test_pow_with_bool_modulo_raises(self, uint_class: Type[BaseUint]) -> None:
-        """Three-argument pow rejects a bool as the modulo operand."""
-        with pytest.raises(TypeError, match=r"expected 'int' but got 'bool'"):
-            pow(uint_class(2), 10, True)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rpow_success(self, uint_class: Type[BaseUint]) -> None:
@@ -505,39 +503,44 @@ class TestPowAndRpow:
         assert result == uint_class(8)
         assert isinstance(result, uint_class)
 
-    @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
-    def test_rpow_rejects_bool(self, uint_class: Type[BaseUint]) -> None:
-        """Reverse pow rejects a bool as the base operand."""
-        with pytest.raises(TypeError, match=r"expected 'int' but got 'bool'"):
-            uint_class(3).__rpow__(True)
 
-
-class TestValidateIntOperand:
-    """Tests for _validate_int_operand which rejects bools and non-ints."""
+class TestPowShiftStrictOperands:
+    """Pow and shift operators require same-type operands like every other binary op."""
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
-    def test_pow_rejects_bool_exponent(self, uint_class: Type[BaseUint]) -> None:
-        """Exponentiation rejects a bool as the exponent."""
-        with pytest.raises(TypeError, match=r"expected 'int' but got 'bool'"):
-            uint_class(2) ** True
+    @pytest.mark.parametrize("bad", [3, True, "3", 1.5])
+    def test_pow_rejects_non_uint_exponent(self, uint_class: Type[BaseUint], bad: Any) -> None:
+        """Exponentiation rejects any exponent of a different type."""
+        with pytest.raises(TypeError, match=r"\*\*"):
+            uint_class(2) ** bad  # type: ignore[operator]
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
-    def test_pow_rejects_string_exponent(self, uint_class: Type[BaseUint]) -> None:
-        """Exponentiation rejects a string as the exponent."""
-        with pytest.raises(TypeError, match=r"expected 'int' but got 'str'"):
-            uint_class(2) ** "3"  # type: ignore[operator]
+    @pytest.mark.parametrize("bad", [100, True])
+    def test_pow_rejects_non_uint_modulo(self, uint_class: Type[BaseUint], bad: Any) -> None:
+        """Three-argument pow rejects any modulo of a different type."""
+        with pytest.raises(TypeError, match=r"\*\*"):
+            pow(uint_class(2), uint_class(10), bad)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
-    def test_lshift_rejects_bool(self, uint_class: Type[BaseUint]) -> None:
-        """Left shift rejects a bool as the shift amount."""
-        with pytest.raises(TypeError, match=r"expected 'int' but got 'bool'"):
-            uint_class(1) << True
+    @pytest.mark.parametrize("bad", [2, True])
+    def test_rpow_rejects_non_uint_base(self, uint_class: Type[BaseUint], bad: Any) -> None:
+        """Reverse pow rejects any base of a different type."""
+        with pytest.raises(TypeError, match=r"\*\*"):
+            uint_class(3).__rpow__(bad)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
-    def test_rshift_rejects_bool(self, uint_class: Type[BaseUint]) -> None:
-        """Right shift rejects a bool as the shift amount."""
-        with pytest.raises(TypeError, match=r"expected 'int' but got 'bool'"):
-            uint_class(8) >> True
+    @pytest.mark.parametrize("bad", [3, True])
+    def test_lshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
+        """Left shift rejects any shift amount of a different type."""
+        with pytest.raises(TypeError, match="<<"):
+            uint_class(1) << bad  # type: ignore[operator]
+
+    @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
+    @pytest.mark.parametrize("bad", [2, True])
+    def test_rshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
+        """Right shift rejects any shift amount of a different type."""
+        with pytest.raises(TypeError, match=">>"):
+            uint_class(8) >> bad  # type: ignore[operator]
 
 
 class TestDivmodEdgeCases:
@@ -595,29 +598,31 @@ class TestReverseShiftOperators:
     def test_rlshift_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse left shift computes other << self."""
         # __rlshift__(other) computes other << self => 1 << 2 == 4
-        result = uint_class(2).__rlshift__(1)
+        result = uint_class(2).__rlshift__(uint_class(1))
         assert result == uint_class(4)
         assert isinstance(result, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
-    def test_rlshift_rejects_bool(self, uint_class: Type[BaseUint]) -> None:
-        """Reverse left shift rejects a bool operand."""
-        with pytest.raises(TypeError, match=r"expected 'int' but got 'bool'"):
-            uint_class(2).__rlshift__(True)
+    @pytest.mark.parametrize("bad", [1, True])
+    def test_rlshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
+        """Reverse left shift rejects any operand of a different type."""
+        with pytest.raises(TypeError, match="<<"):
+            uint_class(2).__rlshift__(bad)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rrshift_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse right shift computes other >> self."""
         # __rrshift__(other) computes other >> self => 8 >> 2 == 2
-        result = uint_class(2).__rrshift__(8)
+        result = uint_class(2).__rrshift__(uint_class(8))
         assert result == uint_class(2)
         assert isinstance(result, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
-    def test_rrshift_rejects_bool(self, uint_class: Type[BaseUint]) -> None:
-        """Reverse right shift rejects a bool operand."""
-        with pytest.raises(TypeError, match=r"expected 'int' but got 'bool'"):
-            uint_class(2).__rrshift__(True)
+    @pytest.mark.parametrize("bad", [8, True])
+    def test_rrshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
+        """Reverse right shift rejects any operand of a different type."""
+        with pytest.raises(TypeError, match=">>"):
+            uint_class(2).__rrshift__(bad)
 
 
 class TestComparisonTypeErrors:

--- a/tests/lean_spec/types/test_uint.py
+++ b/tests/lean_spec/types/test_uint.py
@@ -2,6 +2,7 @@
 
 import io
 import operator
+from itertools import permutations
 from typing import Any, Type
 
 import pytest
@@ -13,6 +14,9 @@ from lean_spec.types.uint import BaseUint
 
 ALL_UINT_TYPES = (Uint8, Uint16, Uint32, Uint64)
 """A collection of all Uint types to test against."""
+
+CROSS_UINT_TYPE_PAIRS = list(permutations(ALL_UINT_TYPES, 2))
+"""Every ordered pair of distinct unsigned integer widths."""
 
 
 # Model classes for Pydantic validation tests
@@ -649,3 +653,32 @@ class TestIndexReturnsPlainInt:
         assert result == 42
         # The type must be plain int, not a BaseUint subclass.
         assert type(result) is int
+
+
+class TestCrossWidthEqualityIsStrict:
+    """Equality across different unsigned integer widths must raise."""
+
+    @pytest.mark.parametrize("type_a, type_b", CROSS_UINT_TYPE_PAIRS)
+    def test_eq_across_widths_raises(self, type_a: Type[BaseUint], type_b: Type[BaseUint]) -> None:
+        """Equality across two distinct widths raises."""
+        with pytest.raises(TypeError, match="=="):
+            _ = type_a(5) == type_b(5)
+
+    @pytest.mark.parametrize("type_a, type_b", CROSS_UINT_TYPE_PAIRS)
+    def test_ne_across_widths_raises(self, type_a: Type[BaseUint], type_b: Type[BaseUint]) -> None:
+        """Inequality across two distinct widths raises."""
+        with pytest.raises(TypeError, match="!="):
+            _ = type_a(5) != type_b(5)
+
+    @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
+    def test_eq_same_width_same_value_still_equal(self, uint_class: Type[BaseUint]) -> None:
+        """Within a single width, equal values still compare equal."""
+        assert uint_class(7) == uint_class(7)
+        assert not (uint_class(7) != uint_class(7))
+
+    @pytest.mark.parametrize("type_a, type_b", CROSS_UINT_TYPE_PAIRS)
+    def test_hash_differs_across_widths(
+        self, type_a: Type[BaseUint], type_b: Type[BaseUint]
+    ) -> None:
+        """Equal-by-value instances of different widths hash differently."""
+        assert hash(type_a(5)) != hash(type_b(5))

--- a/tests/lean_spec/types/test_uint.py
+++ b/tests/lean_spec/types/test_uint.py
@@ -2,6 +2,7 @@
 
 import io
 import operator
+import re
 from itertools import permutations
 from typing import Any, Type
 
@@ -82,8 +83,8 @@ def test_instantiation_from_invalid_types_raises_error(
     uint_class: Type[BaseUint], invalid_value: Any, expected_type_name: str
 ) -> None:
     """Tests that instantiating with non-integer types raises SSZTypeError."""
-    expected_msg = f"Expected int, got {expected_type_name}"
-    with pytest.raises(SSZTypeError, match=expected_msg):
+    expected = f"Expected int, got {expected_type_name}"
+    with pytest.raises(SSZTypeError, match=rf"^{re.escape(expected)}$"):
         uint_class(invalid_value)
 
 
@@ -99,7 +100,8 @@ def test_instantiation_and_type(uint_class: Type[BaseUint]) -> None:
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_instantiation_negative(uint_class: Type[BaseUint]) -> None:
     """Tests that instantiating with a negative number raises SSZValueError."""
-    with pytest.raises(SSZValueError):
+    expected = f"-5 out of range for {uint_class.__name__} [0, {2**uint_class.BITS - 1}]"
+    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
         uint_class(-5)
 
 
@@ -107,7 +109,8 @@ def test_instantiation_negative(uint_class: Type[BaseUint]) -> None:
 def test_instantiation_too_large(uint_class: Type[BaseUint]) -> None:
     """Tests that instantiating with a value >= MAX raises SSZValueError."""
     max_value = 2**uint_class.BITS
-    with pytest.raises(SSZValueError):
+    expected = f"{max_value} out of range for {uint_class.__name__} [0, {max_value - 1}]"
+    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
         uint_class(max_value)
 
 
@@ -125,21 +128,26 @@ def test_arithmetic_operators(uint_class: Type[BaseUint]) -> None:
     a_val, b_val = (100, 3) if uint_class.BITS > 8 else (20, 3)
     a = uint_class(a_val)
     b = uint_class(b_val)
-    max_val = uint_class((2**uint_class.BITS) - 1)
+    max_int = (2**uint_class.BITS) - 1
+    max_val = uint_class(max_int)
+    name = uint_class.__name__
 
     # Addition
     assert a + b == uint_class(a_val + b_val)
-    with pytest.raises(SSZValueError):
+    expected = f"{max_int + b_val} out of range for {name} [0, {max_int}]"
+    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
         _ = max_val + b
 
     # Subtraction
     assert a - b == uint_class(a_val - b_val)
-    with pytest.raises(SSZValueError):
+    expected = f"{b_val - a_val} out of range for {name} [0, {max_int}]"
+    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
         _ = b - a
 
     # Multiplication
     assert a * b == uint_class(a_val * b_val)
-    with pytest.raises(SSZValueError):
+    expected = f"{max_int * b_val} out of range for {name} [0, {max_int}]"
+    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
         _ = max_val * b
 
     # Floor Division
@@ -151,22 +159,34 @@ def test_arithmetic_operators(uint_class: Type[BaseUint]) -> None:
     # Exponentiation
     assert uint_class(b_val) ** uint_class(4) == uint_class(b_val**4)
     if uint_class.BITS <= 16:  # Pow gets too big quickly
-        with pytest.raises(SSZValueError):
+        expected = f"{a_val**b_val} out of range for {name} [0, {max_int}]"
+        with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
             _ = a**b
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_reverse_arithmetic_operators_raise_error(uint_class: Type[BaseUint]) -> None:
     """Tests that reverse arithmetic operators raise a TypeError."""
-    with pytest.raises(TypeError):
+    name = uint_class.__name__
+
+    expected = f"Unsupported operand type(s) for +: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = 100 + uint_class(3)
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for -: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = 100 - uint_class(3)
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for *: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = 100 * uint_class(3)
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for //: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = 100 // uint_class(3)
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for %: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = 100 % uint_class(3)
 
 
@@ -179,8 +199,9 @@ def test_divmod(uint_class: Type[BaseUint]) -> None:
     assert isinstance(q, uint_class)
     assert isinstance(r, uint_class)
 
-    with pytest.raises(TypeError):
-        _ = divmod(100, uint_class(3))
+    expected = f"Unsupported operand type(s) for divmod: '{uint_class.__name__}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        _ = divmod(100, uint_class(3))  # type: ignore[call-overload]
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -201,6 +222,7 @@ def test_bitwise_operators(uint_class: Type[BaseUint]) -> None:
     """Tests all standard bitwise operators."""
     a = uint_class(0b1100)  # 12
     b = uint_class(0b1010)  # 10
+    name = uint_class.__name__
 
     assert a & b == uint_class(0b1000)
     assert a | b == uint_class(0b1110)
@@ -208,15 +230,24 @@ def test_bitwise_operators(uint_class: Type[BaseUint]) -> None:
     assert a << uint_class(2) == uint_class(0b110000)
     assert a >> uint_class(2) == uint_class(0b11)
 
-    with pytest.raises(TypeError):
+    expected = f"Unsupported operand type(s) for &: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = a & 1
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for |: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = a | 1
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for ^: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = a ^ 1
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for <<: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = a << 1
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for >>: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = a >> 1
 
 
@@ -236,17 +267,32 @@ def test_all_comparisons_with_other_types_raise_error(
     uint_class: Type[BaseUint],
 ) -> None:
     """Tests that all comparisons with incompatible types raise TypeError."""
-    with pytest.raises(TypeError):
+    name = uint_class.__name__
+
+    expected = f"Unsupported operand type(s) for ==: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = uint_class(10) == 10
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for !=: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = 10 != uint_class(10)
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for >: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = uint_class(10) > 5
-    with pytest.raises(TypeError):
+
+    # 5 < uint(10) routes to uint(10).__gt__(5) because uint is a strict int subclass.
+    expected = f"Unsupported operand type(s) for >: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = 5 < uint_class(10)
-    with pytest.raises(TypeError):
+
+    expected = f"Unsupported operand type(s) for >=: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = uint_class(10) >= 10
-    with pytest.raises(TypeError):
+
+    # 10 <= uint(10) routes to uint(10).__ge__(10) by subclass priority.
+    expected = f"Unsupported operand type(s) for >=: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
         _ = 10 <= uint_class(10)
 
 
@@ -368,8 +414,12 @@ class TestUintSSZ:
     def test_decode_bytes_invalid_length(self, uint_class: Type[BaseUint]) -> None:
         """Tests that `decode_bytes` raises SSZSerializationError for wrong length data."""
         # Create byte string that is one byte too short.
-        invalid_data = b"\x00" * (uint_class.get_byte_length() - 1)
-        with pytest.raises(SSZSerializationError, match="expected .* bytes, got"):
+        expected_length = uint_class.get_byte_length()
+        invalid_data = b"\x00" * (expected_length - 1)
+        expected = (
+            f"{uint_class.__name__}: expected {expected_length} bytes, got {expected_length - 1}"
+        )
+        with pytest.raises(SSZSerializationError, match=rf"^{re.escape(expected)}$"):
             uint_class.decode_bytes(invalid_data)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -394,9 +444,14 @@ class TestUintSSZ:
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_deserialize_invalid_scope(self, uint_class: Type[BaseUint]) -> None:
         """Tests that `deserialize` raises an SSZSerializationError if the scope is incorrect."""
-        stream = io.BytesIO(b"\x00" * uint_class.get_byte_length())
-        invalid_scope = uint_class.get_byte_length() - 1
-        with pytest.raises(SSZSerializationError, match="invalid scope"):
+        byte_length = uint_class.get_byte_length()
+        stream = io.BytesIO(b"\x00" * byte_length)
+        invalid_scope = byte_length - 1
+        expected = (
+            f"{uint_class.__name__}: invalid scope, "
+            f"expected {byte_length} bytes, got {invalid_scope}"
+        )
+        with pytest.raises(SSZSerializationError, match=rf"^{re.escape(expected)}$"):
             uint_class.deserialize(stream, scope=invalid_scope)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -405,26 +460,23 @@ class TestUintSSZ:
         byte_length = uint_class.get_byte_length()
         # Create a stream that is shorter than what the type requires.
         stream = io.BytesIO(b"\x00" * (byte_length - 1))
-        with pytest.raises(SSZSerializationError, match="expected .* bytes, got"):
+        expected = f"{uint_class.__name__}: expected {byte_length} bytes, got {byte_length - 1}"
+        with pytest.raises(SSZSerializationError, match=rf"^{re.escape(expected)}$"):
             uint_class.deserialize(stream, scope=byte_length)
 
 
 class TestForwardArithmeticTypeErrors:
-    """Tests that forward arithmetic operators reject plain int operands.
-
-    When calling e.g. Uint64(5).__add__(3), the forward operator must raise
-    TypeError because 3 is a plain int, not a BaseUint subclass.
-    """
+    """Tests that forward arithmetic operators reject plain int operands."""
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize(
         "method, op_symbol",
         [
-            ("__add__", r"\+"),
-            ("__sub__", r"-"),
-            ("__mul__", r"\*"),
-            ("__floordiv__", r"//"),
-            ("__mod__", r"%"),
+            ("__add__", "+"),
+            ("__sub__", "-"),
+            ("__mul__", "*"),
+            ("__floordiv__", "//"),
+            ("__mod__", "%"),
         ],
     )
     def test_forward_operator_rejects_plain_int(
@@ -432,16 +484,13 @@ class TestForwardArithmeticTypeErrors:
     ) -> None:
         """Forward arithmetic operator raises TypeError when given a plain int."""
         # Call the dunder method directly with a plain int operand.
-        with pytest.raises(TypeError, match=op_symbol):
+        expected = f"Unsupported operand type(s) for {op_symbol}: '{uint_class.__name__}' and 'int'"
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             getattr(uint_class(5), method)(3)
 
 
 class TestReverseArithmeticSuccessPaths:
-    """Tests that reverse arithmetic operators succeed when both operands are BaseUint.
-
-    Calling the reverse dunder directly (e.g. Uint64(3).__radd__(Uint64(5)))
-    exercises the success return path of each reverse operator.
-    """
+    """Tests that reverse arithmetic operators succeed when both operands are BaseUint."""
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_radd_success(self, uint_class: Type[BaseUint]) -> None:
@@ -503,6 +552,14 @@ class TestPowAndRpow:
         assert result == uint_class(8)
         assert isinstance(result, uint_class)
 
+    @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
+    def test_rpow_with_modulo(self, uint_class: Type[BaseUint]) -> None:
+        """Three-argument reverse pow validates the modulo and returns the correct result."""
+        # __rpow__(base, mod) computes pow(base, self, mod) => pow(2, 10, 100) == 24
+        result = uint_class(10).__rpow__(uint_class(2), uint_class(100))
+        assert result == uint_class(24)
+        assert isinstance(result, uint_class)
+
 
 class TestPowShiftStrictOperands:
     """Pow and shift operators require same-type operands like every other binary op."""
@@ -511,35 +568,66 @@ class TestPowShiftStrictOperands:
     @pytest.mark.parametrize("bad", [3, True, "3", 1.5])
     def test_pow_rejects_non_uint_exponent(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Exponentiation rejects any exponent of a different type."""
-        with pytest.raises(TypeError, match=r"\*\*"):
+        expected = (
+            f"Unsupported operand type(s) for **: "
+            f"'{uint_class.__name__}' and '{type(bad).__name__}'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             uint_class(2) ** bad  # type: ignore[operator]
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [100, True])
     def test_pow_rejects_non_uint_modulo(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Three-argument pow rejects any modulo of a different type."""
-        with pytest.raises(TypeError, match=r"\*\*"):
+        expected = (
+            f"Unsupported operand type(s) for **: "
+            f"'{uint_class.__name__}' and '{type(bad).__name__}'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             pow(uint_class(2), uint_class(10), bad)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [2, True])
     def test_rpow_rejects_non_uint_base(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Reverse pow rejects any base of a different type."""
-        with pytest.raises(TypeError, match=r"\*\*"):
+        expected = (
+            f"Unsupported operand type(s) for **: "
+            f"'{uint_class.__name__}' and '{type(bad).__name__}'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             uint_class(3).__rpow__(bad)
+
+    @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
+    @pytest.mark.parametrize("bad", [100, True])
+    def test_rpow_rejects_non_uint_modulo(self, uint_class: Type[BaseUint], bad: Any) -> None:
+        """Three-argument reverse pow rejects any modulo of a different type."""
+        expected = (
+            f"Unsupported operand type(s) for **: "
+            f"'{uint_class.__name__}' and '{type(bad).__name__}'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+            uint_class(10).__rpow__(uint_class(2), bad)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [3, True])
     def test_lshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Left shift rejects any shift amount of a different type."""
-        with pytest.raises(TypeError, match="<<"):
+        expected = (
+            f"Unsupported operand type(s) for <<: "
+            f"'{uint_class.__name__}' and '{type(bad).__name__}'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             uint_class(1) << bad  # type: ignore[operator]
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [2, True])
     def test_rshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Right shift rejects any shift amount of a different type."""
-        with pytest.raises(TypeError, match=">>"):
+        expected = (
+            f"Unsupported operand type(s) for >>: "
+            f"'{uint_class.__name__}' and '{type(bad).__name__}'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             uint_class(8) >> bad  # type: ignore[operator]
 
 
@@ -549,7 +637,8 @@ class TestDivmodEdgeCases:
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_divmod_rejects_plain_int(self, uint_class: Type[BaseUint]) -> None:
         """Forward divmod raises TypeError when the divisor is a plain int."""
-        with pytest.raises(TypeError, match="divmod"):
+        expected = f"Unsupported operand type(s) for divmod: '{uint_class.__name__}' and 'int'"
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             divmod(uint_class(10), 3)  # type: ignore[call-overload]
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -606,7 +695,11 @@ class TestReverseShiftOperators:
     @pytest.mark.parametrize("bad", [1, True])
     def test_rlshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Reverse left shift rejects any operand of a different type."""
-        with pytest.raises(TypeError, match="<<"):
+        expected = (
+            f"Unsupported operand type(s) for <<: "
+            f"'{uint_class.__name__}' and '{type(bad).__name__}'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             uint_class(2).__rlshift__(bad)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -621,29 +714,29 @@ class TestReverseShiftOperators:
     @pytest.mark.parametrize("bad", [8, True])
     def test_rrshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Reverse right shift rejects any operand of a different type."""
-        with pytest.raises(TypeError, match=">>"):
+        expected = (
+            f"Unsupported operand type(s) for >>: "
+            f"'{uint_class.__name__}' and '{type(bad).__name__}'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             uint_class(2).__rrshift__(bad)
 
 
 class TestComparisonTypeErrors:
-    """Tests that comparison operators raise TypeError when given plain int operands.
-
-    The existing test_all_comparisons_with_other_types_raise_error uses the operator
-    syntax (e.g., `uint < 10`) which for __lt__ and __le__ may be resolved by Python
-    as int.__gt__ and int.__ge__ instead. Calling the dunder directly ensures the
-    BaseUint implementation is exercised.
-    """
+    """Tests that comparison operators raise TypeError when given plain int operands."""
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_lt_rejects_plain_int(self, uint_class: Type[BaseUint]) -> None:
         """Less-than raises TypeError when compared to a plain int directly."""
-        with pytest.raises(TypeError, match="<"):
+        expected = f"Unsupported operand type(s) for <: '{uint_class.__name__}' and 'int'"
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             uint_class(5).__lt__(10)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_le_rejects_plain_int(self, uint_class: Type[BaseUint]) -> None:
         """Less-than-or-equal raises TypeError when compared to a plain int directly."""
-        with pytest.raises(TypeError, match="<="):
+        expected = f"Unsupported operand type(s) for <=: '{uint_class.__name__}' and 'int'"
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             uint_class(5).__le__(10)
 
 
@@ -666,13 +759,19 @@ class TestCrossWidthEqualityIsStrict:
     @pytest.mark.parametrize("type_a, type_b", CROSS_UINT_TYPE_PAIRS)
     def test_eq_across_widths_raises(self, type_a: Type[BaseUint], type_b: Type[BaseUint]) -> None:
         """Equality across two distinct widths raises."""
-        with pytest.raises(TypeError, match="=="):
+        expected = (
+            f"Unsupported operand type(s) for ==: '{type_a.__name__}' and '{type_b.__name__}'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             _ = type_a(5) == type_b(5)
 
     @pytest.mark.parametrize("type_a, type_b", CROSS_UINT_TYPE_PAIRS)
     def test_ne_across_widths_raises(self, type_a: Type[BaseUint], type_b: Type[BaseUint]) -> None:
         """Inequality across two distinct widths raises."""
-        with pytest.raises(TypeError, match="!="):
+        expected = (
+            f"Unsupported operand type(s) for !=: '{type_a.__name__}' and '{type_b.__name__}'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
             _ = type_a(5) != type_b(5)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)


### PR DESCRIPTION
## Summary

- Enforce strict same-type equality in `BaseUint`: `Uint8(5) == Uint16(5)` previously returned `True` while `hash(Uint8(5)) != hash(Uint16(5))`, silently corrupting set and dict membership. `__eq__` and `__ne__` now require `type(other) is type(self)`.
- Add parametrized tests covering every ordered pair of distinct widths, plus a sanity test that hashes still diverge across widths (consistent with the strict-eq rule).

This is the first commit in a series — more uint polish will follow on this branch.

## Test plan

- [x] `uv run pytest tests/lean_spec/types/test_uint.py` — 309 passed
- [x] `just check` — ruff, format, ty, codespell, mdformat all clean