### PR TITLE
refactor(types): fold lone offset constant into ssz_base, drop constants.py

### DIFF
--- a/src/lean_spec/subspecs/xmss/constants.py
+++ b/src/lean_spec/subspecs/xmss/constants.py
@@ -18,7 +18,7 @@ from pydantic import model_validator
 
 from lean_spec.config import LEAN_ENV
 from lean_spec.types import StrictBaseModel, Uint64
-from lean_spec.types.constants import OFFSET_BYTE_LENGTH
+from lean_spec.types.ssz_base import BYTES_PER_LENGTH_OFFSET
 
 from ..koalabear import P_BYTES, P
 
@@ -115,7 +115,7 @@ class XmssConfig(StrictBaseModel):
         hashes_size = self.DIMENSION * self.HASH_LEN_FE * P_BYTES
 
         # SSZ offset overhead: 3 variable fields × 4 bytes each
-        ssz_offset_overhead = 3 * OFFSET_BYTE_LENGTH
+        ssz_offset_overhead = 3 * BYTES_PER_LENGTH_OFFSET
 
         return path_siblings_size + rho_size + hashes_size + ssz_offset_overhead
 

--- a/src/lean_spec/types/collections.py
+++ b/src/lean_spec/types/collections.py
@@ -17,11 +17,9 @@ from typing import (
 
 from pydantic import Field, field_serializer, field_validator
 
-from lean_spec.types.constants import OFFSET_BYTE_LENGTH
-
 from .byte_arrays import BaseBytes
 from .exceptions import SSZSerializationError, SSZTypeError, SSZValueError
-from .ssz_base import SSZModel, SSZType
+from .ssz_base import BYTES_PER_LENGTH_OFFSET, SSZModel, SSZType
 from .uint import Uint32
 
 
@@ -170,7 +168,7 @@ class SSZVector[T: SSZType](SSZModel):
             # Use a temporary in-memory stream to hold the serialized variable data.
             variable_data_stream = io.BytesIO()
             # The first offset points to the end of all the offset data.
-            offset = self.LENGTH * OFFSET_BYTE_LENGTH
+            offset = self.LENGTH * BYTES_PER_LENGTH_OFFSET
             # Write the offsets to the main stream and the data to the temporary stream.
             for element in self.data:
                 Uint32(offset).serialize(stream)
@@ -199,15 +197,16 @@ class SSZVector[T: SSZType](SSZModel):
         # If elements are variable-size, read offsets to determine element boundaries.
         else:
             # The first offset tells us where the data starts, which must be after all offsets.
-            first_offset = int(Uint32.deserialize(stream, OFFSET_BYTE_LENGTH))
-            if first_offset != cls.LENGTH * OFFSET_BYTE_LENGTH:
-                expected = cls.LENGTH * OFFSET_BYTE_LENGTH
+            first_offset = int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
+            if first_offset != cls.LENGTH * BYTES_PER_LENGTH_OFFSET:
+                expected = cls.LENGTH * BYTES_PER_LENGTH_OFFSET
                 raise SSZSerializationError(
                     f"{cls.__name__}: invalid offset {first_offset}, expected {expected}"
                 )
             # Read the remaining offsets and add the total scope as the final boundary.
             offsets = [first_offset] + [
-                int(Uint32.deserialize(stream, OFFSET_BYTE_LENGTH)) for _ in range(cls.LENGTH - 1)
+                int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
+                for _ in range(cls.LENGTH - 1)
             ]
             offsets.append(scope)
             # Validate all offsets upfront before processing elements.
@@ -356,7 +355,7 @@ class SSZList[T: SSZType](SSZModel):
             # Variable-size elements: serialize offsets, then data
             variable_data_stream = io.BytesIO()
             # The first offset points to the end of all the offset data
-            offset = len(self.data) * OFFSET_BYTE_LENGTH
+            offset = len(self.data) * BYTES_PER_LENGTH_OFFSET
             # Write the offsets to the main stream and the data to the temporary stream
             for element in self.data:
                 Uint32(offset).serialize(stream)
@@ -394,23 +393,23 @@ class SSZList[T: SSZType](SSZModel):
             if scope == 0:
                 # Empty list case
                 return cls(data=[])
-            if scope < OFFSET_BYTE_LENGTH:
+            if scope < BYTES_PER_LENGTH_OFFSET:
                 raise SSZSerializationError(
                     f"{cls.__name__}: scope {scope} too small for variable-size list"
                 )
 
             # Read the first offset to determine the number of elements.
-            first_offset = int(Uint32.deserialize(stream, OFFSET_BYTE_LENGTH))
-            if first_offset > scope or first_offset % OFFSET_BYTE_LENGTH != 0:
+            first_offset = int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
+            if first_offset > scope or first_offset % BYTES_PER_LENGTH_OFFSET != 0:
                 raise SSZSerializationError(f"{cls.__name__}: invalid offset {first_offset}")
 
-            count = first_offset // OFFSET_BYTE_LENGTH
+            count = first_offset // BYTES_PER_LENGTH_OFFSET
             if count > cls.LIMIT:
                 raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {count}")
 
             # Read the rest of the offsets.
             offsets = [first_offset] + [
-                int(Uint32.deserialize(stream, OFFSET_BYTE_LENGTH)) for _ in range(count - 1)
+                int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET)) for _ in range(count - 1)
             ]
             offsets.append(scope)
             # Validate all offsets upfront before processing elements.

--- a/src/lean_spec/types/constants.py
+++ b/src/lean_spec/types/constants.py
@@ -1,8 +1,0 @@
-"""Constants used throughout the library."""
-
-from __future__ import annotations
-
-from typing import Final
-
-OFFSET_BYTE_LENGTH: Final = 4
-"""The number of bytes used to represent the offset of a variable-sized element."""

--- a/src/lean_spec/types/container.py
+++ b/src/lean_spec/types/container.py
@@ -9,9 +9,8 @@ Ethereum's serialization format.
 
 from typing import IO, Any, Self, override
 
-from .constants import OFFSET_BYTE_LENGTH
 from .exceptions import SSZSerializationError, SSZTypeError
-from .ssz_base import SSZModel, SSZType
+from .ssz_base import BYTES_PER_LENGTH_OFFSET, SSZModel, SSZType
 from .uint import Uint32
 
 
@@ -137,7 +136,7 @@ class Container(SSZModel):
                 variable_data.append(value.encode_bytes())
 
         # Calculate where variable data starts (after all fixed parts)
-        offset = sum(len(part) if part else OFFSET_BYTE_LENGTH for part in fixed_parts)
+        offset = sum(len(part) if part else BYTES_PER_LENGTH_OFFSET for part in fixed_parts)
 
         # Write fixed part with calculated offsets
         var_iter = iter(variable_data)
@@ -194,15 +193,15 @@ class Container(SSZModel):
                 bytes_read += size
             else:
                 # Read offset pointer for variable field
-                offset_bytes = stream.read(OFFSET_BYTE_LENGTH)
-                if len(offset_bytes) != OFFSET_BYTE_LENGTH:
+                offset_bytes = stream.read(BYTES_PER_LENGTH_OFFSET)
+                if len(offset_bytes) != BYTES_PER_LENGTH_OFFSET:
                     raise SSZSerializationError(
                         f"{cls.__name__}.{field_name}: "
-                        f"expected {OFFSET_BYTE_LENGTH} offset bytes, got {len(offset_bytes)}"
+                        f"expected {BYTES_PER_LENGTH_OFFSET} offset bytes, got {len(offset_bytes)}"
                     )
                 offset = int(Uint32.decode_bytes(offset_bytes))
                 var_fields.append((field_name, field_type, offset))
-                bytes_read += OFFSET_BYTE_LENGTH
+                bytes_read += BYTES_PER_LENGTH_OFFSET
 
         # Phase 2: Read variable part if present
         if var_fields:

--- a/src/lean_spec/types/ssz_base.py
+++ b/src/lean_spec/types/ssz_base.py
@@ -2,10 +2,14 @@
 
 import io
 from abc import ABC, abstractmethod
-from typing import IO, Self
+from typing import IO, Final, Self
 
 from .base import StrictBaseModel
 from .exceptions import SSZSerializationError
+
+BYTES_PER_LENGTH_OFFSET: Final = 4
+"""Width of an SSZ offset prefixing each variable-size element.
+Encoded as a uint32 in little-endian byte order."""
 
 
 class SSZType(ABC):


### PR DESCRIPTION
## Summary

- `src/lean_spec/types/constants.py` held a single entry — `OFFSET_BYTE_LENGTH = 4`, the SSZ variable-element offset width. A one-constant file is awkward to discover and easy to overlook.
- Move the value into `types/ssz_base.py` (the home of SSZ primitive abstractions, already imported by both `container.py` and `collections.py`) and rename to `BYTES_PER_LENGTH_OFFSET` to match the canonical SSZ-spec name used in `consensus-specs`.
- Delete `types/constants.py` and update the three import sites (`types/container.py`, `types/collections.py`, `subspecs/xmss/constants.py`). No backward-compat shim — call sites use the new name directly.

### Why ssz_base, not subspecs/ssz/constants.py?

Co-locating with `BYTES_PER_CHUNK` in `subspecs/ssz/constants.py` was the first instinct, but it breaks the layering: `subspecs/ssz/__init__.py` eagerly imports `hash.py`, which imports `Container` from `types/`, so `types/` cannot import from `subspecs/ssz/`. The two SSZ constant groupings reflect a real layering — serialization primitives in `types/`, merkleization primitives in `subspecs/ssz/`.

## Test plan

- [x] `just check` (lint, format, ty, codespell, mdformat) passes
- [x] `uv run pytest tests/lean_spec/types/ tests/lean_spec/subspecs/xmss/` — 1169 tests pass
- [x] `grep -rn OFFSET_BYTE_LENGTH src/` returns no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)