### PR TITLE
style: reformat verify_multi_message_proofs.py

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/verify_multi_message_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_multi_message_proofs.py
@@ -169,9 +169,7 @@ class VerifyMultiMessageProofsTest(BaseConsensusFixture):
             slots.append(attestation_data.slot)
             public_keys = [key_manager.get_public_keys(i)[0] for i in validator_indices]
             public_keys_per_message.append(public_keys)
-            aggregation_bits_per_message.append(
-                AggregationBits.from_indices(validator_indices)
-            )
+            aggregation_bits_per_message.append(AggregationBits.from_indices(validator_indices))
             components.append(
                 self._single_message_aggregate(
                     key_manager, attestation_data, validator_indices, public_keys


### PR DESCRIPTION
## Summary
- Fixes a ruff format violation in `verify_multi_message_proofs.py` by collapsing a multi-line `AggregationBits.from_indices` call onto a single line.

## Test plan
- `just check` passes (lint, format, type check, spell check, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)