### PR TITLE
refactor(clock): relocate Interval to the spec layer and tidy SlotClock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,16 @@ subspecifications that the Lean Ethereum protocol relies on.
     or any on-the-wire string. Rename the Python identifier, never the serialized contract.
   - When a fully-expanded name becomes unwieldy, prefer a shorter but still complete phrasing
     (drop redundant words) rather than re-introducing an abbreviation.
+- **CRITICAL - TEST STRUCTURE MIRRORS SOURCE STRUCTURE**: This is a STRICT requirement. The
+  test tree under `tests/lean_spec/` mirrors the source tree under `src/lean_spec/` one-to-one.
+  A source module `src/lean_spec/<path>/<name>.py` has its unit tests in
+  `tests/lean_spec/<path>/test_<name>.py`, and every test file tests the single source module it
+  mirrors.
+  - When you MOVE a class or function to a different module, MOVE its tests to the matching test
+    module in the SAME change. Never leave tests behind in the old location.
+  - When you CREATE a new source module, its tests go in the mirrored test path, not appended to
+    an unrelated test file.
+  - When you DELETE or RENAME a source module, delete or rename its test module to match.
+  - A test file must never test a type that lives in a different source module. For example, tests
+    for `Interval` (in `spec/forks/lstar/interval.py`) belong in
+    `tests/lean_spec/spec/forks/lstar/test_interval.py`, never in `node/chain/test_clock.py`.

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -11,9 +11,9 @@ from typing import ClassVar, Self
 
 from pydantic import Field, model_validator
 
-from lean_spec.node.chain.clock import Interval
+from lean_spec.node.chain.clock import SlotClock
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestations,
     Block,
@@ -22,7 +22,6 @@ from lean_spec.spec.forks.lstar.containers import (
     Validators,
 )
 from lean_spec.spec.forks.lstar.spec import LstarSpec
-from lean_spec.spec.ssz import Uint64
 
 from ..keys import (
     XmssKeyManager,
@@ -278,10 +277,11 @@ class ForkChoiceTest(BaseConsensusFixture):
                         else:
                             assert step.time is not None
                             # TickStep.time is a Unix timestamp in seconds.
-                            # Convert to intervals since genesis for the store.
-                            target_interval = Interval.from_unix_time(
-                                Uint64(step.time), store.config.genesis_time
-                            )
+                            # The slot clock converts it to intervals since genesis.
+                            target_interval = SlotClock(
+                                genesis_time=store.config.genesis_time,
+                                time_fn=lambda t=step.time: float(t),
+                            ).total_intervals()
                         store, _ = spec.on_tick(
                             store,
                             target_interval,

--- a/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
@@ -8,12 +8,12 @@ to coordinate block proposals and attestations.
 from typing import Any, ClassVar
 
 from lean_spec.node.chain.clock import Interval, SlotClock
-from lean_spec.node.chain.config import (
+from lean_spec.spec.forks import Slot
+from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MILLISECONDS_PER_INTERVAL,
     SECONDS_PER_SLOT,
 )
-from lean_spec.spec.forks import Slot
 from lean_spec.spec.ssz import Uint64
 
 from .base import BaseConsensusFixture

--- a/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
@@ -7,8 +7,8 @@ to coordinate block proposals and attestations.
 
 from typing import Any, ClassVar
 
-from lean_spec.node.chain.clock import Interval, SlotClock
-from lean_spec.spec.forks import Slot
+from lean_spec.node.chain.clock import SlotClock
+from lean_spec.spec.forks import Interval, Slot
 from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MILLISECONDS_PER_INTERVAL,
@@ -66,10 +66,10 @@ class SlotClockTest(BaseConsensusFixture):
 
     def _make_from_unix_time(self) -> dict[str, Any]:
         """Convert unix timestamp to interval count since genesis."""
-        unix_seconds = Uint64(self.input["unixSeconds"])
         genesis_time = Uint64(self.input["genesisTime"])
-        interval = Interval.from_unix_time(unix_seconds, genesis_time)
-        return {"interval": int(interval)}
+        unix_seconds = float(self.input["unixSeconds"])
+        clock = SlotClock(genesis_time=genesis_time, time_fn=lambda: unix_seconds)
+        return {"interval": int(clock.total_intervals())}
 
     def _make_from_slot(self) -> dict[str, Any]:
         """Convert slot number to interval at that slot's start."""

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -6,10 +6,9 @@ import copy
 from collections import defaultdict
 
 from lean_spec.base import CamelModel
-from lean_spec.node.chain.clock import Interval
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.crypto.xmss.containers import Signature
-from lean_spec.spec.forks import AggregationBits, Slot, ValidatorIndex
+from lean_spec.spec.forks import AggregationBits, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
     AggregatedAttestations,

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -3,9 +3,8 @@
 from typing import Literal
 
 from lean_spec.base import CamelModel
-from lean_spec.node.chain.clock import Interval
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import AttestationData, Block, Store
 from lean_spec.spec.forks.lstar.spec import LstarSpec
 from lean_spec.spec.ssz import ZERO_HASH, Bytes32

--- a/src/lean_spec/cli/run.py
+++ b/src/lean_spec/cli/run.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 
 import logging
 
-from lean_spec.node.chain.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.node.metrics import PrometheusObserver, registry as metrics
 from lean_spec.node.networking.client import LiveNetworkEventSource
 from lean_spec.node.networking.gossipsub import GossipTopic
 from lean_spec.node.node import Node, NodeConfig
 from lean_spec.node.observability import set_observer
 from lean_spec.spec.forks import SubnetId
+from lean_spec.spec.forks.lstar.config import ATTESTATION_COMMITTEE_COUNT
 
 from .bootstrap import NodeBootstrap
 

--- a/src/lean_spec/node/chain/__init__.py
+++ b/src/lean_spec/node/chain/__init__.py
@@ -1,8 +1,7 @@
 """Specifications for chain and consensus parameters."""
 
-from .clock import Interval, SlotClock
+from .clock import SlotClock
 
 __all__ = [
-    "Interval",
     "SlotClock",
 ]

--- a/src/lean_spec/node/chain/clock.py
+++ b/src/lean_spec/node/chain/clock.py
@@ -1,12 +1,4 @@
-"""
-Slot Clock.
-
-Time-to-slot conversion for Lean Consensus.
-
-The slot clock bridges wall-clock time to the discrete slot-based time
-model used by consensus. Every node must agree on slot boundaries to
-coordinate block proposals and attestations.
-"""
+"""Slot clock."""
 
 from __future__ import annotations
 
@@ -15,80 +7,23 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from time import time as wall_time
 
+from lean_spec.spec.forks import Interval, Slot
 from lean_spec.spec.forks.lstar.config import (
-    INTERVALS_PER_SLOT,
     MILLISECONDS_PER_INTERVAL,
     MILLISECONDS_PER_SLOT,
-    SECONDS_PER_SLOT,
 )
 from lean_spec.spec.ssz import Uint64
 
 
-class Interval(Uint64):
-    """Interval count since genesis (matches `Store.time`)."""
-
-    @classmethod
-    def from_unix_time(cls, unix_seconds: Uint64, genesis_time: Uint64) -> Interval:
-        """
-        Convert a Unix timestamp to a total interval count since genesis.
-
-        Useful when external inputs provide absolute timestamps but the
-        store tracks time as intervals (800 ms each, 5 per slot).
-
-        Args:
-            unix_seconds: Absolute Unix timestamp in seconds.
-            genesis_time: Genesis Unix timestamp in seconds.
-
-        Returns:
-            Total intervals elapsed between genesis and the given time.
-        """
-        # Convert the elapsed seconds to milliseconds.
-        #
-        # The store measures time at sub-second granularity (800 ms intervals),
-        # so second-precision input must be scaled up before dividing.
-        delta_ms = (unix_seconds - genesis_time) * Uint64(1000)
-
-        # Truncate to whole intervals.
-        return cls(delta_ms // MILLISECONDS_PER_INTERVAL)
-
-    @classmethod
-    def from_slot(cls, slot: Slot) -> Interval:  # noqa: F821  # ty: ignore[unresolved-reference]
-        """
-        Convert a slot number to the interval at that slot's start.
-
-        Each slot spans a fixed number of intervals.
-        This gives the first interval of the given slot.
-
-        Args:
-            slot: Slot number since genesis.
-
-        Returns:
-            Interval count at the start of the given slot.
-        """
-        # Slot boundaries fall on exact multiples of the interval count.
-        return cls(int(slot) * int(INTERVALS_PER_SLOT))
-
-
 @dataclass(frozen=True, slots=True)
 class SlotClock:
-    """
-    Converts wall-clock time to consensus slots and intervals.
-
-    All time values are in seconds (Unix timestamps).
-    """
+    """Converts wall-clock time to consensus slots and intervals."""
 
     genesis_time: Uint64
     """Unix timestamp (seconds) when slot 0 began."""
 
     time_fn: Callable[[], float] = wall_time
     """Time source function (injectable for testing)."""
-
-    def _seconds_since_genesis(self) -> Uint64:
-        """Seconds elapsed since genesis (0 if before genesis)."""
-        now = self.current_time()
-        if now < self.genesis_time:
-            return Uint64(0)
-        return now - self.genesis_time
 
     def _milliseconds_since_genesis(self) -> Uint64:
         """Milliseconds elapsed since genesis (0 if before genesis)."""
@@ -98,11 +33,9 @@ class SlotClock:
             return Uint64(0)
         return Uint64(now_ms - genesis_ms)
 
-    def current_slot(self) -> Slot:  # noqa: F821  # ty: ignore[unresolved-reference]
+    def current_slot(self) -> Slot:
         """Get the current slot number (0 if before genesis)."""
-        from lean_spec.spec.forks import Slot
-
-        return Slot(self._seconds_since_genesis() // SECONDS_PER_SLOT)
+        return Slot(self._milliseconds_since_genesis() // MILLISECONDS_PER_SLOT)
 
     def current_interval(self) -> Interval:
         """Get the current interval within the slot (0-4)."""
@@ -110,11 +43,7 @@ class SlotClock:
         return Interval(milliseconds_into_slot // MILLISECONDS_PER_INTERVAL)
 
     def total_intervals(self) -> Interval:
-        """
-        Get total intervals elapsed since genesis.
-
-        This is the value expected by our store time type.
-        """
+        """Get total intervals elapsed since genesis."""
         return Interval(self._milliseconds_since_genesis() // MILLISECONDS_PER_INTERVAL)
 
     def current_time(self) -> Uint64:
@@ -125,22 +54,23 @@ class SlotClock:
         """
         Calculate seconds until the next interval boundary.
 
-        Returns time until genesis if before genesis.
-        Returns 0.0 if exactly at an interval boundary.
+        - Returns time until genesis if called before genesis.
+        - Returns a full interval when exactly on a boundary, never zero.
         """
         now = self.time_fn()
         genesis = int(self.genesis_time)
         elapsed = now - genesis
 
         if elapsed < 0:
-            # Before genesis - return time until genesis.
             return -elapsed
 
-        # Convert to milliseconds and find time into current interval.
+        # Position within the current interval, in milliseconds.
         elapsed_ms = int(elapsed * 1000)
         time_into_interval_ms = elapsed_ms % int(MILLISECONDS_PER_INTERVAL)
 
-        # Time until next boundary (may be 0 if exactly at boundary).
+        # Remaining milliseconds until the boundary.
+        #
+        # A full interval when already exactly on a boundary.
         ms_until_next = int(MILLISECONDS_PER_INTERVAL) - time_into_interval_ms
         return ms_until_next / 1000.0
 

--- a/src/lean_spec/node/chain/clock.py
+++ b/src/lean_spec/node/chain/clock.py
@@ -15,14 +15,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from time import time as wall_time
 
-from lean_spec.spec.ssz import Uint64
-
-from .config import (
+from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MILLISECONDS_PER_INTERVAL,
     MILLISECONDS_PER_SLOT,
     SECONDS_PER_SLOT,
 )
+from lean_spec.spec.ssz import Uint64
 
 
 class Interval(Uint64):

--- a/src/lean_spec/node/chain/service.py
+++ b/src/lean_spec/node/chain/service.py
@@ -26,9 +26,9 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 
-from lean_spec.node.chain.config import INTERVALS_PER_SLOT
 from lean_spec.node.sync import SyncService
 from lean_spec.spec.forks import LstarSpec, SignedAggregatedAttestation
+from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT
 
 from .clock import Interval, SlotClock
 

--- a/src/lean_spec/node/chain/service.py
+++ b/src/lean_spec/node/chain/service.py
@@ -27,10 +27,10 @@ import logging
 from dataclasses import dataclass, field
 
 from lean_spec.node.sync import SyncService
-from lean_spec.spec.forks import LstarSpec, SignedAggregatedAttestation
+from lean_spec.spec.forks import Interval, LstarSpec, SignedAggregatedAttestation
 from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT
 
-from .clock import Interval, SlotClock
+from .clock import SlotClock
 
 logger = logging.getLogger(__name__)
 

--- a/src/lean_spec/node/networking/gossipsub/parameters.py
+++ b/src/lean_spec/node/networking/gossipsub/parameters.py
@@ -60,9 +60,9 @@ References:
 from __future__ import annotations
 
 from lean_spec.base import StrictBaseModel
-from lean_spec.node.chain.config import JUSTIFICATION_LOOKBACK_SLOTS, SECONDS_PER_SLOT
 from lean_spec.node.networking.config import GOSSIPSUB_DEFAULT_PROTOCOL_ID
 from lean_spec.node.networking.types import ProtocolId
+from lean_spec.spec.forks.lstar.config import JUSTIFICATION_LOOKBACK_SLOTS, SECONDS_PER_SLOT
 
 
 class GossipsubParameters(StrictBaseModel):

--- a/src/lean_spec/node/node.py
+++ b/src/lean_spec/node/node.py
@@ -21,7 +21,6 @@ from typing import Final
 
 from lean_spec.node.api import AggregatorController, ApiServer, ApiServerConfig
 from lean_spec.node.chain import SlotClock
-from lean_spec.node.chain.clock import Interval
 from lean_spec.node.chain.service import ChainService
 from lean_spec.node.metrics import registry as metrics
 from lean_spec.node.networking import NetworkService
@@ -35,6 +34,7 @@ from lean_spec.spec.forks import (
     Block,
     BlockBody,
     ForkProtocol,
+    Interval,
     LstarSpec,
     SignedAttestation,
     SignedBlock,

--- a/src/lean_spec/node/node.py
+++ b/src/lean_spec/node/node.py
@@ -22,7 +22,6 @@ from typing import Final
 from lean_spec.node.api import AggregatorController, ApiServer, ApiServerConfig
 from lean_spec.node.chain import SlotClock
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.node.chain.service import ChainService
 from lean_spec.node.metrics import registry as metrics
 from lean_spec.node.networking import NetworkService
@@ -44,6 +43,7 @@ from lean_spec.spec.forks import (
     ValidatorIndex,
     Validators,
 )
+from lean_spec.spec.forks.lstar.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.spec.ssz import Bytes32, Uint64
 
 logger = logging.getLogger(__name__)

--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -37,7 +37,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Literal
 
-from lean_spec.node.chain.clock import Interval, SlotClock
+from lean_spec.node.chain.clock import SlotClock
 from lean_spec.node.sync import SyncService
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.crypto.xmss import TARGET_SIGNATURE_SCHEME
@@ -45,6 +45,7 @@ from lean_spec.spec.crypto.xmss.containers import PublicKey, Signature
 from lean_spec.spec.forks import (
     AttestationData,
     Block,
+    Interval,
     LstarSpec,
     SignedAttestation,
     SignedBlock,

--- a/src/lean_spec/spec/forks/__init__.py
+++ b/src/lean_spec/spec/forks/__init__.py
@@ -25,6 +25,7 @@ from .lstar.containers import (
     ValidatorIndices,
     Validators,
 )
+from .lstar.interval import Interval
 from .lstar.spec import LstarSpec, LstarStore
 from .protocol import ForkProtocol, SpecStateType, SpecStoreType
 from .registry import ForkRegistry
@@ -55,6 +56,7 @@ __all__ = [
     "ForkProtocol",
     "ForkRegistry",
     "IMMEDIATE_JUSTIFICATION_WINDOW",
+    "Interval",
     "LstarSpec",
     "LstarStore",
     "SignedAggregatedAttestation",

--- a/src/lean_spec/spec/forks/lstar/config.py
+++ b/src/lean_spec/spec/forks/lstar/config.py
@@ -45,8 +45,7 @@ HISTORICAL_ROOTS_LIMIT: Final = Uint64(2**18)
 """
 The maximum number of historical block roots to store in the state.
 
-With a 4-second slot, this corresponds to a history
-of approximately 12.1 days.
+With a 4-second slot, this corresponds to a history of approximately 12.1 days.
 """
 
 ATTESTATION_COMMITTEE_COUNT: Final = Uint64(1)

--- a/src/lean_spec/spec/forks/lstar/containers.py
+++ b/src/lean_spec/spec/forks/lstar/containers.py
@@ -14,12 +14,12 @@ from pydantic import Field
 
 from lean_spec.base import StrictBaseModel
 from lean_spec.config import LEAN_ENV
-from lean_spec.node.chain.clock import Interval
 from lean_spec.spec.crypto.xmss.containers import PublicKey, Signature
 from lean_spec.spec.forks.lstar.config import HISTORICAL_ROOTS_LIMIT
 from lean_spec.spec.ssz import Boolean, ByteList512KiB, Bytes32, Bytes52, Container, SSZList, Uint64
 from lean_spec.spec.ssz.bitfields import BaseBitlist
 
+from .interval import Interval
 from .slot import IMMEDIATE_JUSTIFICATION_WINDOW, Slot
 
 __all__ = [

--- a/src/lean_spec/spec/forks/lstar/containers.py
+++ b/src/lean_spec/spec/forks/lstar/containers.py
@@ -15,8 +15,8 @@ from pydantic import Field
 from lean_spec.base import StrictBaseModel
 from lean_spec.config import LEAN_ENV
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import HISTORICAL_ROOTS_LIMIT
 from lean_spec.spec.crypto.xmss.containers import PublicKey, Signature
+from lean_spec.spec.forks.lstar.config import HISTORICAL_ROOTS_LIMIT
 from lean_spec.spec.ssz import Boolean, ByteList512KiB, Bytes32, Bytes52, Container, SSZList, Uint64
 from lean_spec.spec.ssz.bitfields import BaseBitlist
 

--- a/src/lean_spec/spec/forks/lstar/interval.py
+++ b/src/lean_spec/spec/forks/lstar/interval.py
@@ -1,0 +1,31 @@
+"""Interval time unit."""
+
+from __future__ import annotations
+
+from lean_spec.spec.ssz import Uint64
+
+from .config import INTERVALS_PER_SLOT
+from .slot import Slot
+
+
+class Interval(Uint64):
+    """Interval count since genesis."""
+
+    @classmethod
+    def from_slot(cls, slot: Slot) -> Interval:
+        """
+        Convert a slot number to the interval at that slot's start.
+
+        Each slot spans a fixed number of intervals.
+        This gives the first interval of the given slot.
+
+        Args:
+            slot: Slot number since genesis.
+
+        Returns:
+            Interval count at the start of the given slot.
+        """
+        # Slot boundaries fall on exact multiples of the interval count.
+        #
+        # The two values are distinct unsigned types, so drop to plain ints to multiply.
+        return cls(int(slot) * int(INTERVALS_PER_SLOT))

--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from collections.abc import Iterable, Sequence, Set as AbstractSet
 from typing import Any, ClassVar
 
-from lean_spec.node.chain.clock import Interval
 from lean_spec.node.observability import (
     observe_on_attestation,
     observe_on_block,
@@ -50,6 +49,7 @@ from lean_spec.spec.forks.lstar.containers import (
 from lean_spec.spec.ssz import ZERO_HASH, Boolean, Bytes32, SSZList, Uint8, Uint64
 
 from ..protocol import ForkProtocol, SpecBlockType, SpecStateType
+from .interval import Interval
 
 LstarStore = Store[State, Block]
 """Concrete Store specialization owned by the lstar fork."""

--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -7,12 +7,6 @@ from collections.abc import Iterable, Sequence, Set as AbstractSet
 from typing import Any, ClassVar
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import (
-    GOSSIP_DISPARITY_INTERVALS,
-    INTERVALS_PER_SLOT,
-    JUSTIFICATION_LOOKBACK_SLOTS,
-    MAX_ATTESTATIONS_DATA,
-)
 from lean_spec.node.observability import (
     observe_on_attestation,
     observe_on_block,
@@ -22,6 +16,12 @@ from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.crypto.xmss.containers import PublicKey
 from lean_spec.spec.crypto.xmss.interface import TARGET_SIGNATURE_SCHEME
 from lean_spec.spec.forks.lstar.aggregation_select import select_greedily
+from lean_spec.spec.forks.lstar.config import (
+    GOSSIP_DISPARITY_INTERVALS,
+    INTERVALS_PER_SLOT,
+    JUSTIFICATION_LOOKBACK_SLOTS,
+    MAX_ATTESTATIONS_DATA,
+)
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
     AggregatedAttestations,

--- a/tests/consensus/lstar/fc/test_attestation_target_selection.py
+++ b/tests/consensus/lstar/fc/test_attestation_target_selection.py
@@ -9,8 +9,8 @@ from consensus_testing import (
     StoreChecks,
 )
 
-from lean_spec.node.chain.config import JUSTIFICATION_LOOKBACK_SLOTS
 from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import JUSTIFICATION_LOOKBACK_SLOTS
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/lstar/fc/test_block_attestation_limits.py
+++ b/tests/consensus/lstar/fc/test_block_attestation_limits.py
@@ -12,8 +12,8 @@ from consensus_testing import (
 )
 from consensus_testing.keys import XmssKeyManager
 
-from lean_spec.node.chain.config import MAX_ATTESTATIONS_DATA
 from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import MAX_ATTESTATIONS_DATA
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/lstar/fc/test_block_production.py
+++ b/tests/consensus/lstar/fc/test_block_production.py
@@ -16,13 +16,13 @@ from consensus_testing import (
     TickStep,
 )
 
-from lean_spec.node.chain.config import (
+from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MAX_ATTESTATIONS_DATA,
     MILLISECONDS_PER_INTERVAL,
     SECONDS_PER_SLOT,
 )
-from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/consensus/lstar/fc/test_checkpoint_sync.py
+++ b/tests/consensus/lstar/fc/test_checkpoint_sync.py
@@ -12,9 +12,9 @@ from consensus_testing import (
 )
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import INTERVALS_PER_SLOT, SECONDS_PER_SLOT
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT, SECONDS_PER_SLOT
 from lean_spec.spec.ssz import Bytes32
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_checkpoint_sync.py
+++ b/tests/consensus/lstar/fc/test_checkpoint_sync.py
@@ -11,9 +11,8 @@ from consensus_testing import (
     build_anchor,
 )
 
-from lean_spec.node.chain.clock import Interval
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT, SECONDS_PER_SLOT
 from lean_spec.spec.ssz import Bytes32
 

--- a/tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py
@@ -12,8 +12,8 @@ from consensus_testing import (
 )
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.ssz import Bytes32
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py
@@ -11,8 +11,7 @@ from consensus_testing import (
     TickStep,
 )
 
-from lean_spec.node.chain.clock import Interval
-from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.ssz import Bytes32
 

--- a/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
@@ -12,8 +12,8 @@ from consensus_testing import (
 )
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.ssz import Bytes32
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
@@ -11,8 +11,7 @@ from consensus_testing import (
     TickStep,
 )
 
-from lean_spec.node.chain.clock import Interval
-from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.ssz import Bytes32
 

--- a/tests/consensus/lstar/fc/test_tick_system.py
+++ b/tests/consensus/lstar/fc/test_tick_system.py
@@ -12,8 +12,7 @@ from consensus_testing import (
     TickStep,
 )
 
-from lean_spec.node.chain.clock import Interval
-from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 

--- a/tests/interop/helpers/node_runner.py
+++ b/tests/interop/helpers/node_runner.py
@@ -12,7 +12,6 @@ import time
 from dataclasses import dataclass, field
 from typing import cast
 
-from lean_spec.node.chain.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.node.networking import PeerId
 from lean_spec.node.networking.client import LiveNetworkEventSource
 from lean_spec.node.networking.gossipsub.types import TopicId
@@ -25,6 +24,7 @@ from lean_spec.node.validator.registry import ValidatorEntry
 from lean_spec.spec.crypto.xmss import TARGET_SIGNATURE_SCHEME, SecretKey
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
+from lean_spec.spec.forks.lstar.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.spec.forks.lstar.containers import Validator, Validators
 from lean_spec.spec.forks.lstar.spec import LstarSpec
 from lean_spec.spec.ssz import Bytes52, Uint64

--- a/tests/lean_spec/cli/test_run.py
+++ b/tests/lean_spec/cli/test_run.py
@@ -11,12 +11,12 @@ from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.cli import NodeBootstrap
 from lean_spec.cli.run import _build_event_source
-from lean_spec.node.chain.config import ATTESTATION_COMMITTEE_COUNT
 from lean_spec.node.genesis import GenesisConfig
 from lean_spec.node.networking.gossipsub import GossipTopic
 from lean_spec.node.validator import ValidatorRegistry
 from lean_spec.node.validator.registry import ValidatorEntry
 from lean_spec.spec.forks import DEFAULT_REGISTRY, Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import ATTESTATION_COMMITTEE_COUNT
 
 
 class _RecordingEventSource:

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -11,7 +11,7 @@ from typing import NamedTuple, cast
 
 from consensus_testing.keys import XmssKeyManager
 
-from lean_spec.node.chain.clock import Interval, SlotClock
+from lean_spec.node.chain.clock import SlotClock
 from lean_spec.node.networking import PeerId
 from lean_spec.node.networking.peer import PeerInfo
 from lean_spec.node.networking.reqresp.message import Status
@@ -30,7 +30,7 @@ from lean_spec.spec.crypto.xmss.types import (
     HashTreeOpening,
     Randomness,
 )
-from lean_spec.spec.forks import AggregationBits, Checkpoint, Slot, ValidatorIndex
+from lean_spec.spec.forks import AggregationBits, Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import AttestationSignatureEntry, State, Store
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,

--- a/tests/lean_spec/node/chain/test_clock.py
+++ b/tests/lean_spec/node/chain/test_clock.py
@@ -2,352 +2,280 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
-from lean_spec.node.chain import Interval, SlotClock
-from lean_spec.spec.forks import Slot
-from lean_spec.spec.forks.lstar.config import (
-    INTERVALS_PER_SLOT,
-    MILLISECONDS_PER_INTERVAL,
-    MILLISECONDS_PER_SLOT,
-    SECONDS_PER_SLOT,
-)
+from lean_spec.node.chain import SlotClock
+from lean_spec.spec.forks import Interval, Slot
+from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT
 from lean_spec.spec.ssz import Uint64
 
-GENESIS_TIME = Uint64(1_700_000_000)
 
-
-class TestIntervalFromUnixTime:
-    """Tests for Interval.from_unix_time()."""
-
-    def test_at_genesis(self) -> None:
-        """Returns interval 0 when unix_seconds equals genesis_time."""
-        assert Interval.from_unix_time(GENESIS_TIME, GENESIS_TIME) == Interval(0)
-
-    def test_one_second_after_genesis(self) -> None:
-        """One second equals 1000ms, yielding 1000 // 800 = 1 interval."""
-        result = Interval.from_unix_time(GENESIS_TIME + Uint64(1), GENESIS_TIME)
-        assert result == Interval(1)
-
-    def test_one_slot_after_genesis(self) -> None:
-        """One full slot (4s = 4000ms) yields 4000 // 800 = 5 intervals."""
-        result = Interval.from_unix_time(GENESIS_TIME + SECONDS_PER_SLOT, GENESIS_TIME)
-        expected = Interval(int(MILLISECONDS_PER_SLOT // MILLISECONDS_PER_INTERVAL))
-        assert result == expected
-
-    def test_sub_interval_rounds_down(self) -> None:
-        """Partial intervals are truncated by integer division.
-
-        At 0 full seconds past genesis the delta_ms is 0, so the result is 0.
-        The method only accepts whole-second Uint64 values, so sub-interval
-        precision only surfaces when 1000ms is not a multiple of the interval.
-        Here we verify the floor behaviour across the first few seconds.
-        """
-        # 0s -> 0ms -> 0 intervals
-        assert Interval.from_unix_time(GENESIS_TIME, GENESIS_TIME) == Interval(0)
-        # 1s -> 1000ms -> 1000 // 800 = 1 (remainder 200ms truncated)
-        assert Interval.from_unix_time(GENESIS_TIME + Uint64(1), GENESIS_TIME) == Interval(1)
-        # 2s -> 2000ms -> 2000 // 800 = 2 (remainder 400ms truncated)
-        assert Interval.from_unix_time(GENESIS_TIME + Uint64(2), GENESIS_TIME) == Interval(2)
-        # 3s -> 3000ms -> 3000 // 800 = 3 (remainder 600ms truncated)
-        assert Interval.from_unix_time(GENESIS_TIME + Uint64(3), GENESIS_TIME) == Interval(3)
-
-    def test_multiple_slots(self) -> None:
-        """Ten slots (40s = 40000ms) yields 40000 // 800 = 50 intervals."""
-        ten_slots = Uint64(10) * SECONDS_PER_SLOT
-        result = Interval.from_unix_time(GENESIS_TIME + ten_slots, GENESIS_TIME)
-        expected_intervals = (ten_slots * Uint64(1000)) // MILLISECONDS_PER_INTERVAL
-        assert result == Interval(expected_intervals)
-
-    def test_return_type_is_interval(self) -> None:
-        """Return value is an Interval instance, not a plain Uint64."""
-        result = Interval.from_unix_time(GENESIS_TIME + Uint64(5), GENESIS_TIME)
-        assert isinstance(result, Interval)
-
-    def test_large_time_delta(self) -> None:
-        """Works correctly with a large time delta (one day = 86400s)."""
-        one_day = Uint64(86400)
-        result = Interval.from_unix_time(GENESIS_TIME + one_day, GENESIS_TIME)
-        expected = Interval((one_day * Uint64(1000)) // MILLISECONDS_PER_INTERVAL)
-        assert result == expected
-
-    def test_genesis_time_zero(self) -> None:
-        """Works when genesis_time is zero."""
-        result = Interval.from_unix_time(Uint64(4), Uint64(0))
-        # 4s = 4000ms -> 4000 // 800 = 5
-        assert result == Interval(5)
-
-
-class TestIntervalFromSlot:
-    """Tests for Interval.from_slot()."""
-
-    def test_slot_zero(self) -> None:
-        """Slot 0 maps to interval 0."""
-        assert Interval.from_slot(Slot(0)) == Interval(0)
-
-    def test_slot_one(self) -> None:
-        """Slot 1 maps to interval equal to INTERVALS_PER_SLOT."""
-        assert Interval.from_slot(Slot(1)) == Interval(INTERVALS_PER_SLOT)
-
-    def test_slot_three(self) -> None:
-        """Slot 3 maps to interval 3 * INTERVALS_PER_SLOT."""
-        assert Interval.from_slot(Slot(3)) == Interval(3 * int(INTERVALS_PER_SLOT))
-
-    def test_multiple_slots(self) -> None:
-        """Each slot N maps to interval N * INTERVALS_PER_SLOT."""
-        for n in range(10):
-            slot = Slot(n)
-            assert Interval.from_slot(slot) == Interval(int(slot) * int(INTERVALS_PER_SLOT))
-
-    def test_return_type_is_interval(self) -> None:
-        """Return value is an Interval instance, not a plain Uint64."""
-        result = Interval.from_slot(Slot(2))
-        assert isinstance(result, Interval)
-
-    def test_consistent_with_from_unix_time(self) -> None:
-        """from_slot(N) equals from_unix_time at genesis + N * SECONDS_PER_SLOT."""
-        for n in range(5):
-            slot = Slot(n)
-            from_slot_result = Interval.from_slot(slot)
-            from_unix_result = Interval.from_unix_time(
-                GENESIS_TIME + Uint64(int(slot) * int(SECONDS_PER_SLOT)), GENESIS_TIME
-            )
-            assert from_slot_result == from_unix_result
+def clock_at(genesis_seconds: int, now_seconds: float) -> SlotClock:
+    """Build a SlotClock frozen at the given genesis and current time, both in seconds."""
+    return SlotClock(genesis_time=Uint64(genesis_seconds), time_fn=lambda: now_seconds)
 
 
 class TestCurrentSlot:
     """Tests for current_slot()."""
 
-    def test_at_genesis(self) -> None:
-        """Slot is 0 at exactly genesis time."""
-        genesis = Uint64(1700000000)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: float(genesis))
-        assert clock.current_slot() == Slot(0)
+    @pytest.mark.parametrize(
+        ("genesis", "now", "expected_slot"),
+        [
+            # Exactly at genesis.
+            (0, 0.0, 0),
+            # Just before the slot 1 boundary: a slot is 4s = 4000ms.
+            (0, 3.999, 0),
+            # Slot 1 begins exactly at 4s.
+            (0, 4.0, 1),
+            # 10s -> 10000ms // 4000 = slot 2.
+            (0, 10.0, 2),
+            # Non-zero genesis: 6s elapsed lands in slot 1.
+            (1000, 1006.0, 1),
+            # One second before genesis clamps to slot 0.
+            (1000, 999.0, 0),
+            # Large elapsed time stays exact.
+            (0, 4000.0, 1000),
+        ],
+    )
+    def test_floors_elapsed_time_to_whole_slots(
+        self, genesis: int, now: float, expected_slot: int
+    ) -> None:
+        """The slot number is elapsed milliseconds floored to whole slots."""
+        assert clock_at(genesis, now).current_slot() == Slot(expected_slot)
 
-    def test_before_genesis(self) -> None:
-        """Slot is 0 before genesis."""
-        genesis = Uint64(1700000000)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: float(genesis - Uint64(100)))
-        assert clock.current_slot() == Slot(0)
-
-    def test_progression(self) -> None:
-        """Slot increments every 4 seconds (SECONDS_PER_SLOT)."""
-        genesis = Uint64(1700000000)
-        for expected_slot in range(5):
-            slot_duration_seconds = Uint64(expected_slot) * SECONDS_PER_SLOT
-            time = genesis + slot_duration_seconds
-            clock = SlotClock(genesis_time=genesis, time_fn=lambda t=time: float(t))
-            assert clock.current_slot() == Slot(expected_slot)
-
-    def test_mid_slot(self) -> None:
-        """Slot remains constant within a slot."""
-        genesis = Uint64(1700000000)
-        slot_3_seconds = Uint64(3) * SECONDS_PER_SLOT
-        time = genesis + slot_3_seconds + Uint64(2)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: float(time))
-        assert clock.current_slot() == Slot(3)
-
-    def test_at_slot_boundary_minus_one(self) -> None:
-        """Slot does not increment until boundary is reached."""
-        genesis = Uint64(1700000000)
-        slot_duration_seconds = SECONDS_PER_SLOT
-        time = genesis + slot_duration_seconds - Uint64(1)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: float(time))
-        assert clock.current_slot() == Slot(0)
+    def test_constant_within_a_slot(self) -> None:
+        """The slot does not change between its first and last interval."""
+        assert clock_at(0, 8.0).current_slot() == Slot(2)
+        assert clock_at(0, 11.999).current_slot() == Slot(2)
 
 
 class TestCurrentInterval:
     """Tests for current_interval()."""
 
-    def test_at_slot_start(self) -> None:
-        """Interval is 0 at slot start."""
-        genesis = Uint64(1700000000)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: float(genesis))
-        assert clock.current_interval() == Interval(0)
-
-    def test_progression(self) -> None:
-        """Interval increments based on milliseconds since genesis.
-
-        With MILLISECONDS_PER_INTERVAL = 800:
-        - 0ms → interval 0
-        - 800ms → interval 1
-        - 1600ms → interval 2
-        - 2400ms → interval 3
-        - 3200ms → interval 4
-        """
-        genesis = Uint64(1700000000)
-        # Test with sub-second precision
-        expected_intervals = [
+    @pytest.mark.parametrize(
+        ("now", "expected_interval"),
+        [
+            # Each interval is 800ms; a slot holds 5 of them.
             (0.0, 0),  # 0ms -> interval 0
-            (0.8, 1),  # 800ms -> interval 1 (exactly at boundary)
-            (1.0, 1),  # 1000ms -> interval 1
+            (0.8, 1),  # 800ms exactly -> interval 1
+            (1.0, 1),  # 1000ms // 800 -> interval 1
             (1.6, 2),  # 1600ms -> interval 2
-            (2.0, 2),  # 2000ms -> interval 2
             (2.4, 3),  # 2400ms -> interval 3
-            (3.0, 3),  # 3000ms -> interval 3
-            (3.2, 4),  # 3200ms -> interval 4 (previously unreachable)
-            (3.9, 4),  # 3900ms -> interval 4
-        ]
-        for secs_after_genesis, expected_interval in expected_intervals:
-            time = float(genesis) + secs_after_genesis
-            clock = SlotClock(genesis_time=genesis, time_fn=lambda t=time: t)
-            assert clock.current_interval() == Interval(expected_interval), (
-                f"At {secs_after_genesis}s, expected interval {expected_interval}"
-            )
+            (3.2, 4),  # 3200ms -> interval 4, the last interval of the slot
+            (3.9, 4),  # 3900ms -> still interval 4
+            (4.0, 0),  # next slot resets the interval to 0
+            (4.8, 1),  # 800ms into slot 1 -> interval 1
+        ],
+    )
+    def test_position_within_slot(self, now: float, expected_interval: int) -> None:
+        """The interval is the sub-slot position floored to 800ms steps."""
+        assert clock_at(0, now).current_interval() == Interval(expected_interval)
 
-    def test_wraps_at_slot_boundary(self) -> None:
-        """Interval resets to 0 at next slot."""
-        genesis = Uint64(1700000000)
-        slot_duration_seconds = SECONDS_PER_SLOT
-        time = genesis + slot_duration_seconds
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: float(time))
-        assert clock.current_interval() == Interval(0)
+    @pytest.mark.parametrize(
+        ("now", "expected_interval"),
+        [
+            # Sub-second precision decides the interval at the boundary.
+            (0.75, 0),  # 750ms is still inside interval 0
+            (0.85, 1),  # 850ms has crossed into interval 1
+        ],
+    )
+    def test_sub_second_precision(self, now: float, expected_interval: int) -> None:
+        """Milliseconds below one second still move the interval."""
+        assert clock_at(0, now).current_interval() == Interval(expected_interval)
 
-    def test_before_genesis(self) -> None:
-        """Interval is 0 before genesis."""
-        genesis = Uint64(1700000000)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: float(genesis - Uint64(100)))
-        assert clock.current_interval() == Interval(0)
-
-    def test_last_interval_of_slot(self) -> None:
-        """Interval 4 at 3.2s (3200ms // 800 = 4)."""
-        genesis = Uint64(1700000000)
-        time = float(genesis) + 3.2
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: time)
-        assert clock.current_interval() == Interval(4)
-
-    def test_subsecond_precision(self) -> None:
-        """Verifies sub-second timing affects interval calculation."""
-        genesis = Uint64(1700000000)
-        # 750ms into genesis should give interval 0 (not 1)
-        clock_750ms = SlotClock(genesis_time=genesis, time_fn=lambda: float(genesis) + 0.75)
-        assert clock_750ms.current_interval() == Interval(0)
-
-        # 850ms into genesis should give interval 1
-        clock_850ms = SlotClock(genesis_time=genesis, time_fn=lambda: float(genesis) + 0.85)
-        assert clock_850ms.current_interval() == Interval(1)
+    def test_before_genesis_is_zero(self) -> None:
+        """The interval is 0 for any time before genesis."""
+        assert clock_at(1000, 900.0).current_interval() == Interval(0)
 
 
 class TestTotalIntervals:
     """Tests for total_intervals()."""
 
-    def test_counts_all_intervals(self) -> None:
-        """total_intervals counts all intervals since genesis with sub-second precision.
+    @pytest.mark.parametrize(
+        ("genesis", "now", "expected_total"),
+        [
+            # Counts every 800ms interval since genesis.
+            (0, 0.0, 0),  # 0ms
+            (0, 0.8, 1),  # 800ms
+            (0, 4.0, 5),  # one full slot is 5 intervals
+            (0, 14.4, 18),  # 14400ms // 800
+            (1000, 1004.0, 5),  # non-zero genesis, one slot elapsed
+        ],
+    )
+    def test_counts_intervals_since_genesis(
+        self, genesis: int, now: float, expected_total: int
+    ) -> None:
+        """The total is elapsed milliseconds floored to whole intervals."""
+        assert clock_at(genesis, now).total_intervals() == Interval(expected_total)
 
-        With MILLISECONDS_PER_INTERVAL = 800:
-        14.4 seconds = 14400ms = 18 intervals (14400 // 800)
-        """
-        genesis = Uint64(1700000000)
-        # 14.4 seconds = 14400ms = 18 intervals (14400 // 800)
-        time = float(genesis) + 14.4
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: time)
-        assert clock.total_intervals() == Interval(18)
+    def test_before_genesis_is_zero(self) -> None:
+        """The total is 0 for any time before genesis."""
+        assert clock_at(1000, 900.0).total_intervals() == Interval(0)
 
-    def test_before_genesis(self) -> None:
-        """total_intervals is 0 before genesis."""
-        genesis = Uint64(1700000000)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: float(genesis - Uint64(100)))
-        assert clock.total_intervals() == Interval(0)
+
+class TestCurrentTime:
+    """Tests for current_time()."""
+
+    @pytest.mark.parametrize(
+        ("now", "expected_seconds"),
+        [
+            # Whole seconds pass through unchanged.
+            (1_700_000_000.0, 1_700_000_000),
+            # Sub-second precision truncates toward zero.
+            (123.999, 123),
+            (0.0, 0),
+        ],
+    )
+    def test_truncates_to_whole_seconds(self, now: float, expected_seconds: int) -> None:
+        """The wall-clock reading floors to whole Unix seconds."""
+        assert clock_at(0, now).current_time() == Uint64(expected_seconds)
+
+    def test_default_time_source_is_wall_clock(self) -> None:
+        """Without an injected source the clock reads real wall-clock time."""
+        clock = SlotClock(genesis_time=Uint64(0))
+        # Real Unix time is well past the test's reference epoch.
+        assert int(clock.current_time()) > 1_700_000_000
+
+
+class TestSecondsUntilNextInterval:
+    """Tests for seconds_until_next_interval()."""
+
+    @pytest.mark.parametrize(
+        ("genesis", "now", "expected_seconds"),
+        [
+            # 250ms into an 800ms interval leaves 550ms.
+            (1000, 1000.25, 0.55),
+            # 500ms into the interval leaves 300ms.
+            (1000, 1000.5, 0.3),
+            # 1000ms past genesis sits 200ms into an interval, leaving 600ms.
+            (1000, 1001.0, 0.6),
+            # Exactly on a boundary returns a full interval, never zero.
+            (1000, 1000.0, 0.8),
+            # Before genesis returns the time remaining until genesis.
+            (1000, 900.0, 100.0),
+        ],
+    )
+    def test_time_until_boundary(self, genesis: int, now: float, expected_seconds: float) -> None:
+        """Returns the seconds remaining until the next interval boundary."""
+        result = clock_at(genesis, now).seconds_until_next_interval()
+        assert result == pytest.approx(expected_seconds, abs=1e-3)
+
+
+class TestSleepUntilNextInterval:
+    """Tests for sleep_until_next_interval()."""
+
+    @pytest.mark.parametrize(
+        ("genesis", "now", "expected_sleep"),
+        [
+            # 500ms into an 800ms interval sleeps the remaining 300ms.
+            (1000, 1000.5, 0.3),
+            # Called before genesis sleeps until genesis arrives.
+            (1000, 900.0, 100.0),
+        ],
+    )
+    async def test_sleeps_until_next_boundary(
+        self, genesis: int, now: float, expected_sleep: float
+    ) -> None:
+        """Awaits a sleep equal to the time until the next interval boundary."""
+        captured: list[float] = []
+
+        async def capture_sleep(duration: float) -> None:
+            captured.append(duration)
+
+        with patch("asyncio.sleep", new=capture_sleep):
+            await clock_at(genesis, now).sleep_until_next_interval()
+
+        assert captured == [pytest.approx(expected_sleep, abs=1e-3)]
+
+    async def test_skips_sleep_when_no_time_remains(self) -> None:
+        """The guard avoids a zero-length sleep when nothing is left to wait."""
+        clock = clock_at(1000, 1000.0)
+        slept = False
+
+        async def record_sleep(duration: float) -> None:
+            nonlocal slept
+            slept = True
+
+        # The boundary calculation never yields a non-positive wait on its own.
+        # Force one to exercise the guard that skips the sleep.
+        with (
+            patch.object(SlotClock, "seconds_until_next_interval", return_value=0.0),
+            patch("asyncio.sleep", new=record_sleep),
+        ):
+            await clock.sleep_until_next_interval()
+
+        assert slept is False
+
+
+class TestClockConsistency:
+    """Cross-method invariants that must hold at every instant."""
+
+    @pytest.mark.parametrize(
+        "milliseconds_since_genesis",
+        [
+            # genesis
+            0,
+            # first millisecond
+            1,
+            # last millisecond of interval 0
+            799,
+            # first interval boundary
+            800,
+            # just past the boundary
+            801,
+            # interval 2 boundary
+            1600,
+            # interval 4 boundary
+            3200,
+            # last millisecond of slot 0
+            3999,
+            # slot 1 boundary
+            4000,
+            # just into slot 1
+            4001,
+            # slot 2 boundary
+            8000,
+            # arbitrary mid-slot offset
+            12345,
+            # far from genesis
+            1_000_000,
+        ],
+    )
+    def test_slot_and_interval_decompose_total_intervals(
+        self, milliseconds_since_genesis: int
+    ) -> None:
+        """Slot and interval are the quotient and remainder of total intervals over a slot."""
+        clock = clock_at(0, milliseconds_since_genesis / 1000.0)
+        total = int(clock.total_intervals())
+
+        # The slot is total intervals divided by the intervals in one slot.
+        assert clock.current_slot() == Slot(total // int(INTERVALS_PER_SLOT))
+        # The interval is the leftover position inside the current slot.
+        assert clock.current_interval() == Interval(total % int(INTERVALS_PER_SLOT))
+        # The interval index always stays within a single slot.
+        assert 0 <= int(clock.current_interval()) < int(INTERVALS_PER_SLOT)
 
 
 class TestSlotClockImmutability:
     """Tests for SlotClock immutability."""
 
     def test_is_frozen(self) -> None:
-        """SlotClock is immutable."""
-        clock = SlotClock(genesis_time=Uint64(1700000000))
+        """The clock is immutable, so reassigning a field raises."""
+        clock = SlotClock(genesis_time=Uint64(1_700_000_000))
         with pytest.raises(AttributeError):
-            clock.genesis_time = Uint64(1700000001)  # type: ignore[misc]
-
-
-class TestCurrentTime:
-    """Tests for current_time()."""
-
-    def test_returns_uint64(self) -> None:
-        """current_time returns Uint64."""
-        genesis = Uint64(1700000000)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: 1700000005.5)
-        result = clock.current_time()
-        assert isinstance(result, Uint64)
-        assert result == Uint64(1700000005)
-
-    def test_truncates_to_integer(self) -> None:
-        """current_time truncates float to integer seconds."""
-        genesis = Uint64(0)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: 123.999)
-        assert clock.current_time() == Uint64(123)
-
-    def test_at_genesis(self) -> None:
-        """current_time returns genesis time at genesis."""
-        genesis = Uint64(1700000000)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: float(genesis))
-        assert clock.current_time() == genesis
-
-
-class TestSecondsUntilNextInterval:
-    """Tests for seconds_until_next_interval()."""
-
-    def test_mid_interval(self) -> None:
-        """Returns time until next boundary when mid-interval."""
-        genesis = Uint64(1000)
-        interval_seconds = float(MILLISECONDS_PER_INTERVAL) / 1000.0
-        # Half way into first interval.
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: 1000.0 + interval_seconds / 2)
-        result = clock.seconds_until_next_interval()
-        assert abs(result - interval_seconds / 2) < 0.01
-
-    def test_at_interval_boundary(self) -> None:
-        """Returns one full interval when exactly at boundary.
-
-        With MILLISECONDS_PER_INTERVAL = 800:
-        At 1s = 1000ms, time_into_interval = 1000 % 800 = 200ms
-        At 800ms exactly (0.8s), time_into_interval = 0
-        But using fractional seconds has FP precision issues.
-
-        Instead test at 1s: should return 800 - 200 = 600ms = 0.6s
-        """
-        genesis = Uint64(1000)
-        # At 1 second after genesis: 1000ms % 800 = 200ms into interval
-        # Time until next = 800 - 200 = 600ms = 0.6s
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: 1001.0)
-        result = clock.seconds_until_next_interval()
-        assert abs(result - 0.6) < 0.01
-
-    def test_before_genesis(self) -> None:
-        """Returns time until genesis when before genesis."""
-        genesis = Uint64(1000)
-        # 100 seconds before genesis.
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: 900.0)
-        result = clock.seconds_until_next_interval()
-        assert abs(result - 100.0) < 0.001
-
-    def test_at_genesis(self) -> None:
-        """Returns one full interval at exactly genesis."""
-        genesis = Uint64(1000)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: 1000.0)
-        result = clock.seconds_until_next_interval()
-        assert abs(result - (float(MILLISECONDS_PER_INTERVAL) / 1000.0)) < 0.001
-
-    def test_fractional_precision(self) -> None:
-        """Preserves fractional seconds in calculation."""
-        genesis = Uint64(1000)
-        # 0.123 seconds into interval.
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: 1000.123)
-        result = clock.seconds_until_next_interval()
-        expected = (float(MILLISECONDS_PER_INTERVAL) / 1000.0) - 0.123
-        assert abs(result - expected) < 0.001
+            clock.genesis_time = Uint64(1_700_000_001)  # type: ignore[misc]
 
 
 class TestReturnTypes:
-    """Tests for proper return types."""
+    """Tests for domain-specific return types."""
 
-    def test_types_are_correct(self) -> None:
-        """All return types are domain-specific."""
-        genesis = Uint64(1700000000)
-        clock = SlotClock(genesis_time=genesis, time_fn=lambda: float(genesis))
-
+    def test_methods_return_domain_types(self) -> None:
+        """Each accessor returns its narrow domain type, not a plain integer or float."""
+        clock = clock_at(1_700_000_000, 1_700_000_005.5)
         assert isinstance(clock.current_slot(), Slot)
-        assert isinstance(clock.current_interval(), Uint64)
-        assert isinstance(clock.total_intervals(), Uint64)
+        assert isinstance(clock.current_interval(), Interval)
+        assert isinstance(clock.total_intervals(), Interval)
         assert isinstance(clock.current_time(), Uint64)
         assert isinstance(clock.seconds_until_next_interval(), float)

--- a/tests/lean_spec/node/chain/test_clock.py
+++ b/tests/lean_spec/node/chain/test_clock.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import pytest
 
 from lean_spec.node.chain import Interval, SlotClock
-from lean_spec.node.chain.config import (
+from lean_spec.spec.forks import Slot
+from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MILLISECONDS_PER_INTERVAL,
     MILLISECONDS_PER_SLOT,
     SECONDS_PER_SLOT,
 )
-from lean_spec.spec.forks import Slot
 from lean_spec.spec.ssz import Uint64
 
 GENESIS_TIME = Uint64(1_700_000_000)

--- a/tests/lean_spec/node/chain/test_service.py
+++ b/tests/lean_spec/node/chain/test_service.py
@@ -6,9 +6,8 @@ from dataclasses import dataclass, field
 from unittest.mock import patch
 
 from lean_spec.node.chain import SlotClock
-from lean_spec.node.chain.clock import Interval
 from lean_spec.node.chain.service import ChainService
-from lean_spec.spec.forks import Slot
+from lean_spec.spec.forks import Interval, Slot
 from lean_spec.spec.forks.lstar.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.spec.forks.lstar.containers import SignedAggregatedAttestation
 from lean_spec.spec.ssz import ZERO_HASH, Bytes32, Uint64

--- a/tests/lean_spec/node/chain/test_service.py
+++ b/tests/lean_spec/node/chain/test_service.py
@@ -7,9 +7,9 @@ from unittest.mock import patch
 
 from lean_spec.node.chain import SlotClock
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.node.chain.service import ChainService
 from lean_spec.spec.forks import Slot
+from lean_spec.spec.forks.lstar.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.spec.forks.lstar.containers import SignedAggregatedAttestation
 from lean_spec.spec.ssz import ZERO_HASH, Bytes32, Uint64
 from tests.lean_spec.helpers.mocks import StoreInterceptingSpec

--- a/tests/lean_spec/node/test_node.py
+++ b/tests/lean_spec/node/test_node.py
@@ -11,13 +11,12 @@ import pytest
 from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.node.api import ApiServerConfig
-from lean_spec.node.chain.clock import Interval
 from lean_spec.node.node import Node, NodeConfig
 from lean_spec.node.storage.sqlite import SQLiteDatabase
 from lean_spec.node.validator import ValidatorRegistry
 from lean_spec.node.validator.registry import ValidatorEntry
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
+from lean_spec.spec.forks import Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import State
 from lean_spec.spec.forks.lstar.config import (
     ATTESTATION_COMMITTEE_COUNT,

--- a/tests/lean_spec/node/test_node.py
+++ b/tests/lean_spec/node/test_node.py
@@ -12,12 +12,6 @@ from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.node.api import ApiServerConfig
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import (
-    ATTESTATION_COMMITTEE_COUNT,
-    HISTORICAL_ROOTS_LIMIT,
-    INTERVALS_PER_SLOT,
-    SECONDS_PER_SLOT,
-)
 from lean_spec.node.node import Node, NodeConfig
 from lean_spec.node.storage.sqlite import SQLiteDatabase
 from lean_spec.node.validator import ValidatorRegistry
@@ -25,6 +19,12 @@ from lean_spec.node.validator.registry import ValidatorEntry
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import State
+from lean_spec.spec.forks.lstar.config import (
+    ATTESTATION_COMMITTEE_COUNT,
+    HISTORICAL_ROOTS_LIMIT,
+    INTERVALS_PER_SLOT,
+    SECONDS_PER_SLOT,
+)
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestations,
     Block,

--- a/tests/lean_spec/node/validator/test_service.py
+++ b/tests/lean_spec/node/validator/test_service.py
@@ -8,7 +8,6 @@ import pytest
 from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.node.chain.clock import SlotClock
-from lean_spec.node.chain.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.node.sync.block_cache import BlockCache
 from lean_spec.node.sync.peer_manager import PeerManager
 from lean_spec.node.sync.service import SyncService
@@ -19,6 +18,7 @@ from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.crypto.xmss import TARGET_SIGNATURE_SCHEME
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
+from lean_spec.spec.forks.lstar.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.spec.forks.lstar.containers import (
     AttestationData,
     Block,

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/conftest.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/conftest.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from lean_spec.node.chain.clock import Interval
+from lean_spec.spec.forks import Interval
 from lean_spec.spec.forks.lstar import Store
 from tests.lean_spec.helpers import TEST_VALIDATOR_INDEX, make_store
 

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py
@@ -6,10 +6,10 @@ import pytest
 from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import JUSTIFICATION_LOOKBACK_SLOTS
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
+from lean_spec.spec.forks.lstar.config import JUSTIFICATION_LOOKBACK_SLOTS
 from lean_spec.spec.forks.lstar.containers import (
     Attestation,
     AttestationData,

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_attestation_target.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import pytest
 from consensus_testing.keys import XmssKeyManager
 
-from lean_spec.node.chain.clock import Interval
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
+from lean_spec.spec.forks import Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
 from lean_spec.spec.forks.lstar.config import JUSTIFICATION_LOOKBACK_SLOTS
 from lean_spec.spec.forks.lstar.containers import (

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_block_production_justification_gap.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_block_production_justification_gap.py
@@ -6,9 +6,8 @@ from consensus_testing.keys import XmssKeyManager
 from consensus_testing.test_types.aggregated_attestation_spec import AggregatedAttestationSpec
 from consensus_testing.test_types.block_spec import BlockSpec
 
-from lean_spec.node.chain.clock import Interval
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
+from lean_spec.spec.forks import Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
 from lean_spec.spec.forks.lstar.containers import Block
 from lean_spec.spec.forks.lstar.spec import LstarSpec

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_store_attestations.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_store_attestations.py
@@ -6,10 +6,10 @@ import pytest
 from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import INTERVALS_PER_SLOT
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import AttestationSignatureEntry
+from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT
 from lean_spec.spec.forks.lstar.containers import (
     AttestationData,
     SignedAggregatedAttestation,

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_store_attestations.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_store_attestations.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import pytest
 from consensus_testing.keys import XmssKeyManager
 
-from lean_spec.node.chain.clock import Interval
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
+from lean_spec.spec.forks import Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import AttestationSignatureEntry
 from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT
 from lean_spec.spec.forks.lstar.containers import (

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_time_management.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_time_management.py
@@ -3,15 +3,15 @@
 from hypothesis import given, settings, strategies as st
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import (
+from lean_spec.spec.crypto.merkleization import hash_tree_root
+from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar import Store
+from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,
     MILLISECONDS_PER_INTERVAL,
     MILLISECONDS_PER_SLOT,
     SECONDS_PER_SLOT,
 )
-from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Slot, ValidatorIndex
-from lean_spec.spec.forks.lstar import Store
 from lean_spec.spec.forks.lstar.containers import Block, Validators
 from lean_spec.spec.forks.lstar.spec import LstarSpec
 from lean_spec.spec.ssz import Bytes32, Uint64

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_time_management.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_time_management.py
@@ -2,9 +2,8 @@
 
 from hypothesis import given, settings, strategies as st
 
-from lean_spec.node.chain.clock import Interval
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
 from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_validate_attestation.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_validate_attestation.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import pytest
 
 from lean_spec.node.chain.clock import Interval
-from lean_spec.node.chain.config import GOSSIP_DISPARITY_INTERVALS, INTERVALS_PER_SLOT
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
+from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS, INTERVALS_PER_SLOT
 from lean_spec.spec.forks.lstar.containers import (
     Attestation,
     AttestationData,

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_validate_attestation.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_validate_attestation.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from lean_spec.node.chain.clock import Interval
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
+from lean_spec.spec.forks import Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
 from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS, INTERVALS_PER_SLOT
 from lean_spec.spec.forks.lstar.containers import (

--- a/tests/lean_spec/spec/forks/lstar/forkchoice/test_validator.py
+++ b/tests/lean_spec/spec/forks/lstar/forkchoice/test_validator.py
@@ -3,9 +3,8 @@
 import pytest
 from consensus_testing.keys import XmssKeyManager
 
-from lean_spec.node.chain.clock import Interval
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
+from lean_spec.spec.forks import Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import AttestationSignatureEntry, Store
 from lean_spec.spec.forks.lstar.containers import (
     Attestation,

--- a/tests/lean_spec/spec/forks/lstar/test_interval.py
+++ b/tests/lean_spec/spec/forks/lstar/test_interval.py
@@ -1,0 +1,41 @@
+"""Tests for the Interval time unit."""
+
+from __future__ import annotations
+
+import pytest
+
+from lean_spec.spec.forks import Interval, Slot
+from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT
+
+
+class TestIntervalFromSlot:
+    """Tests for Interval.from_slot()."""
+
+    @pytest.mark.parametrize(
+        ("slot", "expected_interval"),
+        [
+            # Genesis slot starts at interval 0.
+            (0, 0),
+            # Each slot spans INTERVALS_PER_SLOT (5) intervals.
+            (1, 5),
+            (2, 10),
+            (3, 15),
+            (10, 50),
+            (100, 500),
+            # Large slot stays exact: no overflow, no rounding.
+            (1_000_000, 5_000_000),
+        ],
+    )
+    def test_maps_slot_to_its_starting_interval(self, slot: int, expected_interval: int) -> None:
+        """A slot maps to the interval count at its first interval."""
+        assert Interval.from_slot(Slot(slot)) == Interval(expected_interval)
+
+    @pytest.mark.parametrize("slot", [0, 1, 7, 42, 1000])
+    def test_advancing_one_slot_adds_one_slot_of_intervals(self, slot: int) -> None:
+        """Advancing a single slot adds exactly INTERVALS_PER_SLOT intervals."""
+        step = Interval.from_slot(Slot(slot + 1)) - Interval.from_slot(Slot(slot))
+        assert step == Interval(INTERVALS_PER_SLOT)
+
+    def test_return_type_is_interval(self) -> None:
+        """Return value is an Interval instance, not a plain Uint64."""
+        assert isinstance(Interval.from_slot(Slot(2)), Interval)


### PR DESCRIPTION
## Summary

`Interval` is the type of the store's `time` field, yet it lived in the node-layer clock module. That forced the consensus spec (`spec.py`, `containers.py`) to import `Interval` *from* the node layer — an inverted dependency that was papered over with `# noqa: F821 # ty: ignore[unresolved-reference]` suppressions on the `Slot` annotations in `clock.py`.

This PR relocates `Interval` to where it belongs and cleans up `SlotClock`, removing the suppressions entirely.

## Changes

- **Relocate `Interval`** to `src/lean_spec/spec/forks/lstar/interval.py`, next to the `config` and `slot` primitives it depends on. `clock.py` now imports `Slot` and `Interval` normally at module top — no `noqa`, no `ty: ignore`.
- **Delete the test-only `Interval.from_unix_time`.** Its only callers were the fork-choice fixture tick path and the slot-clock conformance fixture; both now go through `SlotClock.total_intervals`, the node-layer owner of wall-clock→interval conversion. Generated test vectors are unchanged (verified bit-identical).
- **Derive `current_slot` from the millisecond base** and drop the redundant seconds helper, removing a latent precision asymmetry between the slot and interval paths.
- **Mirror tests to source.** `Interval` tests move to `tests/lean_spec/spec/forks/lstar/test_interval.py`; `test_clock.py` keeps only `SlotClock`. Adds a `CLAUDE.md` rule requiring the test tree to mirror the source tree.
- **Rewrite the tests as parametrized suites** with cross-method consistency invariants (`current_slot == total_intervals // INTERVALS_PER_SLOT`, etc.), reaching 100% line and branch coverage for both modules.

> Note: this branch is stacked on the unmerged `refactor: move chain config to lstar fork spec` commit, which the new `clock.py` import path depends on; it appears in the diff.

## Testing

- `just check` passes (ruff, format, ty, codespell, mdformat).
- 66 unit tests pass; `interval.py` and `clock.py` at 100% coverage.
- Slot-clock conformance fixtures regenerate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)