### PR TITLE
fix: skip finalization advance for stale finalized sources

### DIFF
--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -522,9 +522,11 @@ class LstarSpec(ForkProtocol):
                 # Finalization requires a continuous chain of trust from the
                 # previously finalized checkpoint up to the new justified point.
                 #
-                # If the source is newer than the old finalized point and every
-                # slot in between is justifiable relative to that old finalized
-                # point, then the earlier source checkpoint becomes finalized.
+                # Finalization advances only when the source lies past the old finalized point.
+                # A source at or behind that boundary is already final.
+                # Such a source may still justify a newer target, but it must not re-finalize.
+                # When the source is newer and every slot in between is justifiable
+                # relative to that old finalized point, the source checkpoint becomes finalized.
                 #
                 # In short:
                 #

--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -522,13 +522,14 @@ class LstarSpec(ForkProtocol):
                 # Finalization requires a continuous chain of trust from the
                 # previously finalized checkpoint up to the new justified point.
                 #
-                # If every slot in between is justifiable relative to the old
-                # finalized point, then the earlier source checkpoint becomes finalized.
+                # If the source is newer than the old finalized point and every
+                # slot in between is justifiable relative to that old finalized
+                # point, then the earlier source checkpoint becomes finalized.
                 #
                 # In short:
                 #
                 #     If there is no break in the chain, advance finalization.
-                if not any(
+                if source.slot > finalized_slot and not any(
                     Slot(slot).is_justifiable_after(finalized_slot)
                     for slot in range(source.slot + Slot(1), target.slot)
                 ):

--- a/tests/consensus/lstar/state_transition/test_finalization.py
+++ b/tests/consensus/lstar/state_transition/test_finalization.py
@@ -493,6 +493,131 @@ def test_finalization_prunes_stale_pending_votes_and_rebases_window(
     )
 
 
+def test_stale_finalized_source_justifies_without_rewinding_finalization(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test the post-state when a vote uses a source behind the finalized boundary.
+
+    Scenario
+    --------
+    1. Finalize block_4 through ordinary supermajority attestations
+    2. Process block_7 with a supermajority attesting from block_1 to block_6
+
+    Expected Behavior
+    -----------------
+    1. The post-state slot is 7
+    2. latest_justified_slot advances to 6
+    3. latest_finalized_slot remains 4
+    4. justified_slots marks slots 5 and 6 as justified
+    5. There are no pending justifications
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[
+            BlockSpec(slot=Slot(1), label="block_1"),
+            BlockSpec(
+                slot=Slot(2),
+                parent_label="block_1",
+                label="block_2",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                    ),
+                ],
+            ),
+            BlockSpec(
+                slot=Slot(3),
+                parent_label="block_2",
+                label="block_3",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                        ],
+                        slot=Slot(3),
+                        target_slot=Slot(2),
+                        target_root_label="block_2",
+                    ),
+                ],
+            ),
+            BlockSpec(slot=Slot(4), parent_label="block_3", label="block_4"),
+            BlockSpec(
+                slot=Slot(5),
+                parent_label="block_4",
+                label="block_5",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(5),
+                        target_slot=Slot(4),
+                        target_root_label="block_4",
+                    ),
+                ],
+            ),
+            BlockSpec(
+                slot=Slot(6),
+                parent_label="block_5",
+                label="block_6",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(6),
+                        target_slot=Slot(5),
+                        target_root_label="block_5",
+                    ),
+                ],
+            ),
+            BlockSpec(
+                slot=Slot(7),
+                parent_label="block_6",
+                forced_attestations=[
+                    AggregatedAttestationSpec(
+                        validator_ids=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(7),
+                        source_slot=Slot(1),
+                        source_root_label="block_1",
+                        target_slot=Slot(6),
+                        target_root_label="block_6",
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(7),
+            latest_justified_slot=Slot(6),
+            latest_justified_root_label="block_6",
+            latest_finalized_slot=Slot(4),
+            latest_finalized_root_label="block_4",
+            justified_slots=JustifiedSlots(data=[]).model_copy(
+                update={"data": [Boolean(True), Boolean(True)]}
+            ),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
+        ),
+    )
+
+
 def test_non_adjacent_justification_finalizes_across_non_justifiable_gap(
     state_transition_test: StateTransitionTestFiller,
 ) -> None:

--- a/tests/consensus/lstar/state_transition/test_finalization.py
+++ b/tests/consensus/lstar/state_transition/test_finalization.py
@@ -616,6 +616,133 @@ def test_stale_finalized_source_justifies_without_rewinding_finalization(
     )
 
 
+def test_source_at_finalized_boundary_justifies_without_refinalizing(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test the post-state when a vote uses a source exactly at the finalized boundary.
+
+    This pins the boundary case of the finalization-advance guard.
+    A source whose slot equals the finalized slot is already final.
+    It may justify a newer target, but it must never re-finalize.
+
+    Scenario
+    --------
+    1. Finalize block_4 through ordinary supermajority attestations
+    2. Process block_7 with a supermajority attesting from block_4 to block_6
+
+    Expected Behavior
+    -----------------
+    1. The post-state slot is 7
+    2. latest_justified_slot advances to 6
+    3. latest_finalized_slot remains 4
+    4. justified_slots marks slots 5 and 6 as justified
+    5. There are no pending justifications
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[
+            BlockSpec(slot=Slot(1), label="block_1"),
+            BlockSpec(
+                slot=Slot(2),
+                parent_label="block_1",
+                label="block_2",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_indices=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                    ),
+                ],
+            ),
+            BlockSpec(
+                slot=Slot(3),
+                parent_label="block_2",
+                label="block_3",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_indices=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                        ],
+                        slot=Slot(3),
+                        target_slot=Slot(2),
+                        target_root_label="block_2",
+                    ),
+                ],
+            ),
+            BlockSpec(slot=Slot(4), parent_label="block_3", label="block_4"),
+            BlockSpec(
+                slot=Slot(5),
+                parent_label="block_4",
+                label="block_5",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_indices=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(5),
+                        target_slot=Slot(4),
+                        target_root_label="block_4",
+                    ),
+                ],
+            ),
+            BlockSpec(
+                slot=Slot(6),
+                parent_label="block_5",
+                label="block_6",
+                attestations=[
+                    AggregatedAttestationSpec(
+                        validator_indices=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(6),
+                        target_slot=Slot(5),
+                        target_root_label="block_5",
+                    ),
+                ],
+            ),
+            BlockSpec(
+                slot=Slot(7),
+                parent_label="block_6",
+                forced_attestations=[
+                    AggregatedAttestationSpec(
+                        validator_indices=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(7),
+                        source_slot=Slot(4),
+                        source_root_label="block_4",
+                        target_slot=Slot(6),
+                        target_root_label="block_6",
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(7),
+            latest_justified_slot=Slot(6),
+            latest_justified_root_label="block_6",
+            latest_finalized_slot=Slot(4),
+            latest_finalized_root_label="block_4",
+            justified_slots=JustifiedSlots(data=[Boolean(True), Boolean(True)]),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
+        ),
+    )
+
+
 def test_non_adjacent_justification_finalizes_across_non_justifiable_gap(
     state_transition_test: StateTransitionTestFiller,
 ) -> None:

--- a/tests/consensus/lstar/state_transition/test_finalization.py
+++ b/tests/consensus/lstar/state_transition/test_finalization.py
@@ -522,7 +522,7 @@ def test_stale_finalized_source_justifies_without_rewinding_finalization(
                 label="block_2",
                 attestations=[
                     AggregatedAttestationSpec(
-                        validator_ids=[
+                        validator_indices=[
                             ValidatorIndex(0),
                             ValidatorIndex(1),
                             ValidatorIndex(2),
@@ -539,7 +539,7 @@ def test_stale_finalized_source_justifies_without_rewinding_finalization(
                 label="block_3",
                 attestations=[
                     AggregatedAttestationSpec(
-                        validator_ids=[
+                        validator_indices=[
                             ValidatorIndex(0),
                             ValidatorIndex(1),
                         ],
@@ -556,7 +556,7 @@ def test_stale_finalized_source_justifies_without_rewinding_finalization(
                 label="block_5",
                 attestations=[
                     AggregatedAttestationSpec(
-                        validator_ids=[
+                        validator_indices=[
                             ValidatorIndex(0),
                             ValidatorIndex(1),
                             ValidatorIndex(2),
@@ -573,7 +573,7 @@ def test_stale_finalized_source_justifies_without_rewinding_finalization(
                 label="block_6",
                 attestations=[
                     AggregatedAttestationSpec(
-                        validator_ids=[
+                        validator_indices=[
                             ValidatorIndex(0),
                             ValidatorIndex(1),
                             ValidatorIndex(2),
@@ -589,7 +589,7 @@ def test_stale_finalized_source_justifies_without_rewinding_finalization(
                 parent_label="block_6",
                 forced_attestations=[
                     AggregatedAttestationSpec(
-                        validator_ids=[
+                        validator_indices=[
                             ValidatorIndex(0),
                             ValidatorIndex(1),
                             ValidatorIndex(2),
@@ -609,9 +609,7 @@ def test_stale_finalized_source_justifies_without_rewinding_finalization(
             latest_justified_root_label="block_6",
             latest_finalized_slot=Slot(4),
             latest_finalized_root_label="block_4",
-            justified_slots=JustifiedSlots(data=[]).model_copy(
-                update={"data": [Boolean(True), Boolean(True)]}
-            ),
+            justified_slots=JustifiedSlots(data=[Boolean(True), Boolean(True)]),
             justifications_roots=JustificationRoots(data=[]),
             justifications_validators=JustificationValidators(data=[]),
         ),


### PR DESCRIPTION
## Summary

This fixes an Lstar finalization edge case where an attestation with a source checkpoint at or behind the current finalized boundary could justify a newer target, then incorrectly enter the finalization-advance scan from below the finalized boundary.

Finalized sources are valid justification anchors: `JustifiedSlots.is_slot_justified()` treats slots at or below `latest_finalized.slot` as already justified. But once such an attestation crossed the supermajority threshold, the finalization logic scanned `source.slot + 1 .. target.slot` and called `Slot.is_justifiable_after(finalized_slot)` on candidate slots before `finalized_slot`, triggering `Candidate slot must not be before finalized slot`.

The fix gates finalization advancement on `source.slot > finalized_slot`. Stale finalized sources may still justify newer targets, but they no longer try to rewind or scan below the finalized boundary.

## Validation

- `uv run --group test fill tests/consensus/lstar/state_transition/test_finalization.py --fork=Lstar --clean -q`
- `uv run --group lint ruff check src/lean_spec/forks/lstar/spec.py tests/consensus/lstar/state_transition/test_finalization.py`
- `uv run --group lint ruff format --check src/lean_spec/forks/lstar/spec.py tests/consensus/lstar/state_transition/test_finalization.py`