### PR TITLE
refactor(koalabear): make Fp an int subclass and tighten field surface

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
@@ -61,5 +61,5 @@ class PoseidonPermutationTest(BaseConsensusFixture):
         output_state = engine.permute(input_state)
 
         return self.model_copy(
-            update={"output": {"outputState": [str(fp.value) for fp in output_state]}}
+            update={"output": {"outputState": [str(int(fp)) for fp in output_state]}}
         )

--- a/src/lean_spec/subspecs/koalabear/field.py
+++ b/src/lean_spec/subspecs/koalabear/field.py
@@ -1,10 +1,16 @@
 """Core definition of the KoalaBear prime field Fp."""
 
-from __future__ import annotations
+from typing import IO, Any, Final, NoReturn, Self, override
 
-from typing import IO, Final, Self, override
+from pydantic.annotated_handlers import GetCoreSchemaHandler
+from pydantic_core import core_schema
 
 from lean_spec.types import SSZType
+from lean_spec.types.exceptions import (
+    SSZSerializationError,
+    SSZTypeError,
+    SSZValueError,
+)
 
 P: Final = 2**31 - 2**24 + 1
 """
@@ -20,7 +26,7 @@ P_BYTES: Final = (P_BITS + 7) // 8
 """The size of a KoalaBear field element in bytes."""
 
 
-class Fp(SSZType):
+class Fp(int, SSZType):
     """
     An element in the KoalaBear prime field F_p.
 
@@ -29,7 +35,9 @@ class Fp(SSZType):
     Each field element is represented as a 4-byte little-endian unsigned integer.
     """
 
-    def __init__(self, value: int) -> None:
+    __slots__ = ()
+
+    def __new__(cls, value: int) -> Self:
         """
         Create a field element.
 
@@ -39,13 +47,33 @@ class Fp(SSZType):
             Negative values will be normalized to the range [0, P).
 
         Raises:
-            TypeError: If value is not an integer.
+            SSZTypeError: If value is not an integer.
         """
         if not isinstance(value, int) or isinstance(value, bool):
-            raise TypeError(f"Field value must be an integer, got {type(value).__name__}")
+            raise SSZTypeError(f"Field value must be an integer, got {type(value).__name__}")
 
         # Normalize to [0, P) - handles negative values correctly
-        self.value: int = value % P
+        return super().__new__(cls, value % P)
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        """Hook into Pydantic's validation system."""
+        # A plain validator wraps a pre-validated int into a typed instance.
+        from_int_validator = core_schema.no_info_plain_validator_function(cls)
+        # Strict int validation enforces the canonical residue range before construction.
+        python_schema = core_schema.chain_schema(
+            [core_schema.int_schema(ge=0, lt=P, strict=True), from_int_validator]
+        )
+        # Existing instances bypass validation; raw ints flow through the strict chain.
+        return core_schema.union_schema(
+            [
+                core_schema.is_instance_schema(cls),
+                python_schema,
+            ],
+            serialization=core_schema.plain_serializer_function_ser_schema(int),
+        )
 
     @classmethod
     @override
@@ -62,7 +90,7 @@ class Fp(SSZType):
     @override
     def serialize(self, stream: IO[bytes]) -> int:
         """Serialize the field element to a binary stream."""
-        stream.write(self.value.to_bytes(P_BYTES, byteorder="little"))
+        stream.write(int(self).to_bytes(P_BYTES, byteorder="little"))
         return P_BYTES
 
     @classmethod
@@ -70,56 +98,91 @@ class Fp(SSZType):
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
         """Deserialize a field element from a binary stream."""
         if scope != P_BYTES:
-            raise ValueError(f"Expected {P_BYTES} bytes for Fp, got {scope}")
+            raise SSZSerializationError(f"Expected {P_BYTES} bytes for Fp, got {scope}")
         data = stream.read(P_BYTES)
         if len(data) != P_BYTES:
-            raise ValueError(f"Expected {P_BYTES} bytes for Fp, got {len(data)}")
+            raise SSZSerializationError(f"Expected {P_BYTES} bytes for Fp, got {len(data)}")
         value = int.from_bytes(data, byteorder="little")
         if value >= P:
-            raise ValueError(f"Value {value} exceeds field modulus {P}")
-        return cls(value=value)
+            raise SSZValueError(f"Value {value} exceeds field modulus {P}")
+        return cls(value)
 
-    def __add__(self, other: Self) -> Self:
+    def _reject(self, other: Any, op: str) -> NoReturn:
+        """Raise a consistent TypeError for a non-Fp operand."""
+        raise TypeError(
+            f"Unsupported operand type(s) for {op}: "
+            f"'{type(self).__name__}' and '{type(other).__name__}'"
+        )
+
+    def __add__(self, other: Any) -> Self:
         """Field addition."""
-        return self.__class__(value=self.value + other.value)
+        if type(other) is not type(self):
+            self._reject(other, "+")
+        return type(self)(int(self) + int(other))
 
-    def __sub__(self, other: Self) -> Self:
+    def __radd__(self, other: Any) -> NoReturn:
+        """Reverse addition: reject non-Fp left operand to prevent silent int fallback."""
+        self._reject(other, "+")
+
+    def __sub__(self, other: Any) -> Self:
         """Field subtraction."""
-        return self.__class__(value=self.value - other.value)
+        if type(other) is not type(self):
+            self._reject(other, "-")
+        return type(self)(int(self) - int(other))
+
+    def __rsub__(self, other: Any) -> NoReturn:
+        """Reverse subtraction: reject non-Fp left operand to prevent silent int fallback."""
+        self._reject(other, "-")
 
     def __neg__(self) -> Self:
         """Field negation."""
-        return self.__class__(value=-self.value)
+        return type(self)(-int(self))
 
-    def __mul__(self, other: Self) -> Self:
+    def __mul__(self, other: Any) -> Self:
         """Field multiplication."""
-        return self.__class__(value=self.value * other.value)
+        if type(other) is not type(self):
+            self._reject(other, "*")
+        return type(self)(int(self) * int(other))
 
-    def __pow__(self, exponent: int) -> Self:
+    def __rmul__(self, other: Any) -> NoReturn:
+        """Reverse multiplication: reject non-Fp left operand to prevent silent int fallback."""
+        self._reject(other, "*")
+
+    def __pow__(self, exponent: int) -> Self:  # ty: ignore[invalid-method-override]
         """Field exponentiation."""
-        return self.__class__(value=pow(self.value, exponent, P))
+        return type(self)(pow(int(self), exponent, P))
 
     def inverse(self) -> Self:
         """Computes the multiplicative inverse."""
-        if self.value == 0:
+        if int(self) == 0:
             raise ZeroDivisionError("Cannot invert the zero element.")
-        # a^(P-2) is the multiplicative inverse of a in F_p
-        return self ** (P - 2)
+        # pow(a, -1, P) returns the modular inverse via the extended Euclidean algorithm
+        return type(self)(pow(int(self), -1, P))
 
-    def __truediv__(self, other: Self) -> Self:
+    def __truediv__(self, other: Any) -> Self:
         """Field division."""
+        if type(other) is not type(self):
+            self._reject(other, "/")
         return self * other.inverse()
+
+    def __rtruediv__(self, other: Any) -> NoReturn:
+        """Reverse division: reject non-Fp left operand to prevent silent float fallback."""
+        self._reject(other, "/")
 
     def __eq__(self, other: object) -> bool:
         """Check equality of two field elements."""
-        if not isinstance(other, Fp):
+        if type(other) is not type(self):
             return False
-        return self.value == other.value
+        return super().__eq__(other)
+
+    def __ne__(self, other: object) -> bool:
+        """Check inequality of two field elements."""
+        return not self.__eq__(other)
 
     def __hash__(self) -> int:
         """Compute hash of the field element."""
-        return hash(self.value)
+        return hash((type(self), int(self)))
 
     def __repr__(self) -> str:
         """String representation."""
-        return f"Fp(value={self.value})"
+        return f"Fp(value={int(self)})"

--- a/src/lean_spec/subspecs/poseidon1/permutation.py
+++ b/src/lean_spec/subspecs/poseidon1/permutation.py
@@ -187,13 +187,11 @@ class Poseidon1:
         self._rounds_p = params.rounds_p
 
         # Build the dense circulant MDS matrix from first row.
-        first_row_ints = [fp.value for fp in params.mds_first_row]
+        first_row_ints = [int(fp) for fp in params.mds_first_row]
         self._mds = _build_circulant_mds(first_row_ints, params.width, P)
 
         # Pre-convert round constants to numpy array.
-        self._round_constants = np.array(
-            [fp.value for fp in params.round_constants], dtype=np.int64
-        )
+        self._round_constants = np.array([int(fp) for fp in params.round_constants], dtype=np.int64)
 
     def permute(self, current_state: list[Fp]) -> list[Fp]:
         """
@@ -214,7 +212,7 @@ class Poseidon1:
         if len(current_state) != self._width:
             raise ValueError(f"Input state must have length {self._width}")
 
-        state = np.array([fp.value for fp in current_state], dtype=np.int64)
+        state = np.array([int(fp) for fp in current_state], dtype=np.int64)
 
         _permute_jit(
             state,

--- a/src/lean_spec/subspecs/xmss/message_hash.py
+++ b/src/lean_spec/subspecs/xmss/message_hash.py
@@ -102,7 +102,7 @@ class MessageHasher(StrictBaseModel):
 
         digits: list[int] = []
         for fe in field_elements:
-            a = fe.value
+            a = int(fe)
 
             # Rejection: the only failing case is A_i == P - 1.
             if a >= threshold:

--- a/src/lean_spec/types/collections.py
+++ b/src/lean_spec/types/collections.py
@@ -7,12 +7,10 @@ from typing import (
     IO,
     Any,
     ClassVar,
-    Protocol,
     Self,
     cast,
     overload,
     override,
-    runtime_checkable,
 )
 
 from pydantic import Field, field_serializer, field_validator
@@ -21,16 +19,6 @@ from .byte_arrays import BaseBytes
 from .exceptions import SSZSerializationError, SSZTypeError, SSZValueError
 from .ssz_base import BYTES_PER_LENGTH_OFFSET, SSZModel, SSZType
 from .uint import Uint32
-
-
-@runtime_checkable
-class IntFieldElement(Protocol):
-    """Protocol for field elements with an integer value attribute.
-
-    Used for JSON serialization of field elements (e.g., Fp).
-    """
-
-    value: int
 
 
 def _extract_element_type_from_generic(cls: type, origin_class: type) -> type[SSZType] | None:
@@ -50,8 +38,9 @@ def _serialize_ssz_elements_to_json(value: Sequence[Any]) -> list[Any]:
     for item in value:
         if isinstance(item, BaseBytes):
             result.append("0x" + item.hex())
-        elif isinstance(item, IntFieldElement):
-            result.append(item.value)
+        elif isinstance(item, int) and not isinstance(item, bool):
+            # Covers Fp, BaseUint, and plain ints — emit a primitive int for JSON.
+            result.append(int(item))
         else:
             result.append(item)
     return result

--- a/tests/lean_spec/subspecs/koalabear/test_field.py
+++ b/tests/lean_spec/subspecs/koalabear/test_field.py
@@ -3,11 +3,19 @@ Tests for the KoalaBear prime field Fp.
 """
 
 import io
+import json
 import random
+from typing import Any
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from lean_spec.subspecs.koalabear.field import Fp, P
+from lean_spec.types.exceptions import (
+    SSZSerializationError,
+    SSZTypeError,
+    SSZValueError,
+)
 
 
 def test_constants() -> None:
@@ -74,14 +82,14 @@ def test_ssz_deserialize_wrong_scope() -> None:
     """Test deserialize error when scope doesn't match P_BYTES."""
     data = b"\x2a\x00\x00\x00"
     stream = io.BytesIO(data)
-    with pytest.raises(ValueError, match="Expected 4 bytes for Fp, got 3"):
+    with pytest.raises(SSZSerializationError, match="Expected 4 bytes for Fp, got 3"):
         Fp.deserialize(stream, 3)
 
 
 def test_ssz_deserialize_short_data() -> None:
     """Test deserialize error when stream has insufficient data."""
     stream = io.BytesIO(b"\x01\x02\x03")  # Only 3 bytes
-    with pytest.raises(ValueError, match="Expected 4 bytes for Fp, got 3"):
+    with pytest.raises(SSZSerializationError, match="Expected 4 bytes for Fp, got 3"):
         Fp.deserialize(stream, 4)
 
 
@@ -91,7 +99,7 @@ def test_ssz_deserialize_exceeds_modulus() -> None:
     # Encode a value >= P (use P itself)
     invalid_data = P.to_bytes(4, byteorder="little")
     stream = io.BytesIO(invalid_data)
-    with pytest.raises(ValueError, match="exceeds field modulus"):
+    with pytest.raises(SSZValueError, match="exceeds field modulus"):
         Fp.deserialize(stream, 4)
 
 
@@ -141,3 +149,200 @@ def test_ssz_deterministic() -> None:
 
     # Both should be identical
     assert data1 == data2
+
+
+@pytest.mark.parametrize(
+    ("bad_value", "type_name"),
+    [
+        (3.14, "float"),
+        ("5", "str"),
+        (None, "NoneType"),
+        (True, "bool"),
+        (False, "bool"),
+    ],
+)
+def test_new_rejects_non_int_inputs(bad_value: Any, type_name: str) -> None:
+    """Constructing Fp with a non-int input raises SSZTypeError naming the offending type."""
+    with pytest.raises(SSZTypeError, match=f"got {type_name}"):
+        Fp(bad_value)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (P, 0),
+        (P + 7, 7),
+        (-1, P - 1),
+        (-P, 0),
+        (2 * P + 42, 42),
+    ],
+)
+def test_new_normalizes_into_canonical_range(raw: int, expected: int) -> None:
+    """Constructor reduces the input modulo P into the canonical range."""
+    fp = Fp(raw)
+    assert int(fp) == expected
+    assert fp == Fp(expected)
+
+
+@pytest.mark.parametrize("op", ["+", "-", "*", "/"])
+def test_reverse_arithmetic_rejects_int_left_operand(op: str) -> None:
+    """Reverse operators reject a raw int on the left to block silent int fallback."""
+    a = Fp(2)
+    table = {
+        "+": lambda: 1 + a,
+        "-": lambda: 1 - a,
+        "*": lambda: 1 * a,
+        "/": lambda: 1 / a,
+    }
+    with pytest.raises(TypeError, match="Unsupported operand type"):
+        table[op]()
+
+
+@pytest.mark.parametrize("op", ["+", "-", "*", "/"])
+def test_forward_arithmetic_rejects_raw_int_right_operand(op: str) -> None:
+    """Forward operators reject a raw int on the right to enforce Fp-only arithmetic."""
+    a = Fp(2)
+    table = {
+        "+": lambda: a + 3,
+        "-": lambda: a - 3,
+        "*": lambda: a * 3,
+        "/": lambda: a / 3,
+    }
+    with pytest.raises(TypeError, match="Unsupported operand type"):
+        table[op]()
+
+
+def test_forward_arithmetic_rejects_bool_right_operand() -> None:
+    """Forward arithmetic against a bool right operand is rejected as a non-Fp type."""
+    a = Fp(2)
+    with pytest.raises(TypeError, match="and 'bool'"):
+        a + True  # noqa: B015
+
+
+def test_negation_of_zero_stays_zero() -> None:
+    """Negating the additive identity returns the additive identity."""
+    assert -Fp(0) == Fp(0)
+
+
+@pytest.mark.parametrize(
+    ("base", "exponent", "expected"),
+    [
+        (Fp(7), 0, Fp(1)),
+        (Fp(0), 0, Fp(1)),
+        (Fp(2), P, Fp(2)),
+        (Fp(3), 1, Fp(3)),
+    ],
+)
+def test_pow_covers_zero_and_modular_exponents(base: Fp, exponent: int, expected: Fp) -> None:
+    """Exponentiation handles zero exponent, modular exponent, and identity exponent."""
+    assert base**exponent == expected
+
+
+@pytest.mark.parametrize("a", [Fp(1), Fp(2), Fp(P - 1)])
+def test_inverse_multiplicative_property(a: Fp) -> None:
+    """The inverse satisfies a times a-inverse equals one and matches Fermat's little theorem."""
+    inv = a.inverse()
+    assert a * inv == Fp(1)
+    assert inv == a ** (P - 2)
+
+
+@pytest.mark.parametrize(("a", "b"), [(Fp(7), Fp(3)), (Fp(P - 1), Fp(2)), (Fp(1), Fp(P - 5))])
+def test_truediv_inverts_multiplication(a: Fp, b: Fp) -> None:
+    """Division is the inverse of multiplication for any non-zero divisor."""
+    assert (a / b) * b == a
+
+
+def test_truediv_by_zero_raises_zero_division() -> None:
+    """Dividing by the zero element raises ZeroDivisionError."""
+    with pytest.raises(ZeroDivisionError, match="Cannot invert the zero element"):
+        Fp(5) / Fp(0)
+
+
+def test_equality_matrix_covers_same_other_and_foreign_types() -> None:
+    """Equality returns True only between matching Fp residues, never raises on foreign types."""
+    a = Fp(5)
+    assert a == Fp(5)
+    assert (a == Fp(6)) is False
+    assert (a == 5) is False
+    assert (a == "5") is False
+    assert (a == None) is False  # noqa: E711
+    assert a != Fp(6)
+    assert a != 5
+    assert a != "5"
+    assert a != None  # noqa: E711
+
+
+def test_hash_mixes_in_type_and_keeps_residue_distinct_from_int() -> None:
+    """Hash is stable across equal Fps, differs from a raw int's hash, and behaves in sets."""
+    assert hash(Fp(5)) == hash(Fp(5))
+    assert hash(Fp(5)) != hash(5)
+    assert {Fp(5), Fp(5), Fp(6)} == {Fp(5), Fp(6)}
+    mixed = {Fp(5), 5}
+    assert len(mixed) == 2
+
+
+def test_repr_uses_value_kwarg_form() -> None:
+    """The repr form mirrors the kwarg constructor for round-trip readability."""
+    assert repr(Fp(7)) == "Fp(value=7)"
+
+
+def test_is_fixed_size_and_get_byte_length_are_classmethods() -> None:
+    """The SSZ size hooks resolve through the class, not just an instance."""
+    assert Fp.is_fixed_size() is True
+    assert Fp.get_byte_length() == 4
+
+
+def test_serialize_deserialize_round_trip_at_p_minus_one() -> None:
+    """A value at the upper boundary serializes and deserializes back to itself."""
+    fp = Fp(P - 1)
+    stream = io.BytesIO()
+    fp.serialize(stream)
+    stream.seek(0)
+    assert Fp.deserialize(stream, 4) == fp
+
+
+def test_encode_decode_bytes_round_trip_at_p_minus_one() -> None:
+    """The byte-oriented helpers round-trip the upper-boundary residue."""
+    fp = Fp(P - 1)
+    assert Fp.decode_bytes(fp.encode_bytes()) == fp
+
+
+def test_decode_bytes_rejects_oversized_input() -> None:
+    """A five-byte buffer is rejected because the scope guard fires before any read."""
+    with pytest.raises(SSZSerializationError, match="Expected 4 bytes for Fp, got 5"):
+        Fp.decode_bytes(b"\x00\x00\x00\x00\x01")
+
+
+class _PydanticModelWithFp(BaseModel):
+    """Tiny Pydantic carrier used to exercise the Fp core schema."""
+
+    x: Fp
+
+
+def test_pydantic_schema_accepts_valid_raw_int_and_lifts_to_fp() -> None:
+    """A raw integer in the valid range is validated and stored as an Fp instance."""
+    model = _PydanticModelWithFp(x=42)  # ty: ignore[invalid-argument-type]
+    assert model.x == Fp(42)
+    assert isinstance(model.x, Fp)
+
+
+def test_pydantic_schema_passes_through_existing_fp_instance() -> None:
+    """An existing Fp bypasses revalidation and is stored as-is."""
+    existing = Fp(123)
+    model = _PydanticModelWithFp(x=existing)
+    assert model.x is existing
+
+
+@pytest.mark.parametrize("bad", [P, P + 1, -1])
+def test_pydantic_schema_rejects_out_of_range_ints(bad: int) -> None:
+    """Raw integers outside the canonical range are rejected by Pydantic validation."""
+    with pytest.raises(ValidationError):
+        _PydanticModelWithFp(x=bad)  # ty: ignore[invalid-argument-type]
+
+
+def test_pydantic_json_serialization_drops_subtype_to_plain_int() -> None:
+    """JSON serialization emits a plain integer, hiding the Fp subtype."""
+    model = _PydanticModelWithFp(x=Fp(99))
+    payload = model.model_dump(mode="json")
+    assert payload == {"x": 99}
+    assert json.loads(model.model_dump_json()) == {"x": 99}

--- a/tests/lean_spec/subspecs/koalabear/test_field.py
+++ b/tests/lean_spec/subspecs/koalabear/test_field.py
@@ -5,6 +5,7 @@ Tests for the KoalaBear prime field Fp.
 import io
 import json
 import random
+import re
 from typing import Any
 
 import pytest
@@ -45,7 +46,7 @@ def test_base_field_arithmetic() -> None:
     assert a != "5"
 
     # Test error on inverting the zero element
-    with pytest.raises(ZeroDivisionError, match="Cannot invert the zero element."):
+    with pytest.raises(ZeroDivisionError, match=r"^Cannot invert the zero element\.$"):
         Fp(value=0).inverse()
 
 
@@ -82,14 +83,14 @@ def test_ssz_deserialize_wrong_scope() -> None:
     """Test deserialize error when scope doesn't match P_BYTES."""
     data = b"\x2a\x00\x00\x00"
     stream = io.BytesIO(data)
-    with pytest.raises(SSZSerializationError, match="Expected 4 bytes for Fp, got 3"):
+    with pytest.raises(SSZSerializationError, match=r"^Expected 4 bytes for Fp, got 3$"):
         Fp.deserialize(stream, 3)
 
 
 def test_ssz_deserialize_short_data() -> None:
     """Test deserialize error when stream has insufficient data."""
     stream = io.BytesIO(b"\x01\x02\x03")  # Only 3 bytes
-    with pytest.raises(SSZSerializationError, match="Expected 4 bytes for Fp, got 3"):
+    with pytest.raises(SSZSerializationError, match=r"^Expected 4 bytes for Fp, got 3$"):
         Fp.deserialize(stream, 4)
 
 
@@ -99,7 +100,7 @@ def test_ssz_deserialize_exceeds_modulus() -> None:
     # Encode a value >= P (use P itself)
     invalid_data = P.to_bytes(4, byteorder="little")
     stream = io.BytesIO(invalid_data)
-    with pytest.raises(SSZValueError, match="exceeds field modulus"):
+    with pytest.raises(SSZValueError, match=rf"^Value {P} exceeds field modulus {P}$"):
         Fp.deserialize(stream, 4)
 
 
@@ -163,7 +164,8 @@ def test_ssz_deterministic() -> None:
 )
 def test_new_rejects_non_int_inputs(bad_value: Any, type_name: str) -> None:
     """Constructing Fp with a non-int input raises SSZTypeError naming the offending type."""
-    with pytest.raises(SSZTypeError, match=f"got {type_name}"):
+    expected = rf"^Field value must be an integer, got {type_name}$"
+    with pytest.raises(SSZTypeError, match=expected):
         Fp(bad_value)
 
 
@@ -194,7 +196,8 @@ def test_reverse_arithmetic_rejects_int_left_operand(op: str) -> None:
         "*": lambda: 1 * a,
         "/": lambda: 1 / a,
     }
-    with pytest.raises(TypeError, match="Unsupported operand type"):
+    expected = rf"^Unsupported operand type\(s\) for {re.escape(op)}: 'Fp' and 'int'$"
+    with pytest.raises(TypeError, match=expected):
         table[op]()
 
 
@@ -208,14 +211,15 @@ def test_forward_arithmetic_rejects_raw_int_right_operand(op: str) -> None:
         "*": lambda: a * 3,
         "/": lambda: a / 3,
     }
-    with pytest.raises(TypeError, match="Unsupported operand type"):
+    expected = rf"^Unsupported operand type\(s\) for {re.escape(op)}: 'Fp' and 'int'$"
+    with pytest.raises(TypeError, match=expected):
         table[op]()
 
 
 def test_forward_arithmetic_rejects_bool_right_operand() -> None:
     """Forward arithmetic against a bool right operand is rejected as a non-Fp type."""
     a = Fp(2)
-    with pytest.raises(TypeError, match="and 'bool'"):
+    with pytest.raises(TypeError, match=r"^Unsupported operand type\(s\) for \+: 'Fp' and 'bool'$"):
         a + True  # noqa: B015
 
 
@@ -254,7 +258,7 @@ def test_truediv_inverts_multiplication(a: Fp, b: Fp) -> None:
 
 def test_truediv_by_zero_raises_zero_division() -> None:
     """Dividing by the zero element raises ZeroDivisionError."""
-    with pytest.raises(ZeroDivisionError, match="Cannot invert the zero element"):
+    with pytest.raises(ZeroDivisionError, match=r"^Cannot invert the zero element\.$"):
         Fp(5) / Fp(0)
 
 
@@ -309,7 +313,7 @@ def test_encode_decode_bytes_round_trip_at_p_minus_one() -> None:
 
 def test_decode_bytes_rejects_oversized_input() -> None:
     """A five-byte buffer is rejected because the scope guard fires before any read."""
-    with pytest.raises(SSZSerializationError, match="Expected 4 bytes for Fp, got 5"):
+    with pytest.raises(SSZSerializationError, match=r"^Expected 4 bytes for Fp, got 5$"):
         Fp.decode_bytes(b"\x00\x00\x00\x00\x01")
 
 

--- a/tests/lean_spec/subspecs/koalabear/test_field.py
+++ b/tests/lean_spec/subspecs/koalabear/test_field.py
@@ -164,8 +164,7 @@ def test_ssz_deterministic() -> None:
 )
 def test_new_rejects_non_int_inputs(bad_value: Any, type_name: str) -> None:
     """Constructing Fp with a non-int input raises SSZTypeError naming the offending type."""
-    expected = rf"^Field value must be an integer, got {type_name}$"
-    with pytest.raises(SSZTypeError, match=expected):
+    with pytest.raises(SSZTypeError, match=rf"^Field value must be an integer, got {type_name}$"):
         Fp(bad_value)
 
 
@@ -196,8 +195,10 @@ def test_reverse_arithmetic_rejects_int_left_operand(op: str) -> None:
         "*": lambda: 1 * a,
         "/": lambda: 1 / a,
     }
-    expected = rf"^Unsupported operand type\(s\) for {re.escape(op)}: 'Fp' and 'int'$"
-    with pytest.raises(TypeError, match=expected):
+    with pytest.raises(
+        TypeError,
+        match=rf"^Unsupported operand type\(s\) for {re.escape(op)}: 'Fp' and 'int'$",
+    ):
         table[op]()
 
 
@@ -211,8 +212,10 @@ def test_forward_arithmetic_rejects_raw_int_right_operand(op: str) -> None:
         "*": lambda: a * 3,
         "/": lambda: a / 3,
     }
-    expected = rf"^Unsupported operand type\(s\) for {re.escape(op)}: 'Fp' and 'int'$"
-    with pytest.raises(TypeError, match=expected):
+    with pytest.raises(
+        TypeError,
+        match=rf"^Unsupported operand type\(s\) for {re.escape(op)}: 'Fp' and 'int'$",
+    ):
         table[op]()
 
 

--- a/tests/lean_spec/subspecs/xmss/test_message_hash.py
+++ b/tests/lean_spec/subspecs/xmss/test_message_hash.py
@@ -25,7 +25,7 @@ def test_encode_message() -> None:
     msg_zeros = Bytes32(b"\x00" * 32)
     encoded_zeros = hasher.encode_message(msg_zeros)
     assert len(encoded_zeros) == config.MSG_LEN_FE
-    assert all(fe.value == 0 for fe in encoded_zeros)
+    assert all(fe == Fp(value=0) for fe in encoded_zeros)
 
     # All-max message (0xff)
     msg_max = Bytes32(b"\xff" * 32)

--- a/tests/lean_spec/subspecs/xmss/test_utils.py
+++ b/tests/lean_spec/subspecs/xmss/test_utils.py
@@ -49,7 +49,7 @@ def test_int_to_base_p_roundtrip() -> None:
 
     # Decompose the integer into base-P limbs using the function under test.
     decomposed_limbs_fp = int_to_base_p(original_value, num_limbs)
-    decomposed_limbs = [fp.value for fp in decomposed_limbs_fp]
+    decomposed_limbs = [int(fp) for fp in decomposed_limbs_fp]
 
     # Reconstruct the integer from the decomposed limbs.
     reconstructed_value = sum(val * (P**i) for i, val in enumerate(decomposed_limbs))


### PR DESCRIPTION
## Summary

- Switch `Fp` from a HAS-A wrapper (`self.value: int`) to an IS-A scalar (`class Fp(int, SSZType)`) matching the BaseUint primitive pattern. Drops the `.value` indirection at every call site.
- Replace explicit Fermat exponentiation in `inverse()` with the stdlib `pow(a, -1, P)` form (modular inverse via extended Euclidean).
- Move from bare `ValueError` / `TypeError` to the project's SSZ exception hierarchy (`SSZTypeError`, `SSZSerializationError`, `SSZValueError`).
- Strict typing on arithmetic with reverse-operator guards so `int + Fp` raises instead of silently returning a plain `int`.
- Loose equality (`Fp(5) == 5` returns `False`, doesn't raise) so collection membership checks still work; `__hash__` mixes in the type to keep `Fp(5)` and `5` distinct in sets.
- Add a Pydantic `__get_pydantic_core_schema__` hook: instances pass through, raw ints are strict-validated against `[0, P)`, JSON round-trips drop the subtype.

## Migration

- `xmss/message_hash.py`, `poseidon1/permutation.py`, and the `consensus_testing` poseidon fixture drop their `fp.value` reads in favor of `int(fp)`.
- `types/collections.py` collapses the now-dead `IntFieldElement` protocol into a plain `isinstance(item, int)` check that also covers `BaseUint`.

## Test coverage

- `tests/lean_spec/subspecs/koalabear/test_field.py`: 11 -> 55 tests, branch coverage 84% -> **100%**.
- New parametrized groups cover `__new__` rejection of non-ints, modular reduction at boundary inputs, reverse-operator rejection, `__pow__` edges (zero base, modular exponent), inverse multiplicative identity, full equality matrix, hash-mixing, Pydantic schema lift/reject/round-trip, and the `P - 1` boundary in serialize/deserialize.

## Test plan

- [x] `uv run pytest` — full suite (2956 tests pass)
- [x] `uv run pytest tests/lean_spec/subspecs/koalabear/ --cov=src/lean_spec/subspecs/koalabear/field --cov-report=term-missing` — 100% coverage
- [x] \`just check\` — ruff lint, ruff format, ty typecheck, codespell, mdformat all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)