### PR TITLE
refactor(forks/lstar): share the ancestor weight-walk loop

### DIFF
--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -1309,6 +1309,32 @@ class LstarSpec(ForkProtocol):
                         attestations[validator_index] = attestation_data
         return attestations
 
+    def _accumulate_ancestor_weights(
+        self,
+        store: LstarStore,
+        attestations: dict[ValidatorIndex, AttestationData],
+        start_slot: Slot,
+    ) -> dict[Bytes32, int]:
+        """Accumulate one unit of voting weight per ancestor of each head vote.
+
+        For every vote, follow the chosen head upward through its ancestors.
+        Each visited block above the start slot accumulates one unit of weight
+        from that validator.
+
+        Climbing stops at the start slot or as soon as the chain leaves the
+        known tree, so partial views and ongoing sync are handled naturally.
+        """
+        weights: dict[Bytes32, int] = defaultdict(int)
+
+        for attestation_data in attestations.values():
+            current_root = attestation_data.head.root
+
+            while current_root in store.blocks and store.blocks[current_root].slot > start_slot:
+                weights[current_root] += 1
+                current_root = store.blocks[current_root].parent_root
+
+        return weights
+
     def compute_block_weights(self, store: LstarStore) -> dict[Bytes32, int]:
         """Compute attestation-based weight for each block above the finalized slot.
 
@@ -1319,16 +1345,9 @@ class LstarSpec(ForkProtocol):
             store, store.latest_known_aggregated_payloads
         )
 
-        start_slot = store.latest_finalized.slot
-
-        weights: dict[Bytes32, int] = defaultdict(int)
-
-        for attestation_data in attestations.values():
-            current_root = attestation_data.head.root
-
-            while current_root in store.blocks and store.blocks[current_root].slot > start_slot:
-                weights[current_root] += 1
-                current_root = store.blocks[current_root].parent_root
+        weights = self._accumulate_ancestor_weights(
+            store, attestations, store.latest_finalized.slot
+        )
 
         return dict(weights)
 
@@ -1366,23 +1385,8 @@ class LstarSpec(ForkProtocol):
         # This avoids repeated lookups inside the inner loop.
         start_slot = store.blocks[start_root].slot
 
-        # Prepare a table that will collect voting weight for each block.
-        #
-        # Each entry starts conceptually at zero and then accumulates contributions.
-        weights: dict[Bytes32, int] = defaultdict(int)
-
-        # For every vote, follow the chosen head upward through its ancestors.
-        #
-        # Each visited block accumulates one unit of weight from that validator.
-        for attestation_data in attestations.values():
-            current_root = attestation_data.head.root
-
-            # Climb towards the anchor while staying inside the known tree.
-            #
-            # This naturally handles partial views and ongoing sync.
-            while current_root in store.blocks and store.blocks[current_root].slot > start_slot:
-                weights[current_root] += 1
-                current_root = store.blocks[current_root].parent_root
+        # Collect voting weight for every block above the anchor slot.
+        weights = self._accumulate_ancestor_weights(store, attestations, start_slot)
 
         # Build the parent -> children adjacency.
         #


### PR DESCRIPTION
## Summary

The diagnostic block-weight computation and the LMD-GHOST head walk both climbed from each validator's head vote up through its ancestors, accumulating one unit of weight per visited block above a start slot. The two loops were **byte-identical** except for the start slot:

- block-weight diagnostic → starts at the finalized slot
- LMD-GHOST head walk → starts at the anchor block slot

Because the logic was duplicated, the weights reported by the fork-choice HTTP endpoint could silently diverge from the weights that actually drive the head decision if one copy were ever changed.

This extracts the walk into a single helper parameterized on the start slot and calls it from both sites. The helper returns the `defaultdict`, so the GHOST walk's missing-key accesses still resolve to 0. No behavior change.

## Testing

- `just lint` (ruff) — passed
- `just typecheck` (ty) — passed
- `tests/lean_spec/spec/forks/lstar/forkchoice/` — 88 passed (incl. `test_compute_block_weights.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)