### PR TITLE
framework: rename type-1 verify_proofs fixture to verify_single_message_proofs

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -19,8 +19,8 @@ from .test_fixtures import (
     StateTransitionTest,
     SwapParticipantPublicKey,
     SyncTest,
-    VerifyProofsTest,
     VerifySignaturesTest,
+    VerifySingleMessageProofsTest,
 )
 from .test_types import (
     AggregatedAttestationCheck,
@@ -41,7 +41,7 @@ from .test_types import (
 
 StateTransitionTestFiller = Type[StateTransitionTest]
 ForkChoiceTestFiller = Type[ForkChoiceTest]
-VerifyProofsTestFiller = Type[VerifyProofsTest]
+VerifySingleMessageProofsTestFiller = Type[VerifySingleMessageProofsTest]
 VerifySignaturesTestFiller = Type[VerifySignaturesTest]
 SSZTestFiller = Type[SSZTest]
 NetworkingCodecTestFiller = Type[NetworkingCodecTest]
@@ -66,7 +66,7 @@ __all__ = [
     "BaseConsensusFixture",
     "StateTransitionTest",
     "ForkChoiceTest",
-    "VerifyProofsTest",
+    "VerifySingleMessageProofsTest",
     "RebindToAlternateHeadRoot",
     "IncrementEmittedSlot",
     "SwapParticipantPublicKey",
@@ -93,7 +93,7 @@ __all__ = [
     # Type aliases for test function signatures
     "StateTransitionTestFiller",
     "ForkChoiceTestFiller",
-    "VerifyProofsTestFiller",
+    "VerifySingleMessageProofsTestFiller",
     "VerifySignaturesTestFiller",
     "SSZTestFiller",
     "NetworkingCodecTestFiller",

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -11,19 +11,19 @@ from .slot_clock import SlotClockTest
 from .ssz import SSZTest
 from .state_transition import StateTransitionTest
 from .sync import SyncTest
-from .verify_proofs import (
+from .verify_signatures import VerifySignaturesTest
+from .verify_single_message_proofs import (
     IncrementEmittedSlot,
     RebindToAlternateHeadRoot,
     SwapParticipantPublicKey,
-    VerifyProofsTest,
+    VerifySingleMessageProofsTest,
 )
-from .verify_signatures import VerifySignaturesTest
 
 __all__ = [
     "BaseConsensusFixture",
     "StateTransitionTest",
     "ForkChoiceTest",
-    "VerifyProofsTest",
+    "VerifySingleMessageProofsTest",
     "RebindToAlternateHeadRoot",
     "IncrementEmittedSlot",
     "SwapParticipantPublicKey",

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_single_message_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_single_message_proofs.py
@@ -55,13 +55,13 @@ Tamper = RebindToAlternateHeadRoot | IncrementEmittedSlot | SwapParticipantPubli
 """Discriminated union of post-generation mutations that produce a rejection vector."""
 
 
-class VerifyProofsTest(BaseConsensusFixture):
+class VerifySingleMessageProofsTest(BaseConsensusFixture):
     """Verify a single-message aggregate proof against precomputed bytes."""
 
-    format_name: ClassVar[str] = "verify_proofs_test"
+    format_name: ClassVar[str] = "verify_single_message_proofs_test"
 
     description: ClassVar[str] = (
-        "Tests multi-signature proof verification against precomputed proof bytes."
+        "Tests single-message aggregate proof verification against precomputed proof bytes."
     )
 
     validator_indices: list[ValidatorIndex] = Field(exclude=True)
@@ -95,7 +95,7 @@ class VerifyProofsTest(BaseConsensusFixture):
     proof: ByteList512KiB | None = None
     """Aggregated proof bytes for clients to verify."""
 
-    def make_fixture(self) -> VerifyProofsTest:
+    def make_fixture(self) -> VerifySingleMessageProofsTest:
         """Generate the proof, optionally tamper, self-verify, and return the populated copy.
 
         Raises:

--- a/tests/consensus/lstar/verify_proofs/test_single_message_invalid.py
+++ b/tests/consensus/lstar/verify_proofs/test_single_message_invalid.py
@@ -5,7 +5,7 @@ from consensus_testing import (
     IncrementEmittedSlot,
     RebindToAlternateHeadRoot,
     SwapParticipantPublicKey,
-    VerifyProofsTestFiller,
+    VerifySingleMessageProofsTestFiller,
 )
 
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
@@ -16,10 +16,10 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_single_message_wrong_message(
-    verify_proofs_test: VerifyProofsTestFiller,
+    verify_single_message_proofs_test: VerifySingleMessageProofsTestFiller,
 ) -> None:
     """Proof bound to an alternate head root must not verify against the honest message."""
-    verify_proofs_test(
+    verify_single_message_proofs_test(
         validator_indices=[ValidatorIndex(0)],
         attestation_data=AttestationData(
             slot=Slot(6),
@@ -33,10 +33,10 @@ def test_single_message_wrong_message(
 
 
 def test_single_message_wrong_slot(
-    verify_proofs_test: VerifyProofsTestFiller,
+    verify_single_message_proofs_test: VerifySingleMessageProofsTestFiller,
 ) -> None:
     """Proof bound to slot 4, emitted under slot 5, must reject on the slot binding mismatch."""
-    verify_proofs_test(
+    verify_single_message_proofs_test(
         validator_indices=[ValidatorIndex(0)],
         attestation_data=AttestationData(
             slot=Slot(4),
@@ -50,10 +50,10 @@ def test_single_message_wrong_slot(
 
 
 def test_single_message_wrong_public_keys(
-    verify_proofs_test: VerifyProofsTestFiller,
+    verify_single_message_proofs_test: VerifySingleMessageProofsTestFiller,
 ) -> None:
     """Public key at the only participant slot swapped for another validator's must reject."""
-    verify_proofs_test(
+    verify_single_message_proofs_test(
         validator_indices=[ValidatorIndex(0)],
         attestation_data=AttestationData(
             slot=Slot(7),

--- a/tests/consensus/lstar/verify_proofs/test_single_message_valid.py
+++ b/tests/consensus/lstar/verify_proofs/test_single_message_valid.py
@@ -1,7 +1,7 @@
 """Single-message aggregate proof verification vectors — valid cases."""
 
 import pytest
-from consensus_testing import VerifyProofsTestFiller
+from consensus_testing import VerifySingleMessageProofsTestFiller
 
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import AttestationData
@@ -11,10 +11,10 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_single_message_single_validator(
-    verify_proofs_test: VerifyProofsTestFiller,
+    verify_single_message_proofs_test: VerifySingleMessageProofsTestFiller,
 ) -> None:
     """Single-validator single-message aggregate proof must verify."""
-    verify_proofs_test(
+    verify_single_message_proofs_test(
         validator_indices=[ValidatorIndex(0)],
         attestation_data=AttestationData(
             slot=Slot(1),
@@ -26,10 +26,10 @@ def test_single_message_single_validator(
 
 
 def test_single_message_four_validators(
-    verify_proofs_test: VerifyProofsTestFiller,
+    verify_single_message_proofs_test: VerifySingleMessageProofsTestFiller,
 ) -> None:
     """Four-validator single-message aggregate, all participating, must verify."""
-    verify_proofs_test(
+    verify_single_message_proofs_test(
         validator_indices=[ValidatorIndex(i) for i in range(4)],
         attestation_data=AttestationData(
             slot=Slot(2),
@@ -41,10 +41,10 @@ def test_single_message_four_validators(
 
 
 def test_single_message_four_validators_partial(
-    verify_proofs_test: VerifyProofsTestFiller,
+    verify_single_message_proofs_test: VerifySingleMessageProofsTestFiller,
 ) -> None:
     """Non-contiguous four-validator committee, aggregation bits resolve to [1, 0, 1, 1]."""
-    verify_proofs_test(
+    verify_single_message_proofs_test(
         validator_indices=[ValidatorIndex(0), ValidatorIndex(2), ValidatorIndex(3)],
         attestation_data=AttestationData(
             slot=Slot(3),


### PR DESCRIPTION
## 🗒️ Description
Because single and multi message proof test fixtures are different (#786 vs #810), the old `verify_proofs` name is misleading because it only supports testing single message proofs, not multi message ones.

Renaming `verify_proofs` fixture to `verify_single_message_proofs` to align with the rest of the refactor.

## 🔗 Related Issues or PRs
- #786
- #810

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] Ran local quality checks to avoid unnecessary CI fails:
    ```console
    just check
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
