### PR TITLE
refactor(forks/lstar): drop stale defensive shallow-copies in store

### DIFF
--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -1115,12 +1115,6 @@ class LstarSpec(ForkProtocol):
                 public_key, attestation_data.slot, hash_tree_root(attestation_data), signature
             ), "Signature verification failed"
 
-            # Store signature and attestation data for later aggregation.
-            # Copy the inner sets so we can add to them without mutating the previous store.
-            store.attestation_signatures = {
-                k: set(v) for k, v in store.attestation_signatures.items()
-            }
-
             # Aggregators store all received gossip signatures.
             # The p2p layer only delivers attestations from subscribed subnets,
             # so subnet filtering happens at subscription time, not here.
@@ -1184,10 +1178,6 @@ class LstarSpec(ForkProtocol):
                 f"Committee aggregation signature verification failed: {exc}"
             ) from exc
 
-        # Shallow-copy the dict and its inner sets to preserve immutability.
-        store.latest_new_aggregated_payloads = {
-            k: set(v) for k, v in store.latest_new_aggregated_payloads.items()
-        }
         store.latest_new_aggregated_payloads.setdefault(data, set()).add(proof)
 
         return store
@@ -1280,11 +1270,6 @@ class LstarSpec(ForkProtocol):
             # the known pool at the next acceptance tick.
             # Head weight from block-imported votes is therefore deferred
             # by up to one slot.
-            # Shallow-copy the dict and its inner sets to preserve immutability.
-            store.latest_known_aggregated_payloads = {
-                k: set(v) for k, v in store.latest_known_aggregated_payloads.items()
-            }
-
             for aggregated_attestation in aggregated_attestations:
                 store.latest_known_aggregated_payloads.setdefault(
                     aggregated_attestation.data, set()
@@ -1465,10 +1450,6 @@ class LstarSpec(ForkProtocol):
         influence on fork choice decisions.
         """
         # Merge new aggregated payloads into known aggregated payloads
-        store.latest_known_aggregated_payloads = {
-            attestation_data: set(proofs)
-            for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
-        }
         for attestation_data, proofs in store.latest_new_aggregated_payloads.items():
             store.latest_known_aggregated_payloads.setdefault(attestation_data, set()).update(
                 proofs
@@ -1663,11 +1644,8 @@ class LstarSpec(ForkProtocol):
                 signed_att.proof
             )
 
-        store.attestation_signatures = {
-            data: sigs
-            for data, sigs in store.attestation_signatures.items()
-            if data not in store.latest_new_aggregated_payloads
-        }
+        for data in store.latest_new_aggregated_payloads:
+            store.attestation_signatures.pop(data, None)
         return store, new_aggregates
 
     def tick_interval(


### PR DESCRIPTION
## Summary

Five sites in `spec/forks/lstar/spec.py` rebuilt `store` dicts (and their inner sets) before mutating them. These were defensive shallow-copies left over from when the store API was immutable-by-`model_copy`. Since #789 (commit fb5ff3c7), the store is mutated in place, so these rebuilds:

- protect no invariant (the surrounding code already mutates `store` directly),
- cost O(N) per call on hot paths (`on_gossip_attestation`, `on_gossip_aggregated_attestation`, `on_block`, `accept_new_attestations`, `aggregate`),
- actively mislead readers into thinking the store is immutable.

### Sites changed

| Method | Pattern removed |
|--------|-----------------|
| `on_gossip_attestation` | `store.attestation_signatures = {k: set(v) for k, v in ...}` |
| `on_gossip_aggregated_attestation` | `store.latest_new_aggregated_payloads = {k: set(v) for k, v in ...}` |
| `on_block` | `store.latest_known_aggregated_payloads = {k: set(v) for k, v in ...}` |
| `accept_new_attestations` | `store.latest_known_aggregated_payloads = {data: set(proofs) for ...}` |
| `aggregate` | Rebuild-with-filter replaced by in-place `pop()` loop |

The last case is semantically equivalent: the comprehension was keeping entries whose `data` was not in `latest_new_aggregated_payloads`; the loop pops exactly the complementary keys.

Invalidated header comments (`# Shallow-copy the dict and its inner sets to preserve immutability.`) are removed alongside the code they describe.

## Test plan

- [x] `just check` — ruff, format, ty, codespell, mdformat all pass
- [x] `uv run pytest tests/lean_spec/spec/forks/lstar/` — 65 tests pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)