### PR TITLE
fix(testing): use AggregationBits.from_indices in multi-message proofs

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/verify_multi_message_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_multi_message_proofs.py
@@ -13,7 +13,6 @@ from lean_spec.spec.forks import (
     Checkpoint,
     Slot,
     ValidatorIndex,
-    ValidatorIndices,
 )
 from lean_spec.spec.forks.lstar.containers import (
     AttestationData,
@@ -171,7 +170,7 @@ class VerifyMultiMessageProofsTest(BaseConsensusFixture):
             public_keys = [key_manager.get_public_keys(i)[0] for i in validator_indices]
             public_keys_per_message.append(public_keys)
             aggregation_bits_per_message.append(
-                ValidatorIndices(data=validator_indices).to_aggregation_bits()
+                AggregationBits.from_indices(validator_indices)
             )
             components.append(
                 self._single_message_aggregate(


### PR DESCRIPTION
## Summary

`main` currently fails type checking. The multi-message proof fixture calls `ValidatorIndices(...).to_aggregation_bits()`, but that method was removed in #809 when the index→bits logic moved onto `AggregationBits.from_indices(...)`.

The two PRs landed in an unlucky order:
- **#809** removed `ValidatorIndices.to_aggregation_bits` and updated every call site that existed at the time.
- **#810** added `verify_multi_message_proofs.py` using the old API and merged *after* #809 without a rebase, reintroducing a call to the now-deleted method.

The result is a dangling call on `main`:

```
error[unresolved-attribute]: Object of type `ValidatorIndices` has no attribute `to_aggregation_bits`
 --> packages/testing/src/consensus_testing/test_fixtures/verify_multi_message_proofs.py:174
```

This applies the same fix #809 used everywhere else: build the participation bitfield directly from the indices via `AggregationBits.from_indices(validator_indices)`, and drop the now-unused `ValidatorIndices` import.

## Testing

- `just lint` (ruff) — passed
- `just typecheck` (ty) — passed (was failing on `main` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)