### PR TITLE
refactor(xmss): hoist 0x-hex JSON serialization into a shared mixin

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/containers.py
+++ b/src/lean_spec/spec/crypto/xmss/containers.py
@@ -2,7 +2,7 @@
 
 from typing import override
 
-from pydantic import field_serializer, model_serializer
+from pydantic import model_serializer
 
 from lean_spec.base import StrictBaseModel
 from lean_spec.spec.crypto.xmss.constants import TARGET_CONFIG
@@ -20,7 +20,16 @@ from lean_spec.spec.ssz import Uint64
 from lean_spec.spec.ssz.container import Container
 
 
-class PublicKey(Container):
+class HexSerializedContainer(Container):
+    """Container that serializes to a 0x-prefixed hex SSZ payload in JSON mode."""
+
+    @model_serializer(mode="plain", when_used="json")
+    def _serialize_as_hex(self) -> str:
+        """Serialize as a 0x-prefixed hex string for JSON output."""
+        return "0x" + self.encode_bytes().hex()
+
+
+class PublicKey(HexSerializedContainer):
     """Long-lived public component of an XMSS key pair."""
 
     root: HashDigestVector
@@ -30,7 +39,7 @@ class PublicKey(Container):
     """Public personalization tag mixed into every hash."""
 
 
-class Signature(Container):
+class Signature(HexSerializedContainer):
     """A single XMSS signature for one slot and message under one public key."""
 
     model_config = Container.model_config | {"frozen": True}
@@ -56,17 +65,12 @@ class Signature(Container):
         """Fixed byte length of an SSZ-encoded signature."""
         return TARGET_CONFIG.SIGNATURE_LENGTH_BYTES
 
-    @model_serializer(mode="plain", when_used="json")
-    def _serialize_as_bytes(self) -> str:
-        """Serialize as a 0x-prefixed hex string for JSON output."""
-        return "0x" + self.encode_bytes().hex()
-
     def __hash__(self) -> int:
         """Content-deterministic hash via SSZ encoding."""
         return hash(self.encode_bytes())
 
 
-class SecretKey(Container):
+class SecretKey(HexSerializedContainer):
     """Private state of an XMSS key pair.
 
     Must be kept confidential.
@@ -140,11 +144,6 @@ class KeyPair(StrictBaseModel):
 
     secret_key: SecretKey
     """Secret key."""
-
-    @field_serializer("public_key", "secret_key", when_used="json")
-    def _encode_hex(self, value: PublicKey | SecretKey) -> str:
-        """Emit each half as plain hex in JSON mode only."""
-        return value.encode_bytes().hex()
 
 
 class ValidatorKeyPair(StrictBaseModel):

--- a/tests/lean_spec/spec/crypto/xmss/test_containers.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_containers.py
@@ -34,7 +34,7 @@ def keypair_b() -> KeyPair:
 
 @pytest.fixture(scope="module")
 def hex_dict(keypair_a: KeyPair, keypair_b: KeyPair) -> dict[str, dict[str, str]]:
-    """Nested-hex JSON mapping that mirrors the on-disk format."""
+    """Nested plain-hex mapping accepted as a JSON-load input shape."""
     return {
         "attestation_keypair": {
             "public_key": keypair_a.public_key.encode_bytes().hex(),
@@ -95,12 +95,19 @@ def test_validator_accepts_mixed_inputs(keypair_a: KeyPair, keypair_b: KeyPair) 
     assert vkp.proposal_keypair == keypair_b
 
 
-def test_json_dump_emits_nested_hex_shape(
-    keypair_a: KeyPair, keypair_b: KeyPair, hex_dict: dict[str, dict[str, str]]
-) -> None:
-    """JSON dump produces the on-disk nested-hex layout."""
+def test_json_dump_emits_nested_hex_shape(keypair_a: KeyPair, keypair_b: KeyPair) -> None:
+    """JSON dump emits each key half as a 0x-prefixed hex string."""
     vkp = ValidatorKeyPair(attestation_keypair=keypair_a, proposal_keypair=keypair_b)
-    assert json.loads(vkp.model_dump_json()) == hex_dict
+    assert json.loads(vkp.model_dump_json()) == {
+        "attestation_keypair": {
+            "public_key": "0x" + keypair_a.public_key.encode_bytes().hex(),
+            "secret_key": "0x" + keypair_a.secret_key.encode_bytes().hex(),
+        },
+        "proposal_keypair": {
+            "public_key": "0x" + keypair_b.public_key.encode_bytes().hex(),
+            "secret_key": "0x" + keypair_b.secret_key.encode_bytes().hex(),
+        },
+    }
 
 
 def test_json_roundtrip_preserves_equality(keypair_a: KeyPair, keypair_b: KeyPair) -> None:


### PR DESCRIPTION
## Summary

Simplifies XMSS container JSON serialization by hoisting the repeated `0x`-prefixed hex serializer into a single shared mixin.

- Introduces `HexSerializedContainer`, a `Container` subclass holding the lone `@model_serializer(mode="plain", when_used="json")` that emits `"0x" + encode_bytes().hex()`.
- `PublicKey`, `SecretKey`, and `Signature` now inherit it.
- Deletes the hand-rolled per-field `field_serializer` on `KeyPair` and the duplicate serializer that previously lived on `Signature`.

The base container already decodes such hex strings on the way in (its existing wrap-validator accepts hex with or without a `0x` prefix), so encode/decode roundtrips are unchanged.

## Why a mixin and not the base `Container`

`mode="plain"` *replaces* a model's entire JSON representation. Putting it on the base `Container` would force all 21 subclasses (`Block`, `State`, `Checkpoint`, `Attestation`, ...) to collapse from structured objects into opaque hex blobs, breaking the human-readable fixture format and the state-transition / fork-choice fixtures. Hex is only the right shape for the opaque cryptographic blobs, so it stays opt-in.

## Behavior change

Key halves (`public_key` / `secret_key`) now serialize as `0x`-prefixed hex; previously `KeyPair` emitted plain hex. Plain hex is still accepted on input.

Generated SSZ test vectors for `PublicKey` now emit a `0x` hex string for their `value` field instead of a nested `{root, parameter}` object — consistent with how `Signature` already behaved. Regenerate fixtures with `uv run fill` and review that diff.

## Testing

- `uv run pytest tests/lean_spec/spec/crypto/xmss/` → 196 passed
- `just check` → passes (lint, format, ty, codespell, mdformat, lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)