### PR TITLE
fix: clamp attestation target walk to finalized boundary

### DIFF
--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -40,28 +40,31 @@ class ValidatorDutiesMixin(LstarSpecContract):
     def get_attestation_target(self, store: LstarStore) -> Checkpoint:
         """Calculate target checkpoint for validator attestations.
 
-        Determines appropriate attestation target based on head, safe target,
-        and finalization constraints. The algorithm balances between advancing
-        the chain head and maintaining safety guarantees.
+        Determines the attestation target from the head, the safe target,
+        and the finalization constraints.
+        The algorithm balances advancing the chain head against safety.
 
-        The walk starts at the head and goes backward (up to
-        ``JUSTIFICATION_LOOKBACK_SLOTS`` steps) until both the safe-target
-        bound and the justifiability rules of the slot are satisfied.
+        The walk starts at the head and goes backward.
+        It takes up to JUSTIFICATION_LOOKBACK_SLOTS steps.
+        It stops once both the lower-bound slot and the justifiability rules are satisfied.
+
+        The walk never crosses the finalized boundary.
+        If the safe target lags behind finalization, the finalized slot is the lower bound.
         """
         # Start from current head
         target_block_root = store.head
 
-        # Walk back toward safe target (up to `JUSTIFICATION_LOOKBACK_SLOTS` steps).
+        # Walk back toward the safe target, up to JUSTIFICATION_LOOKBACK_SLOTS steps.
         #
-        # If safe target is stale behind the finalized checkpoint, the finalized
-        # slot becomes the lower bound. Target selection must never inspect
-        # candidate slots before the finalized boundary.
+        # If the safe target is stale behind the finalized checkpoint, the finalized slot
+        # becomes the lower bound.
+        # Target selection must never inspect candidate slots before the finalized boundary.
         safe_target_slot = store.blocks[store.safe_target].slot
         finalized_slot = store.latest_finalized.slot
-        lower_bound_slot = safe_target_slot if safe_target_slot > finalized_slot else finalized_slot
+        lower_bound_slot = max(safe_target_slot, finalized_slot)
 
-        # This ensures the target doesn't advance too far ahead of safe target,
-        # providing a balance between liveness and safety.
+        # This keeps the target from advancing too far ahead of the safe target.
+        # It balances liveness against safety.
         for _ in range(int(JUSTIFICATION_LOOKBACK_SLOTS)):
             if store.blocks[target_block_root].slot > lower_bound_slot:
                 target_block_root = store.blocks[target_block_root].parent_root
@@ -73,10 +76,10 @@ class ValidatorDutiesMixin(LstarSpecContract):
         # Walk back until we find a slot that satisfies justifiability rules
         # relative to the latest finalized checkpoint.
         while store.blocks[target_block_root].slot > finalized_slot:
-            target_slot = store.blocks[target_block_root].slot
-            if target_slot.is_justifiable_after(finalized_slot):
+            target_block = store.blocks[target_block_root]
+            if target_block.slot.is_justifiable_after(finalized_slot):
                 break
-            target_block_root = store.blocks[target_block_root].parent_root
+            target_block_root = target_block.parent_root
 
         # Create checkpoint from selected target block
         target_block = store.blocks[target_block_root]

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -51,12 +51,19 @@ class ValidatorDutiesMixin(LstarSpecContract):
         # Start from current head
         target_block_root = store.head
 
-        # Walk back toward safe target (up to `JUSTIFICATION_LOOKBACK_SLOTS` steps)
+        # Walk back toward safe target (up to `JUSTIFICATION_LOOKBACK_SLOTS` steps).
         #
+        # If safe target is stale behind the finalized checkpoint, the finalized
+        # slot becomes the lower bound. Target selection must never inspect
+        # candidate slots before the finalized boundary.
+        safe_target_slot = store.blocks[store.safe_target].slot
+        finalized_slot = store.latest_finalized.slot
+        lower_bound_slot = safe_target_slot if safe_target_slot > finalized_slot else finalized_slot
+
         # This ensures the target doesn't advance too far ahead of safe target,
         # providing a balance between liveness and safety.
         for _ in range(int(JUSTIFICATION_LOOKBACK_SLOTS)):
-            if store.blocks[target_block_root].slot > store.blocks[store.safe_target].slot:
+            if store.blocks[target_block_root].slot > lower_bound_slot:
                 target_block_root = store.blocks[target_block_root].parent_root
             else:
                 break
@@ -65,9 +72,10 @@ class ValidatorDutiesMixin(LstarSpecContract):
         #
         # Walk back until we find a slot that satisfies justifiability rules
         # relative to the latest finalized checkpoint.
-        while not store.blocks[target_block_root].slot.is_justifiable_after(
-            store.latest_finalized.slot
-        ):
+        while store.blocks[target_block_root].slot > finalized_slot:
+            target_slot = store.blocks[target_block_root].slot
+            if target_slot.is_justifiable_after(finalized_slot):
+                break
             target_block_root = store.blocks[target_block_root].parent_root
 
         # Create checkpoint from selected target block

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py
@@ -98,6 +98,31 @@ class TestGetAttestationTarget:
         # The target slot must be justifiable after the finalized slot
         assert target.slot.is_justifiable_after(finalized_slot)
 
+    def test_attestation_target_ignores_stale_safe_target_below_finalized(
+        self,
+        observer_store: Store,
+        spec: LstarSpec,
+    ) -> None:
+        """A stale safe target behind finalization must not pull target selection below it."""
+        store = observer_store
+        roots: dict[Slot, Bytes32] = {}
+
+        for slot_num in range(1, 7):
+            slot = Slot(slot_num)
+            proposer = ValidatorIndex(slot_num % len(store.states[store.head].validators))
+            store, block, _ = spec.produce_block_with_signatures(store, slot, proposer)
+            roots[slot] = hash_tree_root(block)
+
+        finalized = Checkpoint(root=roots[Slot(4)], slot=Slot(4))
+        store.latest_justified = finalized
+        store.latest_finalized = finalized
+        assert store.blocks[store.safe_target].slot == Slot(0)
+
+        target = spec.get_attestation_target(store)
+
+        assert target.root == finalized.root
+        assert target.slot == finalized.slot
+
     def test_attestation_target_consistency_with_head(
         self, observer_store: Store, spec: LstarSpec
     ) -> None:

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py
@@ -120,8 +120,60 @@ class TestGetAttestationTarget:
 
         target = spec.get_attestation_target(store)
 
-        assert target.root == finalized.root
-        assert target.slot == finalized.slot
+        assert target == finalized
+
+    def test_attestation_target_walks_back_to_nearest_justifiable_slot(
+        self,
+        observer_store: Store,
+        spec: LstarSpec,
+    ) -> None:
+        """A non-justifiable candidate slot must step back to the nearest justifiable one."""
+        store = observer_store
+        roots: dict[Slot, Bytes32] = {}
+
+        for slot_num in range(1, 12):
+            slot = Slot(slot_num)
+            proposer = ValidatorIndex(slot_num % len(store.states[store.head].validators))
+            store, block, _ = spec.produce_block_with_signatures(store, slot, proposer)
+            roots[slot] = hash_tree_root(block)
+
+        # Fixture state: finalized and safe target at slot 0, head at slot 10.
+        # The lookback walk takes 3 steps from slot 10 and lands on slot 7.
+        # Distance 7 from finalization is neither <= 5, a perfect square, nor pronic.
+        # Distance 6 is pronic (2 * 3), so slot 6 is the nearest justifiable slot below.
+        assert store.blocks[store.head].slot == Slot(10)
+        assert not Slot(7).is_justifiable_after(Slot(0))
+        assert Slot(6).is_justifiable_after(Slot(0))
+
+        target = spec.get_attestation_target(store)
+
+        assert target == Checkpoint(root=roots[Slot(6)], slot=Slot(6))
+
+    def test_attestation_target_uses_safe_target_when_ahead_of_finalized(
+        self,
+        observer_store: Store,
+        spec: LstarSpec,
+    ) -> None:
+        """When the safe target leads finalization, it is the walk's lower bound."""
+        store = observer_store
+        roots: dict[Slot, Bytes32] = {}
+
+        for slot_num in range(1, 5):
+            slot = Slot(slot_num)
+            proposer = ValidatorIndex(slot_num % len(store.states[store.head].validators))
+            store, block, _ = spec.produce_block_with_signatures(store, slot, proposer)
+            roots[slot] = hash_tree_root(block)
+
+        # Fixture state: finalized at slot 1, safe target at slot 3, head at slot 4.
+        # The safe target leads finalization, so it sets the lower bound at slot 3.
+        store.safe_target = roots[Slot(3)]
+        finalized = Checkpoint(root=roots[Slot(1)], slot=Slot(1))
+        store.latest_justified = finalized
+        store.latest_finalized = finalized
+
+        target = spec.get_attestation_target(store)
+
+        assert target == Checkpoint(root=roots[Slot(3)], slot=Slot(3))
 
     def test_attestation_target_consistency_with_head(
         self, observer_store: Store, spec: LstarSpec


### PR DESCRIPTION
## Summary

Fixes an Lstar attestation-target boundary bug where `get_attestation_target()` could walk below the latest finalized checkpoint when `safe_target` was stale behind finalization.

The target-selection walk now uses `max(safe_target.slot, latest_finalized.slot)` as its lower bound, and the justifiability walk stops at the finalized boundary before calling `is_justifiable_after()`.

## Root Cause

`safe_target` can legally lag behind `latest_finalized`. In that state, the previous implementation walked backward from head toward the stale safe target, crossed below the finalized slot, and then called:

```python
slot.is_justifiable_after(latest_finalized.slot)
```

on a candidate slot before finalization. That violates the slot helper invariant and raises:

```text
Candidate slot must not be before finalized slot
```

## Validation

- Pre-fix targeted regression fails with `Candidate slot must not be before finalized slot`
- `uv run --group test pytest tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py -q --no-cov`
- `uv run --group test pytest tests/lean_spec/spec/forks/lstar/forkchoice/test_block_production_justification_gap.py tests/lean_spec/spec/forks/lstar/state -q --no-cov`
- `uv run --group lint ruff check src/lean_spec/spec/forks/lstar/validator_duties.py tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py`
- `uv run --group lint ruff format --check src/lean_spec/spec/forks/lstar/validator_duties.py tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py`
- `uv run --group lint ty check src/lean_spec/spec/forks/lstar/validator_duties.py tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py`
- `git diff --check`
