### PR TITLE
framework: set rayon thread to 1 and re-enable parallel prod fill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,9 @@ jobs:
       - name: Run tests
         run: just test
 
-  # coverage-gate, fill-tests and interop-tests run on macOS because the
-  # lean_multisig_py prover's process-global setup is corrupted by xdist
-  # parallelism; these jobs must run serially and macOS runners were the
-  # stable choice during bring-up. This is an upstream limitation, not a
-  # preference: revisit (and prefer ubuntu for cost) once the prover setup
-  # is per-process safe. See the matching note in the Justfile fill-ci.
   coverage-gate:
     name: Coverage gate - Python 3.12
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout leanSpec
         uses: actions/checkout@v4
@@ -110,7 +104,7 @@ jobs:
 
   fill-tests:
     name: Fill test fixtures - Python 3.14
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout leanSpec
         uses: actions/checkout@v4
@@ -134,6 +128,7 @@ jobs:
       - name: Fill test fixtures
         run: just fill-ci
 
+  # Interop tests stay on macOS until the wall-clock-driven slot ticker tolerates Ubuntu's noisier scheduler.
   interop-tests:
     name: Interop tests - Multi-node consensus
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,14 @@ jobs:
       - name: Run tests
         run: just test
 
+  # coverage-gate, fill-tests and interop-tests run on macOS because the
+  # SNARK-heavy fixture filler measured faster on macos-latest than on
+  # ubuntu-latest, even with RAYON_NUM_THREADS=1 pinned to avoid xdist x
+  # rayon oversubscription. The Tests matrix above already covers
+  # ubuntu-latest for cross-platform safety.
   coverage-gate:
     name: Coverage gate - Python 3.12
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout leanSpec
         uses: actions/checkout@v4
@@ -104,7 +109,7 @@ jobs:
 
   fill-tests:
     name: Fill test fixtures - Python 3.14
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout leanSpec
         uses: actions/checkout@v4
@@ -128,7 +133,6 @@ jobs:
       - name: Fill test fixtures
         run: just fill-ci
 
-  # Interop tests stay on macOS until the wall-clock-driven slot ticker tolerates Ubuntu's noisier scheduler.
   interop-tests:
     name: Interop tests - Multi-node consensus
     runs-on: macos-latest

--- a/.github/workflows/prod-vectors.yml
+++ b/.github/workflows/prod-vectors.yml
@@ -93,6 +93,9 @@ jobs:
           key: prod-keys-${{ hashFiles('src/lean_spec/subspecs/xmss/**', 'src/lean_spec/subspecs/poseidon1/**') }}
 
       - name: Fill production test fixtures
+        env:
+          # RAYON_NUM_THREADS=1 keeps the runner from oversubscribing cores by giving each xdist worker one rayon thread.
+          RAYON_NUM_THREADS: "1"
         run: just fill-ci --scheme=prod
 
       - name: Bundle keys with fixtures

--- a/.github/workflows/prod-vectors.yml
+++ b/.github/workflows/prod-vectors.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [check, keygen]
     # Trick to run even when keygen was skipped, but not on failure or cancel.
     if: always() && !failure() && !cancelled()
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout leanSpec

--- a/Justfile
+++ b/Justfile
@@ -80,14 +80,10 @@ test-cov-gate *args:
 test-consensus *args:
     uv run --group test pytest -n auto --maxprocesses=10 --durations=10 --dist=worksteal tests/lean_spec/subspecs/containers tests/lean_spec/subspecs/forkchoice tests/lean_spec/subspecs/networking "$@"
 
-# Canonical CI fixture run; contributors should use `uv run fill` directly
-# Runs serially (no -n auto): xdist workers race on the lean_multisig_py
-# prover's process-global setup, which corrupts proofs intermittently.
-# This is an upstream limitation; restore -n auto once the prover setup
-# is per-process safe. See the matching note in .github/workflows/ci.yml.
+# Canonical CI fixture run; contributors should use `uv run fill` directly.
 [group('tests'), private]
 fill-ci *args:
-    uv run --group test fill --fork=Lstar --clean "$@"
+    RAYON_NUM_THREADS=1 uv run --group test fill --fork=Lstar --clean -n auto --dist=worksteal "$@"
 
 # Run API conformance tests against an external client
 [group('tests')]

--- a/Justfile
+++ b/Justfile
@@ -83,7 +83,7 @@ test-consensus *args:
 # Canonical CI fixture run; contributors should use `uv run fill` directly.
 [group('tests'), private]
 fill-ci *args:
-    RAYON_NUM_THREADS=1 uv run --group test fill --fork=Lstar --clean -n auto --dist=worksteal "$@"
+    uv run --group test fill --fork=Lstar --clean -n auto --dist=worksteal "$@"
 
 # Run API conformance tests against an external client
 [group('tests')]


### PR DESCRIPTION
## 🗒️ Description

Pin `RAYON_NUM_THREADS=1` instead of letting the default sets to the number of cores. This previously caused issues with parallel workers because `-n auto` spins up equal runners as number of cores, then rayon also spin the equal number of threads. E.g. on CI worker with 4 cores it becomes 4 workers with 4 rayon threads on each worker, oversubscribing the cores.

Now we can bring back `-n auto` in fill-ci ~~and also back to ubuntu workers instead of macOS (except interop tests that have another issue)~~ (macos-latest is still much faster than ubuntu-latest).

Prod filling time goes down from [4h49m](https://github.com/leanEthereum/leanSpec/actions/runs/26249173140/job/77296419280) to [3h49m](https://github.com/unnawut/leanSpec/actions/runs/26382723126/job/77655004145) (tested on forked repo).