### PR TITLE
refactor: rename exception variable from `exc` to `exception`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ subspecifications that the Lean Ethereum protocol relies on.
     - `prop` → `proposal`, `conn` → `connection`, `addr` → `address`, `cert` → `certificate`
     - `privkey` → `private_key`, `elem` → `element`, `buf` → `buffer`, `dir` → `directory`
     - `len` → `length` (inside a name, never the `len()` builtin), `fe` → `field_elements`
+    - `exc` / `e` → `exception` (in `except X as exc:` clauses, use `exception`; the stdlib
+      `exc_info` name is still kept verbatim)
   - Use the correct domain term, not just any expansion: a validator is referenced by its
     INDEX, so `validator_id` → `validator_index` (never `validator_id`).
   - KEEP canonical protocol identifiers that genuinely use "ID": `peer_id`, `node_id`,

--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -144,8 +144,8 @@ class NetworkingCodecTest(BaseConsensusFixture):
         exception_raised: Exception | None = None
         try:
             decoder(raw)
-        except Exception as exc:
-            exception_raised = exc
+        except Exception as exception:
+            exception_raised = exception
 
         if exception_raised is None:
             raise AssertionError(

--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -121,8 +121,8 @@ class SSZTest(BaseConsensusFixture):
         exception_raised: Exception | None = None
         try:
             decoder.decode_bytes(raw)
-        except Exception as exc:
-            exception_raised = exc
+        except Exception as exception:
+            exception_raised = exception
 
         if exception_raised is None:
             raise AssertionError(

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
@@ -155,8 +155,8 @@ class VerifyProofsTest(BaseConsensusFixture):
         # a comparable "expected X got Y" message instead of crashing the filler.
         try:
             candidate.verify(public_keys, message, slot)
-        except Exception as exc:
-            exception_raised = exc
+        except Exception as exception:
+            exception_raised = exception
 
         if self.expect_exception is None:
             if exception_raised is not None:

--- a/src/lean_spec/cli/bootstrap.py
+++ b/src/lean_spec/cli/bootstrap.py
@@ -118,11 +118,11 @@ class NodeBootstrap:
                     for s in args.aggregate_subnet_ids_raw.split(",")
                     if s.strip()
                 )
-            except ValueError as exc:
+            except ValueError as exception:
                 raise CliValidationError(
                     "--aggregate-subnet-ids expects comma-separated integers, "
                     f"got {args.aggregate_subnet_ids_raw!r}"
-                ) from exc
+                ) from exception
 
         # Genesis load.
         logger.info("Loading genesis from %s", args.genesis_path)

--- a/src/lean_spec/cli/main.py
+++ b/src/lean_spec/cli/main.py
@@ -27,8 +27,8 @@ def main() -> None:
     # Validate cross-field rules and load referenced files.
     try:
         boot = NodeBootstrap.from_cli_args(args)
-    except (CliValidationError, FileNotFoundError) as exc:
-        logger.error("%s", exc)
+    except (CliValidationError, FileNotFoundError) as exception:
+        logger.error("%s", exception)
         sys.exit(1)
 
     # Run the node under an event loop until shutdown or a fatal error.

--- a/src/lean_spec/node/api/endpoints/aggregator.py
+++ b/src/lean_spec/node/api/endpoints/aggregator.py
@@ -58,8 +58,8 @@ async def handle_toggle(request: web.Request) -> web.Response:
 
     try:
         payload = await request.json()
-    except json.JSONDecodeError as exc:
-        raise web.HTTPBadRequest(reason="Invalid JSON body") from exc
+    except json.JSONDecodeError as exception:
+        raise web.HTTPBadRequest(reason="Invalid JSON body") from exception
 
     if not isinstance(payload, dict) or "enabled" not in payload:
         raise web.HTTPBadRequest(reason="Missing 'enabled' field in body")

--- a/src/lean_spec/node/networking/client/event_source/live.py
+++ b/src/lean_spec/node/networking/client/event_source/live.py
@@ -424,8 +424,8 @@ class LiveNetworkEventSource:
             logger.info("Connecting to bootnode %s", multiaddr)
             try:
                 peer_id = await self.dial(multiaddr)
-            except Exception as exc:
-                logger.warning("Failed to connect to bootnode %s: %s", multiaddr, exc)
+            except Exception as exception:
+                logger.warning("Failed to connect to bootnode %s: %s", multiaddr, exception)
                 continue
             if peer_id is not None:
                 logger.info("Connected to bootnode, peer_id=%s", peer_id)

--- a/src/lean_spec/node/sync/checkpoint_sync.py
+++ b/src/lean_spec/node/sync/checkpoint_sync.py
@@ -90,14 +90,14 @@ async def fetch_finalized_state(url: str, state_class: type[State]) -> State:
 
             return state
 
-    except httpx.RequestError as exc:
+    except httpx.RequestError as exception:
         raise CheckpointSyncError(
-            f"Network error while connecting to {exc.request.url}: {exc}"
-        ) from exc
-    except httpx.HTTPStatusError as exc:
+            f"Network error while connecting to {exception.request.url}: {exception}"
+        ) from exception
+    except httpx.HTTPStatusError as exception:
         raise CheckpointSyncError(
-            f"HTTP error {exc.response.status_code}: {exc.response.text[:200]}"
-        ) from exc
+            f"HTTP error {exception.response.status_code}: {exception.response.text[:200]}"
+        ) from exception
     except Exception as e:
         raise CheckpointSyncError(f"Failed to fetch state: {e}") from e
 

--- a/src/lean_spec/node/sync/head_sync.py
+++ b/src/lean_spec/node/sync/head_sync.py
@@ -310,10 +310,10 @@ class HeadSync:
                     )
                     processed_count += description_count
 
-                except Exception as exc:
+                except Exception as exception:
                     # Processing failed. Leave in cache for retry or discard.
                     # Do not cascade the error; continue with other children.
-                    logger.debug("Failed to process cached descendant: %s", exc)
+                    logger.debug("Failed to process cached descendant: %s", exception)
 
             finally:
                 self._processing.discard(child_root)

--- a/src/lean_spec/node/sync/service.py
+++ b/src/lean_spec/node/sync/service.py
@@ -631,8 +631,8 @@ class SyncService:
                 else:
                     # Data unseen locally: nothing to merge, use as-is.
                     combined = block_single_message_aggregate
-            except (AggregationError, AssertionError, KeyError, ValueError) as exc:
-                logger.debug("Post-block re-aggregation failed for %s: %s", data_root, exc)
+            except (AggregationError, AssertionError, KeyError, ValueError) as exception:
+                logger.debug("Post-block re-aggregation failed for %s: %s", data_root, exception)
                 continue
 
             # The combined proof is a superset of every local partial that

--- a/src/lean_spec/spec/forks/lstar/containers.py
+++ b/src/lean_spec/spec/forks/lstar/containers.py
@@ -222,8 +222,8 @@ class SingleMessageAggregate(Container):
                 children_bytes or None,
                 mode=LEAN_ENV,
             )
-        except Exception as exc:
-            raise AggregationError(str(exc)) from exc
+        except Exception as exception:
+            raise AggregationError(str(exception)) from exception
 
         return cls(
             participants=participants,
@@ -267,8 +267,10 @@ class SingleMessageAggregate(Container):
                 bytes(self.proof.data),
                 mode=LEAN_ENV,
             )
-        except Exception as exc:
-            raise AggregationError(f"single-message aggregate verification failed: {exc}") from exc
+        except Exception as exception:
+            raise AggregationError(
+                f"single-message aggregate verification failed: {exception}"
+            ) from exception
 
     def __hash__(self) -> int:
         """Content-deterministic hash via SSZ encoding."""
@@ -341,8 +343,8 @@ class MultiMessageAggregate(Container):
                 LOG_INV_RATE,
                 mode=LEAN_ENV,
             )
-        except Exception as exc:
-            raise AggregationError(str(exc)) from exc
+        except Exception as exception:
+            raise AggregationError(str(exception)) from exception
 
         return cls(proof=ByteList512KiB(data=multi_message_aggregate_wire))
 
@@ -391,8 +393,10 @@ class MultiMessageAggregate(Container):
                 LOG_INV_RATE,
                 mode=LEAN_ENV,
             )
-        except Exception as exc:
-            raise AggregationError(f"multi-message aggregate split failed: {exc}") from exc
+        except Exception as exception:
+            raise AggregationError(
+                f"multi-message aggregate split failed: {exception}"
+            ) from exception
 
         return SingleMessageAggregate(
             participants=participants,
@@ -446,8 +450,10 @@ class MultiMessageAggregate(Container):
                 bytes(self.proof.data),
                 mode=LEAN_ENV,
             )
-        except Exception as exc:
-            raise AggregationError(f"multi-message aggregate verification failed: {exc}") from exc
+        except Exception as exception:
+            raise AggregationError(
+                f"multi-message aggregate verification failed: {exception}"
+            ) from exception
 
     def __hash__(self) -> int:
         """Content-deterministic hash via SSZ encoding."""

--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -904,8 +904,8 @@ class LstarSpec(ForkProtocol):
                 public_keys_per_message=public_keys_per_message,
                 messages=message_bindings,
             )
-        except AggregationError as exc:
-            raise AssertionError(f"Block proof verification failed: {exc}") from exc
+        except AggregationError as exception:
+            raise AssertionError(f"Block proof verification failed: {exception}") from exception
 
         return True
 
@@ -1175,10 +1175,10 @@ class LstarSpec(ForkProtocol):
                 message=hash_tree_root(data),
                 slot=data.slot,
             )
-        except AggregationError as exc:
+        except AggregationError as exception:
             raise AssertionError(
-                f"Committee aggregation signature verification failed: {exc}"
-            ) from exc
+                f"Committee aggregation signature verification failed: {exception}"
+            ) from exception
 
         store.latest_new_aggregated_payloads.setdefault(data, set()).add(proof)
 

--- a/src/lean_spec/spec/forks/registry.py
+++ b/src/lean_spec/spec/forks/registry.py
@@ -58,6 +58,6 @@ class ForkRegistry:
         """
         try:
             return self._by_name[name]
-        except KeyError as exc:
+        except KeyError as exception:
             known = sorted(self._by_name)
-            raise KeyError(f"Unknown fork: {name!r}. Known: {known}") from exc
+            raise KeyError(f"Unknown fork: {name!r}. Known: {known}") from exception


### PR DESCRIPTION
## Summary

- Renames `exc` to `exception` in every `except X as exc:` clause across `src/` and `packages/testing/`, plus all references inside those handlers (`from exc`, `f"{exc}"`, etc.).
- Adds the rule to the abbreviation list in `CLAUDE.md` so future code keeps the full spelling.
- The stdlib `exc_info` name is explicitly preserved (it is already in the kept-as-is list).

## Test plan

- [x] `just check` passes (ruff lint, ruff format, ty, codespell, mdformat).
- [x] `grep -rn "as exc:" --include="*.py"` returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)