### PR TITLE
refactor(xmss): collapse PROD/TEST Poseidon into a single POSEIDON

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/interface.py
+++ b/src/lean_spec/spec/crypto/xmss/interface.py
@@ -7,7 +7,7 @@ from lean_spec.spec.crypto.xmss.containers import KeyPair, PublicKey, SecretKey,
 from lean_spec.spec.crypto.xmss.encoding import target_sum_encode
 from lean_spec.spec.crypto.xmss.field import random_parameter
 from lean_spec.spec.crypto.xmss.merkle import HashSubTree, combined_path, verify_path
-from lean_spec.spec.crypto.xmss.poseidon import PROD_POSEIDON, TEST_POSEIDON, PoseidonXmss
+from lean_spec.spec.crypto.xmss.poseidon import POSEIDON, PoseidonXmss
 from lean_spec.spec.crypto.xmss.prf import PRFKey
 from lean_spec.spec.crypto.xmss.types import HashDigestList, HashDigestVector
 from lean_spec.spec.forks.lstar.slot import Slot
@@ -397,10 +397,10 @@ class GeneralizedXmssScheme(StrictBaseModel):
         return secret_key
 
 
-PROD_SIGNATURE_SCHEME = GeneralizedXmssScheme(config=PROD_CONFIG, poseidon=PROD_POSEIDON)
+PROD_SIGNATURE_SCHEME = GeneralizedXmssScheme(config=PROD_CONFIG, poseidon=POSEIDON)
 """Signature scheme instance with production parameters."""
 
-TEST_SIGNATURE_SCHEME = GeneralizedXmssScheme(config=TEST_CONFIG, poseidon=TEST_POSEIDON)
+TEST_SIGNATURE_SCHEME = GeneralizedXmssScheme(config=TEST_CONFIG, poseidon=POSEIDON)
 """Signature scheme instance with test parameters."""
 
 TARGET_SIGNATURE_SCHEME = TEST_SIGNATURE_SCHEME if LEAN_ENV == "test" else PROD_SIGNATURE_SCHEME

--- a/src/lean_spec/spec/crypto/xmss/poseidon.py
+++ b/src/lean_spec/spec/crypto/xmss/poseidon.py
@@ -253,8 +253,5 @@ class PoseidonXmss(StrictBaseModel):
         return current_digest
 
 
-PROD_POSEIDON = PoseidonXmss(params16=PARAMS_16, params24=PARAMS_24)
-"""Poseidon engine with production parameters."""
-
-TEST_POSEIDON = PROD_POSEIDON
-"""Test environment reuses the production Poseidon parameters."""
+POSEIDON = PoseidonXmss(params16=PARAMS_16, params24=PARAMS_24)
+"""Poseidon engine."""

--- a/tests/lean_spec/spec/crypto/xmss/test_encoding.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_encoding.py
@@ -13,7 +13,7 @@ from lean_spec.spec.crypto.xmss.encoding import (
     target_sum_encode,
 )
 from lean_spec.spec.crypto.xmss.field import int_to_base_p, random_field_elements
-from lean_spec.spec.crypto.xmss.poseidon import TEST_POSEIDON
+from lean_spec.spec.crypto.xmss.poseidon import POSEIDON
 from lean_spec.spec.crypto.xmss.types import Parameter, Randomness
 from lean_spec.spec.ssz import Bytes32, Uint64
 
@@ -91,7 +91,7 @@ def test_message_hash_yields_valid_codeword() -> None:
     randomness = Randomness(data=random_field_elements(config.RAND_LENGTH_FIELD_ELEMENTS))
 
     result = message_hash(
-        TEST_POSEIDON, config, parameter, Uint64(313), randomness, Bytes32(b"\xaa" * 32)
+        POSEIDON, config, parameter, Uint64(313), randomness, Bytes32(b"\xaa" * 32)
     )
 
     assert result is not None
@@ -106,9 +106,7 @@ def test_target_sum_encode_accepts_codeword_on_target_layer() -> None:
     # Attempt counter three lands the all-zero message on the target-sum layer.
     rho = Randomness(data=int_to_base_p(3, config.RAND_LENGTH_FIELD_ELEMENTS))
 
-    codeword = target_sum_encode(
-        TEST_POSEIDON, config, parameter, Bytes32(b"\x00" * 32), rho, Uint64(0)
-    )
+    codeword = target_sum_encode(POSEIDON, config, parameter, Bytes32(b"\x00" * 32), rho, Uint64(0))
 
     # The digits sum to the target of six, landing on the accepted layer.
     assert codeword == [3, 0, 3, 0]
@@ -122,7 +120,7 @@ def test_target_sum_encode_rejects_codeword_off_target_layer() -> None:
     rho = Randomness(data=int_to_base_p(0, config.RAND_LENGTH_FIELD_ELEMENTS))
 
     assert (
-        target_sum_encode(TEST_POSEIDON, config, parameter, Bytes32(b"\x00" * 32), rho, Uint64(0))
+        target_sum_encode(POSEIDON, config, parameter, Bytes32(b"\x00" * 32), rho, Uint64(0))
         is None
     )
 
@@ -140,7 +138,7 @@ def test_target_sum_encode_propagates_aborting_decode_failure(
 
     assert (
         target_sum_encode(
-            TEST_POSEIDON,
+            POSEIDON,
             TEST_CONFIG,
             _parameter(),
             Bytes32(b"\x00" * 32),

--- a/tests/lean_spec/spec/crypto/xmss/test_merkle.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_merkle.py
@@ -11,7 +11,7 @@ from lean_spec.spec.crypto.xmss.merkle import (
     combined_path,
     verify_path,
 )
-from lean_spec.spec.crypto.xmss.poseidon import PROD_POSEIDON, TEST_POSEIDON, PoseidonXmss
+from lean_spec.spec.crypto.xmss.poseidon import POSEIDON, PoseidonXmss
 from lean_spec.spec.crypto.xmss.prf import PRFKey
 from lean_spec.spec.crypto.xmss.types import (
     HashDigestList,
@@ -95,7 +95,7 @@ def test_commit_open_verify_roundtrip(
     """A built tree opens and verifies every leaf for various shapes."""
     assert start_index + num_leaves <= (1 << depth)
     _run_commit_open_verify_roundtrip(
-        PROD_POSEIDON, PROD_CONFIG, num_leaves, depth, start_index, leaf_parts_length
+        POSEIDON, PROD_CONFIG, num_leaves, depth, start_index, leaf_parts_length
     )
 
 
@@ -103,7 +103,7 @@ def test_new_rejects_nodes_overflowing_their_level() -> None:
     """A node run that does not fit its level raises with the level and bounds named."""
     with pytest.raises(ValueError, match=r"Overflow at layer 0: start=3, count=2, max=4"):
         HashSubTree.new(
-            poseidon=TEST_POSEIDON,
+            poseidon=POSEIDON,
             config=TEST_CONFIG,
             lowest_layer=Uint64(0),
             depth=Uint64(2),
@@ -117,7 +117,7 @@ def test_new_top_tree_rejects_odd_depth() -> None:
     """The top tree requires an even depth for the top-bottom split."""
     with pytest.raises(ValueError, match=r"Depth must be even for top-bottom split, got 7."):
         HashSubTree.new_top_tree(
-            TEST_POSEIDON, TEST_CONFIG, 7, Uint64(0), random_parameter(TEST_CONFIG), []
+            POSEIDON, TEST_CONFIG, 7, Uint64(0), random_parameter(TEST_CONFIG), []
         )
 
 
@@ -125,7 +125,7 @@ def test_new_bottom_tree_rejects_odd_depth() -> None:
     """The bottom tree requires an even depth for the top-bottom split."""
     with pytest.raises(ValueError, match=r"Depth must be even for top-bottom split, got 7."):
         HashSubTree.new_bottom_tree(
-            TEST_POSEIDON, TEST_CONFIG, 7, Uint64(0), random_parameter(TEST_CONFIG), []
+            POSEIDON, TEST_CONFIG, 7, Uint64(0), random_parameter(TEST_CONFIG), []
         )
 
 
@@ -133,7 +133,7 @@ def test_new_bottom_tree_rejects_wrong_leaf_count() -> None:
     """The bottom tree requires exactly the square-root-of-lifetime leaves."""
     with pytest.raises(ValueError, match=r"Expected 16 leaves for depth=8, got 0."):
         HashSubTree.new_bottom_tree(
-            TEST_POSEIDON, TEST_CONFIG, 8, Uint64(0), random_parameter(TEST_CONFIG), []
+            POSEIDON, TEST_CONFIG, 8, Uint64(0), random_parameter(TEST_CONFIG), []
         )
 
 
@@ -215,21 +215,21 @@ def prf_trees() -> tuple[Parameter, HashSubTree, HashSubTree, HashSubTree]:
     prf_key = PRFKey.generate()
     parameter = random_parameter(config)
     bottom_zero = HashSubTree.from_prf_key(
-        poseidon=TEST_POSEIDON,
+        poseidon=POSEIDON,
         config=config,
         prf_key=prf_key,
         bottom_tree_index=Uint64(0),
         parameter=parameter,
     )
     bottom_one = HashSubTree.from_prf_key(
-        poseidon=TEST_POSEIDON,
+        poseidon=POSEIDON,
         config=config,
         prf_key=prf_key,
         bottom_tree_index=Uint64(1),
         parameter=parameter,
     )
     top = HashSubTree.new_top_tree(
-        TEST_POSEIDON,
+        POSEIDON,
         config,
         config.LOG_LIFETIME,
         Uint64(0),
@@ -289,7 +289,7 @@ def test_from_prf_key_builds_a_bottom_tree() -> None:
     """A prf-derived bottom tree has the expected depth, layers, and leaf count."""
     config = TEST_CONFIG
     bottom_tree = HashSubTree.from_prf_key(
-        poseidon=TEST_POSEIDON,
+        poseidon=POSEIDON,
         config=config,
         prf_key=PRFKey.generate(),
         bottom_tree_index=Uint64(0),
@@ -307,14 +307,14 @@ def test_from_prf_key_is_deterministic() -> None:
     prf_key = PRFKey.generate()
     parameter = random_parameter(config)
     first = HashSubTree.from_prf_key(
-        poseidon=TEST_POSEIDON,
+        poseidon=POSEIDON,
         config=config,
         prf_key=prf_key,
         bottom_tree_index=Uint64(0),
         parameter=parameter,
     )
     second = HashSubTree.from_prf_key(
-        poseidon=TEST_POSEIDON,
+        poseidon=POSEIDON,
         config=config,
         prf_key=prf_key,
         bottom_tree_index=Uint64(0),
@@ -329,14 +329,14 @@ def test_from_prf_key_distinct_indices_give_distinct_roots() -> None:
     prf_key = PRFKey.generate()
     parameter = random_parameter(config)
     tree_zero = HashSubTree.from_prf_key(
-        poseidon=TEST_POSEIDON,
+        poseidon=POSEIDON,
         config=config,
         prf_key=prf_key,
         bottom_tree_index=Uint64(0),
         parameter=parameter,
     )
     tree_one = HashSubTree.from_prf_key(
-        poseidon=TEST_POSEIDON,
+        poseidon=POSEIDON,
         config=config,
         prf_key=prf_key,
         bottom_tree_index=Uint64(1),
@@ -363,7 +363,7 @@ def test_verify_path_rejects_position_exceeding_capacity(position: int) -> None:
     opening = HashTreeOpening(siblings=HashDigestList(data=siblings))
     assert (
         verify_path(
-            poseidon=PROD_POSEIDON,
+            poseidon=POSEIDON,
             config=PROD_CONFIG,
             parameter=random_parameter(PROD_CONFIG),
             root=random_domain(PROD_CONFIG),
@@ -380,7 +380,7 @@ def test_verify_path_accepts_boundary_position_without_raising() -> None:
     siblings = [random_domain(PROD_CONFIG) for _ in range(4)]
     opening = HashTreeOpening(siblings=HashDigestList(data=siblings))
     result = verify_path(
-        poseidon=PROD_POSEIDON,
+        poseidon=POSEIDON,
         config=PROD_CONFIG,
         parameter=random_parameter(PROD_CONFIG),
         root=random_domain(PROD_CONFIG),

--- a/tests/lean_spec/spec/crypto/xmss/test_poseidon.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_poseidon.py
@@ -5,7 +5,7 @@ import pytest
 from lean_spec.spec.crypto.koalabear import Fp
 from lean_spec.spec.crypto.xmss.constants import TEST_CONFIG
 from lean_spec.spec.crypto.xmss.field import random_domain
-from lean_spec.spec.crypto.xmss.poseidon import TEST_POSEIDON
+from lean_spec.spec.crypto.xmss.poseidon import POSEIDON
 from lean_spec.spec.crypto.xmss.types import (
     ChainTweak,
     HashDigestVector,
@@ -23,76 +23,74 @@ def _parameter() -> Parameter:
 @pytest.mark.parametrize("width", [16, 24])
 def test_get_engine_caches_supported_widths(width: int) -> None:
     """A supported width yields the same engine instance on repeated calls."""
-    assert TEST_POSEIDON._get_engine(width) is TEST_POSEIDON._get_engine(width)
+    assert POSEIDON._get_engine(width) is POSEIDON._get_engine(width)
 
 
 @pytest.mark.parametrize("width", [0, 8, 15, 17, 32])
 def test_get_engine_rejects_unsupported_width(width: int) -> None:
     """An unsupported width raises with the offending value named."""
     with pytest.raises(ValueError, match=f"Width must be 16 or 24, got {width}"):
-        TEST_POSEIDON._get_engine(width)
+        POSEIDON._get_engine(width)
 
 
 @pytest.mark.parametrize("width", [16, 24])
 def test_compress_returns_requested_output_length(width: int) -> None:
     """Compression returns exactly the requested number of output elements."""
-    result = TEST_POSEIDON.compress([Fp(value=i) for i in range(8)], width, 8)
+    result = POSEIDON.compress([Fp(value=i) for i in range(8)], width, 8)
     assert len(result) == 8
 
 
 def test_compress_truncates_to_short_output() -> None:
     """A short output length yields a truncated digest."""
-    result = TEST_POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 1)
+    result = POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 1)
     assert len(result) == 1
 
 
 def test_compress_is_deterministic() -> None:
     """The same input compresses to the same output."""
-    a = TEST_POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 8)
-    b = TEST_POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 8)
+    a = POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 8)
+    b = POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 8)
     assert a == b
 
 
 def test_compress_rejects_output_longer_than_input() -> None:
     """Requesting more output than the raw input length raises."""
     with pytest.raises(ValueError, match="Input vector is too short for requested output length."):
-        TEST_POSEIDON.compress([Fp(value=1), Fp(value=2)], 16, 8)
+        POSEIDON.compress([Fp(value=1), Fp(value=2)], 16, 8)
 
 
 def test_safe_domain_separator_returns_capacity_length() -> None:
     """The domain separator returns a vector of the requested capacity length."""
-    assert len(TEST_POSEIDON.safe_domain_separator([5, 2, 4, 8], 9)) == 9
+    assert len(POSEIDON.safe_domain_separator([5, 2, 4, 8], 9)) == 9
 
 
 def test_safe_domain_separator_distinguishes_shapes() -> None:
     """Different length parameters produce different capacity values."""
-    assert TEST_POSEIDON.safe_domain_separator([1, 2], 9) != TEST_POSEIDON.safe_domain_separator(
-        [2, 1], 9
-    )
+    assert POSEIDON.safe_domain_separator([1, 2], 9) != POSEIDON.safe_domain_separator([2, 1], 9)
 
 
 def test_sponge_returns_requested_output_length() -> None:
     """The sponge returns exactly the requested number of output elements."""
-    capacity = TEST_POSEIDON.safe_domain_separator([1, 2, 3, 4], 9)
-    assert len(TEST_POSEIDON.sponge([Fp(value=1)] * 5, capacity, 8, 24)) == 8
+    capacity = POSEIDON.safe_domain_separator([1, 2, 3, 4], 9)
+    assert len(POSEIDON.sponge([Fp(value=1)] * 5, capacity, 8, 24)) == 8
 
 
 def test_sponge_squeezes_more_than_one_rate_block() -> None:
     """Requesting more output than one rate block permutes again to squeeze enough."""
-    capacity = TEST_POSEIDON.safe_domain_separator([1, 2, 3, 4], 9)
+    capacity = POSEIDON.safe_domain_separator([1, 2, 3, 4], 9)
     rate = 24 - len(capacity)
-    assert len(TEST_POSEIDON.sponge([Fp(value=1)] * 5, capacity, rate + 1, 24)) == rate + 1
+    assert len(POSEIDON.sponge([Fp(value=1)] * 5, capacity, rate + 1, 24)) == rate + 1
 
 
 def test_sponge_rejects_capacity_not_smaller_than_width() -> None:
     """A capacity that fills the whole state leaves no rate slot and raises."""
     with pytest.raises(ValueError, match="Capacity length must be smaller than the state width."):
-        TEST_POSEIDON.sponge([Fp(value=1)], [Fp(value=0)] * 16, 1, 16)
+        POSEIDON.sponge([Fp(value=1)], [Fp(value=0)] * 16, 1, 16)
 
 
 def test_tweak_hash_chain_uses_width_sixteen_compression() -> None:
     """A single digest input hashes through width-sixteen compression."""
-    result = TEST_POSEIDON.tweak_hash(
+    result = POSEIDON.tweak_hash(
         TEST_CONFIG,
         _parameter(),
         ChainTweak(epoch=Uint64(0), chain_index=1, step=1),
@@ -104,7 +102,7 @@ def test_tweak_hash_chain_uses_width_sixteen_compression() -> None:
 
 def test_tweak_hash_node_uses_width_twenty_four_compression() -> None:
     """Two digest inputs hash through width-twenty-four compression."""
-    result = TEST_POSEIDON.tweak_hash(
+    result = POSEIDON.tweak_hash(
         TEST_CONFIG,
         _parameter(),
         TreeTweak(level=1, index=Uint64(0)),
@@ -116,7 +114,7 @@ def test_tweak_hash_node_uses_width_twenty_four_compression() -> None:
 def test_tweak_hash_leaf_uses_sponge_mode() -> None:
     """More than two digest inputs hash through sponge mode."""
     parts = [random_domain(TEST_CONFIG) for _ in range(TEST_CONFIG.DIMENSION)]
-    result = TEST_POSEIDON.tweak_hash(
+    result = POSEIDON.tweak_hash(
         TEST_CONFIG, _parameter(), TreeTweak(level=0, index=Uint64(0)), parts
     )
     assert len(result.data) == TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS
@@ -125,11 +123,11 @@ def test_tweak_hash_leaf_uses_sponge_mode() -> None:
 def test_tweak_hash_chain_and_tree_tweaks_are_domain_separated() -> None:
     """A chain tweak and a tree tweak over one digest produce different hashes."""
     digest = random_domain(TEST_CONFIG)
-    chain = TEST_POSEIDON.tweak_hash(
+    chain = POSEIDON.tweak_hash(
         TEST_CONFIG, _parameter(), ChainTweak(epoch=Uint64(0), chain_index=0, step=1), [digest]
     )
     # A single-part tree tweak still routes through width-sixteen compression.
-    tree = TEST_POSEIDON.tweak_hash(
+    tree = POSEIDON.tweak_hash(
         TEST_CONFIG, _parameter(), TreeTweak(level=0, index=Uint64(0)), [digest]
     )
     assert chain != tree
@@ -138,7 +136,7 @@ def test_tweak_hash_chain_and_tree_tweaks_are_domain_separated() -> None:
 def test_hash_chain_zero_steps_returns_start_digest() -> None:
     """Walking zero steps returns the starting digest unchanged."""
     start = random_domain(TEST_CONFIG)
-    result = TEST_POSEIDON.hash_chain(
+    result = POSEIDON.hash_chain(
         config=TEST_CONFIG,
         parameter=_parameter(),
         epoch=Uint64(0),
@@ -154,7 +152,7 @@ def test_hash_chain_is_composable() -> None:
     """Walking two steps equals walking one step then one more."""
     parameter = _parameter()
     start = random_domain(TEST_CONFIG)
-    two = TEST_POSEIDON.hash_chain(
+    two = POSEIDON.hash_chain(
         config=TEST_CONFIG,
         parameter=parameter,
         epoch=Uint64(0),
@@ -163,7 +161,7 @@ def test_hash_chain_is_composable() -> None:
         num_steps=2,
         start_digest=start,
     )
-    one = TEST_POSEIDON.hash_chain(
+    one = POSEIDON.hash_chain(
         config=TEST_CONFIG,
         parameter=parameter,
         epoch=Uint64(0),
@@ -172,7 +170,7 @@ def test_hash_chain_is_composable() -> None:
         num_steps=1,
         start_digest=start,
     )
-    one_more = TEST_POSEIDON.hash_chain(
+    one_more = POSEIDON.hash_chain(
         config=TEST_CONFIG,
         parameter=parameter,
         epoch=Uint64(0),


### PR DESCRIPTION
## Summary

`TEST_POSEIDON` was defined as a pure alias of `PROD_POSEIDON`:

```python
PROD_POSEIDON = PoseidonXmss(params16=PARAMS_16, params24=PARAMS_24)
TEST_POSEIDON = PROD_POSEIDON
```

The Poseidon permutation parameters (`PARAMS_16`, `PARAMS_24`) are environment-independent — they are identical in test and production. The only thing that genuinely differs between environments is the XMSS *config* (`TEST_CONFIG` vs `PROD_CONFIG`). So the `PROD_`/`TEST_` split at the engine level is meaningless, and the alias is exactly the kind of shim the project disallows.

This collapses both names into a single `POSEIDON` engine.

## Changes

- `poseidon.py`: `PROD_POSEIDON` → `POSEIDON`; delete the `TEST_POSEIDON` alias.
- `interface.py`: both `PROD_SIGNATURE_SCHEME` and `TEST_SIGNATURE_SCHEME` now reference the single `POSEIDON`. The schemes stay split because their *config* genuinely differs.
- Repoint the three XMSS test modules (`test_poseidon.py`, `test_encoding.py`, `test_merkle.py`) to `POSEIDON`.

## Verification

- `just check` passes: ruff check, ruff format, `ty`, codespell, mdformat.
- `uv run pytest tests/lean_spec/spec/crypto/xmss/` — 196 passed. Behavior is unchanged (the two names already pointed at the same object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)