### PR TITLE
refactor(forks/lstar): drop vestigial valid_signatures parameter

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -145,11 +145,7 @@ class StateTransitionTest(BaseConsensusFixture):
                 elif getattr(block_spec, "skip_slot_processing", False):
                     state = spec.process_block(state, block)
                 else:
-                    state = spec.state_transition(
-                        state,
-                        block=block,
-                        valid_signatures=True,
-                    )
+                    state = spec.state_transition(state, block=block)
 
             actual_post_state = state
         except (AssertionError, ValueError) as e:

--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -586,24 +586,20 @@ class LstarSpec(ForkProtocol):
         self,
         state: State,
         block: Block,
-        valid_signatures: bool = True,
     ) -> State:
         """
         Apply the complete state transition function for a block.
 
         This method represents the full state transition function:
-        1. Validate signatures if required
-        2. Process slots up to the block's slot
-        3. Process the block header and body
-        4. Validate the computed state root
+        1. Process slots up to the block's slot
+        2. Process the block header and body
+        3. Validate the computed state root
+
+        Signatures are verified outside this function, before it is called.
 
         Raises:
-            AssertionError: If signature validation fails or state root is invalid.
+            AssertionError: If the computed state root is invalid.
         """
-        # Validate signatures if required
-        if not valid_signatures:
-            raise AssertionError("Block signatures must be valid")
-
         with observe_state_transition():
             # First, process any intermediate slots.
             advanced = self.process_slots(state, block.slot)
@@ -1239,11 +1235,13 @@ class LstarSpec(ForkProtocol):
                 f"maximum is {MAX_ATTESTATIONS_DATA}"
             )
 
-            # Validate cryptographic signatures
-            valid_signatures = self.verify_signatures(signed_block, parent_state.validators)
+            # Validate cryptographic signatures.
+            #
+            # This raises on any invalid signature, aborting the import.
+            self.verify_signatures(signed_block, parent_state.validators)
 
             # Execute state transition function to compute post-block state
-            post_state = self.state_transition(parent_state, block, valid_signatures)
+            post_state = self.state_transition(parent_state, block)
 
             # Propagate checkpoint advances from the post-state.
             #

--- a/tests/lean_spec/spec/forks/lstar/state/test_state_aggregation.py
+++ b/tests/lean_spec/spec/forks/lstar/state/test_state_aggregation.py
@@ -264,7 +264,7 @@ def test_build_block_state_root_valid_when_signatures_split(
         "Compacted attestation should cover all three validators"
     )
 
-    result_state = spec.state_transition(pre_state, block, valid_signatures=True)
+    result_state = spec.state_transition(pre_state, block)
 
     assert result_state.slot == Slot(1)
     assert result_state.latest_block_header.slot == Slot(1)


### PR DESCRIPTION
## Summary

The state transition function carried a `valid_signatures: bool = True` parameter whose only non-default value raised immediately:

```python
if not valid_signatures:
    raise AssertionError("Block signatures must be valid")
```

Any path that proceeded therefore had it set to `True`. The sole real caller passed the result of `verify_signatures(...)`, which already returns `True` or raises on any invalid signature. The flag was thus dead and misleading — it implied the state transition could optionally skip signature checks, when in fact the state transition never inspects signatures at all.

This removes the parameter and the dead branch. Signature verification stays where it belongs, in the block-import path before the call, and aborts the import on failure. The docstring and the test/fixture call sites are updated to match.

No behavior change.

## Testing

- `just lint` (ruff) — passed
- `just typecheck` (ty) — passed
- `tests/lean_spec/spec/forks/lstar/{state,forkchoice}/` — 104 passed
- Confirmed no `valid_signatures` references remain anywhere in `src/`, `tests/`, or `packages/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)