### PR TITLE
refactor(poseidon): use native Pydantic field constraints

### DIFF
--- a/src/lean_spec/spec/crypto/poseidon.py
+++ b/src/lean_spec/spec/crypto/poseidon.py
@@ -13,7 +13,7 @@ from typing import Self
 import numpy as np
 from numba import njit
 from numpy.typing import NDArray
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, model_validator
 
 from ...base import StrictBaseModel
 from .koalabear import Fp, P
@@ -1347,30 +1347,26 @@ class PoseidonParams(StrictBaseModel):
     - This minimum is not enforced here. Callers must choose secure parameters.
     """
 
-    width: int = Field(gt=0, description="The size of the state (t).")
-    rounds_f: int = Field(gt=0, description="Total number of 'full' rounds.")
-    rounds_p: int = Field(ge=0, description="Total number of 'partial' rounds.")
-    mds_first_row: list[Fp] = Field(
-        min_length=1,
-        description="First row of the circulant MDS matrix.",
-    )
-    round_constants: list[Fp] = Field(
-        min_length=1,
-        description="The list of pre-computed constants for all rounds.",
-    )
+    width: int = Field(gt=0)
+    """The size of the state (t)."""
 
-    @field_validator("rounds_f")
-    @classmethod
-    def _rounds_f_must_be_even(cls, value: int) -> int:
-        """Require an even full-round count.
+    rounds_f: int = Field(gt=0, multiple_of=2)
+    """Total number of 'full' rounds.
 
-        - The permutation runs equal halves of full rounds before and after the partial middle.
-        - An odd count silently drops one full round and orphans a width-sized block of constants.
-        - The original Poseidon design assumes an even split.
-        """
-        if value % 2 != 0:
-            raise ValueError("Full-round count must be even.")
-        return value
+    Must be even:
+    - The permutation runs equal halves of full rounds before and after the partial middle.
+    - An odd count silently drops one full round and orphans a width-sized block of constants.
+    - The original Poseidon design assumes an even split.
+    """
+
+    rounds_p: int = Field(ge=0)
+    """Total number of 'partial' rounds."""
+
+    mds_first_row: list[Fp] = Field(min_length=1)
+    """First row of the circulant MDS matrix."""
+
+    round_constants: list[Fp] = Field(min_length=1)
+    """The list of pre-computed constants for all rounds."""
 
     @model_validator(mode="after")
     def check_lengths(self) -> Self:

--- a/tests/lean_spec/spec/crypto/test_poseidon.py
+++ b/tests/lean_spec/spec/crypto/test_poseidon.py
@@ -190,7 +190,7 @@ class TestPoseidonParamsValidation:
 
     def test_rounds_f_must_be_even(self) -> None:
         """Rejects odd full-round counts that would leave constants unused."""
-        with pytest.raises(ValidationError, match=r"Full-round count must be even\."):
+        with pytest.raises(ValidationError, match=r"Input should be a multiple of 2"):
             PoseidonParams(
                 width=3,
                 rounds_f=7,


### PR DESCRIPTION
## Summary

Tidies up `PoseidonParams` to follow the codebase's existing conventions and lean on Pydantic's native field constraints instead of a custom validator.

- Move the `Field(description=...)` text into attribute docstrings, matching the docstring-after-field convention used elsewhere (e.g. the `Poseidon` class right below it).
- Replace the `rounds_f` even-count `field_validator` with the native `multiple_of=2` constraint. The validation constraints (`gt`, `ge`, `min_length`) are preserved on the fields.
- Preserve the "why it must be even" rationale in the field docstring.
- Drop the now-unused `field_validator` import.

## Notes

The native `multiple_of` error message (`"Input should be a multiple of 2"`) is less domain-specific than the old custom message. The test was updated accordingly. All other validators in the codebase were reviewed and genuinely can't move to native constraints — they're either input coercion (`mode="before"`), dynamic per-subclass bounds (`cls.LENGTH`/`cls.LIMIT`), or cross-field relationships.

## Testing

- `just check` passes (lint, format, typecheck, spell, mdformat).
- `uv run pytest tests/lean_spec/spec/crypto/test_poseidon.py` — 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)