### PR TITLE
refactor(node): remove dead code in event source and head sync

### DIFF
--- a/src/lean_spec/node/networking/client/event_source/live.py
+++ b/src/lean_spec/node/networking/client/event_source/live.py
@@ -81,7 +81,6 @@ from lean_spec.node.networking.gossipsub.topic import GossipTopic, TopicKind
 from lean_spec.node.networking.gossipsub.types import TopicId
 from lean_spec.node.networking.reqresp.handler import (
     REQRESP_PROTOCOL_IDS,
-    AsyncBlockBySlotLookup,
     AsyncBlockLookup,
     CurrentSlotLookup,
     ReqRespServer,
@@ -329,20 +328,6 @@ class LiveNetworkEventSource:
         """
         self._reqresp_handler.block_lookup = lookup
 
-    def set_block_by_slot_lookup(self, lookup: AsyncBlockBySlotLookup) -> None:
-        """
-        Set the callback for looking up canonical blocks by slot.
-
-        Used by the inbound ReqResp handler to serve BlocksByRange requests.
-
-        The callback MUST consult fork choice.
-        It returns the canonical block at that slot, or None for empty slots.
-
-        Args:
-            lookup: Async function from Slot to SignedBlock or None.
-        """
-        self._reqresp_handler.block_by_slot_lookup = lookup
-
     def set_current_slot_lookup(self, lookup: CurrentSlotLookup) -> None:
         """
         Set the callback returning the node's current slot.
@@ -582,7 +567,7 @@ class LiveNetworkEventSource:
             task.add_done_callback(self._gossip_tasks.discard)
 
             # Exchange status.
-            await self._exchange_status(peer_id, connection)
+            await self._exchange_status(peer_id)
 
             # Set up gossipsub stream for full protocol support.
             await self._setup_gossipsub_stream(peer_id, connection)
@@ -698,17 +683,12 @@ class LiveNetworkEventSource:
 
         logger.info("Accepted connection from peer %s", peer_id)
 
-    async def _exchange_status(
-        self,
-        peer_id: PeerId,
-        connection: QuicConnection,
-    ) -> None:
+    async def _exchange_status(self, peer_id: PeerId) -> None:
         """
         Exchange Status messages with a peer.
 
         Args:
             peer_id: Peer identifier.
-            connection: QuicConnection to use.
         """
         if self._our_status is None:
             logger.debug("No status set, skipping status exchange")

--- a/src/lean_spec/node/sync/head_sync.py
+++ b/src/lean_spec/node/sync/head_sync.py
@@ -182,7 +182,6 @@ class HeadSync:
             logger.debug("on_gossip_block: parent found, processing")
             return await self._process_block_with_descendants(
                 block=block,
-                peer_id=peer_id,
                 store=store,
             )
 
@@ -200,7 +199,6 @@ class HeadSync:
     async def _process_block_with_descendants(
         self,
         block: SignedBlock,
-        peer_id: PeerId | None,
         store: Store,
     ) -> tuple[HeadSyncResult, Store]:
         """
@@ -211,7 +209,6 @@ class HeadSync:
 
         Args:
             block: Block to process.
-            peer_id: Peer that sent the block.
             store: Current store.
 
         Returns:


### PR DESCRIPTION
## Summary

Removes three unused items in the node layer, each verified to have zero live call sites across `src/`, `tests/`, and `packages/`:

1. **`set_block_by_slot_lookup`** (`event_source/live.py`) — a setter wrapping the request handler's `block_by_slot_lookup` field. Never called anywhere. Removing it also leaves the `AsyncBlockBySlotLookup` import unused, so that's dropped too. (The sibling `set_block_lookup` is kept — it has a test caller.)
2. **`connection` parameter** on `_exchange_status` (`event_source/live.py`) — status exchange goes through the reqresp client; the connection was never read. Removed from the signature and the single call site.
3. **`peer_id` parameter** on `_process_block_with_descendants` (`sync/head_sync.py`) — threaded in and documented but never read in the body. Removed from the signature and the single call site.

## Verification

- `just check` passes: ruff check, ruff format, `ty`, codespell, mdformat.
- `uv run pytest` for event source, sync, and ENR suites — 632 passed.

## Note on the audit

The original audit also flagged the `attestation_subnets` property (`enr/enr.py`) as dead. **This is incorrect** — it is read by the networking codec test filler (`packages/testing/.../networking_codec.py:353`) and exercised by consensus fixtures (`test_enr_attnets_all_zeros` / `test_enr_attnets_all_ones`). The audit only searched `src/` and missed the `packages/` reader. It is left untouched.

The orphaned `tests/lean_spec/types/` directory was also cleaned up locally, but it contained only untracked `__pycache__` bytecode so there is no diff for it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)