### PR TITLE
refactor(types/container): lean rewrite, fix canonical-offset gap, full test coverage

### DIFF
--- a/src/lean_spec/types/container.py
+++ b/src/lean_spec/types/container.py
@@ -1,13 +1,8 @@
-"""
-SSZ Container Type: Ordered heterogeneous collections with named fields.
+"""SSZ Container Type."""
 
-This module implements the SSZ Container type specification.
-
-Containers are the primary way to define structured data in
-Ethereum's serialization format.
-"""
-
-from typing import IO, Any, Self, override
+import io
+from itertools import pairwise
+from typing import IO, Self, override
 
 from .exceptions import SSZSerializationError, SSZTypeError
 from .ssz_base import BYTES_PER_LENGTH_OFFSET, SSZModel, SSZType
@@ -15,227 +10,87 @@ from .uint import Uint32
 
 
 class Container(SSZModel):
-    """
-    SSZ Container: A strict, ordered collection of heterogeneous named fields.
-
-    Containers are the fundamental composite type in SSZ, similar to structs
-    in C or dataclasses in Python. Each field has a name and type, and the
-    serialization preserves field order.
-
-    Inherits from SSZModel to get:
-    - Pydantic validation and immutability (StrictBaseModel)
-    - SSZ serialization interface (SSZType)
-    - Collection methods that work with named fields
-
-    Key properties:
-    - Fields are serialized in definition order
-    - Fixed-size fields are packed directly
-    - Variable-size fields use offset pointers
-    - Field iteration via inherited __iter__ method
-
-    Serialization format:
-        [fixed_field_1][fixed_field_2]...[offset_1][offset_2]...[variable_data_1][variable_data_2]...
-    """
-
-    @staticmethod
-    def _get_ssz_field_type(annotation: Any) -> type[SSZType]:
-        """
-        Extract the SSZType class from a field annotation, with validation.
-
-        Args:
-            annotation: The field type annotation.
-
-        Returns:
-            The SSZType class.
-
-        Raises:
-            SSZTypeError: If the annotation is not a valid SSZType class.
-        """
-        if not (isinstance(annotation, type) and issubclass(annotation, SSZType)):
-            raise SSZTypeError(f"Expected SSZType subclass, got {annotation}")
-        return annotation
+    """Ordered struct of named heterogeneous SSZ fields."""
 
     @classmethod
     @override
     def is_fixed_size(cls) -> bool:
-        """
-        Check if this container has a fixed byte length.
-
-        A container is fixed-size only when ALL its fields are fixed-size.
-        This affects how the container is serialized and merkleized.
-
-        Returns:
-            True if all fields have fixed size, False if any field is variable.
-        """
-        # Check each field's type for fixed size property
-        return all(
-            cls._get_ssz_field_type(field.annotation).is_fixed_size()
-            for field in cls.model_fields.values()
-        )
+        """True only when every field is fixed-size."""
+        return all(f.annotation.is_fixed_size() for f in cls.model_fields.values())
 
     @classmethod
     @override
     def get_byte_length(cls) -> int:
-        """
-        Calculate the exact byte length for fixed-size containers.
-
-        Returns:
-            Total byte length of all fields summed together.
-
-        Raises:
-            SSZTypeDefinitionError: If called on a variable-size container.
-        """
-        # Only fixed-size containers have a deterministic byte length
+        """Sum of field widths; raises for variable-size containers."""
         if not cls.is_fixed_size():
             raise SSZTypeError(f"{cls.__name__}: variable-size container has no fixed byte length")
-
-        # Sum the byte lengths of all fixed-size fields
-        return sum(
-            cls._get_ssz_field_type(field.annotation).get_byte_length()
-            for field in cls.model_fields.values()
-        )
+        return sum(f.annotation.get_byte_length() for f in cls.model_fields.values())
 
     @override
     def serialize(self, stream: IO[bytes]) -> int:
-        """
-        Serialize container to bytes following SSZ specification.
+        """Write the fixed part with offsets, then the variable payloads."""
+        values = [getattr(self, name) for name in type(self).model_fields]
 
-        SSZ serialization uses a two-part format:
-        1. Fixed part: Fixed-size fields and offsets for variable fields
-        2. Variable part: Actual data of variable-size fields
+        # Leading-part width: each slot is either the field's byte length or one offset.
+        offset = sum(
+            type(v).get_byte_length() if type(v).is_fixed_size() else BYTES_PER_LENGTH_OFFSET
+            for v in values
+        )
 
-        Args:
-            stream: Binary stream to write serialized bytes to.
-
-        Returns:
-            Number of bytes written to the stream.
-        """
-        # Collect serialized field data
-        #
-        # Fixed-size field bytes or empty for variable fields
-        fixed_parts = []
-        # Actual data for variable-size fields
-        variable_data = []
-
-        # Process each field in definition order
-        for field_name in type(self).model_fields:
-            # Get the field value and its type
-            value = getattr(self, field_name)
-            # Use the actual runtime type of the value, which should be an SSZType
-            field_type = type(value)
-
-            # Serialize based on field type
-            if field_type.is_fixed_size():
-                # Fixed fields go directly in the fixed part
-                fixed_parts.append(value.encode_bytes())
+        # Variable payloads stage in a buffer while the output takes the fixed part.
+        tail = io.BytesIO()
+        for value in values:
+            if type(value).is_fixed_size():
+                value.serialize(stream)
             else:
-                # Variable fields: placeholder in fixed part, data in variable part
-                #
-                # Will be replaced with offset
-                fixed_parts.append(b"")
-                variable_data.append(value.encode_bytes())
-
-        # Calculate where variable data starts (after all fixed parts)
-        offset = sum(len(part) if part else BYTES_PER_LENGTH_OFFSET for part in fixed_parts)
-
-        # Write fixed part with calculated offsets
-        var_iter = iter(variable_data)
-        for part in fixed_parts:
-            if part:  # Fixed-size field data
-                stream.write(part)
-            else:  # Variable-size field offset
-                stream.write(Uint32(offset).encode_bytes())
-                offset += len(next(var_iter))
-
-        # Append all variable data at the end
-        for data in variable_data:
-            stream.write(data)
-
-        return offset  # Total bytes written
+                Uint32(offset).serialize(stream)
+                offset += value.serialize(tail)
+        stream.write(tail.getvalue())
+        return offset
 
     @classmethod
     @override
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
-        """
-        Deserialize container from byte stream.
+        """Read the fixed part with offsets, then each variable payload by its offset window."""
+        fields: dict[str, SSZType] = {}
+        var_fields: list[tuple[str, type[SSZType], int]] = []
+        bytes_read = 0
 
-        Reverses the serialization process by:
-        1. Reading fixed fields and offsets from the fixed part
-        2. Using offsets to locate and read variable field data
-
-        Args:
-            stream: Binary stream to read from.
-            scope: Total bytes available for this container.
-
-        Returns:
-            New container instance with deserialized values.
-
-        Raises:
-            SSZSerializationError: If stream ends unexpectedly or offsets are invalid.
-        """
-        fields = {}  # Collected field values
-        var_fields = []  # (name, type, offset) for variable fields
-        bytes_read = 0  # Track position in fixed part
-
-        # Phase 1: Read fixed part
-        for field_name, field_info in cls.model_fields.items():
-            field_type = cls._get_ssz_field_type(field_info.annotation)
-
-            if field_type.is_fixed_size():
-                # Read and deserialize fixed field directly
-                size = field_type.get_byte_length()
-                data = stream.read(size)
-                if len(data) != size:
-                    raise SSZSerializationError(
-                        f"{cls.__name__}.{field_name}: expected {size} bytes, got {len(data)}"
-                    )
-                fields[field_name] = field_type.decode_bytes(data)
-                bytes_read += size
+        # Phase 1: each slot is either the field itself or an offset to its tail payload.
+        for name, info in cls.model_fields.items():
+            ftype: type[SSZType] = info.annotation
+            if ftype.is_fixed_size():
+                width = ftype.get_byte_length()
+                fields[name] = ftype.deserialize(stream, width)
+                bytes_read += width
             else:
-                # Read offset pointer for variable field
-                offset_bytes = stream.read(BYTES_PER_LENGTH_OFFSET)
-                if len(offset_bytes) != BYTES_PER_LENGTH_OFFSET:
-                    raise SSZSerializationError(
-                        f"{cls.__name__}.{field_name}: "
-                        f"expected {BYTES_PER_LENGTH_OFFSET} offset bytes, got {len(offset_bytes)}"
-                    )
-                offset = int(Uint32.decode_bytes(offset_bytes))
-                var_fields.append((field_name, field_type, offset))
+                offset = int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
+                var_fields.append((name, ftype, offset))
                 bytes_read += BYTES_PER_LENGTH_OFFSET
 
-        # Phase 2: Read variable part if present
-        if var_fields:
-            # Read entire variable section at once
-            var_section_size = scope - bytes_read
-            var_section = stream.read(var_section_size)
-            if len(var_section) != var_section_size:
+        if not var_fields:
+            return cls(**fields)
+
+        # Canonical form: the first offset must point to the end of the fixed part.
+        # Any other value leaves a gap or overlap, allowing two encodings of one value.
+        if var_fields[0][2] != bytes_read:
+            raise SSZSerializationError(
+                f"{cls.__name__}: first offset {var_fields[0][2]} != fixed-part end {bytes_read}"
+            )
+
+        # Phase 2: each variable payload spans from its offset to the next.
+        # Scope closes the final span.
+        boundaries = [o for _, _, o in var_fields] + [scope]
+        for (name, ftype, _), (start, end) in zip(var_fields, pairwise(boundaries), strict=True):
+            if end < start:
                 raise SSZSerializationError(
-                    f"{cls.__name__}: "
-                    f"expected {var_section_size} variable bytes, got {len(var_section)}"
+                    f"{cls.__name__}.{name}: non-monotonic offsets ({start} > {end})"
                 )
+            fields[name] = ftype.deserialize(stream, end - start)
 
-            # Extract each variable field using offsets
-            offsets = [offset for _, _, offset in var_fields] + [scope]
-            for i, (name, field_type, start) in enumerate(var_fields):
-                # Calculate slice boundaries relative to variable section
-                end = offsets[i + 1]
-                rel_start = start - bytes_read
-                rel_end = end - bytes_read
-
-                # Validate offset bounds
-                if rel_start < 0 or rel_start > rel_end:
-                    raise SSZSerializationError(
-                        f"{cls.__name__}.{name}: invalid offsets start={start}, end={end}"
-                    )
-
-                # Deserialize field from its slice
-                field_data = var_section[rel_start:rel_end]
-                fields[name] = field_type.decode_bytes(field_data)
-
-        # Construct container with all fields
         return cls(**fields)
 
     @classmethod
     def from_hex(cls, value: str) -> Self:
-        """Decode from a hex string with an optional "0x" prefix."""
+        """Decode from a hex string with an optional 0x prefix."""
         return cls.decode_bytes(bytes.fromhex(value.removeprefix("0x")))

--- a/tests/lean_spec/types/test_checkpoint.py
+++ b/tests/lean_spec/types/test_checkpoint.py
@@ -119,7 +119,7 @@ class TestCheckpointSerialization:
         """A 39-byte input is one byte short of the slot field and is rejected."""
         with pytest.raises(SSZSerializationError) as exc_info:
             Checkpoint.decode_bytes(b"\x00" * 39)
-        assert str(exc_info.value) == "Checkpoint.slot: expected 8 bytes, got 7"
+        assert str(exc_info.value) == "Slot: expected 8 bytes, got 7"
 
     def test_decode_rejects_trailing_bytes(self) -> None:
         """A 41-byte input carries one trailing byte past the canonical encoding."""

--- a/tests/lean_spec/types/test_container.py
+++ b/tests/lean_spec/types/test_container.py
@@ -1,0 +1,382 @@
+"""Tests for the SSZ Container base class."""
+
+import io
+
+import pytest
+
+from lean_spec.types.collections import SSZList
+from lean_spec.types.container import Container
+from lean_spec.types.exceptions import SSZSerializationError, SSZTypeError
+from lean_spec.types.uint import Uint8, Uint16, Uint32, Uint64
+
+
+class Uint16List4(SSZList[Uint16]):
+    """A list with up to 4 Uint16 values for variable-field testing."""
+
+    LIMIT = 4
+
+
+class TwoUint64(Container):
+    """Two fixed-size Uint64 fields, total width 16 bytes."""
+
+    a: Uint64
+    b: Uint64
+
+
+class TwoVar(Container):
+    """Two variable-size list fields, total width is dynamic."""
+
+    a: Uint16List4
+    b: Uint16List4
+
+
+class Mixed(Container):
+    """Interleaved fixed and variable fields covering the canonical mixed shape."""
+
+    a: Uint64
+    b: Uint16List4
+    c: Uint32
+    d: Uint16List4
+
+
+class OneVar(Container):
+    """Single variable-size field, exercises the single-offset branch."""
+
+    a: Uint16List4
+
+
+class InnerFixed(Container):
+    """Inner fixed-size container nested inside another container."""
+
+    x: Uint64
+    y: Uint64
+
+
+class OuterFixedNested(Container):
+    """Outer fixed-size container that holds a fixed-size container as a field."""
+
+    z: Uint64
+    inner: InnerFixed
+
+
+class InnerVar(Container):
+    """Inner variable-size container with one variable field."""
+
+    a: Uint64
+    b: Uint16List4
+
+
+class OuterVarNested(Container):
+    """Outer container that holds a variable-size container as a field."""
+
+    head: Uint64
+    inner: InnerVar
+
+
+class Attestation(Container):
+    """Parent container with a fixed slot and a variable data list."""
+
+    slot: Uint64
+    data: Uint16List4
+
+
+class SignedAttestation(Attestation):
+    """Subclass appending a signature field after the parent fields."""
+
+    signature: Uint64
+
+
+class EmptyContainer(Container):
+    """Zero-field container, exercises the all-fixed sum over an empty iterator."""
+
+
+class OneByte(Container):
+    """Smallest non-empty fixed container, used for hex helpers."""
+
+    a: Uint8
+
+
+class TestFixedContainer:
+    """Fixed-size container metadata, encoding, and roundtrip behavior."""
+
+    def test_is_fixed_size_true(self) -> None:
+        """A container of only fixed-size fields reports as fixed-size."""
+        assert TwoUint64.is_fixed_size() is True
+
+    def test_get_byte_length_sums_field_widths(self) -> None:
+        """The fixed byte width is the sum of each field's byte width."""
+        assert TwoUint64.get_byte_length() == 16
+
+    def test_serialize_writes_little_endian_fields(self) -> None:
+        """Encoding concatenates each field's little-endian bytes in order."""
+        encoded = TwoUint64(a=Uint64(1), b=Uint64(2)).encode_bytes()
+        assert encoded == b"\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00"
+
+    @pytest.mark.parametrize(
+        ("a", "b"),
+        [
+            pytest.param(0, 0, id="edge_zero"),
+            pytest.param(1, 2, id="small"),
+            pytest.param(0xDEADBEEF, 0xCAFEBABE, id="medium"),
+            pytest.param(2**64 - 1, 2**64 - 1, id="large"),
+        ],
+    )
+    def test_roundtrip_preserves_value(self, a: int, b: int) -> None:
+        """Encoding then decoding recovers the original fixed container exactly."""
+        original = TwoUint64(a=Uint64(a), b=Uint64(b))
+        assert TwoUint64.decode_bytes(original.encode_bytes()) == original
+
+    def test_empty_container_has_zero_byte_length(self) -> None:
+        """A container with no fields has a fixed byte length of zero."""
+        assert EmptyContainer.is_fixed_size() is True
+        assert EmptyContainer.get_byte_length() == 0
+        assert EmptyContainer().encode_bytes() == b""
+
+
+class TestVariableContainer:
+    """All-variable container shape and metadata."""
+
+    def test_is_fixed_size_false(self) -> None:
+        """A container with only variable-size fields reports as not fixed-size."""
+        assert TwoVar.is_fixed_size() is False
+
+    def test_get_byte_length_raises(self) -> None:
+        """A variable-size container has no fixed byte length and must raise."""
+        with pytest.raises(SSZTypeError) as exc_info:
+            TwoVar.get_byte_length()
+        assert exc_info.value.args[0] == "TwoVar: variable-size container has no fixed byte length"
+
+    def test_all_variable_roundtrip(self) -> None:
+        """A container of two variable lists roundtrips through encode then decode."""
+        original = TwoVar(
+            a=Uint16List4(data=[Uint16(0x1234), Uint16(0x5678)]),
+            b=Uint16List4(data=[Uint16(0x9ABC)]),
+        )
+        # Fixed-part width is 8 bytes for two Uint32 offsets.
+        # First offset is 8, second offset is 12 because the first payload spans 4 bytes.
+        expected = bytes.fromhex("080000000c00000034127856bc9a")
+        assert original.encode_bytes() == expected
+        assert TwoVar.decode_bytes(expected) == original
+
+
+class TestOneVariableField:
+    """Edge case where the variable-field list contains exactly one entry."""
+
+    def test_one_variable_field_roundtrip(self) -> None:
+        """A container with a single variable field encodes one offset and the payload."""
+        original = OneVar(a=Uint16List4(data=[Uint16(0x1234)]))
+        # Fixed part is one offset of 4 bytes pointing to 4, then the payload.
+        assert original.encode_bytes() == bytes.fromhex("040000003412")
+        assert OneVar.decode_bytes(bytes.fromhex("040000003412")) == original
+
+    def test_one_variable_field_with_empty_payload(self) -> None:
+        """An empty variable field exercises the start equals end span branch."""
+        original = OneVar(a=Uint16List4(data=[]))
+        # The offset still points to byte 4, and the payload is zero bytes long.
+        encoded = original.encode_bytes()
+        assert encoded == bytes.fromhex("04000000")
+        assert OneVar.decode_bytes(encoded) == original
+
+
+class TestMixedContainer:
+    """Interleaved fixed and variable fields, the canonical wire layout."""
+
+    def test_mixed_is_variable(self) -> None:
+        """Any variable field forces the whole container to be variable-size."""
+        assert Mixed.is_fixed_size() is False
+
+    def test_mixed_get_byte_length_raises(self) -> None:
+        """The mixed container has no fixed byte length and must raise."""
+        with pytest.raises(SSZTypeError) as exc_info:
+            Mixed.get_byte_length()
+        assert exc_info.value.args[0] == "Mixed: variable-size container has no fixed byte length"
+
+    def test_mixed_wire_layout(self) -> None:
+        """The fixed slots and offsets land before the tail payloads in field order."""
+        # Fixture state:
+        #   a (Uint64) = 0xAABBCCDD       -> ddccbbaa00000000   (8 bytes)
+        #   b offset   = 20               -> 14000000           (4 bytes)
+        #   c (Uint32) = 0xEEFF           -> ffee0000           (4 bytes)
+        #   d offset   = 24               -> 18000000           (4 bytes)
+        #   b payload  = [1, 2] Uint16    -> 01000200           (4 bytes)
+        #   d payload  = [3]   Uint16     -> 0300               (2 bytes)
+        original = Mixed(
+            a=Uint64(0xAABBCCDD),
+            b=Uint16List4(data=[Uint16(1), Uint16(2)]),
+            c=Uint32(0xEEFF),
+            d=Uint16List4(data=[Uint16(3)]),
+        )
+        expected = bytes.fromhex("ddccbbaa0000000014000000ffee000018000000010002000300")
+        assert original.encode_bytes() == expected
+        assert Mixed.decode_bytes(expected) == original
+
+
+class TestNestedContainer:
+    """Containers nested as fields of other containers."""
+
+    def test_fixed_inside_fixed_is_fixed(self) -> None:
+        """A fixed container holding another fixed container stays fixed-size."""
+        assert OuterFixedNested.is_fixed_size() is True
+        # 8 bytes for z plus 16 bytes for the inner pair.
+        assert OuterFixedNested.get_byte_length() == 24
+
+    def test_fixed_inside_fixed_roundtrip(self) -> None:
+        """Encoding lays out the outer field then the inner fields back to back."""
+        original = OuterFixedNested(z=Uint64(7), inner=InnerFixed(x=Uint64(1), y=Uint64(2)))
+        encoded = original.encode_bytes()
+        assert encoded == bytes.fromhex("070000000000000001000000000000000200000000000000")
+        assert OuterFixedNested.decode_bytes(encoded) == original
+
+    def test_variable_inside_outer_is_variable(self) -> None:
+        """A variable inner container forces the outer to be variable-size."""
+        assert OuterVarNested.is_fixed_size() is False
+
+    def test_variable_inside_outer_roundtrip(self) -> None:
+        """The inner variable container is treated as a single variable field on the outer."""
+        # Fixture state:
+        #   head    = 99            -> 6300000000000000   (8 bytes fixed)
+        #   inner offset = 12       -> 0c000000           (4 bytes)
+        #   inner payload begins at byte 12:
+        #     inner.a = 7           -> 0700000000000000   (8 bytes)
+        #     inner.b offset = 12   -> 0c000000           (4 bytes)
+        #     inner.b payload [1,2] -> 01000200           (4 bytes)
+        original = OuterVarNested(
+            head=Uint64(99),
+            inner=InnerVar(a=Uint64(7), b=Uint16List4(data=[Uint16(1), Uint16(2)])),
+        )
+        expected = bytes.fromhex("63000000000000000c00000007000000000000000c00000001000200")
+        assert original.encode_bytes() == expected
+        assert OuterVarNested.decode_bytes(expected) == original
+
+
+class TestSubclassInheritance:
+    """Pydantic merges parent and child fields in declaration order."""
+
+    def test_subclass_field_order_preserved(self) -> None:
+        """The subclass exposes parent fields first then its own fields."""
+        assert list(SignedAttestation.model_fields.keys()) == ["slot", "data", "signature"]
+
+    def test_subclass_roundtrip(self) -> None:
+        """A subclass that adds a fixed field after a variable field roundtrips correctly."""
+        original = SignedAttestation(
+            slot=Uint64(5),
+            data=Uint16List4(data=[Uint16(1)]),
+            signature=Uint64(99),
+        )
+        # Fixed part is slot (8) plus data offset (4) plus signature (8) for 20 bytes.
+        # Data offset value is therefore 20 and the payload is [1] as Uint16.
+        expected = bytes.fromhex("05000000000000001400000063000000000000000100")
+        assert original.encode_bytes() == expected
+        assert SignedAttestation.decode_bytes(expected) == original
+
+
+class TestSerialize:
+    """Stream-level behavior of the serialize method."""
+
+    def test_serialize_returns_total_bytes_written(self) -> None:
+        """Serialize returns the total byte count including the variable tail."""
+        original = OneVar(a=Uint16List4(data=[Uint16(1), Uint16(2), Uint16(3)]))
+        stream = io.BytesIO()
+        # Fixed part is 4 bytes for the single offset.
+        # The payload is 6 bytes for three Uint16 elements.
+        assert original.serialize(stream) == 10
+        assert stream.getvalue() == bytes.fromhex("04000000010002000300")
+
+
+class TestDeserialize:
+    """Stream-level behavior of the deserialize method."""
+
+    def test_deserialize_with_scope_reads_full_value(self) -> None:
+        """Reading from a stream with a matching scope reconstructs the value."""
+        original = Mixed(
+            a=Uint64(1),
+            b=Uint16List4(data=[Uint16(7)]),
+            c=Uint32(2),
+            d=Uint16List4(data=[Uint16(8), Uint16(9)]),
+        )
+        encoded = original.encode_bytes()
+        stream = io.BytesIO(encoded)
+        assert Mixed.deserialize(stream, len(encoded)) == original
+
+
+class TestErrors:
+    """Spec-compliance error paths for malformed inputs."""
+
+    @pytest.mark.parametrize(
+        ("bad_offset", "expected_message"),
+        [
+            pytest.param(11, "Mixed: first offset 11 != fixed-part end 20", id="below_fixed_end"),
+            pytest.param(21, "Mixed: first offset 21 != fixed-part end 20", id="above_fixed_end"),
+        ],
+    )
+    def test_first_offset_must_match_fixed_part_end(
+        self, bad_offset: int, expected_message: str
+    ) -> None:
+        """The first variable offset must equal the end of the fixed part."""
+        # Fixed part of Mixed is 8 + 4 + 4 + 4 = 20 bytes.
+        # The payload deviates by one byte in either direction from the canonical offset.
+        data = (
+            (1).to_bytes(8, "little")
+            + bad_offset.to_bytes(4, "little")
+            + (2).to_bytes(4, "little")
+            + (24).to_bytes(4, "little")
+            + bytes.fromhex("01000200")
+            + bytes.fromhex("0300")
+        )
+        with pytest.raises(SSZSerializationError) as exc_info:
+            Mixed.decode_bytes(data)
+        assert exc_info.value.args[0] == expected_message
+
+    def test_non_monotonic_offsets_raise(self) -> None:
+        """A second offset below the first triggers a non-monotonic offsets error."""
+        # Fixed part is 8 bytes for two Uint32 offsets.
+        # First offset is 8 (valid), second offset is 5 (decreasing).
+        data = (8).to_bytes(4, "little") + (5).to_bytes(4, "little") + b"\x34\x12"
+        with pytest.raises(SSZSerializationError) as exc_info:
+            TwoVar.decode_bytes(data)
+        assert exc_info.value.args[0] == "TwoVar.a: non-monotonic offsets (8 > 5)"
+
+    def test_short_input_on_fixed_field_raises(self) -> None:
+        """A truncated stream on a fixed field surfaces the field type's own error."""
+        # 15 bytes is one short of the 16-byte fixed width.
+        with pytest.raises(SSZSerializationError) as exc_info:
+            TwoUint64.decode_bytes(b"\x00" * 15)
+        assert exc_info.value.args[0] == "Uint64: expected 8 bytes, got 7"
+
+    def test_trailing_bytes_raises(self) -> None:
+        """An input one byte longer than the canonical encoding is rejected."""
+        with pytest.raises(SSZSerializationError) as exc_info:
+            TwoUint64.decode_bytes(b"\x00" * 17)
+        assert exc_info.value.args[0] == "TwoUint64: 1 trailing byte(s) after decode"
+
+
+class TestFromHex:
+    """Hex-string entry point for container decoding."""
+
+    @pytest.mark.parametrize(
+        "hex_input",
+        [
+            pytest.param("0xab", id="with_prefix"),
+            pytest.param("ab", id="without_prefix"),
+            pytest.param("0xAB", id="uppercase_with_prefix"),
+        ],
+    )
+    def test_from_hex_accepts_prefix_and_case(self, hex_input: str) -> None:
+        """Hex parsing tolerates the 0x prefix and mixed case alike."""
+        assert OneByte.from_hex(hex_input) == OneByte(a=Uint8(0xAB))
+
+    @pytest.mark.parametrize(
+        "hex_input",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("0x", id="prefix_only"),
+        ],
+    )
+    def test_from_hex_empty_string_decodes_empty_container(self, hex_input: str) -> None:
+        """An empty hex string decodes to a zero-field container."""
+        assert EmptyContainer.from_hex(hex_input) == EmptyContainer()
+
+    def test_from_hex_bad_hex_raises_value_error(self) -> None:
+        """Non-hex characters surface a ValueError from the underlying parser."""
+        with pytest.raises(ValueError, match="non-hexadecimal number"):
+            OneByte.from_hex("zz")


### PR DESCRIPTION
## Summary

- Rewrites `src/lean_spec/types/container.py` from 242 to 101 lines by mirroring the `io.BytesIO` + `itertools.pairwise` patterns already used in `collections.py`. Drops the `_get_ssz_field_type` helper, the `b""`-sentinel two-pass serialize, and the read-whole-variable-section-and-slice deserialize.
- Fixes a real SSZ canonical-form bug: the first variable offset must equal the end of the fixed part. Without this check a malicious encoder can leave a gap or overlap, allowing two byte sequences to decode to the same value.
- Adds a full test suite at `tests/lean_spec/types/test_container.py` (was empty — which is why the canonical-offset gap slipped through). 35 tests, 100% line and branch coverage of `container.py`.

## Notable change for reviewers

`deserialize` now delegates per-field reads to the field type's own `.deserialize(stream, width)` rather than wrapping `stream.read` itself. As a result a short-input error on a fixed field now reads `Slot: expected 8 bytes, got 7` instead of `Checkpoint.slot: expected 8 bytes, got 7`. The failing type is still named; one test in `test_checkpoint.py` was updated accordingly.

## Test plan

- [x] `uv run pytest tests/lean_spec/types/test_container.py --cov=src/lean_spec/types/container --cov-report=term-missing` — 35 passed, 100% (57/57 statements, 18/18 branches).
- [x] `uv run pytest tests/lean_spec/types/` — 1092 passed.
- [x] `just check` — ruff, format, ty, codespell, mdformat all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)