### PR TITLE
refactor(forks/lstar): make the genesis anchor slot explicit

### DIFF
--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -243,8 +243,8 @@ class LstarSpec(ForkProtocol):
         #   updates rely entirely on validator attestations which are processed
         #   later in the block body.
         if is_genesis_parent:
-            state.latest_justified = Checkpoint(slot=state.latest_justified.slot, root=parent_root)
-            state.latest_finalized = Checkpoint(slot=state.latest_finalized.slot, root=parent_root)
+            state.latest_justified = Checkpoint(slot=Slot(0), root=parent_root)
+            state.latest_finalized = Checkpoint(slot=Slot(0), root=parent_root)
 
         # Historical Data Management
 
@@ -644,7 +644,7 @@ class LstarSpec(ForkProtocol):
             # updates the justified root to parent_root. Apply the same
             # derivation here so attestation sources match.
             if state.latest_block_header.slot == Slot(0):
-                current_justified = Checkpoint(slot=state.latest_justified.slot, root=parent_root)
+                current_justified = Checkpoint(slot=Slot(0), root=parent_root)
             else:
                 current_justified = state.latest_justified
 


### PR DESCRIPTION
## Summary

When the first post-genesis block is processed, the genesis block is forced to be justified and finalized. The code swapped in the parent root but kept the pre-state checkpoint slot:

```python
state.latest_justified = Checkpoint(slot=state.latest_justified.slot, root=parent_root)
state.latest_finalized = Checkpoint(slot=state.latest_finalized.slot, root=parent_root)
```

This is correct only because both checkpoint slots are still `0` at that point (genesis initializes them to `Slot(0)`, and slot processing never touches checkpoints). A reader had to reconstruct that invariant to convince themselves the slot was right.

This writes the slot as `Slot(0)` directly, at both the header-processing anchor and its mirror in the block builder, so the genesis anchor reads as a fixed slot-zero checkpoint with no hidden dependency on the pre-state.

No behavior change — `state.latest_justified.slot` and `state.latest_finalized.slot` are provably `0` on both paths (each builds on the genesis state).

## Testing

- `just lint` (ruff) — passed
- `just typecheck` (ty) — passed
- Impacted unit tests (`tests/.../lstar/state/` + `test_block_production_justification_gap`) — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)