### PR TITLE
refactor(base): raise when to_json is called with mode or by_alias

### DIFF
--- a/src/lean_spec/base.py
+++ b/src/lean_spec/base.py
@@ -21,14 +21,22 @@ class CamelModel(BaseModel):
     )
 
     def to_json(self, **kwargs: Any) -> dict[str, Any]:
-        """Serialize to a JSON-encodable dict with camelCase keys.
-
-        Always uses JSON mode and camelCase aliases regardless of kwargs.
-        Callers cannot override mode or by_alias — these are stripped
-        silently to guarantee correct test vector output.
         """
-        kwargs.pop("mode", None)
-        kwargs.pop("by_alias", None)
+        Serialize to a JSON-encodable dict with camelCase keys.
+
+        Serialization mode is pinned to JSON.
+        Alias style is pinned to camelCase.
+        A caller that overrides either almost certainly expects the override to apply.
+        The override is rejected to avoid silently surprising the caller.
+
+        Raises:
+            TypeError: If mode or by_alias is passed as a keyword argument.
+        """
+        if "mode" in kwargs or "by_alias" in kwargs:
+            raise TypeError(
+                "to_json() does not accept 'mode' or 'by_alias'; "
+                "mode is pinned to 'json' and by_alias to True"
+            )
 
         return self.model_dump(
             mode="json",

--- a/tests/lean_spec/test_base.py
+++ b/tests/lean_spec/test_base.py
@@ -40,32 +40,19 @@ class TestCamelModelToJson:
 
         assert result == {"firstName": "Alice", "currentSlot": 42}
 
-    def test_to_json_strips_mode_kwarg(self) -> None:
-        """Passing mode= does not override the JSON serialization mode.
-
-        The method always uses mode='json'. If a caller accidentally
-        passes mode='python', the pop() silently discards it.
-        """
+    def test_to_json_rejects_mode_kwarg(self) -> None:
+        """Overriding serialization mode raises an error instead of being silently accepted."""
         model = SampleCamelModel(first_name="Bob", current_slot=7)
 
-        # Passing mode= should be silently ignored.
-        result = model.to_json(mode="python")
+        with pytest.raises(TypeError, match="does not accept 'mode' or 'by_alias'"):
+            model.to_json(mode="python")
 
-        assert result == {"firstName": "Bob", "currentSlot": 7}
-
-    def test_to_json_strips_by_alias_kwarg(self) -> None:
-        """Passing by_alias= does not override the alias behavior.
-
-        The method always uses by_alias=True (camelCase). If a caller
-        passes by_alias=False, the pop() silently discards it.
-        """
+    def test_to_json_rejects_by_alias_kwarg(self) -> None:
+        """Overriding alias style raises an error instead of being silently accepted."""
         model = SampleCamelModel(first_name="Carol", current_slot=0)
 
-        # Passing by_alias=False should be silently ignored.
-        result = model.to_json(by_alias=False)
-
-        # Keys are still camelCase despite the caller's request.
-        assert result == {"firstName": "Carol", "currentSlot": 0}
+        with pytest.raises(TypeError, match="does not accept 'mode' or 'by_alias'"):
+            model.to_json(by_alias=False)
 
     def test_to_json_forwards_extra_kwargs(self) -> None:
         """Other kwargs (e.g., exclude_defaults) pass through to model_dump.


### PR DESCRIPTION
## Summary

`CamelModel.to_json` pinned the underlying `model_dump` call to `mode="json"` and `by_alias=True`. When a caller passed either as a keyword argument, the previous implementation silently popped it and went ahead with the pinned values:

```python
kwargs.pop("mode", None)
kwargs.pop("by_alias", None)
return self.model_dump(mode="json", by_alias=True, **kwargs)
```

A caller passing `mode="python"` or `by_alias=False` almost certainly expects the override to take effect. Returning camelCase JSON regardless was a footgun.

This PR raises `TypeError` for those two kwargs and leaves all others (`exclude`, `exclude_none`, `exclude_defaults`, …) forwarding unchanged.

## Caller audit

Only one real caller passes any kwargs:

- `packages/testing/src/framework/test_fixtures/base.py:67` — `self.to_json(exclude_none=True, exclude={"info"})`. Untouched by this change.

Every other call site uses `to_json()` with no kwargs.

## Test plan

- [x] `just check` — ruff, format, ty, codespell, mdformat pass
- [x] `uv run pytest tests/lean_spec/test_base.py` — 7 tests pass
- [ ] CI green on this PR

The two tests that previously asserted the silent-strip behaviour are renamed and updated to assert the new raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)