### PR TITLE
refactor: move chain config to lstar fork spec

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
@@ -8,12 +8,12 @@ to coordinate block proposals and attestations.
 from typing import Any, ClassVar
 
 from lean_spec.node.chain.clock import Interval, SlotClock
-from lean_spec.node.chain.config import (
+from lean_spec.spec.forks import Slot
+from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MILLISECONDS_PER_INTERVAL,
     SECONDS_PER_SLOT,
 )
-from lean_spec.spec.forks import Slot
 from lean_spec.spec.ssz import Uint64
 
 from .base import BaseConsensusFixture

--- a/src/lean_spec/cli/run.py
+++ b/src/lean_spec/cli/run.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 
 import logging
 
-from lean_spec.node.chain.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.node.metrics import PrometheusObserver, registry as metrics
 from lean_spec.node.networking.client import LiveNetworkEventSource
 from lean_spec.node.networking.gossipsub import GossipTopic
 from lean_spec.node.node import Node, NodeConfig
 from lean_spec.node.observability import set_observer
 from lean_spec.spec.forks import SubnetId
+from lean_spec.spec.forks.lstar.config import ATTESTATION_COMMITTEE_COUNT
 
 from .bootstrap import NodeBootstrap
 

--- a/src/lean_spec/node/chain/clock.py
+++ b/src/lean_spec/node/chain/clock.py
@@ -15,14 +15,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from time import time as wall_time
 
-from lean_spec.spec.ssz import Uint64
-
-from .config import (
+from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MILLISECONDS_PER_INTERVAL,
     MILLISECONDS_PER_SLOT,
     SECONDS_PER_SLOT,
 )
+from lean_spec.spec.ssz import Uint64
 
 
 class Interval(Uint64):

--- a/src/lean_spec/node/chain/service.py
+++ b/src/lean_spec/node/chain/service.py
@@ -26,9 +26,9 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 
-from lean_spec.node.chain.config import INTERVALS_PER_SLOT
 from lean_spec.node.sync import SyncService
 from lean_spec.spec.forks import LstarSpec, SignedAggregatedAttestation
+from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT
 
 from .clock import Interval, SlotClock
 

--- a/src/lean_spec/node/networking/gossipsub/parameters.py
+++ b/src/lean_spec/node/networking/gossipsub/parameters.py
@@ -60,9 +60,9 @@ References:
 from __future__ import annotations
 
 from lean_spec.base import StrictBaseModel
-from lean_spec.node.chain.config import JUSTIFICATION_LOOKBACK_SLOTS, SECONDS_PER_SLOT
 from lean_spec.node.networking.config import GOSSIPSUB_DEFAULT_PROTOCOL_ID
 from lean_spec.node.networking.types import ProtocolId
+from lean_spec.spec.forks.lstar.config import JUSTIFICATION_LOOKBACK_SLOTS, SECONDS_PER_SLOT
 
 
 class GossipsubParameters(StrictBaseModel):

--- a/src/lean_spec/node/node.py
+++ b/src/lean_spec/node/node.py
@@ -22,7 +22,6 @@ from typing import Final
 from lean_spec.node.api import AggregatorController, ApiServer, ApiServerConfig
 from lean_spec.node.chain import SlotClock
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.node.chain.service import ChainService
 from lean_spec.node.metrics import registry as metrics
 from lean_spec.node.networking import NetworkService
@@ -44,6 +43,7 @@ from lean_spec.spec.forks import (
     ValidatorIndex,
     Validators,
 )
+from lean_spec.spec.forks.lstar.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.spec.ssz import Bytes32, Uint64
 
 logger = logging.getLogger(__name__)

--- a/src/lean_spec/spec/forks/lstar/config.py
+++ b/src/lean_spec/spec/forks/lstar/config.py
@@ -45,8 +45,7 @@ HISTORICAL_ROOTS_LIMIT: Final = Uint64(2**18)
 """
 The maximum number of historical block roots to store in the state.
 
-With a 4-second slot, this corresponds to a history
-of approximately 12.1 days.
+With a 4-second slot, this corresponds to a history of approximately 12.1 days.
 """
 
 ATTESTATION_COMMITTEE_COUNT: Final = Uint64(1)

--- a/src/lean_spec/spec/forks/lstar/containers.py
+++ b/src/lean_spec/spec/forks/lstar/containers.py
@@ -15,8 +15,8 @@ from pydantic import Field
 from lean_spec.base import StrictBaseModel
 from lean_spec.config import LEAN_ENV
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import HISTORICAL_ROOTS_LIMIT
 from lean_spec.spec.crypto.xmss.containers import PublicKey, Signature
+from lean_spec.spec.forks.lstar.config import HISTORICAL_ROOTS_LIMIT
 from lean_spec.spec.ssz import Boolean, ByteList512KiB, Bytes32, Bytes52, Container, SSZList, Uint64
 from lean_spec.spec.ssz.bitfields import BaseBitlist
 

--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -7,12 +7,6 @@ from collections.abc import Iterable, Sequence, Set as AbstractSet
 from typing import Any, ClassVar
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import (
-    GOSSIP_DISPARITY_INTERVALS,
-    INTERVALS_PER_SLOT,
-    JUSTIFICATION_LOOKBACK_SLOTS,
-    MAX_ATTESTATIONS_DATA,
-)
 from lean_spec.node.observability import (
     observe_on_attestation,
     observe_on_block,
@@ -22,6 +16,12 @@ from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.crypto.xmss.containers import PublicKey
 from lean_spec.spec.crypto.xmss.interface import TARGET_SIGNATURE_SCHEME
 from lean_spec.spec.forks.lstar.aggregation_select import select_greedily
+from lean_spec.spec.forks.lstar.config import (
+    GOSSIP_DISPARITY_INTERVALS,
+    INTERVALS_PER_SLOT,
+    JUSTIFICATION_LOOKBACK_SLOTS,
+    MAX_ATTESTATIONS_DATA,
+)
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
     AggregatedAttestations,

--- a/tests/consensus/lstar/fc/test_attestation_target_selection.py
+++ b/tests/consensus/lstar/fc/test_attestation_target_selection.py
@@ -9,8 +9,8 @@ from consensus_testing import (
     StoreChecks,
 )
 
-from lean_spec.node.chain.config import JUSTIFICATION_LOOKBACK_SLOTS
 from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import JUSTIFICATION_LOOKBACK_SLOTS
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/lstar/fc/test_block_attestation_limits.py
+++ b/tests/consensus/lstar/fc/test_block_attestation_limits.py
@@ -12,8 +12,8 @@ from consensus_testing import (
 )
 from consensus_testing.keys import XmssKeyManager
 
-from lean_spec.node.chain.config import MAX_ATTESTATIONS_DATA
 from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import MAX_ATTESTATIONS_DATA
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/lstar/fc/test_block_production.py
+++ b/tests/consensus/lstar/fc/test_block_production.py
@@ -16,13 +16,13 @@ from consensus_testing import (
     TickStep,
 )
 
-from lean_spec.node.chain.config import (
+from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MAX_ATTESTATIONS_DATA,
     MILLISECONDS_PER_INTERVAL,
     SECONDS_PER_SLOT,
 )
-from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/lstar/fc/test_checkpoint_sync.py
+++ b/tests/consensus/lstar/fc/test_checkpoint_sync.py
@@ -12,9 +12,9 @@ from consensus_testing import (
 )
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import INTERVALS_PER_SLOT, SECONDS_PER_SLOT
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT, SECONDS_PER_SLOT
 from lean_spec.spec.ssz import Bytes32
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py
@@ -12,8 +12,8 @@ from consensus_testing import (
 )
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.ssz import Bytes32
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
@@ -12,8 +12,8 @@ from consensus_testing import (
 )
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.ssz import Bytes32
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/interop/helpers/node_runner.py
+++ b/tests/interop/helpers/node_runner.py
@@ -12,7 +12,6 @@ import time
 from dataclasses import dataclass, field
 from typing import cast
 
-from lean_spec.node.chain.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.node.networking import PeerId
 from lean_spec.node.networking.client import LiveNetworkEventSource
 from lean_spec.node.networking.gossipsub.types import TopicId
@@ -25,6 +24,7 @@ from lean_spec.node.validator.registry import ValidatorEntry
 from lean_spec.spec.crypto.xmss import TARGET_SIGNATURE_SCHEME, SecretKey
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
+from lean_spec.spec.forks.lstar.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.spec.forks.lstar.containers import Validator, Validators
 from lean_spec.spec.forks.lstar.spec import LstarSpec
 from lean_spec.spec.ssz import Bytes52, Uint64

--- a/tests/lean_spec/cli/test_run.py
+++ b/tests/lean_spec/cli/test_run.py
@@ -11,12 +11,12 @@ from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.cli import NodeBootstrap
 from lean_spec.cli.run import _build_event_source
-from lean_spec.node.chain.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.node.genesis import GenesisConfig
 from lean_spec.node.networking.gossipsub import GossipTopic
 from lean_spec.node.validator import ValidatorRegistry
 from lean_spec.node.validator.registry import ValidatorEntry
 from lean_spec.spec.forks import DEFAULT_REGISTRY, Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import ATTESTATION_COMMITTEE_COUNT
 
 
 class _RecordingEventSource:

--- a/tests/lean_spec/node/chain/test_clock.py
+++ b/tests/lean_spec/node/chain/test_clock.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import pytest
 
 from lean_spec.node.chain import Interval, SlotClock
-from lean_spec.node.chain.config import (
+from lean_spec.spec.forks import Slot
+from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MILLISECONDS_PER_INTERVAL,
     MILLISECONDS_PER_SLOT,
     SECONDS_PER_SLOT,
 )
-from lean_spec.spec.forks import Slot
 from lean_spec.spec.ssz import Uint64
 
 GENESIS_TIME = Uint64(1_700_000_000)

--- a/tests/lean_spec/node/chain/test_service.py
+++ b/tests/lean_spec/node/chain/test_service.py
@@ -7,9 +7,9 @@ from unittest.mock import patch
 
 from lean_spec.node.chain import SlotClock
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.node.chain.service import ChainService
 from lean_spec.spec.forks import Slot
+from lean_spec.spec.forks.lstar.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.spec.forks.lstar.containers import SignedAggregatedAttestation
 from lean_spec.spec.ssz import ZERO_HASH, Bytes32, Uint64
 from tests.lean_spec.helpers.mocks import StoreInterceptingSpec

--- a/tests/lean_spec/node/test_node.py
+++ b/tests/lean_spec/node/test_node.py
@@ -12,12 +12,6 @@ from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.node.api import ApiServerConfig
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import (
-    ATTESTATION_COMMITTEE_COUNT,
-    HISTORICAL_ROOTS_LIMIT,
-    INTERVALS_PER_SLOT,
-    SECONDS_PER_SLOT,
-)
 from lean_spec.node.node import Node, NodeConfig
 from lean_spec.node.storage.sqlite import SQLiteDatabase
 from lean_spec.node.validator import ValidatorRegistry
@@ -25,6 +19,12 @@ from lean_spec.node.validator.registry import ValidatorEntry
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import State
+from lean_spec.spec.forks.lstar.config import (
+    ATTESTATION_COMMITTEE_COUNT,
+    HISTORICAL_ROOTS_LIMIT,
+    INTERVALS_PER_SLOT,
+    SECONDS_PER_SLOT,
+)
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestations,
     Block,

--- a/tests/lean_spec/node/validator/test_service.py
+++ b/tests/lean_spec/node/validator/test_service.py
@@ -8,7 +8,6 @@ import pytest
 from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.node.chain.clock import SlotClock
-from lean_spec.node.chain.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.node.sync.block_cache import BlockCache
 from lean_spec.node.sync.peer_manager import PeerManager
 from lean_spec.node.sync.service import SyncService
@@ -19,6 +18,7 @@ from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.crypto.xmss import TARGET_SIGNATURE_SCHEME
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
+from lean_spec.spec.forks.lstar.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.spec.forks.lstar.containers import (
     AttestationData,
     Block,

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py
@@ -6,10 +6,10 @@ import pytest
 from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import JUSTIFICATION_LOOKBACK_SLOTS
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
+from lean_spec.spec.forks.lstar.config import JUSTIFICATION_LOOKBACK_SLOTS
 from lean_spec.spec.forks.lstar.containers import (
     Attestation,
     AttestationData,

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_store_attestations.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_store_attestations.py
@@ -6,10 +6,10 @@ import pytest
 from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import INTERVALS_PER_SLOT
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import AttestationSignatureEntry
+from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT
 from lean_spec.spec.forks.lstar.containers import (
     AttestationData,
     SignedAggregatedAttestation,

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_time_management.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_time_management.py
@@ -3,15 +3,15 @@
 from hypothesis import given, settings, strategies as st
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import (
+from lean_spec.spec.crypto.merkleization import hash_tree_root
+from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar import Store
+from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MILLISECONDS_PER_INTERVAL,
     MILLISECONDS_PER_SLOT,
     SECONDS_PER_SLOT,
 )
-from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Slot, ValidatorIndex
-from lean_spec.spec.forks.lstar import Store
 from lean_spec.spec.forks.lstar.containers import Block, Validators
 from lean_spec.spec.forks.lstar.spec import LstarSpec
 from lean_spec.spec.ssz import Bytes32, Uint64

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_validate_attestation.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_validate_attestation.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import pytest
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import GOSSIP_DISPARITY_INTERVALS, INTERVALS_PER_SLOT
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
+from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS, INTERVALS_PER_SLOT
 from lean_spec.spec.forks.lstar.containers import (
     Attestation,
     AttestationData,


### PR DESCRIPTION
## Summary

Moves `node/chain/config.py` → `spec/forks/lstar/config.py`.

These constants are **protocol parameters that client teams must match**, not node implementation details. Yet several `spec/` modules already imported them from `node/` — an inverted dependency where the protocol-spec layer reached down into a specific node implementation:

```
spec/forks/lstar/containers.py  → HISTORICAL_ROOTS_LIMIT
spec/forks/lstar/spec.py        → INTERVALS_PER_SLOT, JUSTIFICATION_LOOKBACK_SLOTS,
                                   MAX_ATTESTATIONS_DATA, GOSSIP_DISPARITY_INTERVALS, ...
```

The constants are all consensus-critical:
- **SSZ container/list bounds** (`HISTORICAL_ROOTS_LIMIT`, `MAX_ATTESTATIONS_DATA`) — must match exactly or `hash_tree_root` diverges
- **Timing / forkchoice / attestation params** (`SECONDS_PER_SLOT`, `INTERVALS_PER_SLOT`, `JUSTIFICATION_LOOKBACK_SLOTS`, `GOSSIP_DISPARITY_INTERVALS`, `ATTESTATION_COMMITTEE_COUNT`)

Scoping them to the lstar fork matches the per-fork registry pattern in `spec/forks/`, since a future fork could change these values. (Genuinely node-local config — `node/sync/config.py`, `node/genesis/config.py` — correctly stays in `node/`.)

## Changes

- `git mv` the file (history preserved)
- Update all ~26 import sites across `src/`, `tests/`, and `packages/testing/`

## Verification

- `just check` passes (ruff lint, format, ty, codespell, mdformat)
- Affected unit tests pass (143)

🤖 Generated with [Claude Code](https://claude.com/claude-code)