### PR TITLE
refactor: replace hand-rolled patterns with stdlib equivalents

### DIFF
--- a/src/lean_spec/forks/lstar/spec.py
+++ b/src/lean_spec/forks/lstar/spec.py
@@ -444,8 +444,8 @@ class LstarSpec(ForkProtocol):
         # where a root appears to decide whether it is still unfinalized.
         start_slot = int(finalized_slot) + 1
         root_to_slot: dict[Bytes32, Slot] = {}
-        for i in range(start_slot, len(state.historical_block_hashes)):
-            root_to_slot[state.historical_block_hashes[i]] = Slot(i)
+        for i, root in enumerate(state.historical_block_hashes[start_slot:], start=start_slot):
+            root_to_slot[root] = Slot(i)
 
         # Process each attestation independently.
         #

--- a/src/lean_spec/forks/registry.py
+++ b/src/lean_spec/forks/registry.py
@@ -1,5 +1,7 @@
 """Registry of registered forks, ordered oldest to newest."""
 
+from itertools import pairwise
+
 from .protocol import ForkProtocol
 
 
@@ -26,7 +28,7 @@ class ForkRegistry:
             raise ValueError("ForkRegistry requires at least one fork")
 
         versions = [f.VERSION for f in forks]
-        if any(versions[i] >= versions[i + 1] for i in range(len(versions) - 1)):
+        if any(a >= b for a, b in pairwise(versions)):
             raise ValueError(f"Forks must be ordered by strictly increasing VERSION: {versions}")
 
         names = [f.NAME for f in forks]

--- a/src/lean_spec/subspecs/networking/enr/eth2.py
+++ b/src/lean_spec/subspecs/networking/enr/eth2.py
@@ -81,7 +81,7 @@ class AttestationSubnets(BaseBitvector):
 
     def subscribed_subnets(self) -> list[SubnetId]:
         """List of subscribed subnet IDs."""
-        return [SubnetId(i) for i in range(self.LENGTH) if self.data[i]]
+        return [SubnetId(i) for i, bit in enumerate(self.data) if bit]
 
     def subscription_count(self) -> int:
         """Number of subscribed subnets."""

--- a/src/lean_spec/subspecs/networking/gossipsub/mcache.py
+++ b/src/lean_spec/subspecs/networking/gossipsub/mcache.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass, field
+from itertools import islice
 
 from .message import GossipsubMessage
 from .types import MessageId, Timestamp, TopicId
@@ -194,8 +195,8 @@ class MessageCache:
 
         windows_to_check = min(self.mcache_gossip, len(self._windows))
 
-        for i in range(windows_to_check):
-            for msg_id in self._windows[i]:
+        for window in islice(self._windows, windows_to_check):
+            for msg_id in window:
                 entry = self._by_id.get(msg_id)
                 if entry and entry.topic == topic:
                     result.append(msg_id)

--- a/src/lean_spec/subspecs/networking/transport/peer_id.py
+++ b/src/lean_spec/subspecs/networking/transport/peer_id.py
@@ -132,12 +132,7 @@ class Base58:
             Base58-encoded string.
         """
         # Count leading zeros (become leading '1's)
-        leading_zeros = 0
-        for byte in data:
-            if byte == 0:
-                leading_zeros += 1
-            else:
-                break
+        leading_zeros = len(data) - len(data.lstrip(b"\x00"))
 
         # Convert to big integer and then to base58
         num = int.from_bytes(data, "big")
@@ -168,12 +163,7 @@ class Base58:
             ValueError: If string contains invalid characters.
         """
         # Count leading '1's (they represent leading zeros)
-        leading_ones = 0
-        for char in s:
-            if char == "1":
-                leading_ones += 1
-            else:
-                break
+        leading_ones = len(s) - len(s.lstrip("1"))
 
         # Convert from base58 to integer
         num = 0

--- a/src/lean_spec/subspecs/xmss/message_hash.py
+++ b/src/lean_spec/subspecs/xmss/message_hash.py
@@ -113,8 +113,8 @@ class MessageHasher(StrictBaseModel):
 
             # Decompose d into Z base-BASE digits, least significant first.
             for _ in range(config.Z):
-                digits.append(d % config.BASE)
-                d //= config.BASE
+                d, digit = divmod(d, config.BASE)
+                digits.append(digit)
 
         # Take exactly DIMENSION digits.
         return digits[: config.DIMENSION]

--- a/src/lean_spec/subspecs/xmss/subtree.py
+++ b/src/lean_spec/subspecs/xmss/subtree.py
@@ -310,7 +310,7 @@ class HashSubTree(Container):
         )
 
         # Keep bottom half + single root node.
-        truncated = [full_tree.layers[i] for i in range(depth // 2)]
+        truncated = list(full_tree.layers[: depth // 2])
         return cls(
             depth=Uint64(depth),
             lowest_layer=Uint64(0),
@@ -456,9 +456,7 @@ class HashSubTree(Container):
         pos = position
 
         # Iterate over all layers except the last (root).
-        num_layers = len(self.layers)
-        for i in range(num_layers - 1):
-            layer = self.layers[i]
+        for layer in self.layers[:-1]:
             # Sibling index: flip last bit of position, adjust for layer offset.
             sibling_idx = int((pos ^ Uint64(1)) - layer.start_index)
             if not (0 <= sibling_idx < len(layer.nodes)):

--- a/src/lean_spec/types/collections.py
+++ b/src/lean_spec/types/collections.py
@@ -2,6 +2,7 @@
 
 import io
 from collections.abc import Iterator, Sequence
+from itertools import pairwise
 from typing import (
     IO,
     Any,
@@ -69,11 +70,10 @@ def _validate_offsets(offsets: list[int], scope: int, type_name: str) -> None:
     if not offsets:
         return
 
-    for i in range(1, len(offsets)):
-        if offsets[i] < offsets[i - 1]:
+    for prev, curr in pairwise(offsets):
+        if curr < prev:
             raise SSZSerializationError(
-                f"{type_name}: offsets not monotonically increasing: "
-                f"{offsets[i - 1]} -> {offsets[i]}"
+                f"{type_name}: offsets not monotonically increasing: {prev} -> {curr}"
             )
 
     if offsets[-1] > scope:
@@ -213,8 +213,7 @@ class SSZVector[T: SSZType](SSZModel):
             # Validate all offsets upfront before processing elements.
             _validate_offsets(offsets, scope, cls.__name__)
             # Read each element's data from its calculated slice.
-            for i in range(cls.LENGTH):
-                start, end = offsets[i], offsets[i + 1]
+            for start, end in pairwise(offsets):
                 elements.append(cls.ELEMENT_TYPE.deserialize(stream, end - start))
             return cls(data=elements)
 
@@ -418,8 +417,7 @@ class SSZList[T: SSZType](SSZModel):
             _validate_offsets(offsets, scope, cls.__name__)
             # Read each element based on the calculated boundaries.
             elements = []
-            for i in range(count):
-                start, end = offsets[i], offsets[i + 1]
+            for start, end in pairwise(offsets):
                 elements.append(cls.ELEMENT_TYPE.deserialize(stream, end - start))
 
             return cls(data=elements)


### PR DESCRIPTION
## Summary

Sweep for places where custom logic duplicated stdlib functionality. No behavior changes.

- `itertools.pairwise` for adjacent-pair iteration — offset-table validation, vector/list decode, fork-version monotonicity check.
- `bytes.lstrip` / `str.lstrip` in Base58 PeerId encoding/decoding instead of manual leading-character counts.
- `divmod` in the XMSS message-hash base decomposition (replaces adjacent `% BASE` / `//= BASE` on the same operand).
- `enumerate` / direct slicing in place of `range(N)` + indexed access in:
  - XMSS subtree (sibling-path iteration, half-tree truncation)
  - gossipsub mcache (via `itertools.islice` since `_windows` is a `deque`)
  - ENR subnet membership listing
  - lstar historical-block-hash → slot mapping

## What was deliberately NOT changed

- `math.ceil(N / 8)` style call sites stay as-is — the stdlib form is more explicit than `(N + 7) // 8` / `-(-N // 8)`.
- Saturating subtraction with `Slot` / `Uint64` keeps its `0 if a >= b else int(b - a)` guard — Uint subtraction raises on underflow, so the conditional is load-bearing, not stylistic.

## Test plan

- [x] `just check` (ruff, format, ty, codespell, mdformat) passes
- [x] Affected unit tests pass (collections, rlp, bitfields, fork protocol, validator service, xmss, peer_id, enr, gossipsub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)