### PR TITLE
refactor(lstar): freeze constructed-once SSZ containers

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -229,9 +229,14 @@ class ForkChoiceTest(BaseConsensusFixture):
         for i, validator in enumerate(self.anchor_state.validators):
             index = ValidatorIndex(i)
             attestation_public_key, proposal_public_key = key_manager.get_public_keys(index)
-            validator.attestation_public_key = attestation_public_key.encode_bytes()
-            validator.proposal_public_key = proposal_public_key.encode_bytes()
-            updated_validators.append(validator)
+            updated_validators.append(
+                validator.model_copy(
+                    update={
+                        "attestation_public_key": attestation_public_key.encode_bytes(),
+                        "proposal_public_key": proposal_public_key.encode_bytes(),
+                    }
+                )
+            )
 
         # Updating validators changes the state root.
         # We must also update the anchor block to match.

--- a/src/lean_spec/spec/forks/lstar/containers/attestation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/attestation.py
@@ -31,6 +31,8 @@ class SignedAttestation(Attestation):
 class AggregatedAttestation(Container):
     """Aggregated attestation consisting of participation bits and message."""
 
+    model_config = Container.model_config | {"frozen": True}
+
     aggregation_bits: AggregationBits
     """Bitfield indicating which validators participated in the aggregation."""
 
@@ -48,6 +50,8 @@ class SignedAggregatedAttestation(Container):
 
     Contains the attestation data and the aggregated signature proof.
     """
+
+    model_config = Container.model_config | {"frozen": True}
 
     data: AttestationData
     """Combined attestation data similar to the beacon chain format."""

--- a/src/lean_spec/spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/spec/forks/lstar/containers/validator.py
@@ -14,12 +14,16 @@ class GenesisConfig(Container):
     in the absence of more complex mechanisms like RANDAO or deposits.
     """
 
+    model_config = Container.model_config | {"frozen": True}
+
     genesis_time: Uint64
     """The timestamp of the genesis block."""
 
 
 class Validator(Container):
     """Represents a validator's static metadata and operational interface."""
+
+    model_config = Container.model_config | {"frozen": True}
 
     attestation_public_key: Bytes52
     """XMSS public key for signing attestations."""

--- a/tests/lean_spec/spec/forks/lstar/containers/test_attestation.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_attestation.py
@@ -1,5 +1,8 @@
 """Tests for AggregatedAttestation structure."""
 
+import pytest
+from pydantic import ValidationError
+
 from lean_spec.spec.forks import (
     AggregationBits,
     Checkpoint,
@@ -10,8 +13,10 @@ from lean_spec.spec.forks import (
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
     AttestationData,
+    SignedAggregatedAttestation,
+    SingleMessageAggregate,
 )
-from lean_spec.spec.ssz import Bytes32
+from lean_spec.spec.ssz import ByteList512KiB, Bytes32
 
 
 class TestAggregatedAttestation:
@@ -51,3 +56,55 @@ class TestAggregatedAttestation:
 
         recovered = aggregate.aggregation_bits.to_validator_indices()
         assert recovered == validator_indices
+
+
+class TestAggregatedAttestationImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_data_raises(self) -> None:
+        """Assigning new data on a constructed aggregated attestation raises."""
+        attestation_data = AttestationData(
+            slot=Slot(5),
+            head=Checkpoint(root=Bytes32.zero(), slot=Slot(4)),
+            target=Checkpoint(root=Bytes32.zero(), slot=Slot(3)),
+            source=Checkpoint(root=Bytes32.zero(), slot=Slot(2)),
+        )
+        aggregate = AggregatedAttestation(
+            aggregation_bits=AggregationBits.from_indices([ValidatorIndex(1)]),
+            data=attestation_data,
+        )
+        with pytest.raises(ValidationError, match="frozen"):
+            aggregate.data = attestation_data
+
+    def test_assigning_aggregation_bits_raises(self) -> None:
+        """Assigning new bits on a constructed aggregated attestation raises."""
+        attestation_data = AttestationData(
+            slot=Slot(5),
+            head=Checkpoint(root=Bytes32.zero(), slot=Slot(4)),
+            target=Checkpoint(root=Bytes32.zero(), slot=Slot(3)),
+            source=Checkpoint(root=Bytes32.zero(), slot=Slot(2)),
+        )
+        bits = AggregationBits.from_indices([ValidatorIndex(1)])
+        aggregate = AggregatedAttestation(aggregation_bits=bits, data=attestation_data)
+        with pytest.raises(ValidationError, match="frozen"):
+            aggregate.aggregation_bits = bits
+
+
+class TestSignedAggregatedAttestationImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_proof_raises(self) -> None:
+        """Assigning a new proof on a constructed signed aggregated attestation raises."""
+        attestation_data = AttestationData(
+            slot=Slot(5),
+            head=Checkpoint(root=Bytes32.zero(), slot=Slot(4)),
+            target=Checkpoint(root=Bytes32.zero(), slot=Slot(3)),
+            source=Checkpoint(root=Bytes32.zero(), slot=Slot(2)),
+        )
+        proof = SingleMessageAggregate(
+            participants=AggregationBits.from_indices([ValidatorIndex(1)]),
+            proof=ByteList512KiB(data=b""),
+        )
+        signed = SignedAggregatedAttestation(data=attestation_data, proof=proof)
+        with pytest.raises(ValidationError, match="frozen"):
+            signed.proof = proof

--- a/tests/lean_spec/spec/forks/lstar/containers/test_validator.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_validator.py
@@ -1,0 +1,39 @@
+"""Tests for the GenesisConfig and Validator containers."""
+
+import pytest
+from pydantic import ValidationError
+
+from lean_spec.spec.forks.lstar.containers import GenesisConfig, Validator
+from lean_spec.spec.ssz import Bytes52, Uint64
+
+
+class TestGenesisConfigImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_genesis_time_raises(self) -> None:
+        """Assigning a new genesis time on a constructed config raises."""
+        config = GenesisConfig(genesis_time=Uint64(1_700_000_000))
+        with pytest.raises(ValidationError, match="frozen"):
+            config.genesis_time = Uint64(1_700_000_001)
+
+
+class TestValidatorImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_attestation_public_key_raises(self) -> None:
+        """Assigning a new attestation key on a constructed validator raises."""
+        validator = Validator(
+            attestation_public_key=Bytes52.zero(),
+            proposal_public_key=Bytes52.zero(),
+        )
+        with pytest.raises(ValidationError, match="frozen"):
+            validator.attestation_public_key = Bytes52(b"\xff" * 52)
+
+    def test_assigning_proposal_public_key_raises(self) -> None:
+        """Assigning a new proposal key on a constructed validator raises."""
+        validator = Validator(
+            attestation_public_key=Bytes52.zero(),
+            proposal_public_key=Bytes52.zero(),
+        )
+        with pytest.raises(ValidationError, match="frozen"):
+            validator.proposal_public_key = Bytes52(b"\xff" * 52)


### PR DESCRIPTION
## What

Set `frozen=True` on the lstar SSZ containers that are constructed once and never mutated after construction:

- `GenesisConfig`, `Validator` (`containers/validator.py`)
- `AggregatedAttestation`, `SignedAggregatedAttestation` (`containers/attestation.py`)

This completes the freeze already in place on `Checkpoint`, `AttestationData`, `Attestation`, `SingleMessageAggregate`, and `MultiMessageAggregate`, using the same idiom:

```python
model_config = Container.model_config | {"frozen": True}
```

Post-construction field assignment on these types now raises instead of silently succeeding, which aids reproducibility, auditability, and a future port to immutable records.

## Why these, and not the others

Each candidate was checked for in-place mutation across `src/`, `tests/`, and `packages/`. The four frozen here have no mutation site anywhere.

Freezing `Validator` required one call-site change: the fork-choice test fixture injected public keys by mutating each validator in place. It now rebuilds each validator with `model_copy(update=...)`. The resulting registry is byte-identical in `hash_tree_root`, and the originals are left untouched (strictly safer than the previous in-place edit).

### Deferred (still mutable)

- `Block`, `BlockHeader`, `BlockBody`, `SignedBlock` — their `state_root` / `body` are patched in place during block production and the state transition (`block_production.py:285`, `state_transition.py:147`). That two-pass pattern is entangled with the larger state-transition refactor, so freezing them is deferred rather than forced.
- `State`, `Store` — mutable by design (the state transition mutates `State`; `Store` is fork-choice scratch state).

## Caveat

`frozen` is an enforcement aid, not a hard immutability guarantee: `model_config` is itself a mutable dict, and an unfreeze-then-assign sequence can still leave a field mutable ([pydantic#12361](https://github.com/pydantic/pydantic/issues/12361)). It catches accidental mutation; it is not a soundness boundary.

## Tests

Adds immutability regression tests mirroring the existing `TestCheckpointImmutability` idiom, in the source-mirrored paths (`test_attestation.py`, new `test_validator.py`).

## Validation

- `ruff` (lint + format), `ty`, `codespell`, `mdformat`, `uv.lock` — all clean
- Full unit suite: 3134 passed, 92.77% coverage
- `uv run fill --fork=lstar --clean`: 520 passed, vectors regenerate cleanly (freezing affects only attribute assignment, never `hash_tree_root` / SSZ / JSON, so fixtures are byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)