### PR TITLE
fix: enforce attestation checkpoint ancestry

### DIFF
--- a/packages/testing/src/consensus_testing/rejection.py
+++ b/packages/testing/src/consensus_testing/rejection.py
@@ -28,6 +28,14 @@ _REASON_BY_MESSAGE_FRAGMENT: list[tuple[str, RejectionReason]] = [
     ("Source checkpoint slot mismatch", RejectionReason.SOURCE_SLOT_MISMATCH),
     ("Target checkpoint slot mismatch", RejectionReason.TARGET_SLOT_MISMATCH),
     ("Head checkpoint slot mismatch", RejectionReason.HEAD_SLOT_MISMATCH),
+    (
+        "Source checkpoint must be ancestor of target",
+        RejectionReason.SOURCE_NOT_ANCESTOR_OF_TARGET,
+    ),
+    (
+        "Target checkpoint must be ancestor of head",
+        RejectionReason.TARGET_NOT_ANCESTOR_OF_HEAD,
+    ),
     ("Attestation too far in future", RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE),
     ("not found in state", RejectionReason.VALIDATOR_NOT_IN_STATE),
     ("Validator index out of range", RejectionReason.VALIDATOR_INDEX_OUT_OF_RANGE),

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -36,6 +36,32 @@ from lean_spec.spec.ssz import Bytes32, Uint64
 class ForkChoiceMixin(LstarSpecBase):
     """Fork choice and store maintenance for the lstar fork."""
 
+    def _checkpoint_is_ancestor(
+        self,
+        store: LstarStore,
+        ancestor: Checkpoint,
+        descendant: Checkpoint,
+    ) -> bool:
+        """
+        Return whether the ancestor checkpoint lies on the descendant's parent chain.
+
+        Walks parent links from the descendant down to the ancestor's slot.
+        Conservative: a skipped slot or a block missing from the store yields False.
+        """
+        if ancestor.slot > descendant.slot:
+            return False
+
+        current_root = descendant.root
+        while current_root in store.blocks:
+            current_block = store.blocks[current_root]
+            if current_block.slot == ancestor.slot:
+                return current_root == ancestor.root
+            if current_block.slot < ancestor.slot:
+                return False
+            current_root = current_block.parent_root
+
+        return False
+
     def create_store(
         self,
         state: SpecStateType,
@@ -143,7 +169,8 @@ class ForkChoiceMixin(LstarSpecBase):
             2. A vote cannot span backwards in time (source > target).
             3. The head must be at least as recent as source and target.
             4. Checkpoint slots must match the actual block slots.
-            5. The vote's slot must have started locally (a small disparity margin is allowed).
+            5. Source, target, and head must lie on one parent chain.
+            6. The vote's slot must have started locally (a small disparity margin is allowed).
 
         Raises:
             AssertionError: If attestation fails validation.
@@ -185,6 +212,17 @@ class ForkChoiceMixin(LstarSpecBase):
         assert source_block.slot == source_checkpoint.slot, "Source checkpoint slot mismatch"
         assert target_block.slot == target_checkpoint.slot, "Target checkpoint slot mismatch"
         assert head_block.slot == head_checkpoint.slot, "Head checkpoint slot mismatch"
+
+        # Ancestry Check
+        #
+        # Why: fork-choice weight accrues to every ancestor of the attested head.
+        # A sibling head would steer that weight onto a non-canonical branch.
+        assert self._checkpoint_is_ancestor(store, source_checkpoint, target_checkpoint), (
+            "Source checkpoint must be ancestor of target"
+        )
+        assert self._checkpoint_is_ancestor(store, target_checkpoint, head_checkpoint), (
+            "Target checkpoint must be ancestor of head"
+        )
 
         # Time Check
         #

--- a/src/lean_spec/spec/forks/lstar/rejection_reason.py
+++ b/src/lean_spec/spec/forks/lstar/rejection_reason.py
@@ -70,6 +70,12 @@ class RejectionReason(StrEnum):
     HEAD_SLOT_MISMATCH = "HEAD_SLOT_MISMATCH"
     """The head checkpoint slot disagrees with the referenced block."""
 
+    SOURCE_NOT_ANCESTOR_OF_TARGET = "SOURCE_NOT_ANCESTOR_OF_TARGET"
+    """The attestation source checkpoint is not an ancestor of its target."""
+
+    TARGET_NOT_ANCESTOR_OF_HEAD = "TARGET_NOT_ANCESTOR_OF_HEAD"
+    """The attestation target checkpoint is not an ancestor of its head."""
+
     ATTESTATION_TOO_FAR_IN_FUTURE = "ATTESTATION_TOO_FAR_IN_FUTURE"
     """The attestation slot is beyond the store's acceptance horizon."""
 

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -32,7 +32,7 @@ def attestation_data_matches_chain(
     historical_block_hashes: Sequence[Bytes32],
 ) -> bool:
     """
-    Check that source and target checkpoints point to blocks on a chain.
+    Check that attestation checkpoints point to blocks on a chain.
 
     Args:
         attestation_data: The attestation being validated.
@@ -40,15 +40,19 @@ def attestation_data_matches_chain(
             Empty slots carry the zero hash.
 
     Returns:
-        True when both checkpoint roots match the chain at their slot.
-        False when either root is the zero hash.
-        False when either checkpoint slot is past the end of the chain view.
+        True when all checkpoint roots match the chain at their slot.
+        False when any root is the zero hash.
+        False when any checkpoint slot is past the end of the chain view.
     """
     # Reject zero-hash checkpoints up front.
     #
     # Empty slots carry the zero hash on the chain.
     # A vote whose recorded root equals the zero hash is meaningless.
-    if attestation_data.source.root == ZERO_HASH or attestation_data.target.root == ZERO_HASH:
+    if (
+        attestation_data.source.root == ZERO_HASH
+        or attestation_data.target.root == ZERO_HASH
+        or attestation_data.head.root == ZERO_HASH
+    ):
         return False
 
     # Reject checkpoints whose slot is beyond the chain view.
@@ -56,15 +60,19 @@ def attestation_data_matches_chain(
     # Without this guard, indexed access raises IndexError.
     source_slot = int(attestation_data.source.slot)
     target_slot = int(attestation_data.target.slot)
+    head_slot = int(attestation_data.head.slot)
     if source_slot >= len(historical_block_hashes):
         return False
     if target_slot >= len(historical_block_hashes):
         return False
+    if head_slot >= len(historical_block_hashes):
+        return False
 
-    # Both checkpoint roots must match the chain at their slot.
+    # All checkpoint roots must match the chain at their slot.
     return (
         attestation_data.source.root == historical_block_hashes[source_slot]
         and attestation_data.target.root == historical_block_hashes[target_slot]
+        and attestation_data.head.root == historical_block_hashes[head_slot]
     )
 
 

--- a/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
@@ -790,3 +790,105 @@ def test_attestation_unknown_source_block_rejected(
             ),
         ],
     )
+
+
+def test_attestation_head_on_sibling_fork_rejected(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Attestation whose head sits on a sibling fork of the target is rejected.
+
+    Scenario
+    --------
+    Build a common base at slot 1.
+    Create two competing blocks from that same base at slots 2 and 3.
+    Distinct slots give the siblings distinct roots so they never collide.
+    Vote with source on the base, target on the slot-2 block, and head on the
+    slot-3 block.
+    Every slot and availability check passes, yet target and head diverge.
+
+    Expected:
+        - Validation fails with "Target checkpoint must be ancestor of head"
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="base"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), parent_label="base", label="fork_left"),
+                checks=StoreChecks(head_slot=Slot(2)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(3), parent_label="base", label="fork_right"),
+            ),
+            AttestationStep(
+                attestation=GossipAttestationSpec(
+                    validator_index=ValidatorIndex(1),
+                    slot=Slot(3),
+                    target_slot=Slot(2),
+                    target_root_label="fork_left",
+                    head_slot=Slot(3),
+                    head_root_label="fork_right",
+                    source_root_label="base",
+                    valid_signature=False,
+                ),
+                valid=False,
+                expected_error="Target checkpoint must be ancestor of head",
+            ),
+        ],
+    )
+
+
+def test_attestation_source_on_sibling_fork_rejected(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Attestation whose source sits on a sibling fork of the target is rejected.
+
+    Scenario
+    --------
+    Build a common base at slot 1.
+    Create a slot-2 block on one branch from that base.
+    Create a slot-3 block on a competing branch from that same base.
+    Distinct slots give the branches distinct roots so they never collide.
+    Extend the competing branch with a slot-4 block.
+    Vote with source on the abandoned slot-2 block, target on the slot-4 block,
+    and head on that same slot-4 block.
+    Source slot precedes the target slot, yet source lies off the target chain.
+
+    Expected:
+        - Validation fails with "Source checkpoint must be ancestor of target"
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="base"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), parent_label="base", label="fork_left"),
+                checks=StoreChecks(head_slot=Slot(2)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(3), parent_label="base", label="fork_right"),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(4), parent_label="fork_right", label="fork_right_head"),
+            ),
+            AttestationStep(
+                attestation=GossipAttestationSpec(
+                    validator_index=ValidatorIndex(1),
+                    slot=Slot(4),
+                    target_slot=Slot(4),
+                    target_root_label="fork_right_head",
+                    head_root_label="fork_right_head",
+                    source_root_label="fork_left",
+                    valid_signature=False,
+                ),
+                valid=False,
+                expected_error="Source checkpoint must be ancestor of target",
+            ),
+        ],
+    )

--- a/tests/consensus/lstar/state_transition/test_justification.py
+++ b/tests/consensus/lstar/state_transition/test_justification.py
@@ -800,6 +800,64 @@ def test_attestation_with_target_root_not_in_historical_hashes_is_skipped(
     )
 
 
+def test_attestation_with_off_canonical_head_does_not_justify_target(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Test that a vote with an off-canonical head cannot justify its target.
+
+    Scenario
+    --------
+    1. Start from genesis with 4 validators
+    2. Process block_1 at slot 1 and block_2 at slot 2 on the canonical chain
+    3. Force a supermajority attestation into block_2 whose source and target
+       match the canonical chain but whose head points to a sibling root at a
+       slot that already holds a canonical block
+
+    Expected Behavior
+    -----------------
+    1. The source and target roots match the canonical chain at their slots
+    2. The head root does not match the canonical block at its slot
+    3. The whole vote is skipped before any tally is recorded
+    4. latest_justified_slot stays at genesis with no pending votes
+    """
+    state_transition_test(
+        blocks=[
+            BlockSpec(slot=Slot(1), label="block_1"),
+            BlockSpec(
+                slot=Slot(2),
+                parent_label="block_1",
+                forced_attestations=[
+                    # Source genesis and target block_1 both sit on the
+                    # canonical chain.
+                    # The head root is a sibling at slot 1, where the canonical
+                    # block is block_1.
+                    # Threshold: 3 of 4 would justify slot 1 if the head matched.
+                    AggregatedAttestationSpec(
+                        validator_indices=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(2),
+                        target_slot=Slot(1),
+                        target_root_label="block_1",
+                        head_root=Bytes32(b"\x99" * 32),
+                        head_slot=Slot(1),
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(2),
+            latest_justified_slot=Slot(0),
+            latest_finalized_slot=Slot(0),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
+        ),
+    )
+
+
 def test_justification_clears_only_the_resolved_target_votes(
     state_transition_test: StateTransitionTestFiller,
 ) -> None:

--- a/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
+++ b/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
@@ -564,6 +564,118 @@ class TestValidateAttestationHeadChecks:
         spec.validate_attestation(store, attestation.data)
 
 
+def _add_known_block(
+    store: Store,
+    slot: Slot,
+    proposer_index: ValidatorIndex,
+    parent_root: Bytes32,
+    state_seed: int,
+) -> Bytes32:
+    """Insert a block at the given slot into the store, reusing the justified state."""
+    block = make_signed_block(
+        slot=slot,
+        proposer_index=proposer_index,
+        parent_root=parent_root,
+        state_root=make_bytes32(state_seed),
+    ).block
+    block_root = hash_tree_root(block)
+    store.blocks = {**store.blocks, block_root: block}
+    store.states = {**store.states, block_root: store.states[store.latest_justified.root]}
+    return block_root
+
+
+class TestValidateAttestationAncestryChecks:
+    """Source, target, and head must lie on one parent chain."""
+
+    def test_proper_ancestor_chain_passes(
+        self,
+        spec: LstarSpec,
+        observer_store: Store,
+    ) -> None:
+        """A vote whose checkpoints form one chain across three slots validates."""
+        store = observer_store
+        genesis_root = store.latest_justified.root
+        target_root = _add_known_block(store, Slot(1), ValidatorIndex(1), genesis_root, 1)
+        head_root = _add_known_block(store, Slot(2), ValidatorIndex(2), target_root, 2)
+        store.time = Interval.from_slot(Slot(2))
+
+        attestation_data = AttestationData(
+            slot=Slot(2),
+            source=Checkpoint(root=genesis_root, slot=Slot(0)),
+            target=Checkpoint(root=target_root, slot=Slot(1)),
+            head=Checkpoint(root=head_root, slot=Slot(2)),
+        )
+
+        spec.validate_attestation(store, attestation_data)
+
+    def test_target_must_be_ancestor_of_head(
+        self,
+        spec: LstarSpec,
+        observer_store: Store,
+    ) -> None:
+        """A head on a sibling fork must not validate against this target."""
+        store = observer_store
+        genesis_root = store.latest_justified.root
+        target_root = _add_known_block(store, Slot(1), ValidatorIndex(1), genesis_root, 1)
+        sibling_head_root = _add_known_block(store, Slot(2), ValidatorIndex(2), genesis_root, 2)
+        store.time = Interval.from_slot(Slot(2))
+
+        attestation_data = AttestationData(
+            slot=Slot(2),
+            source=Checkpoint(root=genesis_root, slot=Slot(0)),
+            target=Checkpoint(root=target_root, slot=Slot(1)),
+            head=Checkpoint(root=sibling_head_root, slot=Slot(2)),
+        )
+
+        with pytest.raises(AssertionError, match="Target checkpoint must be ancestor of head"):
+            spec.validate_attestation(store, attestation_data)
+
+    def test_source_must_be_ancestor_of_target(
+        self,
+        spec: LstarSpec,
+        observer_store: Store,
+    ) -> None:
+        """A source on a sibling fork must not validate against this target."""
+        store = observer_store
+        genesis_root = store.latest_justified.root
+        source_root = _add_known_block(store, Slot(1), ValidatorIndex(1), genesis_root, 1)
+        target_parent_root = _add_known_block(store, Slot(1), ValidatorIndex(2), genesis_root, 2)
+        target_root = _add_known_block(store, Slot(2), ValidatorIndex(2), target_parent_root, 3)
+        store.time = Interval.from_slot(Slot(2))
+
+        attestation_data = AttestationData(
+            slot=Slot(2),
+            source=Checkpoint(root=source_root, slot=Slot(1)),
+            target=Checkpoint(root=target_root, slot=Slot(2)),
+            head=Checkpoint(root=target_root, slot=Slot(2)),
+        )
+
+        with pytest.raises(AssertionError, match="Source checkpoint must be ancestor of target"):
+            spec.validate_attestation(store, attestation_data)
+
+    def test_head_with_unknown_parent_chain_rejected(
+        self,
+        spec: LstarSpec,
+        observer_store: Store,
+    ) -> None:
+        """A head whose parent chain leaves the store cannot prove ancestry."""
+        store = observer_store
+        genesis_root = store.latest_justified.root
+        target_root = _add_known_block(store, Slot(1), ValidatorIndex(1), genesis_root, 1)
+        orphan_head_root = _add_known_block(store, Slot(2), ValidatorIndex(2), make_bytes32(99), 2)
+        store.time = Interval.from_slot(Slot(2))
+
+        attestation_data = AttestationData(
+            slot=Slot(2),
+            source=Checkpoint(root=genesis_root, slot=Slot(0)),
+            target=Checkpoint(root=target_root, slot=Slot(1)),
+            head=Checkpoint(root=orphan_head_root, slot=Slot(2)),
+        )
+
+        with pytest.raises(AssertionError, match="Target checkpoint must be ancestor of head"):
+            spec.validate_attestation(store, attestation_data)
+
+
 class TestValidateAttestationTimeCheck:
     """
     Time check boundaries.

--- a/tests/lean_spec/spec/forks/lstar/test_state_transition.py
+++ b/tests/lean_spec/spec/forks/lstar/test_state_transition.py
@@ -233,9 +233,7 @@ class TestProcessAttestationsHeadChecks:
         assert len(result_state.justifications_roots) == 0
         assert len(result_state.justifications_validators) == 0
 
-    def test_attestation_with_zero_hash_head_is_silently_rejected(
-        self, spec: LstarSpec
-    ) -> None:
+    def test_attestation_with_zero_hash_head_is_silently_rejected(self, spec: LstarSpec) -> None:
         """
         Reject attestations whose head checkpoint carries the zero hash.
 

--- a/tests/lean_spec/spec/forks/lstar/test_state_transition.py
+++ b/tests/lean_spec/spec/forks/lstar/test_state_transition.py
@@ -12,7 +12,7 @@ from lean_spec.spec.forks.lstar.containers import (
     JustifiedSlots,
 )
 from lean_spec.spec.forks.lstar.spec import LstarSpec
-from lean_spec.spec.ssz import Boolean
+from lean_spec.spec.ssz import ZERO_HASH, Boolean
 from tests.lean_spec.helpers import (
     make_aggregated_attestation,
     make_block,
@@ -186,6 +186,127 @@ class TestProcessAttestationsBoundsCheck:
         #
         # Either check would reject this attestation.
         # The bounds check prevents the crash before root comparison.
+        assert len(result_state.justifications_roots) == 0
+        assert len(result_state.justifications_validators) == 0
+
+
+class TestProcessAttestationsHeadChecks:
+    """Verify attestations whose head checkpoint is off the canonical chain are rejected."""
+
+    def test_attestation_with_head_root_mismatch_is_silently_rejected(
+        self, spec: LstarSpec
+    ) -> None:
+        """
+        Reject attestations whose head checkpoint is not on the canonical history.
+
+        Source and target match the local chain, but the head root names a
+        different block at the head slot. The vote must not justify the target.
+        """
+        state = make_genesis_state(num_validators=3)
+
+        source_root = make_bytes32(1)
+        target_root = make_bytes32(2)
+        canonical_head_root = make_bytes32(3)
+        sibling_head_root = make_bytes32(4)
+
+        state.slot = Slot(3)
+        state.historical_block_hashes = HistoricalBlockHashes(
+            data=[source_root, target_root, canonical_head_root]
+        )
+        state.justified_slots = JustifiedSlots(data=[Boolean(False), Boolean(False)])
+
+        attestation_data = AttestationData(
+            slot=Slot(2),
+            source=Checkpoint(root=source_root, slot=Slot(0)),
+            target=Checkpoint(root=target_root, slot=Slot(1)),
+            head=Checkpoint(root=sibling_head_root, slot=Slot(2)),
+        )
+        attestation = AggregatedAttestation(
+            aggregation_bits=AggregationBits.from_indices([ValidatorIndex(0), ValidatorIndex(1)]),
+            data=attestation_data,
+        )
+
+        result_state = spec.process_attestations(state, [attestation])
+
+        assert result_state.latest_justified == state.latest_justified
+        assert result_state.latest_finalized == state.latest_finalized
+        assert len(result_state.justifications_roots) == 0
+        assert len(result_state.justifications_validators) == 0
+
+    def test_attestation_with_zero_hash_head_is_silently_rejected(
+        self, spec: LstarSpec
+    ) -> None:
+        """
+        Reject attestations whose head checkpoint carries the zero hash.
+
+        A zero-hash head names an empty slot, not a block.
+        Source and target match the local chain, so only the head guard fires.
+        """
+        state = make_genesis_state(num_validators=3)
+
+        source_root = make_bytes32(1)
+        target_root = make_bytes32(2)
+        canonical_head_root = make_bytes32(3)
+
+        state.slot = Slot(3)
+        state.historical_block_hashes = HistoricalBlockHashes(
+            data=[source_root, target_root, canonical_head_root]
+        )
+        state.justified_slots = JustifiedSlots(data=[Boolean(False), Boolean(False)])
+
+        attestation_data = AttestationData(
+            slot=Slot(2),
+            source=Checkpoint(root=source_root, slot=Slot(0)),
+            target=Checkpoint(root=target_root, slot=Slot(1)),
+            head=Checkpoint(root=ZERO_HASH, slot=Slot(2)),
+        )
+        attestation = AggregatedAttestation(
+            aggregation_bits=AggregationBits.from_indices([ValidatorIndex(0), ValidatorIndex(1)]),
+            data=attestation_data,
+        )
+
+        result_state = spec.process_attestations(state, [attestation])
+
+        assert result_state.latest_justified == state.latest_justified
+        assert result_state.latest_finalized == state.latest_finalized
+        assert len(result_state.justifications_roots) == 0
+        assert len(result_state.justifications_validators) == 0
+
+    def test_attestation_with_head_beyond_history_is_silently_rejected(
+        self, spec: LstarSpec
+    ) -> None:
+        """
+        Reject attestations whose head slot exceeds history bounds.
+
+        Source and target sit inside the chain view, only the head does not.
+        The bounds guard must reject the vote instead of raising IndexError.
+        """
+        state = make_genesis_state(num_validators=3)
+
+        source_root = make_bytes32(1)
+        target_root = make_bytes32(2)
+
+        state.slot = Slot(3)
+        state.historical_block_hashes = HistoricalBlockHashes(
+            data=[source_root, target_root, make_bytes32(3)]
+        )
+        state.justified_slots = JustifiedSlots(data=[Boolean(False)] * 10)
+
+        attestation_data = AttestationData(
+            slot=Slot(2),
+            source=Checkpoint(root=source_root, slot=Slot(0)),
+            target=Checkpoint(root=target_root, slot=Slot(1)),
+            head=Checkpoint(root=make_bytes32(10), slot=Slot(10)),
+        )
+        attestation = AggregatedAttestation(
+            aggregation_bits=AggregationBits.from_indices([ValidatorIndex(0), ValidatorIndex(1)]),
+            data=attestation_data,
+        )
+
+        result_state = spec.process_attestations(state, [attestation])
+
+        assert result_state.latest_justified == state.latest_justified
+        assert result_state.latest_finalized == state.latest_finalized
         assert len(result_state.justifications_roots) == 0
         assert len(result_state.justifications_validators) == 0
 


### PR DESCRIPTION
## Summary

Reject attestations whose checkpoints are slot-ordered but not on the same chain.

This enforces the topology implied by `source <= target <= head` in two places:

- gossip validation now checks `source -> target -> head` ancestry through the fork-choice store's block tree
- state transition chain matching now verifies the head checkpoint root against the canonical historical chain, not only source and target

## Root Cause

`validate_attestation()` checked that source, target, and head blocks were known and that their checkpoint slots matched the block slots. It did not check that target was actually an ancestor of head, or that source was an ancestor of target.

Because fork choice weights by `attestation_data.head.root`, accepting a known but sibling `head` lets a validator present a canonical `source -> target` FFG vote while injecting LMD-GHOST weight into a non-canonical branch. `_accumulate_ancestor_weights()` walks upward from the attested head and gives weight to that branch's ancestors, so this is a fork-choice vote-splitting vector.

`attestation_data_matches_chain()` is the state-transition complement. Justification is still keyed on `target.root`, so a sibling head does not justify a non-canonical target. Checking `head` there keeps counted votes internally consistent: no decoupled FFG vote on the canonical chain with an LMD head on a sibling fork.

The two checks use different reference frames intentionally: gossip validation has the fork-choice store tree available, while state transition validates against the linear canonical `historical_block_hashes` view.

## Validation

- `uv run pytest tests/lean_spec/spec/forks/lstar/forkchoice tests/lean_spec/spec/forks/lstar/state/test_state_process_attestations.py tests/lean_spec/spec/forks/lstar/test_block_production.py -q --no-cov`
- `uv run --group test fill tests/consensus/lstar/fc/test_gossip_attestation_validation.py tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py tests/consensus/lstar/state_transition/test_justification.py --fork=Lstar --clean -q`
- `uv run --group lint ruff check src/lean_spec/spec/forks/lstar/fork_choice.py src/lean_spec/spec/forks/lstar/state_transition.py tests/lean_spec/spec/forks/lstar/forkchoice/test_validate_attestation.py tests/lean_spec/spec/forks/lstar/state/test_state_process_attestations.py`
- `uv run --group lint ruff format --check src/lean_spec/spec/forks/lstar/fork_choice.py src/lean_spec/spec/forks/lstar/state_transition.py tests/lean_spec/spec/forks/lstar/forkchoice/test_validate_attestation.py tests/lean_spec/spec/forks/lstar/state/test_state_process_attestations.py`
- `uv run --group lint ty check src/lean_spec/spec/forks/lstar/fork_choice.py src/lean_spec/spec/forks/lstar/state_transition.py tests/lean_spec/spec/forks/lstar/forkchoice/test_validate_attestation.py tests/lean_spec/spec/forks/lstar/state/test_state_process_attestations.py`
- `git diff --check`
