### PR TITLE
refactor(node): replace no-op publisher sentinels with None defaults

### DIFF
--- a/src/lean_spec/node/chain/service.py
+++ b/src/lean_spec/node/chain/service.py
@@ -126,9 +126,12 @@ class ChainService:
             new_aggregated_attestations = await self._tick_to(total_interval)
 
             # Publish any new aggregated attestations produced this tick.
-            if new_aggregated_attestations:
+            #
+            # No publisher is wired in tests and offline runs.
+            publish = self.sync_service.publish_aggregated_attestation
+            if new_aggregated_attestations and publish is not None:
                 for agg in new_aggregated_attestations:
-                    await self.sync_service.publish_aggregated_attestation(agg)
+                    await publish(agg)
 
             logger.info(
                 "Tick: slot=%d interval=%d head=%s finalized=slot%d",

--- a/src/lean_spec/node/sync/service.py
+++ b/src/lean_spec/node/sync/service.py
@@ -46,10 +46,6 @@ from .states import SyncState
 logger = logging.getLogger(__name__)
 
 
-async def _noop_publish_agg(signed_attestation: SignedAggregatedAttestation) -> None:
-    """No-op default for aggregated attestation publishing."""
-
-
 @dataclass(slots=True)
 class SyncService:
     """Central coordinator for the sync state machine."""
@@ -78,12 +74,12 @@ class SyncService:
     is_aggregator: bool = field(default=False)
     """Whether this node functions as an aggregator."""
 
-    publish_aggregated_attestation: Callable[
-        [SignedAggregatedAttestation], Coroutine[None, None, None]
-    ] = field(default=_noop_publish_agg)
+    publish_aggregated_attestation: (
+        Callable[[SignedAggregatedAttestation], Coroutine[None, None, None]] | None
+    ) = field(default=None)
     """Async callback for publishing aggregated attestations to the network.
 
-    Defaults to a no-op so tests and offline runs do not need a publisher wired.
+    Defaults to None so tests and offline runs do not need a publisher wired.
     Assign after construction once NetworkService is built.
     """
 
@@ -684,6 +680,9 @@ class SyncService:
             return
         pending = self._pending_block_aggregates
         self._pending_block_aggregates = []
+        # No publisher wired (tests, offline runs): drop the drained aggregates.
+        if self.publish_aggregated_attestation is None:
+            return
         for signed_attestation in pending:
             await self.publish_aggregated_attestation(signed_attestation)
 

--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -65,14 +65,6 @@ type AttestationPublisher = Callable[[SignedAttestation], Awaitable[None]]
 """Callback for publishing produced attestations."""
 
 
-async def _noop_block_publisher(block: SignedBlock) -> None:  # noqa: ARG001
-    """Default no-op block publisher."""
-
-
-async def _noop_attestation_publisher(attestation: SignedAttestation) -> None:  # noqa: ARG001
-    """Default no-op attestation publisher."""
-
-
 @dataclass(slots=True)
 class ValidatorService:
     """
@@ -94,11 +86,17 @@ class ValidatorService:
     spec: LstarSpec = field(default_factory=LstarSpec)
     """Fork spec driving consensus methods. Default lets tests skip wiring."""
 
-    on_block: BlockPublisher = field(default=_noop_block_publisher)
-    """Callback invoked when a block is produced."""
+    on_block: BlockPublisher | None = field(default=None)
+    """Callback invoked when a block is produced.
 
-    on_attestation: AttestationPublisher = field(default=_noop_attestation_publisher)
-    """Callback invoked when an attestation is produced."""
+    Defaults to None so tests and offline runs do not need a publisher wired.
+    """
+
+    on_attestation: AttestationPublisher | None = field(default=None)
+    """Callback invoked when an attestation is produced.
+
+    Defaults to None so tests and offline runs do not need a publisher wired.
+    """
 
     _running: bool = field(default=False, repr=False)
     """Whether the service is running."""
@@ -314,7 +312,8 @@ class ValidatorService:
                 self._blocks_produced += 1
 
                 # Emit the block for network propagation.
-                await self.on_block(signed_block)
+                if self.on_block is not None:
+                    await self.on_block(signed_block)
 
             except AssertionError as e:
                 # Proposer validation failed.
@@ -396,7 +395,8 @@ class ValidatorService:
                 )
 
             # Emit the attestation for network propagation.
-            await self.on_attestation(signed_attestation)
+            if self.on_attestation is not None:
+                await self.on_attestation(signed_attestation)
 
     def _sign_block(
         self,

--- a/tests/lean_spec/node/test_node.py
+++ b/tests/lean_spec/node/test_node.py
@@ -466,6 +466,7 @@ class TestValidatorPublishWrappers:
     ) -> None:
         """Block wrapper publishes to network and processes locally."""
         assert node_with_validator.validator_service is not None
+        assert node_with_validator.validator_service.on_block is not None
 
         mock_block = MagicMock()
         publish_block = AsyncMock()
@@ -492,6 +493,7 @@ class TestValidatorPublishWrappers:
         verifies the computed value is forwarded correctly to the network.
         """
         assert node_with_validator.validator_service is not None
+        assert node_with_validator.validator_service.on_attestation is not None
 
         mock_attestation = MagicMock()
         # The wrapper calls validator_id.compute_subnet_id(ATTESTATION_COMMITTEE_COUNT).


### PR DESCRIPTION
## Summary

The sync and validator services defaulted their publish callbacks to no-op async functions (`_noop_publish_agg`, `_noop_block_publisher`, `_noop_attestation_publisher`) used purely as sentinels. This replaces them with optional callables defaulting to `None` and guards each call site — a simpler, more honest signature with no behavior change.

## Changes

- **`sync/service.py`**: Delete `_noop_publish_agg`; `publish_aggregated_attestation` is now `Callable[...] | None = None`. The drain method clears its queue first (preserving the original always-clear behavior), then guards the publish call.
- **`validator/service.py`**: Delete `_noop_block_publisher` and `_noop_attestation_publisher`; `on_block` and `on_attestation` are now `... | None = None`, with `is not None` guards at both emit sites.
- **`chain/service.py`**: Bind the publisher to a local and guard before awaiting in the tick loop.
- **`tests/.../test_node.py`**: The two tests invoking the wired publishers directly now assert non-None first.

## Verification

- `just check` — all green (ruff, format, ty, codespell, mdformat, lock).
- Affected test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)