### PR TITLE
refactor(types/collections): share base class, tighten validators, expand docs

### DIFF
--- a/src/lean_spec/types/collections.py
+++ b/src/lean_spec/types/collections.py
@@ -1,4 +1,35 @@
-"""Vector and List Type Specifications."""
+"""
+SSZ vector and list collections.
+
+Two sequence shapes are defined by the SSZ spec:
+
+- A vector holds exactly LENGTH elements of one declared type.
+- A list holds between zero and LIMIT elements of one declared type.
+
+A type is fixed-size when every value encodes to the same number of bytes.
+A variable-size type allows different values to encode to different widths.
+
+The encoding shape follows from the element type:
+
+- Fixed-size elements share one known width.
+  Bodies pack back-to-back with no separator.
+
+- Variable-size elements are prefixed by a uint32 offset table.
+  Each offset is a byte position from the start of the sequence.
+  It points at the start of one encoded element body.
+
+The offset table takes 4 * N bytes for N elements.
+The first offset therefore equals 4 * N — the byte position right after the table.
+
+For example, three variable-size bodies of widths 5, 3, and 7 encode to 27 bytes:
+
+    bytes 0..3   : off_0 = 12   (first body starts at byte 12)
+    bytes 4..7   : off_1 = 17   (second body starts at byte 17)
+    bytes 8..11  : off_2 = 20   (third body starts at byte 20)
+    bytes 12..16 : body_0       (5 bytes)
+    bytes 17..19 : body_1       (3 bytes)
+    bytes 20..26 : body_2       (7 bytes)
+"""
 
 import io
 from collections.abc import Iterator, Sequence
@@ -21,420 +52,568 @@ from .ssz_base import BYTES_PER_LENGTH_OFFSET, SSZModel, SSZType
 from .uint import Uint32
 
 
-def _extract_element_type_from_generic(cls: type, origin_class: type) -> type[SSZType] | None:
-    """Extract ELEMENT_TYPE from Pydantic's generic metadata."""
-    for base in cls.__bases__:
-        metadata = getattr(base, "__pydantic_generic_metadata__", None)
-        if metadata and metadata.get("origin") is origin_class:
-            args = metadata.get("args", ())
-            if args:
-                return cast(type[SSZType], args[0])
-    return None
-
-
-def _serialize_ssz_elements_to_json(value: Sequence[Any]) -> list[Any]:
-    """Serialize SSZ collection elements to JSON-compatible format."""
-    result: list[Any] = []
-    for item in value:
-        if isinstance(item, BaseBytes):
-            result.append("0x" + item.hex())
-        elif isinstance(item, int) and not isinstance(item, bool):
-            # Covers Fp, BaseUint, and plain ints — emit a primitive int for JSON.
-            result.append(int(item))
-        else:
-            result.append(item)
-    return result
-
-
 def _validate_offsets(offsets: list[int], scope: int, type_name: str) -> None:
-    """Validate offset table before processing elements.
-
-    Checks:
-
-    - Offsets are monotonically non-decreasing
-    - Final offset does not exceed scope
     """
+    Enforce the offset-table invariants before reading element bodies.
+
+    Two rules imply that every (start, end) pair is valid:
+
+    - Offsets are monotonically non-decreasing, so no body has negative width.
+    - The final offset stays within scope, so no body reads past its budget.
+
+    Raises:
+        SSZSerializationError: When a later offset is smaller than an earlier one.
+        SSZSerializationError: When the final offset exceeds the available scope.
+    """
+    # Empty sequences have no bodies and therefore no boundaries to enforce.
     if not offsets:
         return
 
+    # Pairwise comparison catches any decreasing step in the table.
     for prev, curr in pairwise(offsets):
         if curr < prev:
             raise SSZSerializationError(
                 f"{type_name}: offsets not monotonically increasing: {prev} -> {curr}"
             )
 
+    # The final boundary is the scope appended by the decoder.
+    # A larger final offset would extend past the available bytes.
     if offsets[-1] > scope:
         raise SSZSerializationError(
             f"{type_name}: final offset {offsets[-1]} exceeds scope {scope}"
         )
 
 
-class SSZVector[T: SSZType](SSZModel):
-    """Fixed-length, immutable SSZ sequence.
+class _SSZSequence[T: SSZType](SSZModel):
+    """
+    Shared scaffolding for fixed- and variable-length SSZ sequences.
 
-    Contains exactly LENGTH elements of type ELEMENT_TYPE.
-    Length is fixed at the type level and cannot change at runtime.
+    Two subclasses concretize this base:
 
-    Subclasses must define LENGTH.
-    ELEMENT_TYPE is auto-inferred from the generic parameter.
+    - A vector pins the element count at LENGTH.
+    - A list bounds the element count by LIMIT.
 
-    SSZ encoding:
+    Both store elements in a Pydantic field named data.
+    Both expose tuple-style iteration and indexing.
+    Both share the offset-table writer used by variable-size encodings.
 
-    - Fixed-size elements: serialized back-to-back
-    - Variable-size elements: offset table followed by element data
+    The element type is inferred from the generic parameter, once per subclass.
     """
 
     ELEMENT_TYPE: ClassVar[type[SSZType]]
-    """The SSZ type of elements in this vector (auto-inferred from generic parameter)."""
-
-    LENGTH: ClassVar[int]
-    """The exact number of elements (fixed at the type level)."""
+    """SSZ type of every element, inferred from the generic parameter."""
 
     data: Sequence[T] = Field(default_factory=tuple)
+    """
+    Immutable sequence of elements.
+
+    Accepts lists, tuples, or iterables of compatible values on input.
+    Stored as an immutable tuple after validation.
+    """
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Automatically set ELEMENT_TYPE from the generic parameter."""
-        super().__init_subclass__(**kwargs)
+        """
+        Read the element type from the generic parameter in a class declaration.
 
-        # Skip if ELEMENT_TYPE is explicitly defined in this class
+        When a subclass is written as:
+
+            class Uint16Vector2(SSZVector[Uint16]):
+                LENGTH = 2
+
+        the Uint16 inside the brackets is copied into Uint16Vector2.ELEMENT_TYPE.
+        This way, a user does not have to write ELEMENT_TYPE = Uint16 by hand.
+        """
+        super().__init_subclass__(**kwargs)
         if "ELEMENT_TYPE" in cls.__dict__:
             return
 
-        element_type = _extract_element_type_from_generic(cls, SSZVector)
-        if element_type is not None:
-            cls.ELEMENT_TYPE = element_type
+        # Walk direct parents looking for a parameterized SSZ sequence base.
+        # The first concrete element type wins.
+        # Layers carrying only a TypeVar are skipped.
+        for base in cls.__bases__:
+            # Pydantic stores the generic parameterization on every generic parent.
+            # An empty default skips bases that were never made generic.
+            metadata = getattr(base, "__pydantic_generic_metadata__", {})
+
+            # Origin is the unparameterized class — for example SSZVector itself.
+            # Skip bases outside the sequence hierarchy.
+            origin = metadata.get("origin")
+            if not (isinstance(origin, type) and issubclass(origin, _SSZSequence)):
+                continue
+
+            # Args holds the types that appeared between the brackets.
+            # A real SSZType subclass wins.
+            # A bare TypeVar means an abstract layer has not bound the parameter yet.
+            for arg in metadata.get("args", ()):
+                if isinstance(arg, type) and issubclass(arg, SSZType):
+                    cls.ELEMENT_TYPE = arg
+                    return
 
     @field_serializer("data", when_used="json")
     def _serialize_data(self, value: Sequence[T]) -> list[Any]:
-        """Serialize vector elements to JSON."""
-        return _serialize_ssz_elements_to_json(value)
+        """
+        Render the elements as a JSON-friendly list.
+
+        Two leaf shapes need bespoke handling:
+
+        - Byte arrays render as 0x-prefixed hex strings.
+        - Integer leaves (uints, field elements) flatten to a plain int.
+
+        Anything else passes through for Pydantic's downstream serializers.
+        """
+        # Pydantic does not auto-flatten SSZ leaf types into JSON primitives.
+        # Each element is inspected and rewritten according to the rules below.
+        result: list[Any] = []
+        for item in value:
+            # Byte-array leaves render as 0x-prefixed hex strings.
+            # This matches how every other byte value appears in spec output.
+            if isinstance(item, BaseBytes):
+                result.append("0x" + item.hex())
+
+            # Integer leaves (uints, field elements) flatten to a plain int.
+            # Bool also subclasses int.
+            # It is excluded so True and False survive in JSON unchanged.
+            elif isinstance(item, int) and not isinstance(item, bool):
+                result.append(int(item))
+
+            # Anything else passes through for Pydantic's downstream serializers.
+            # Nested containers, booleans, strings, and primitive values land here.
+            else:
+                result.append(item)
+        return result
+
+    def _write_variable_payload(self, stream: IO[bytes], offset_count: int) -> int:
+        """
+        Write the offset table followed by the buffered element bodies.
+
+        Offsets are emitted to the output stream first.
+        Bodies are buffered and flushed after the table.
+
+        Args:
+            stream: Output binary stream.
+            offset_count: Number of offset entries in the table.
+
+        Returns:
+            Total bytes written, equal to the final offset value.
+        """
+        # A forward-only stream cannot revisit earlier offset slots to fix them up.
+        # Bodies must be buffered until the table is fully written.
+        bodies = io.BytesIO()
+
+        # The first offset points past the entire offset table.
+        # Each subsequent offset advances by the previous body's width.
+        offset = offset_count * BYTES_PER_LENGTH_OFFSET
+        for element in self.data:
+            Uint32(offset).serialize(stream)
+            offset += element.serialize(bodies)
+
+        # Bodies land at the byte positions the offsets just declared.
+        stream.write(bodies.getvalue())
+        return offset
+
+    @override
+    def __len__(self) -> int:
+        """Return the number of elements in the sequence."""
+        return len(self.data)
+
+    @override
+    def __iter__(self) -> Iterator[T]:  # type: ignore[override]
+        """
+        Iterate over the elements.
+
+        Defined explicitly because the parent Pydantic model otherwise yields
+        name/value pairs of its fields.
+        """
+        return iter(self.data)
+
+    @overload
+    def __getitem__(self, index: int) -> T: ...
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[T]: ...
+
+    def __getitem__(self, index: int | slice) -> T | Sequence[T]:
+        """Index by integer or slice the underlying tuple."""
+        return self.data[index]
+
+    @property
+    def elements(self) -> list[T]:
+        """Return a mutable copy of the elements as a list."""
+        return list(self.data)
+
+
+class SSZVector[T: SSZType](_SSZSequence[T]):
+    """
+    Fixed-length, immutable SSZ sequence.
+
+    Holds exactly LENGTH elements of one declared type.
+    The element count is pinned at the type level and never changes at runtime.
+
+    Two encoding shapes follow from the element type:
+
+    - Fixed-size elements pack back-to-back with no separators.
+    - Variable-size elements use the offset-table layout.
+
+    Subclasses declare LENGTH directly in the class body.
+    The element type is inferred from the generic parameter.
+
+    For example, three Uint16 values encode as six raw bytes:
+
+        bytes 0..1 : 67 45   (= 0x4567, little-endian)
+        bytes 2..3 : 23 01   (= 0x0123)
+        bytes 4..5 : ef cd   (= 0xCDEF)
+
+    Two variable-size bodies of widths 5 and 7 encode to 20 bytes:
+
+        bytes 0..3   : off_0 = 8    (first body starts at byte 8)
+        bytes 4..7   : off_1 = 13   (second body starts at byte 13)
+        bytes 8..12  : body_0       (5 bytes)
+        bytes 13..19 : body_1       (7 bytes)
+    """
+
+    LENGTH: ClassVar[int]
+    """Exact number of elements, fixed at the type level."""
 
     @field_validator("data", mode="before")
     @classmethod
-    def _validate_vector_data(cls, v: Any) -> tuple[SSZType, ...]:
-        """Validate and convert input to a typed tuple of exactly LENGTH elements."""
+    def _coerce_and_validate(cls, v: Any) -> tuple[SSZType, ...]:
+        """
+        Enforce the exact element count and coerce inputs into ELEMENT_TYPE.
+
+        Three rejections happen before coercion:
+
+        - Misconfigured subclasses without ELEMENT_TYPE or LENGTH fail.
+        - String and bytes inputs are rejected to avoid silent character iteration.
+        - Non-iterable inputs fail fast with a descriptive message.
+
+        Each element passes through the declared type's constructor on coercion.
+        Failures re-raise with the high-level expectation in the message.
+        The chained cause preserves the underlying coercion detail.
+        """
+        # Subclasses must declare both annotations before any instance can validate.
         if not hasattr(cls, "ELEMENT_TYPE") or not hasattr(cls, "LENGTH"):
             raise SSZTypeError(f"{cls.__name__} must define ELEMENT_TYPE and LENGTH")
 
-        if not isinstance(v, (list, tuple)):
-            v = tuple(v)
+        # Accept the natural input shapes:
+        #
+        #   - list or tuple    pass through directly.
+        #   - other iterables  materialize into a list so the length check works.
+        #   - str or bytes     rejected — iterating yields characters or ints.
+        if isinstance(v, (list, tuple)):
+            items: Sequence[Any] = v
+        elif isinstance(v, (str, bytes, bytearray)):
+            raise SSZTypeError(
+                f"{cls.__name__}: Expected iterable of {cls.ELEMENT_TYPE.__name__}, "
+                f"got {type(v).__name__}"
+            )
+        elif hasattr(v, "__iter__"):
+            items = list(v)
+        else:
+            raise SSZTypeError(f"{cls.__name__}: Expected iterable, got {type(v).__name__}")
 
-        # Convert each element to the declared type
-        typed_values = tuple(
-            item if isinstance(item, cls.ELEMENT_TYPE) else cast(Any, cls.ELEMENT_TYPE)(item)
-            for item in v
-        )
-
-        if len(typed_values) != cls.LENGTH:
+        # Fixed-length type: the input must contain exactly LENGTH elements.
+        if len(items) != cls.LENGTH:
             raise SSZValueError(
-                f"{cls.__name__} requires exactly {cls.LENGTH} elements, got {len(typed_values)}"
+                f"{cls.__name__} requires exactly {cls.LENGTH} elements, got {len(items)}"
             )
 
-        return typed_values
+        # Coerce each non-typed element through the declared element type.
+        # Inner errors are re-raised with the high-level expectation.
+        # The chained cause preserves the underlying coercion detail.
+        result: list[SSZType] = []
+        for item in items:
+            if isinstance(item, cls.ELEMENT_TYPE):
+                result.append(item)
+                continue
+            try:
+                result.append(cast(Any, cls.ELEMENT_TYPE)(item))
+            except (SSZTypeError, SSZValueError, TypeError, ValueError) as e:
+                raise SSZTypeError(
+                    f"Expected {cls.ELEMENT_TYPE.__name__}, got {type(item).__name__}: {e}"
+                ) from e
+        return tuple(result)
 
     @classmethod
     @override
     def is_fixed_size(cls) -> bool:
-        """An SSZVector is fixed-size if and only if its elements are fixed-size."""
+        """A vector is fixed-size if and only if its elements are fixed-size."""
         return cls.ELEMENT_TYPE.is_fixed_size()
 
     @classmethod
     @override
     def get_byte_length(cls) -> int:
-        """Get the byte length if the SSZVector is fixed-size."""
+        """
+        Return the fixed encoded byte length.
+
+        Raises:
+            SSZTypeError: When the element type is variable-size.
+        """
         if not cls.is_fixed_size():
             raise SSZTypeError(f"{cls.__name__}: variable-size vector has no fixed byte length")
         return cls.ELEMENT_TYPE.get_byte_length() * cls.LENGTH
 
     @override
     def serialize(self, stream: IO[bytes]) -> int:
-        """Serialize the vector to a binary stream."""
-        # If elements are fixed-size, serialize them back-to-back.
+        """Write the SSZ encoding to a binary stream and return the byte count."""
+        # Fixed-size elements: serialize each body directly, no offsets needed.
         if self.is_fixed_size():
             return sum(element.serialize(stream) for element in self.data)
-        # If elements are variable-size, serialize their offsets, then their data.
-        else:
-            # Use a temporary in-memory stream to hold the serialized variable data.
-            variable_data_stream = io.BytesIO()
-            # The first offset points to the end of all the offset data.
-            offset = self.LENGTH * BYTES_PER_LENGTH_OFFSET
-            # Write the offsets to the main stream and the data to the temporary stream.
-            for element in self.data:
-                Uint32(offset).serialize(stream)
-                offset += element.serialize(variable_data_stream)
-            # Write the serialized variable data after the offsets.
-            stream.write(variable_data_stream.getvalue())
-            # The total bytes written is the final offset value.
-            return offset
+        # Variable-size elements: emit a table of LENGTH offsets, then the bodies.
+        return self._write_variable_payload(stream, self.LENGTH)
 
     @classmethod
     @override
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
-        """Deserialize a vector from a binary stream."""
-        # If elements are fixed-size, read `LENGTH` elements of a fixed size.
-        elements: list[SSZType] = []
+        """
+        Read one vector from a binary stream within the given byte budget.
+
+        Two cases mirror the encoder:
+
+        - Fixed-size elements: scope equals LENGTH times the element byte width.
+        - Variable-size elements: a LENGTH-wide offset table precedes the bodies.
+
+        Raises:
+            SSZSerializationError: When scope or any offset is inconsistent.
+        """
+        # Fixed-size case: elements pack back-to-back at a known stride.
+        # The byte budget must match LENGTH times the element width exactly.
         if cls.is_fixed_size():
-            elem_byte_length = cls.get_byte_length() // cls.LENGTH
-            if scope != cls.get_byte_length():
+            elem_byte_length = cls.ELEMENT_TYPE.get_byte_length()
+            expected_total = elem_byte_length * cls.LENGTH
+            if scope != expected_total:
                 raise SSZSerializationError(
-                    f"{cls.__name__}: expected {cls.get_byte_length()} bytes, got {scope}"
+                    f"{cls.__name__}: expected {expected_total} bytes, got {scope}"
                 )
             elements = [
                 cls.ELEMENT_TYPE.deserialize(stream, elem_byte_length) for _ in range(cls.LENGTH)
             ]
             return cls(data=elements)
-        # If elements are variable-size, read offsets to determine element boundaries.
-        else:
-            # The first offset tells us where the data starts, which must be after all offsets.
-            first_offset = int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
-            if first_offset != cls.LENGTH * BYTES_PER_LENGTH_OFFSET:
-                expected = cls.LENGTH * BYTES_PER_LENGTH_OFFSET
-                raise SSZSerializationError(
-                    f"{cls.__name__}: invalid offset {first_offset}, expected {expected}"
-                )
-            # Read the remaining offsets and add the total scope as the final boundary.
-            offsets = [first_offset] + [
-                int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
-                for _ in range(cls.LENGTH - 1)
+
+        # Variable-size case: read the full offset table, then slice each body.
+        #
+        # Scope must cover at least the offset table itself.
+        # The first offset must then equal the table's own byte width.
+        # Scope is appended as the final boundary so pairwise iteration yields every span.
+        expected_first = cls.LENGTH * BYTES_PER_LENGTH_OFFSET
+        if scope < expected_first:
+            raise SSZSerializationError(
+                f"{cls.__name__}: scope {scope} too small, expected at least {expected_first}"
+            )
+        offsets = [
+            int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET)) for _ in range(cls.LENGTH)
+        ]
+        if offsets[0] != expected_first:
+            raise SSZSerializationError(
+                f"{cls.__name__}: invalid offset {offsets[0]}, expected {expected_first}"
+            )
+        offsets.append(scope)
+        _validate_offsets(offsets, scope, cls.__name__)
+
+        return cls(
+            data=[
+                cls.ELEMENT_TYPE.deserialize(stream, end - start)
+                for start, end in pairwise(offsets)
             ]
-            offsets.append(scope)
-            # Validate all offsets upfront before processing elements.
-            _validate_offsets(offsets, scope, cls.__name__)
-            # Read each element's data from its calculated slice.
-            for start, end in pairwise(offsets):
-                elements.append(cls.ELEMENT_TYPE.deserialize(stream, end - start))
-            return cls(data=elements)
-
-    def __len__(self) -> int:
-        """Return the number of elements in the vector."""
-        return len(self.data)
-
-    def __iter__(self) -> Iterator[T]:  # type: ignore[override]
-        """Iterate over vector elements."""
-        return iter(self.data)
-
-    @overload
-    def __getitem__(self, index: int) -> T: ...
-    @overload
-    def __getitem__(self, index: slice) -> Sequence[T]: ...
-
-    def __getitem__(self, index: int | slice) -> T | Sequence[T]:
-        """
-        Access element(s) by index or slice.
-
-        Returns properly typed results:
-
-        - `vec[0]` returns `T`
-        - `vec[0:2]` returns `Sequence[T]`
-        """
-        return self.data[index]
-
-    @property
-    def elements(self) -> list[T]:
-        """Return the elements as a typed list."""
-        return list(self.data)
+        )
 
 
-class SSZList[T: SSZType](SSZModel):
-    """Variable-length SSZ sequence with a maximum capacity.
+class SSZList[T: SSZType](_SSZSequence[T]):
+    """
+    Variable-length SSZ sequence with a maximum capacity.
 
-    Contains between 0 and LIMIT elements of type ELEMENT_TYPE.
-    Unlike Vector, length can vary at runtime.
+    Holds between zero and LIMIT elements of one declared type.
+    The element count is set at construction time and varies between instances.
 
-    Subclasses must define LIMIT.
-    ELEMENT_TYPE is auto-inferred from the generic parameter.
+    Two encoding shapes mirror the vector cases:
 
-    SSZ encoding:
+    - Fixed-size elements pack back-to-back, count recovered from wire scope.
+    - Variable-size elements use an offset table that also reveals the count.
 
-    - Fixed-size elements: serialized back-to-back
-    - Variable-size elements: offset table followed by element data
-    - Hash tree root includes element count (mixed-in)
+    The hash tree root mixes in the element count alongside the chunked data.
+    Two lists with identical contents but different LIMITs hash differently.
+
+    Subclasses declare LIMIT directly in the class body.
+    The element type is inferred from the generic parameter.
+
+    For example, three Uint16 values under a limit of eight encode as six bytes:
+
+        bytes 0..1 : bb aa   (= 0xAABB, little-endian, no length prefix)
+        bytes 2..3 : ad c0   (= 0xC0AD)
+        bytes 4..5 : ff ee   (= 0xEEFF)
+
+    Two variable-size bodies of widths 4 and 6 encode to 18 bytes:
+
+        bytes 0..3   : off_0 = 8    (first body starts at byte 8)
+        bytes 4..7   : off_1 = 12   (second body starts at byte 12)
+        bytes 8..11  : body_0       (4 bytes)
+        bytes 12..17 : body_1       (6 bytes)
     """
 
-    ELEMENT_TYPE: ClassVar[type[SSZType]]
-    """The SSZ type of elements in this list (auto-inferred from generic parameter)."""
-
     LIMIT: ClassVar[int]
-    """The maximum number of elements allowed."""
-
-    data: Sequence[T] = Field(default_factory=tuple)
-    """The immutable sequence of elements."""
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Automatically set ELEMENT_TYPE from the generic parameter."""
-        super().__init_subclass__(**kwargs)
-
-        # Skip if ELEMENT_TYPE is explicitly defined in this class
-        if "ELEMENT_TYPE" in cls.__dict__:
-            return
-
-        element_type = _extract_element_type_from_generic(cls, SSZList)
-        if element_type is not None:
-            cls.ELEMENT_TYPE = element_type
-
-    @field_serializer("data", when_used="json")
-    def _serialize_data(self, value: Sequence[T]) -> list[Any]:
-        """Serialize list elements to JSON."""
-        return _serialize_ssz_elements_to_json(value)
+    """Maximum number of elements allowed."""
 
     @field_validator("data", mode="before")
     @classmethod
-    def _validate_list_data(cls, v: Any) -> tuple[SSZType, ...]:
-        """Validate and convert input to a tuple of SSZType elements."""
+    def _coerce_and_validate(cls, v: Any) -> tuple[SSZType, ...]:
+        """
+        Enforce the maximum element count and coerce inputs into ELEMENT_TYPE.
+
+        Three rejections happen before coercion:
+
+        - Misconfigured subclasses without ELEMENT_TYPE or LIMIT fail.
+        - String and bytes inputs are rejected to avoid silent character iteration.
+        - Non-iterable inputs fail fast with a descriptive message.
+
+        Each element passes through the declared type's constructor on coercion.
+        Failures re-raise with the high-level expectation in the message.
+        The chained cause preserves the underlying coercion detail.
+        """
+        # Subclasses must declare both annotations before any instance can validate.
         if not hasattr(cls, "ELEMENT_TYPE") or not hasattr(cls, "LIMIT"):
             raise SSZTypeError(f"{cls.__name__} must define ELEMENT_TYPE and LIMIT")
 
-        # Handle various input types
+        # Accept the natural input shapes:
+        #
+        #   - list or tuple    pass through directly.
+        #   - other iterables  materialize into a list so the length check works.
+        #   - str or bytes     rejected — iterating yields characters or ints.
         if isinstance(v, (list, tuple)):
-            elements = v
-        elif hasattr(v, "__iter__") and not isinstance(v, (str, bytes)):
-            elements = list(v)
+            items: Sequence[Any] = v
+        elif isinstance(v, (str, bytes, bytearray)):
+            raise SSZTypeError(
+                f"{cls.__name__}: Expected iterable of {cls.ELEMENT_TYPE.__name__}, "
+                f"got {type(v).__name__}"
+            )
+        elif hasattr(v, "__iter__"):
+            items = list(v)
         else:
-            raise SSZTypeError(f"Expected iterable, got {type(v).__name__}")
+            raise SSZTypeError(f"{cls.__name__}: Expected iterable, got {type(v).__name__}")
 
-        # Check limit
-        if len(elements) > cls.LIMIT:
-            raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {len(elements)}")
+        # Variable-length type: any count is fine, up to LIMIT.
+        if len(items) > cls.LIMIT:
+            raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {len(items)}")
 
-        # Convert and validate each element
-        typed_values = []
-        for element in elements:
-            if isinstance(element, cls.ELEMENT_TYPE):
-                typed_values.append(element)
-            else:
-                try:
-                    typed_values.append(cast(Any, cls.ELEMENT_TYPE)(element))
-                except Exception as e:
-                    raise SSZTypeError(
-                        f"Expected {cls.ELEMENT_TYPE.__name__}, got {type(element).__name__}"
-                    ) from e
-
-        return tuple(typed_values)
+        # Coerce each non-typed element through the declared element type.
+        # Inner errors are re-raised with the high-level expectation.
+        # The chained cause preserves the underlying coercion detail.
+        result: list[SSZType] = []
+        for item in items:
+            if isinstance(item, cls.ELEMENT_TYPE):
+                result.append(item)
+                continue
+            try:
+                result.append(cast(Any, cls.ELEMENT_TYPE)(item))
+            except (SSZTypeError, SSZValueError, TypeError, ValueError) as e:
+                raise SSZTypeError(
+                    f"Expected {cls.ELEMENT_TYPE.__name__}, got {type(item).__name__}: {e}"
+                ) from e
+        return tuple(result)
 
     def __add__(self, other: Any) -> Self:
-        """Concatenate this list with another sequence."""
-        if isinstance(other, SSZList):
-            new_data = self.data + other.data
-        elif isinstance(other, (list, tuple)):
-            new_data = tuple(self.data) + tuple(other)
-        else:
-            return NotImplemented
+        """
+        Concatenate with another sequence and return a new list.
+
+        The validator on the resulting instance enforces LIMIT.
+        Overflowing concatenations raise SSZValueError at construction.
+        """
+        match other:
+            case SSZList():
+                new_data = (*self.data, *other.data)
+            case list() | tuple():
+                new_data = (*self.data, *other)
+            case _:
+                return NotImplemented
         return type(self)(data=new_data)
 
     @classmethod
     @override
     def is_fixed_size(cls) -> bool:
-        """An SSZList is never fixed-size (length varies from 0 to LIMIT)."""
+        """A list is never fixed-size since the element count ranges from zero to LIMIT."""
         return False
 
     @classmethod
     @override
     def get_byte_length(cls) -> int:
-        """Lists are variable-size, so this raises an SSZTypeError."""
+        """
+        Variable-size types have no fixed byte length.
+
+        Raises:
+            SSZTypeError: Always — call this only on fixed-size types.
+        """
         raise SSZTypeError(f"{cls.__name__}: variable-size list has no fixed byte length")
 
     @override
     def serialize(self, stream: IO[bytes]) -> int:
-        """Serialize the list to a binary stream."""
-        # Lists are always variable-size, so we serialize offsets + data
+        """Write the SSZ encoding to a binary stream and return the byte count."""
+        # Fixed-size elements pack back-to-back with no length prefix.
+        # The element count is recovered on decode from the wire scope.
         if self.ELEMENT_TYPE.is_fixed_size():
-            # Fixed-size elements: serialize them back-to-back
             return sum(element.serialize(stream) for element in self.data)
-        else:
-            # Variable-size elements: serialize offsets, then data
-            variable_data_stream = io.BytesIO()
-            # The first offset points to the end of all the offset data
-            offset = len(self.data) * BYTES_PER_LENGTH_OFFSET
-            # Write the offsets to the main stream and the data to the temporary stream
-            for element in self.data:
-                Uint32(offset).serialize(stream)
-                offset += element.serialize(variable_data_stream)
-            # Write the serialized variable data after the offsets
-            stream.write(variable_data_stream.getvalue())
-            # The total bytes written is the final offset value
-            return offset
+        # Variable-size elements: emit a table sized for the runtime count, then bodies.
+        return self._write_variable_payload(stream, len(self.data))
 
     @classmethod
     @override
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
-        """Deserialize a list from a binary stream."""
+        """
+        Read one list from a binary stream within the given byte budget.
+
+        Three cases cover all valid inputs:
+
+        - Empty scope decodes to an empty list.
+        - Fixed-size elements: count equals scope divided by element width.
+        - Variable-size elements: the first offset locates bodies and reveals the count.
+
+        Raises:
+            SSZSerializationError: When scope or any offset is malformed.
+            SSZValueError: When the recovered element count exceeds LIMIT.
+        """
+        # Empty case: any zero-byte payload decodes to an empty list.
+        if scope == 0:
+            return cls(data=())
+
+        # Fixed-size case: elements pack back-to-back at a known stride.
+        # The count is recovered by dividing the byte budget by the element width.
         if cls.ELEMENT_TYPE.is_fixed_size():
-            # Fixed-size elements: read them back-to-back
             element_size = cls.ELEMENT_TYPE.get_byte_length()
             if scope % element_size != 0:
                 raise SSZSerializationError(
                     f"{cls.__name__}: scope {scope} not divisible by element size {element_size}"
                 )
-
             num_elements = scope // element_size
             if num_elements > cls.LIMIT:
                 raise SSZValueError(
                     f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {num_elements}"
                 )
-
             elements = [
                 cls.ELEMENT_TYPE.deserialize(stream, element_size) for _ in range(num_elements)
             ]
-
             return cls(data=elements)
-        else:
-            # Variable-size elements: read offsets first, then data
-            if scope == 0:
-                # Empty list case
-                return cls(data=[])
-            if scope < BYTES_PER_LENGTH_OFFSET:
-                raise SSZSerializationError(
-                    f"{cls.__name__}: scope {scope} too small for variable-size list"
-                )
 
-            # Read the first offset to determine the number of elements.
-            first_offset = int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
-            if first_offset > scope or first_offset % BYTES_PER_LENGTH_OFFSET != 0:
-                raise SSZSerializationError(f"{cls.__name__}: invalid offset {first_offset}")
+        # Variable-size case: the first offset reveals both where bodies begin
+        # and the element count (the offset width divides the table width).
+        if scope < BYTES_PER_LENGTH_OFFSET:
+            raise SSZSerializationError(
+                f"{cls.__name__}: scope {scope} too small for variable-size list"
+            )
+        first_offset = int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
+        if first_offset > scope or first_offset % BYTES_PER_LENGTH_OFFSET != 0:
+            raise SSZSerializationError(f"{cls.__name__}: invalid offset {first_offset}")
+        count = first_offset // BYTES_PER_LENGTH_OFFSET
+        if count > cls.LIMIT:
+            raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {count}")
 
-            count = first_offset // BYTES_PER_LENGTH_OFFSET
-            if count > cls.LIMIT:
-                raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {count}")
+        # Read the remaining offsets, append scope as the final boundary,
+        # then pairwise-iterate the boundary list to yield each body's byte span.
+        offsets = [
+            first_offset,
+            *(int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET)) for _ in range(count - 1)),
+            scope,
+        ]
+        _validate_offsets(offsets, scope, cls.__name__)
 
-            # Read the rest of the offsets.
-            offsets = [first_offset] + [
-                int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET)) for _ in range(count - 1)
+        return cls(
+            data=[
+                cls.ELEMENT_TYPE.deserialize(stream, end - start)
+                for start, end in pairwise(offsets)
             ]
-            offsets.append(scope)
-            # Validate all offsets upfront before processing elements.
-            _validate_offsets(offsets, scope, cls.__name__)
-            # Read each element based on the calculated boundaries.
-            elements = []
-            for start, end in pairwise(offsets):
-                elements.append(cls.ELEMENT_TYPE.deserialize(stream, end - start))
-
-            return cls(data=elements)
-
-    def __len__(self) -> int:
-        """Return the number of elements in the list."""
-        return len(self.data)
-
-    def __iter__(self) -> Iterator[T]:  # type: ignore[override]
-        """Iterate over list elements."""
-        return iter(self.data)
-
-    @overload
-    def __getitem__(self, index: int) -> T: ...
-    @overload
-    def __getitem__(self, index: slice) -> Sequence[T]: ...
-
-    def __getitem__(self, index: int | slice) -> T | Sequence[T]:
-        """
-        Access element(s) by index or slice.
-
-        Returns properly typed results:
-
-        - `lst[0]` returns `T`
-        - `lst[0:2]` returns `Sequence[T]`
-        """
-        return self.data[index]
-
-    @property
-    def elements(self) -> list[T]:
-        """Return the elements as a typed list."""
-        return list(self.data)
+        )

--- a/src/lean_spec/types/ssz_base.py
+++ b/src/lean_spec/types/ssz_base.py
@@ -9,6 +9,7 @@ from .exceptions import SSZSerializationError
 
 BYTES_PER_LENGTH_OFFSET: Final = 4
 """Width of an SSZ offset prefixing each variable-size element.
+
 Encoded as a uint32 in little-endian byte order."""
 
 

--- a/tests/lean_spec/types/test_collections.py
+++ b/tests/lean_spec/types/test_collections.py
@@ -1,5 +1,6 @@
-"""Tests for the SSZVector and List types."""
+"""Tests for the SSZVector and SSZList types."""
 
+import re
 from typing import Any, cast
 
 import pytest
@@ -8,20 +9,14 @@ from pydantic import BaseModel, ValidationError
 from lean_spec.subspecs.koalabear import Fp
 from lean_spec.types import Bytes32, Uint8, Uint16, Uint32
 from lean_spec.types.boolean import Boolean
-from lean_spec.types.collections import (
-    SSZList,
-    SSZVector,
-    _validate_offsets,
-)
+from lean_spec.types.collections import SSZList, SSZVector
 from lean_spec.types.container import Container
 from lean_spec.types.exceptions import SSZSerializationError, SSZTypeError, SSZValueError
 
-# Type alias for errors that can be SSZValueError or wrapped in ValidationError
 ValueOrValidationError = (SSZValueError, ValidationError)
 TypeOrValidationError = (SSZTypeError, ValidationError)
 
 
-# Define some List types that are needed for Container definitions
 class Uint16List4(SSZList[Uint16]):
     """A list with up to 4 Uint16 values."""
 
@@ -42,7 +37,6 @@ class VariableContainer(Container):
     b: Uint16List4
 
 
-# Define explicit SSZVector types for testing
 class Uint16Vector2(SSZVector[Uint16]):
     """A vector of exactly 2 Uint16 values."""
 
@@ -79,7 +73,6 @@ class VariableContainerVector2(SSZVector[VariableContainer]):
     LENGTH = 2
 
 
-# Define explicit List types for testing
 class Uint16List32(SSZList[Uint16]):
     """A list with up to 32 Uint16 values."""
 
@@ -116,7 +109,12 @@ class VariableContainerList2(SSZList[VariableContainer]):
     LIMIT = 2
 
 
-# Additional SSZVector classes for tests
+class FixedContainerList2(SSZList[FixedContainer]):
+    """A list with up to 2 FixedContainer values."""
+
+    LIMIT = 2
+
+
 class Uint8Vector32(SSZVector[Uint8]):
     """A vector of exactly 32 Uint8 values."""
 
@@ -147,7 +145,6 @@ class FpVector8(SSZVector[Fp]):
     LENGTH = 8
 
 
-# Additional List classes for tests
 class Uint8List32(SSZList[Uint8]):
     """A list with up to 32 Uint8 values."""
 
@@ -178,144 +175,10 @@ class FpList8(SSZList[Fp]):
     LIMIT = 8
 
 
-# Test data for the 'sig' vector test case
-sig_test_data_list = [0] * 96
-for i, v in {0: 1, 32: 2, 64: 3, 95: 0xFF}.items():
-    sig_test_data_list[i] = v
-sig_test_data = tuple(sig_test_data_list)
-
-
 class Uint8Vector2Model(BaseModel):
     """Model for testing Pydantic validation of Uint8Vector2."""
 
     value: Uint8Vector2
-
-
-class TestCollectionHelpers:
-    """Tests for SSZ collection helper functions."""
-
-    def test_validate_offsets_accepts_empty_and_monotonic_offsets(self) -> None:
-        """Tests offset validation success cases."""
-        _validate_offsets([], scope=0, type_name="TestType")
-        _validate_offsets([4, 8, 12], scope=12, type_name="TestType")
-
-    def test_validate_offsets_rejects_non_monotonic_offsets(self) -> None:
-        """Tests offset validation rejects decreasing offsets."""
-        with pytest.raises(SSZSerializationError, match="offsets not monotonically increasing"):
-            _validate_offsets([4, 3], scope=4, type_name="TestType")
-
-    def test_validate_offsets_rejects_final_offset_beyond_scope(self) -> None:
-        """Tests offset validation rejects a final offset beyond scope."""
-        with pytest.raises(SSZSerializationError, match="final offset 8 exceeds scope 7"):
-            _validate_offsets([4, 8], scope=7, type_name="TestType")
-
-
-class TestSSZVector:
-    """Tests for the fixed-length, immutable SSZVector type."""
-
-    def test_class_getitem_creates_specialized_type(self) -> None:
-        """Tests that explicit SSZVector classes have the correct parameters."""
-        vec_type_a = Uint8Vector32
-        vec_type_b = Uint16Vector32
-        assert vec_type_a is not Uint8Vector64  # type: ignore[comparison-overlap]
-        assert vec_type_a is not vec_type_b  # type: ignore[comparison-overlap]
-        assert vec_type_a.LENGTH == 32
-        assert vec_type_a.ELEMENT_TYPE is Uint8
-        assert "Uint8Vector32" in repr(vec_type_a)
-
-    def test_init_subclass_infers_element_type_from_generic(self) -> None:
-        """Tests generic subclasses infer their element type automatically."""
-
-        class LocalVector(SSZVector[Uint16]):
-            LENGTH = 1
-
-        assert LocalVector.ELEMENT_TYPE is Uint16
-
-    def test_init_subclass_preserves_explicit_element_type(self) -> None:
-        """Tests an explicit ELEMENT_TYPE is not overwritten by generic inference."""
-
-        class LocalVector(SSZVector[Uint8]):
-            ELEMENT_TYPE = Uint16
-            LENGTH = 1
-
-        assert LocalVector.ELEMENT_TYPE is Uint16
-
-    def test_instantiate_raw_type_raises_error(self) -> None:
-        """Tests that the raw, non-specialized SSZVector cannot be instantiated."""
-        with pytest.raises(TypeError, match="BaseModel.__init__\\(\\) takes 1 positional argument"):
-            SSZVector([])  # type: ignore[misc]
-
-    def test_instantiation_success(self) -> None:
-        """Tests successful instantiation with the correct number of valid items."""
-        vec_type = Uint8Vector4
-        instance = vec_type(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
-        assert len(instance) == 4
-        assert list(instance) == [Uint8(1), Uint8(2), Uint8(3), Uint8(4)]
-
-    def test_instantiation_with_wrong_length_raises_error(self) -> None:
-        """Tests that providing the wrong number of items during instantiation fails."""
-        vec_type = Uint8Vector4
-        with pytest.raises(ValueOrValidationError):
-            vec_type(data=[Uint8(1), Uint8(2), Uint8(3)])  # Too few
-        with pytest.raises(ValueOrValidationError):
-            vec_type(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4), Uint8(5)])  # Too many
-
-    def test_instantiation_from_iterator_coerces_values(self) -> None:
-        """Tests iterator input is consumed and elements are coerced to ELEMENT_TYPE."""
-        instance = Uint8Vector4(data=cast(Any, (value for value in range(1, 5))))
-
-        assert tuple(instance) == (Uint8(1), Uint8(2), Uint8(3), Uint8(4))
-
-    def test_instantiation_without_length_raises_error(self) -> None:
-        """Tests misconfigured vector subclasses fail validation."""
-
-        class MissingLengthVector(SSZVector[Uint8]):
-            pass
-
-        with pytest.raises(TypeOrValidationError, match="must define ELEMENT_TYPE and LENGTH"):
-            MissingLengthVector(data=cast(Any, [1]))
-
-    def test_pydantic_validation(self) -> None:
-        """Tests that Pydantic validation works for SSZVector types."""
-        # Test valid data - Pydantic coerces dict to Uint8Vector2
-        instance = Uint8Vector2Model(value={"data": [10, 20]})  # type: ignore[arg-type]
-        assert isinstance(instance.value, Uint8Vector2)
-        assert list(instance.value) == [Uint8(10), Uint8(20)]
-        # Test invalid data
-        with pytest.raises(ValueOrValidationError):
-            Uint8Vector2Model(value={"data": [10]})  # type: ignore[arg-type]
-        with pytest.raises(ValueOrValidationError):
-            Uint8Vector2Model(value={"data": [10, 20, 30]})  # type: ignore[arg-type]
-        with pytest.raises(SSZTypeError):
-            Uint8Vector2Model(value={"data": [10, "bad"]})  # type: ignore[arg-type]
-
-    def test_vector_is_immutable(self) -> None:
-        """Tests that attempting to change an item in an SSZVector raises a TypeError."""
-        vec = Uint8Vector2(data=[Uint8(1), Uint8(2)])
-        with pytest.raises(TypeError):
-            vec[0] = 3  # type: ignore[index]  # Should fail because SSZModel is immutable
-
-    def test_variable_size_vector_has_no_fixed_byte_length(self) -> None:
-        """Tests variable-size vectors do not expose a fixed byte length."""
-        with pytest.raises(SSZTypeError, match="variable-size vector has no fixed byte length"):
-            VariableContainerVector2.get_byte_length()
-
-    def test_elements_returns_copy_and_slice_returns_sequence(self) -> None:
-        """Tests vector convenience accessors return safe views of the data."""
-        vec = Uint8Vector4(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
-
-        elements = vec.elements
-        elements.append(Uint8(9))
-
-        assert elements == [Uint8(1), Uint8(2), Uint8(3), Uint8(4), Uint8(9)]
-        assert list(vec) == [Uint8(1), Uint8(2), Uint8(3), Uint8(4)]
-        assert vec[1:3] == (Uint8(2), Uint8(3))
-
-    def test_model_dump_json_serializes_vector_elements(self) -> None:
-        """Tests vector field serializers are used in JSON mode."""
-        instance = FpVector8(data=[Fp(1), Fp(2), Fp(3), Fp(4), Fp(5), Fp(6), Fp(7), Fp(8)])
-
-        assert instance.model_dump(mode="json")["data"] == [1, 2, 3, 4, 5, 6, 7, 8]
 
 
 class Uint8List4Model(BaseModel):
@@ -324,150 +187,473 @@ class Uint8List4Model(BaseModel):
     value: Uint8List4
 
 
-class TestList:
-    """Tests for the variable-length, capacity-limited List type."""
+class TestSSZVectorValidator:
+    """Tests for the SSZVector field validator and its rejection paths."""
+
+    def test_missing_element_type_and_length_rejected(self) -> None:
+        """A subclass without ELEMENT_TYPE or LENGTH cannot validate any input."""
+
+        class MissingBoth(SSZVector):  # type: ignore[type-arg]
+            pass
+
+        with pytest.raises(
+            TypeOrValidationError,
+            match=re.escape("MissingBoth must define ELEMENT_TYPE and LENGTH"),
+        ):
+            MissingBoth(data=cast(Any, [1]))
+
+    def test_missing_length_rejected(self) -> None:
+        """A subclass with ELEMENT_TYPE but no LENGTH cannot validate."""
+
+        class MissingLengthVector(SSZVector[Uint8]):
+            pass
+
+        with pytest.raises(
+            TypeOrValidationError,
+            match=re.escape("MissingLengthVector must define ELEMENT_TYPE and LENGTH"),
+        ):
+            MissingLengthVector(data=cast(Any, [1]))
+
+    @pytest.mark.parametrize(
+        "bad_input, type_name",
+        [
+            ("ab", "str"),
+            (b"ab", "bytes"),
+            (bytearray(b"ab"), "bytearray"),
+        ],
+    )
+    def test_byte_like_inputs_rejected(self, bad_input: Any, type_name: str) -> None:
+        """Strings, bytes, and bytearrays never iterate as element collections."""
+        with pytest.raises(
+            TypeOrValidationError,
+            match=re.escape(f"Uint8Vector2: Expected iterable of Uint8, got {type_name}"),
+        ):
+            Uint8Vector2(data=bad_input)
+
+    def test_non_iterable_scalar_rejected(self) -> None:
+        """Scalar inputs without an iterator interface raise an iterable error."""
+        with pytest.raises(
+            TypeOrValidationError,
+            match=re.escape("Uint8Vector2: Expected iterable, got int"),
+        ):
+            Uint8Vector2(data=cast(Any, 42))
+
+    def test_generator_input_coerced(self) -> None:
+        """A generator is materialized and each value is coerced to ELEMENT_TYPE."""
+        instance = Uint8Vector4(data=cast(Any, (value for value in range(1, 5))))
+
+        assert tuple(instance) == (Uint8(1), Uint8(2), Uint8(3), Uint8(4))
+
+    def test_already_typed_elements_pass_through(self) -> None:
+        """Inputs already typed as ELEMENT_TYPE skip the coercion constructor."""
+        original = [Uint8(1), Uint8(2), Uint8(3), Uint8(4)]
+        instance = Uint8Vector4(data=original)
+
+        assert tuple(instance) == tuple(original)
+
+    def test_raw_values_coerced_through_element_type(self) -> None:
+        """Raw Python ints are coerced through the declared element type."""
+        instance = Uint8Vector4(data=cast(Any, [1, 2, 3, 4]))
+
+        assert tuple(instance) == (Uint8(1), Uint8(2), Uint8(3), Uint8(4))
+
+    def test_element_coercion_failure_includes_chained_cause(self) -> None:
+        """A failed element coercion surfaces both the outer and inner error message."""
+        with pytest.raises(
+            TypeOrValidationError,
+            match=re.escape("Expected Uint8, got str: Expected int, got str"),
+        ):
+            Uint8Vector4(data=cast(Any, [1, "bad", 3, 4]))
+
+    def test_too_few_elements_rejected(self) -> None:
+        """A vector requires exactly LENGTH elements and rejects shorter inputs."""
+        with pytest.raises(
+            ValueOrValidationError,
+            match=re.escape("Uint8Vector4 requires exactly 4 elements, got 3"),
+        ):
+            Uint8Vector4(data=cast(Any, [1, 2, 3]))
+
+    def test_too_many_elements_rejected(self) -> None:
+        """A vector requires exactly LENGTH elements and rejects longer inputs."""
+        with pytest.raises(
+            ValueOrValidationError,
+            match=re.escape("Uint8Vector4 requires exactly 4 elements, got 5"),
+        ):
+            Uint8Vector4(data=cast(Any, [1, 2, 3, 4, 5]))
+
+
+class TestSSZVectorClassMetadata:
+    """Tests for SSZVector class-level metadata and inference."""
 
     def test_class_getitem_creates_specialized_type(self) -> None:
-        """Tests that explicit List classes have the correct parameters."""
-        list_type_a = Uint8List32
-        list_type_b = Uint16List32
-        assert list_type_a is not Uint8List64  # type: ignore[comparison-overlap]
-        assert list_type_a is not list_type_b  # type: ignore[comparison-overlap]
-        assert list_type_a.LIMIT == 32
-        assert list_type_a.ELEMENT_TYPE is Uint8
-        assert "Uint8List32" in repr(list_type_a)
+        """Explicit subclasses keep distinct LENGTH and ELEMENT_TYPE bindings."""
+        assert Uint8Vector32 is not Uint8Vector64
+        assert Uint8Vector32 is not Uint16Vector32
+        assert Uint8Vector32.LENGTH == 32
+        assert Uint8Vector32.ELEMENT_TYPE is Uint8
+        assert "Uint8Vector32" in repr(Uint8Vector32)
 
     def test_init_subclass_infers_element_type_from_generic(self) -> None:
-        """Tests generic list subclasses infer their element type automatically."""
+        """Generic subclasses copy the bracketed type into ELEMENT_TYPE."""
+
+        class LocalVector(SSZVector[Uint16]):
+            LENGTH = 1
+
+        assert LocalVector.ELEMENT_TYPE is Uint16
+
+    def test_init_subclass_preserves_explicit_element_type(self) -> None:
+        """An explicit ELEMENT_TYPE in the class body wins over generic inference."""
+
+        class LocalVector(SSZVector[Uint8]):
+            ELEMENT_TYPE = Uint16
+            LENGTH = 1
+
+        assert LocalVector.ELEMENT_TYPE is Uint16
+
+    def test_instantiate_raw_type_raises_error(self) -> None:
+        """The raw SSZVector base cannot be instantiated as a Pydantic model."""
+        with pytest.raises(TypeError, match=r"BaseModel.__init__\(\) takes 1 positional argument"):
+            SSZVector([])  # type: ignore[misc]
+
+    def test_fixed_size_vector_reports_fixed_size_true(self) -> None:
+        """A vector of fixed-size elements is itself fixed-size."""
+        assert Uint8Vector4.is_fixed_size() is True
+
+    def test_variable_size_vector_reports_fixed_size_false(self) -> None:
+        """A vector of variable-size elements is not fixed-size."""
+        assert VariableContainerVector2.is_fixed_size() is False
+
+    def test_fixed_size_vector_byte_length_matches_total(self) -> None:
+        """Byte length equals the element width times the element count."""
+        assert Uint8Vector4.get_byte_length() == 4
+        assert Uint16Vector2.get_byte_length() == 4
+        assert FixedContainerVector2.get_byte_length() == 6
+
+    def test_variable_size_vector_has_no_fixed_byte_length(self) -> None:
+        """Variable-size vectors raise when asked for a fixed byte length."""
+        with pytest.raises(
+            SSZTypeError,
+            match=re.escape(
+                "VariableContainerVector2: variable-size vector has no fixed byte length"
+            ),
+        ):
+            VariableContainerVector2.get_byte_length()
+
+
+class TestSSZVectorAccessors:
+    """Tests for SSZVector accessor and immutability behavior."""
+
+    def test_instantiation_success(self) -> None:
+        """Building with the exact element count yields a sequence of typed values."""
+        instance = Uint8Vector4(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
+
+        assert len(instance) == 4
+        assert list(instance) == [Uint8(1), Uint8(2), Uint8(3), Uint8(4)]
+
+    def test_integer_index_returns_typed_element(self) -> None:
+        """Positive integer indexing returns the corresponding typed element."""
+        instance = Uint8Vector4(data=[Uint8(10), Uint8(20), Uint8(30), Uint8(40)])
+
+        assert instance[0] == Uint8(10)
+        assert instance[2] == Uint8(30)
+
+    def test_negative_index_returns_typed_element(self) -> None:
+        """Negative integer indexing addresses elements from the end of the sequence."""
+        instance = Uint8Vector4(data=[Uint8(10), Uint8(20), Uint8(30), Uint8(40)])
+
+        assert instance[-1] == Uint8(40)
+        assert instance[-4] == Uint8(10)
+
+    def test_slice_returns_sequence(self) -> None:
+        """Slicing returns the underlying tuple slice of typed elements."""
+        instance = Uint8Vector4(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
+
+        assert instance[1:3] == (Uint8(2), Uint8(3))
+
+    def test_elements_returns_mutable_copy(self) -> None:
+        """The elements property exposes a mutable list copy of the data."""
+        instance = Uint8Vector4(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
+
+        copy = instance.elements
+        copy.append(Uint8(9))
+
+        assert copy == [Uint8(1), Uint8(2), Uint8(3), Uint8(4), Uint8(9)]
+        assert list(instance) == [Uint8(1), Uint8(2), Uint8(3), Uint8(4)]
+
+    def test_vector_is_immutable(self) -> None:
+        """Item assignment raises because the underlying model is frozen."""
+        instance = Uint8Vector2(data=[Uint8(1), Uint8(2)])
+
+        with pytest.raises(TypeError):
+            instance[0] = 3  # type: ignore[index]
+
+    def test_pydantic_dict_input_coerces_to_vector(self) -> None:
+        """Pydantic coerces a dict payload into an SSZVector with typed elements."""
+        instance = Uint8Vector2Model(value=cast(Any, {"data": [10, 20]}))
+
+        assert instance.value == Uint8Vector2(data=[Uint8(10), Uint8(20)])
+
+    def test_pydantic_dict_input_rejects_wrong_length(self) -> None:
+        """A dict payload with the wrong element count surfaces the length error."""
+        with pytest.raises(
+            ValueOrValidationError,
+            match=re.escape("Uint8Vector2 requires exactly 2 elements, got 1"),
+        ):
+            Uint8Vector2Model(value=cast(Any, {"data": [10]}))
+
+
+class TestSSZListValidator:
+    """Tests for the SSZList field validator and its rejection paths."""
+
+    def test_missing_element_type_and_limit_rejected(self) -> None:
+        """A subclass without ELEMENT_TYPE or LIMIT cannot validate any input."""
+
+        class MissingBoth(SSZList):  # type: ignore[type-arg]
+            pass
+
+        with pytest.raises(
+            TypeOrValidationError,
+            match=re.escape("MissingBoth must define ELEMENT_TYPE and LIMIT"),
+        ):
+            MissingBoth(data=cast(Any, [1]))
+
+    def test_missing_limit_rejected(self) -> None:
+        """A subclass with ELEMENT_TYPE but no LIMIT cannot validate."""
+
+        class MissingLimitList(SSZList[Uint8]):
+            pass
+
+        with pytest.raises(
+            TypeOrValidationError,
+            match=re.escape("MissingLimitList must define ELEMENT_TYPE and LIMIT"),
+        ):
+            MissingLimitList(data=cast(Any, [1]))
+
+    def test_raw_base_class_rejected(self) -> None:
+        """Instantiating the raw SSZList base surfaces the metadata-missing error."""
+        with pytest.raises(
+            SSZTypeError,
+            match=re.escape("SSZList must define ELEMENT_TYPE and LIMIT"),
+        ):
+            SSZList(data=[])
+
+    @pytest.mark.parametrize(
+        "bad_input, type_name",
+        [
+            ("ab", "str"),
+            (b"ab", "bytes"),
+            (bytearray(b"ab"), "bytearray"),
+        ],
+    )
+    def test_byte_like_inputs_rejected(self, bad_input: Any, type_name: str) -> None:
+        """Strings, bytes, and bytearrays never iterate as element collections."""
+        with pytest.raises(
+            TypeOrValidationError,
+            match=re.escape(f"Uint8List4: Expected iterable of Uint8, got {type_name}"),
+        ):
+            Uint8List4(data=bad_input)
+
+    def test_non_iterable_scalar_rejected(self) -> None:
+        """Scalar inputs without an iterator interface raise an iterable error."""
+        with pytest.raises(
+            TypeOrValidationError,
+            match=re.escape("Uint8List4: Expected iterable, got int"),
+        ):
+            Uint8List4(data=cast(Any, 5))
+
+    def test_generator_input_coerced(self) -> None:
+        """A generator is materialized and each value is coerced to ELEMENT_TYPE."""
+        instance = Uint8List4(data=cast(Any, (value for value in range(3))))
+
+        assert list(instance) == [Uint8(0), Uint8(1), Uint8(2)]
+
+    def test_already_typed_elements_pass_through(self) -> None:
+        """Inputs already typed as ELEMENT_TYPE skip the coercion constructor."""
+        instance = Uint8List4(data=[Uint8(1), Uint8(2)])
+
+        assert list(instance) == [Uint8(1), Uint8(2)]
+
+    def test_raw_values_coerced_through_element_type(self) -> None:
+        """Raw Python ints are coerced through the declared element type."""
+        instance = Uint8List4(data=cast(Any, [1, 2, 3]))
+
+        assert list(instance) == [Uint8(1), Uint8(2), Uint8(3)]
+
+    def test_element_coercion_failure_includes_chained_cause(self) -> None:
+        """A failed element coercion surfaces both the outer and inner error message."""
+        with pytest.raises(
+            TypeOrValidationError,
+            match=re.escape("Expected Uint8, got str: Expected int, got str"),
+        ):
+            Uint8List4(data=cast(Any, [1, "bad"]))
+
+    def test_empty_list_allowed(self) -> None:
+        """A list with zero elements is always valid, regardless of LIMIT."""
+        instance = Uint8List4(data=[])
+
+        assert list(instance) == []
+        assert len(instance) == 0
+
+    def test_construction_at_limit_allowed(self) -> None:
+        """A list with exactly LIMIT elements is valid."""
+        instance = Uint8List4(data=cast(Any, [1, 2, 3, 4]))
+
+        assert list(instance) == [Uint8(1), Uint8(2), Uint8(3), Uint8(4)]
+
+    def test_over_limit_rejected(self) -> None:
+        """A list with more than LIMIT elements raises the exceeds-limit error."""
+        with pytest.raises(
+            ValueOrValidationError,
+            match=re.escape("Uint8List4 exceeds limit of 4, got 5"),
+        ):
+            Uint8List4(data=cast(Any, [1, 2, 3, 4, 5]))
+
+    def test_over_limit_rejected_for_boolean_list(self) -> None:
+        """The same exceeds-limit error fires for a list of booleans."""
+        with pytest.raises(
+            ValueOrValidationError,
+            match=re.escape("BooleanList4 exceeds limit of 4, got 5"),
+        ):
+            BooleanList4(data=[Boolean(True)] * 5)
+
+
+class TestSSZListClassMetadata:
+    """Tests for SSZList class-level metadata and inference."""
+
+    def test_class_getitem_creates_specialized_type(self) -> None:
+        """Explicit subclasses keep distinct LIMIT and ELEMENT_TYPE bindings."""
+        assert Uint8List32 is not Uint8List64
+        assert Uint8List32 is not Uint16List32
+        assert Uint8List32.LIMIT == 32
+        assert Uint8List32.ELEMENT_TYPE is Uint8
+        assert "Uint8List32" in repr(Uint8List32)
+
+    def test_init_subclass_infers_element_type_from_generic(self) -> None:
+        """Generic subclasses copy the bracketed type into ELEMENT_TYPE."""
 
         class LocalList(SSZList[Uint16]):
             LIMIT = 2
 
         assert LocalList.ELEMENT_TYPE is Uint16
 
-    def test_instantiate_raw_type_raises_error(self) -> None:
-        """Tests that the raw, non-specialized SSZList cannot be instantiated."""
-        with pytest.raises(SSZTypeError, match="must define ELEMENT_TYPE and LIMIT"):
-            SSZList(data=[])
-
-    def test_instantiation_without_limit_raises_error(self) -> None:
-        """Tests misconfigured list subclasses fail validation."""
-
-        class MissingLimitList(SSZList[Uint8]):
-            pass
-
-        with pytest.raises(TypeOrValidationError, match="must define ELEMENT_TYPE and LIMIT"):
-            MissingLimitList(data=cast(Any, [1]))
-
-    def test_instantiation_over_limit_raises_error(self) -> None:
-        """Tests that providing more items than the limit during instantiation fails."""
-        list_type = Uint8List4
-        with pytest.raises(ValueOrValidationError):
-            list_type(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4), Uint8(5)])
-
-    def test_instantiation_from_iterator_coerces_values(self) -> None:
-        """Tests iterator input is materialized and elements are coerced."""
-        instance = Uint8List4(data=cast(Any, (value for value in range(3))))
-
-        assert list(instance) == [Uint8(0), Uint8(1), Uint8(2)]
-
-    def test_non_iterable_input_raises_error(self) -> None:
-        """Tests non-iterable inputs are rejected."""
-        with pytest.raises(TypeOrValidationError, match="Expected iterable"):
-            Uint8List4(data=5)  # type: ignore[arg-type]
-
-    def test_invalid_element_type_raises_descriptive_error(self) -> None:
-        """Tests failed element coercion produces a descriptive error."""
-        with pytest.raises(TypeOrValidationError, match="Expected Uint8, got"):
-            Uint8List4(data=[1, "bad"])  # type: ignore[list-item]
-
-    def test_pydantic_validation(self) -> None:
-        """Tests that Pydantic validation works for List types."""
-        # Test valid data
-        instance = Uint8List4Model(value=Uint8List4(data=[Uint8(10), Uint8(20)]))
-        assert isinstance(instance.value, Uint8List4)
-        assert list(instance.value) == [Uint8(10), Uint8(20)]
-        # Test invalid data - list too long
-        with pytest.raises(ValueOrValidationError):
-            Uint8List4Model(
-                value=Uint8List4(data=[Uint8(10), Uint8(20), Uint8(30), Uint8(40), Uint8(50)])
-            )
-
-    def test_append_at_limit_raises_error(self) -> None:
-        """Tests that creating a list at limit +1 fails during construction."""
-        with pytest.raises(ValueOrValidationError):
-            BooleanList4(data=[Boolean(True)] * 5)
-
-    def test_extend_over_limit_raises_error(self) -> None:
-        """Tests that creating a list over the limit fails during construction."""
-        with pytest.raises(ValueOrValidationError):
-            BooleanList4(
-                data=[Boolean(True), Boolean(False), Boolean(True), Boolean(False), Boolean(True)]
-            )
-
-    def test_add_with_list(self) -> None:
-        """Tests concatenating an SSZList with a regular list."""
-        list1 = Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3)])
-        result = list1 + [4, 5]
-        assert list(result) == [Uint8(1), Uint8(2), Uint8(3), Uint8(4), Uint8(5)]
-        assert isinstance(result, Uint8List10)
-
-    def test_add_with_sszlist(self) -> None:
-        """Tests concatenating two SSZLists of the same type."""
-        list1 = Uint8List10(data=[Uint8(1), Uint8(2)])
-        list2 = Uint8List10(data=[Uint8(3), Uint8(4)])
-        result = list1 + list2
-        assert list(result) == [Uint8(1), Uint8(2), Uint8(3), Uint8(4)]
-        assert isinstance(result, Uint8List10)
-
-    def test_add_with_tuple(self) -> None:
-        """Tests concatenating an SSZList with a tuple."""
-        list1 = Uint8List10(data=[Uint8(1), Uint8(2)])
-        result = list1 + (3, 4)
-
-        assert list(result) == [Uint8(1), Uint8(2), Uint8(3), Uint8(4)]
-        assert isinstance(result, Uint8List10)
-
-    def test_add_with_unsupported_type_returns_not_implemented(self) -> None:
-        """Tests unsupported operands return NotImplemented from __add__."""
-        list1 = Uint8List10(data=[Uint8(1), Uint8(2)])
-
-        assert list1.__add__(object()) is NotImplemented
-
-    def test_add_exceeding_limit_raises_error(self) -> None:
-        """Tests that concatenating beyond the limit raises an error."""
-        list1 = Uint8List4(data=[Uint8(1), Uint8(2), Uint8(3)])
-        with pytest.raises(ValueOrValidationError):
-            list1 + [4, 5]
-
-    def test_elements_returns_copy(self) -> None:
-        """Tests the elements property returns a copy of the underlying data."""
-        instance = Uint8List4(data=[Uint8(1), Uint8(2), Uint8(3)])
-
-        elements = instance.elements
-        elements.append(Uint8(9))
-
-        assert elements == [Uint8(1), Uint8(2), Uint8(3), Uint8(9)]
-        assert list(instance) == [Uint8(1), Uint8(2), Uint8(3)]
-
     def test_list_is_never_fixed_size(self) -> None:
-        """Tests SSZList is always variable-size."""
+        """A list never collapses to a fixed-size encoding."""
         assert Uint8List4.is_fixed_size() is False
+        assert VariableContainerList2.is_fixed_size() is False
 
-    def test_get_byte_length_raises_for_variable_size_list(self) -> None:
-        """Tests lists do not expose a fixed byte length."""
-        with pytest.raises(SSZTypeError, match="variable-size list has no fixed byte length"):
+    def test_get_byte_length_always_raises(self) -> None:
+        """A list type has no fixed byte length even for fixed-size elements."""
+        with pytest.raises(
+            SSZTypeError,
+            match=re.escape("Uint8List4: variable-size list has no fixed byte length"),
+        ):
             Uint8List4.get_byte_length()
 
-    def test_model_dump_json_serializes_list_elements(self) -> None:
-        """Tests list field serializers are used in JSON mode."""
-        instance = Bytes32List32(data=[Bytes32.zero()])
+    def test_get_byte_length_raises_for_variable_element_list(self) -> None:
+        """The same error fires for lists whose elements are variable-size."""
+        with pytest.raises(
+            SSZTypeError,
+            match=re.escape("VariableContainerList2: variable-size list has no fixed byte length"),
+        ):
+            VariableContainerList2.get_byte_length()
 
-        assert instance.model_dump(mode="json")["data"] == ["0x" + ("00" * 32)]
+
+class TestSSZListAccessors:
+    """Tests for SSZList accessor and concatenation behavior."""
+
+    def test_integer_index_returns_typed_element(self) -> None:
+        """Positive integer indexing returns the corresponding typed element."""
+        instance = Uint8List4(data=[Uint8(10), Uint8(20), Uint8(30)])
+
+        assert instance[0] == Uint8(10)
+        assert instance[2] == Uint8(30)
+
+    def test_negative_index_returns_typed_element(self) -> None:
+        """Negative integer indexing addresses elements from the end of the sequence."""
+        instance = Uint8List4(data=[Uint8(10), Uint8(20), Uint8(30)])
+
+        assert instance[-1] == Uint8(30)
+        assert instance[-3] == Uint8(10)
+
+    def test_slice_returns_sequence(self) -> None:
+        """Slicing returns the underlying tuple slice of typed elements."""
+        instance = Uint8List4(data=[Uint8(1), Uint8(2), Uint8(3)])
+
+        assert instance[1:3] == (Uint8(2), Uint8(3))
+
+    def test_elements_returns_mutable_copy(self) -> None:
+        """The elements property exposes a mutable list copy of the data."""
+        instance = Uint8List4(data=[Uint8(1), Uint8(2), Uint8(3)])
+
+        copy = instance.elements
+        copy.append(Uint8(9))
+
+        assert copy == [Uint8(1), Uint8(2), Uint8(3), Uint8(9)]
+        assert list(instance) == [Uint8(1), Uint8(2), Uint8(3)]
+
+    def test_pydantic_dict_input_coerces_to_list(self) -> None:
+        """Pydantic coerces a list payload into an SSZList with typed elements."""
+        instance = Uint8List4Model(value=Uint8List4(data=[Uint8(10), Uint8(20)]))
+
+        assert instance.value == Uint8List4(data=[Uint8(10), Uint8(20)])
+
+    def test_add_with_sszlist(self) -> None:
+        """Concatenating two SSZLists yields a fresh list of the same type."""
+        result = Uint8List10(data=[Uint8(1), Uint8(2)]) + Uint8List10(data=[Uint8(3), Uint8(4)])
+
+        assert result == Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
+        assert isinstance(result, Uint8List10)
+
+    def test_add_with_plain_list(self) -> None:
+        """Concatenating with a plain list coerces the right-hand values."""
+        result = Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3)]) + [4, 5]
+
+        assert result == Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4), Uint8(5)])
+
+    def test_add_with_tuple(self) -> None:
+        """Concatenating with a tuple coerces the right-hand values."""
+        result = Uint8List10(data=[Uint8(1), Uint8(2)]) + (3, 4)
+
+        assert result == Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
+
+    def test_add_empty_to_empty(self) -> None:
+        """Concatenating two empty lists yields an empty list of the same type."""
+        result = Uint8List10(data=[]) + Uint8List10(data=[])
+
+        assert result == Uint8List10(data=[])
+
+    def test_add_empty_to_non_empty(self) -> None:
+        """Concatenating an empty list to a populated one preserves the populated list."""
+        populated = Uint8List10(data=[Uint8(1), Uint8(2)])
+        result = Uint8List10(data=[]) + populated
+
+        assert result == populated
+
+    def test_add_non_empty_to_empty(self) -> None:
+        """Concatenating a populated list to an empty one preserves the populated list."""
+        populated = Uint8List10(data=[Uint8(1), Uint8(2)])
+        result = populated + Uint8List10(data=[])
+
+        assert result == populated
+
+    def test_add_unsupported_type_returns_not_implemented(self) -> None:
+        """Unsupported operands return NotImplemented from the add hook."""
+        instance = Uint8List10(data=[Uint8(1), Uint8(2)])
+
+        assert instance.__add__(object()) is NotImplemented
+
+    def test_add_exceeding_limit_raises_error(self) -> None:
+        """Concatenation that overflows LIMIT raises the exceeds-limit error."""
+        base = Uint8List4(data=[Uint8(1), Uint8(2), Uint8(3)])
+        with pytest.raises(
+            ValueOrValidationError,
+            match=re.escape("Uint8List4 exceeds limit of 4, got 5"),
+        ):
+            base + [4, 5]
 
 
 class TestSSZVectorSerialization:
-    """Tests SSZ serialization and deserialization for the SSZVector type."""
+    """Tests SSZ serialization and deserialization for SSZVector."""
 
     @pytest.mark.parametrize(
         "vector_type, value, expected_hex",
@@ -482,15 +668,21 @@ class TestSSZVectorSerialization:
             ),
             (
                 Uint8Vector96,
-                sig_test_data,
+                tuple(
+                    1 if i == 0 else 2 if i == 32 else 3 if i == 64 else 0xFF if i == 95 else 0
+                    for i in range(96)
+                ),
                 "0100000000000000000000000000000000000000000000000000000000000000"
                 "0200000000000000000000000000000000000000000000000000000000000000"
                 "03000000000000000000000000000000000000000000000000000000000000ff",
             ),
             (
                 FixedContainerVector2,
-                (FixedContainer(a=Uint8(1), b=Uint16(2)), FixedContainer(a=Uint8(3), b=Uint16(4))),
-                "010200030400",  # 010200 for first element, 030400 for second
+                (
+                    FixedContainer(a=Uint8(1), b=Uint16(2)),
+                    FixedContainer(a=Uint8(3), b=Uint16(4)),
+                ),
+                "010200030400",
             ),
             (
                 FpVector8,
@@ -499,55 +691,103 @@ class TestSSZVectorSerialization:
             ),
         ],
     )
-    def test_fixed_size_element_vector_serialization(
-        self, vector_type: type[SSZVector], value: tuple[Any, ...], expected_hex: str
+    def test_fixed_size_element_vector_roundtrip(
+        self,
+        vector_type: type[SSZVector],
+        value: tuple[Any, ...],
+        expected_hex: str,
     ) -> None:
-        """Tests the serialization of vectors with fixed-size elements."""
+        """Fixed-size vectors encode to a known hex layout and round-trip back."""
         instance = vector_type(data=value)
         encoded = instance.encode_bytes()
+
         assert encoded.hex() == expected_hex
-        decoded = vector_type.decode_bytes(encoded)
-        assert decoded == instance
+        assert vector_type.decode_bytes(encoded) == instance
 
-    def test_variable_size_element_vector_serialization(self) -> None:
-        """Tests the serialization of vectors with variable-size elements."""
-        list_type = Uint16List4
-
-        # The inner list (`b`) now serializes to a packed representation, changing the total size
-        val1 = VariableContainer(
-            a=Uint8(1), b=list_type(data=[Uint16(10), Uint16(20)])
-        )  # Serialized size: 1 + 4 + (2*2) = 9 bytes
-        val2 = VariableContainer(
-            a=Uint8(2), b=list_type(data=[Uint16(30)])
-        )  # Serialized size: 1 + 4 + (1*2) = 7 bytes
+    def test_variable_size_element_vector_roundtrip(self) -> None:
+        """Variable-size vectors emit the offset table followed by buffered bodies."""
+        val1 = VariableContainer(a=Uint8(1), b=Uint16List4(data=[Uint16(10), Uint16(20)]))
+        val2 = VariableContainer(a=Uint8(2), b=Uint16List4(data=[Uint16(30)]))
         instance = VariableContainerVector2(data=[val1, val2])
 
-        expected_hex = (
-            "0800000011000000"  # Offsets: val1 starts at 8, val2 starts at 17 (8+9)
-            "01050000000a001400"  # val1 data: a=1, offset=5, b_data=[10,20]
-            "02050000001e00"  # val2 data: a=2, offset=5, b_data=[30]
-        )
-
+        expected_hex = "080000001100000001050000000a00140002050000001e00"
         encoded = instance.encode_bytes()
-        assert encoded.hex() == expected_hex
-        decoded = VariableContainerVector2.decode_bytes(encoded)
-        assert decoded == instance
 
-    def test_variable_size_vector_deserialization_rejects_invalid_first_offset(self) -> None:
-        """Tests variable-size vectors reject an invalid initial offset."""
-        # Payload covers the full offset table (2 * 4 = 8 bytes),
-        # but the first offset is 4 instead of the expected table width 8.
-        with pytest.raises(SSZSerializationError, match="invalid offset 4, expected 8"):
+        assert encoded.hex() == expected_hex
+        assert VariableContainerVector2.decode_bytes(encoded) == instance
+
+    def test_fixed_size_vector_rejects_scope_too_small(self) -> None:
+        """A fixed-size vector rejects payloads shorter than its byte budget."""
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("Uint8Vector4: expected 4 bytes, got 3"),
+        ):
+            Uint8Vector4.decode_bytes(b"\x00\x01\x02")
+
+    def test_fixed_size_vector_rejects_scope_too_large(self) -> None:
+        """A fixed-size vector rejects payloads larger than its byte budget."""
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("Uint8Vector4: expected 4 bytes, got 5"),
+        ):
+            Uint8Vector4.decode_bytes(b"\x00\x01\x02\x03\x04")
+
+    def test_variable_size_vector_rejects_scope_below_offset_table(self) -> None:
+        """A scope smaller than the offset table cannot describe any layout."""
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("VariableContainerVector2: scope 3 too small, expected at least 8"),
+        ):
+            VariableContainerVector2.decode_bytes(b"\x00\x00\x00")
+
+    def test_variable_size_vector_rejects_invalid_first_offset(self) -> None:
+        """The first offset must point past the offset table."""
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("VariableContainerVector2: invalid offset 4, expected 8"),
+        ):
             VariableContainerVector2.decode_bytes(b"\x04\x00\x00\x00\x08\x00\x00\x00")
+
+    def test_variable_size_vector_rejects_non_monotonic_offsets(self) -> None:
+        """A later offset smaller than an earlier one means a body would have negative width."""
+        # Layout:
+        #
+        #     offsets[0] = 8   (table-end, valid first offset)
+        #     offsets[1] = 6   (decreasing, triggers the monotonic check)
+        payload = b"\x08\x00\x00\x00\x06\x00\x00\x00"
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape(
+                "VariableContainerVector2: offsets not monotonically increasing: 8 -> 6"
+            ),
+        ):
+            VariableContainerVector2.decode_bytes(payload)
+
+    def test_variable_size_vector_rejects_final_offset_overflow(self) -> None:
+        """A final offset that exceeds the scope triggers the monotonic check first."""
+        # Layout:
+        #
+        #     offsets[0] = 8       (table-end, valid first offset)
+        #     offsets[1] = 100     (past scope of 20, but also greater than next, scope=20)
+        #
+        # Pairwise iteration appends scope as the final boundary, so the 100 -> 20
+        # transition trips the monotonic check before the final-offset-exceeds-scope check.
+        payload = b"\x08\x00\x00\x00\x64\x00\x00\x00" + b"\x00" * 12
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape(
+                "VariableContainerVector2: offsets not monotonically increasing: 100 -> 20"
+            ),
+        ):
+            VariableContainerVector2.decode_bytes(payload)
 
 
 class TestSSZListSerialization:
-    """Tests SSZ serialization and deserialization for the List type."""
+    """Tests SSZ serialization and deserialization for SSZList."""
 
     @pytest.mark.parametrize(
         "list_type, value, expected_hex",
         [
-            # Lists of fixed-size elements are concatenated, matching the reference spec
             (Uint16List32, (0xAABB, 0xC0AD, 0xEEFF), "bbaaadc0ffee"),
             (Uint8List10, (), ""),
             (Uint8List10, (0, 1, 2, 3, 4, 5, 6), "00010203040506"),
@@ -577,64 +817,147 @@ class TestSSZListSerialization:
             ),
         ],
     )
-    def test_fixed_size_element_list_serialization(
-        self, list_type: type[SSZList], value: tuple[Any, ...], expected_hex: str
+    def test_fixed_size_element_list_roundtrip(
+        self,
+        list_type: type[SSZList],
+        value: tuple[Any, ...],
+        expected_hex: str,
     ) -> None:
-        """Tests the serialization of lists with fixed-size elements."""
+        """Fixed-size lists pack bodies back-to-back without separators."""
         instance = list_type(data=value)
         encoded = instance.encode_bytes()
+
         assert encoded.hex() == expected_hex
-        decoded = list_type.decode_bytes(encoded)
-        assert decoded == instance
+        assert list_type.decode_bytes(encoded) == instance
 
-    def test_variable_size_element_list_serialization(self) -> None:
-        """Tests the serialization of lists with variable-size elements."""
-        list_type = VariableContainerList2
-        element_list_type = Uint16List4
+    def test_variable_size_element_list_roundtrip(self) -> None:
+        """Variable-size lists emit a runtime-sized offset table before the bodies."""
+        val1 = VariableContainer(a=Uint8(1), b=Uint16List4(data=[Uint16(10)]))
+        val2 = VariableContainer(a=Uint8(2), b=Uint16List4(data=[Uint16(30), Uint16(40)]))
+        instance = VariableContainerList2(data=[val1, val2])
 
-        val1 = VariableContainer(
-            a=Uint8(1), b=element_list_type(data=[Uint16(10)])
-        )  # Serialized size: 1 + 4 + 2 = 7 bytes
-        val2 = VariableContainer(
-            a=Uint8(2), b=element_list_type(data=[Uint16(30), Uint16(40)])
-        )  # Serialized size: 1 + 4 + 4 = 9 bytes
-        instance = list_type(data=[val1, val2])
-
-        expected_hex = (
-            "080000000f000000"  # Offsets: val1 starts at 8, val2 starts at 15 (8+7)
-            "01050000000a00"  # val1 data
-            "02050000001e002800"  # val2 data
-        )
-
+        expected_hex = "080000000f00000001050000000a0002050000001e002800"
         encoded = instance.encode_bytes()
-        assert encoded.hex() == expected_hex
-        decoded = list_type.decode_bytes(encoded)
-        assert decoded == instance
 
-    def test_fixed_size_list_deserialization_rejects_invalid_scope(self) -> None:
-        """Tests fixed-size lists reject scopes not divisible by element size."""
-        with pytest.raises(SSZSerializationError, match="scope 1 not divisible by element size 2"):
+        assert encoded.hex() == expected_hex
+        assert VariableContainerList2.decode_bytes(encoded) == instance
+
+    def test_empty_scope_decodes_to_empty_list(self) -> None:
+        """An empty payload always decodes to an empty list."""
+        assert VariableContainerList2.decode_bytes(b"") == VariableContainerList2(data=[])
+
+    def test_fixed_size_list_rejects_scope_not_divisible_by_element_size(self) -> None:
+        """A fixed-size list rejects payloads whose length is not a multiple of the stride."""
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("Uint16List4: scope 1 not divisible by element size 2"),
+        ):
             Uint16List4.decode_bytes(b"\x01")
 
-    def test_variable_size_list_deserialization_accepts_empty_scope(self) -> None:
-        """Tests variable-size lists decode an empty payload as an empty list."""
-        decoded = VariableContainerList2.decode_bytes(b"")
+    def test_fixed_size_list_rejects_count_beyond_limit(self) -> None:
+        """A fixed-size list rejects payloads that decode to more than LIMIT elements."""
+        with pytest.raises(
+            SSZValueError,
+            match=re.escape("Uint8List4 exceeds limit of 4, got 5"),
+        ):
+            Uint8List4.decode_bytes(b"\x00\x01\x02\x03\x04")
 
-        assert decoded == VariableContainerList2(data=[])
-
-    def test_variable_size_list_deserialization_rejects_too_small_scope(self) -> None:
-        """Tests variable-size lists require at least one offset word."""
-        with pytest.raises(SSZSerializationError, match="scope 3 too small"):
+    def test_variable_size_list_rejects_scope_below_offset_word(self) -> None:
+        """A variable-size list requires at least one offset word in the payload."""
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("VariableContainerList2: scope 3 too small for variable-size list"),
+        ):
             VariableContainerList2.decode_bytes(b"\x00\x00\x00")
 
-    def test_variable_size_list_deserialization_rejects_invalid_first_offset(self) -> None:
-        """Tests variable-size lists reject misaligned offsets."""
-        with pytest.raises(SSZSerializationError, match="invalid offset 1"):
-            VariableContainerList2.decode_bytes(b"\x01\x00\x00\x00")
+    def test_variable_size_list_rejects_first_offset_past_scope(self) -> None:
+        """A first offset larger than the available scope is invalid."""
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("VariableContainerList2: invalid offset 100"),
+        ):
+            VariableContainerList2.decode_bytes(b"\x64\x00\x00\x00")
 
-    def test_variable_size_list_deserialization_rejects_count_beyond_limit(self) -> None:
-        """Tests variable-size lists reject counts beyond their limit."""
-        bad_payload = b"\x0c\x00\x00\x00" + (b"\x00" * 8)
+    def test_variable_size_list_rejects_misaligned_first_offset(self) -> None:
+        """A first offset that is not a multiple of the offset width is invalid."""
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("VariableContainerList2: invalid offset 5"),
+        ):
+            VariableContainerList2.decode_bytes(b"\x05\x00\x00\x00\x00\x00\x00\x00")
 
-        with pytest.raises(SSZValueError, match="exceeds limit of 2, got 3"):
-            VariableContainerList2.decode_bytes(bad_payload)
+    def test_variable_size_list_rejects_count_beyond_limit(self) -> None:
+        """A first offset that implies more than LIMIT elements is rejected."""
+        # Layout:
+        #
+        #     first_offset = 12   (count = 12 / 4 = 3, above LIMIT=2)
+        payload = b"\x0c\x00\x00\x00" + b"\x00" * 8
+        with pytest.raises(
+            SSZValueError,
+            match=re.escape("VariableContainerList2 exceeds limit of 2, got 3"),
+        ):
+            VariableContainerList2.decode_bytes(payload)
+
+    def test_variable_size_list_rejects_non_monotonic_offsets(self) -> None:
+        """A later offset smaller than an earlier one means a body would have negative width."""
+        # Layout:
+        #
+        #     first_offset = 8     (count = 2, table-end)
+        #     offsets[1]   = 6     (decreasing, triggers the monotonic check)
+        payload = b"\x08\x00\x00\x00\x06\x00\x00\x00" + b"\x00" * 12
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape("VariableContainerList2: offsets not monotonically increasing: 8 -> 6"),
+        ):
+            VariableContainerList2.decode_bytes(payload)
+
+    def test_variable_size_list_rejects_final_offset_overflow(self) -> None:
+        """An interior offset past the payload's end triggers the monotonic check."""
+        payload = b"\x08\x00\x00\x00\x64\x00\x00\x00" + b"\x00" * 12
+        with pytest.raises(
+            SSZSerializationError,
+            match=re.escape(
+                "VariableContainerList2: offsets not monotonically increasing: 100 -> 20"
+            ),
+        ):
+            VariableContainerList2.decode_bytes(payload)
+
+    def test_variable_size_list_single_element_decodes(self) -> None:
+        """A single-element list reads no further offsets after the first."""
+        val = VariableContainer(a=Uint8(1), b=Uint16List4(data=[Uint16(10)]))
+        encoded = VariableContainerList2(data=[val]).encode_bytes()
+
+        assert VariableContainerList2.decode_bytes(encoded) == VariableContainerList2(data=[val])
+
+
+class TestJsonSerialization:
+    """Tests for the JSON field serializer on SSZ sequences."""
+
+    def test_byte_array_elements_render_as_hex_strings(self) -> None:
+        """Byte-array leaves render as 0x-prefixed hex strings in JSON output."""
+        instance = Bytes32List32(data=[Bytes32.zero()])
+
+        assert instance.model_dump(mode="json") == {"data": ["0x" + ("00" * 32)]}
+
+    def test_integer_elements_render_as_plain_ints(self) -> None:
+        """Field-element leaves flatten to plain Python ints in JSON output."""
+        instance = FpVector8(data=[Fp(1), Fp(2), Fp(3), Fp(4), Fp(5), Fp(6), Fp(7), Fp(8)])
+
+        assert instance.model_dump(mode="json") == {"data": [1, 2, 3, 4, 5, 6, 7, 8]}
+
+    def test_boolean_elements_render_as_true_false(self) -> None:
+        """Booleans are excluded from the int branch and stay as true/false."""
+        instance = BooleanList4(data=[Boolean(True), Boolean(False), Boolean(True)])
+
+        assert instance.model_dump(mode="json") == {"data": [True, False, True]}
+
+    def test_container_elements_pass_through_to_pydantic(self) -> None:
+        """Container elements fall through the else branch and recurse via Pydantic."""
+        instance = FixedContainerList2(
+            data=[
+                FixedContainer(a=Uint8(1), b=Uint16(2)),
+                FixedContainer(a=Uint8(3), b=Uint16(4)),
+            ]
+        )
+
+        assert instance.model_dump(mode="json") == {"data": [{"a": 1, "b": 2}, {"a": 3, "b": 4}]}

--- a/tests/lean_spec/types/test_collections.py
+++ b/tests/lean_spec/types/test_collections.py
@@ -11,8 +11,6 @@ from lean_spec.types.boolean import Boolean
 from lean_spec.types.collections import (
     SSZList,
     SSZVector,
-    _extract_element_type_from_generic,
-    _serialize_ssz_elements_to_json,
     _validate_offsets,
 )
 from lean_spec.types.container import Container
@@ -195,27 +193,6 @@ class Uint8Vector2Model(BaseModel):
 
 class TestCollectionHelpers:
     """Tests for SSZ collection helper functions."""
-
-    def test_extract_element_type_from_generic_returns_element_type(self) -> None:
-        """Tests extracting the element type from Pydantic generic metadata."""
-        assert _extract_element_type_from_generic(Uint16Vector2, SSZVector) is Uint16
-
-    def test_extract_element_type_from_generic_returns_none_without_metadata(self) -> None:
-        """Tests that classes without matching generic metadata return None."""
-
-        class PlainClass:
-            pass
-
-        assert _extract_element_type_from_generic(PlainClass, SSZVector) is None
-
-    def test_serialize_ssz_elements_to_json_handles_supported_types(self) -> None:
-        """Tests JSON serialization for bytes, field elements, and plain values."""
-        marker = object()
-        result = _serialize_ssz_elements_to_json([Bytes32.zero(), Fp(7), marker])
-
-        assert result[0] == "0x" + ("00" * 32)
-        assert result[1] == 7
-        assert result[2] is marker
 
     def test_validate_offsets_accepts_empty_and_monotonic_offsets(self) -> None:
         """Tests offset validation success cases."""
@@ -558,8 +535,10 @@ class TestSSZVectorSerialization:
 
     def test_variable_size_vector_deserialization_rejects_invalid_first_offset(self) -> None:
         """Tests variable-size vectors reject an invalid initial offset."""
+        # Payload covers the full offset table (2 * 4 = 8 bytes),
+        # but the first offset is 4 instead of the expected table width 8.
         with pytest.raises(SSZSerializationError, match="invalid offset 4, expected 8"):
-            VariableContainerVector2.decode_bytes(b"\x04\x00\x00\x00")
+            VariableContainerVector2.decode_bytes(b"\x04\x00\x00\x00\x08\x00\x00\x00")
 
 
 class TestSSZListSerialization:


### PR DESCRIPTION
## Summary

- Extract a private `_SSZSequence[T]` base that holds the shared scaffolding (init_subclass, JSON serializer, offset-table writer, iteration, indexing).
- Tighten both validators: vector now rejects `str`/`bytes` explicitly, list's broad `except Exception` is narrowed to domain exceptions with the inner cause chained.
- Simplify decoders: vector reads its offset table in one comprehension with an upfront scope guard; list uses a star-unpack literal for the offset list plus the trailing scope sentinel.
- Rewrite documentation in the bitfields.py style — module overview defines fixed-size vs variable-size up front, the `__init_subclass__` docstring shows a concrete class declaration, inline comments are glued to each block and explain the *why*.
- Replace fragile column-diagrams with byte-range tables that read cleanly in any editor.

## Test plan

- [x] `uv run pytest tests/lean_spec/types/test_collections.py` (57 passed)
- [x] `uv run pytest tests/lean_spec/types/` (1089 passed)
- [x] `uv run pytest tests/` (2997 passed)
- [x] `just check` (ruff, ruff format, ty, codespell, mdformat all clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)