### PR TITLE
refactor(forks): drop unimplemented store methods from SpecStoreType

### DIFF
--- a/src/lean_spec/spec/forks/protocol.py
+++ b/src/lean_spec/spec/forks/protocol.py
@@ -91,21 +91,6 @@ class SpecAggregatedAttestationsType(SpecSSZType, Protocol):
     """
 
 
-class SpecSignedBlockType(SpecSSZType, Protocol):
-    """Structural contract: any fork's SignedBlock container class.
-
-    A SignedBlock wraps a Block with a single aggregated proof covering
-    every attestation in the body plus the proposer's signature over
-    the block root. Subspecs treat instances as opaque SSZ-encodable
-    payloads passed between sync, gossip, and storage.
-    """
-
-    @property
-    def block(self) -> SpecBlockType:
-        """The wrapped Block payload."""
-        ...
-
-
 class SpecAttestationDataType(SpecSSZType, Protocol):
     """Structural contract: any fork's AttestationData container class.
 
@@ -134,41 +119,11 @@ class SpecAttestationDataType(SpecSSZType, Protocol):
         ...
 
 
-class SpecSignedAttestationType(SpecSSZType, Protocol):
-    """Structural contract: any fork's SignedAttestation container class.
-
-    A single validator's attestation bundled with its signature.
-    """
-
-    @property
-    def data(self) -> SpecAttestationDataType:
-        """The unsigned attestation payload."""
-        ...
-
-    @property
-    def validator_index(self) -> ValidatorIndex:
-        """Index of the validator that produced this attestation."""
-        ...
-
-
 class SpecAggregatedAttestationType(SpecSSZType, Protocol):
     """Structural contract: any fork's AggregatedAttestation container class.
 
     An attestation aggregated over multiple validators via a participation
     bitfield.
-    """
-
-    @property
-    def data(self) -> SpecAttestationDataType:
-        """The unsigned attestation payload."""
-        ...
-
-
-class SpecSignedAggregatedAttestationType(SpecSSZType, Protocol):
-    """Structural contract: any fork's SignedAggregatedAttestation container class.
-
-    The aggregator's broadcast payload — combined attestation data plus the
-    aggregated signature proof.
     """
 
     @property
@@ -217,35 +172,6 @@ class SpecStoreType(Protocol):
     @property
     def states(self) -> Mapping[Bytes32, SpecStateType]:
         """Mapping from block root to post-state of that block."""
-        ...
-
-    @classmethod
-    def from_anchor(
-        cls,
-        state: SpecStateType,
-        anchor_block: SpecBlockType,
-        validator_index: ValidatorIndex | None,
-    ) -> Self:
-        """Construct a forkchoice store anchored at the given state/block."""
-        ...
-
-    def on_block(self, signed_block: "SpecSignedBlockType") -> Self:
-        """Apply a signed block to the store and return the updated store."""
-        ...
-
-    def on_gossip_attestation(
-        self,
-        signed_attestation: "SpecSignedAttestationType",
-        is_aggregator: bool,
-    ) -> Self:
-        """Apply a single-validator attestation and return the updated store."""
-        ...
-
-    def on_gossip_aggregated_attestation(
-        self,
-        signed_attestation: "SpecSignedAggregatedAttestationType",
-    ) -> Self:
-        """Apply an aggregated attestation and return the updated store."""
         ...
 
 


### PR DESCRIPTION
## Summary

`SpecStoreType` declared four methods — `from_anchor`, `on_block`, `on_gossip_attestation`, `on_gossip_aggregated_attestation` — that the concrete `Store` does not implement. The `Store` is a plain Pydantic data model (only fields); those operations actually live on the fork spec and are invoked as `spec.on_block(store, ...)`. The declarations were therefore dead and directly contradicted the comment claiming the store satisfies the protocol structurally.

This removes:
- The four unimplemented method declarations on `SpecStoreType`.
- The three structural protocols (`SpecSignedBlockType`, `SpecSignedAttestationType`, `SpecSignedAggregatedAttestationType`) that existed only to type those signatures and were referenced nowhere else after the removal.

`SpecStoreType` now exposes only the read surface the store actually provides (`head`, `safe_target`, `latest_justified`, `latest_finalized`, `validator_index`, `blocks`, `states`), making the structural-conformance comment true.

`SpecAttestationDataType` and `SpecAggregatedAttestationType` are kept — they back the `attestation_data_class` / `aggregated_attestation_class` fields on `ForkProtocol`.

## Testing

- `just lint` (ruff) — passed
- `just typecheck` (ty) — passed
- `tests/lean_spec/` unit suite — passed (no behavior change; declarations only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)