### PR TITLE
refactor(lstar): freeze the Block family

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -229,9 +229,14 @@ class ForkChoiceTest(BaseConsensusFixture):
         for i, validator in enumerate(self.anchor_state.validators):
             index = ValidatorIndex(i)
             attestation_public_key, proposal_public_key = key_manager.get_public_keys(index)
-            validator.attestation_public_key = attestation_public_key.encode_bytes()
-            validator.proposal_public_key = proposal_public_key.encode_bytes()
-            updated_validators.append(validator)
+            updated_validators.append(
+                validator.model_copy(
+                    update={
+                        "attestation_public_key": attestation_public_key.encode_bytes(),
+                        "proposal_public_key": proposal_public_key.encode_bytes(),
+                    }
+                )
+            )
 
         # Updating validators changes the state root.
         # We must also update the anchor block to match.

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -241,7 +241,9 @@ class ForkChoiceTest(BaseConsensusFixture):
         # Updating validators changes the state root.
         # We must also update the anchor block to match.
         self.anchor_state.validators = Validators(data=updated_validators)
-        self.anchor_block.state_root = hash_tree_root(self.anchor_state)
+        self.anchor_block = self.anchor_block.model_copy(
+            update={"state_root": hash_tree_root(self.anchor_state)}
+        )
 
         # Store initialization
         #

--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -278,8 +278,16 @@ class StateTransitionTest(BaseConsensusFixture):
                 )
                 for fa in spec.forced_attestations
             ]
-            block.body.attestations = AggregatedAttestations(
-                data=[*block.body.attestations.data, *forced]
+            block = block.model_copy(
+                update={
+                    "body": block.body.model_copy(
+                        update={
+                            "attestations": AggregatedAttestations(
+                                data=[*block.body.attestations.data, *forced]
+                            )
+                        }
+                    )
+                }
             )
 
             # The body changed, so re-run the transition to get the correct
@@ -287,7 +295,7 @@ class StateTransitionTest(BaseConsensusFixture):
             if post_state is not None:
                 post_state = LstarSpec().process_slots(state, spec.slot)
                 post_state = LstarSpec().process_block(post_state, block)
-                block.state_root = hash_tree_root(post_state)
+                block = block.model_copy(update={"state_root": hash_tree_root(post_state)})
 
         return block, post_state
 

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -165,8 +165,13 @@ class VerifySignaturesTest(BaseConsensusFixture):
             value = self.tamper.get("value")
             if value is None:
                 raise ValueError("set_proposer_index requires a value")
-            signed_block.block.proposer_index = ValidatorIndex(int(value))
-            return signed_block
+            return signed_block.model_copy(
+                update={
+                    "block": signed_block.block.model_copy(
+                        update={"proposer_index": ValidatorIndex(int(value))}
+                    )
+                }
+            )
 
         if operation == "clear_first_attestation_bits":
             original = signed_block.block.body.attestations.data
@@ -175,18 +180,32 @@ class VerifySignaturesTest(BaseConsensusFixture):
             first = original[0]
             empty_bits = AggregationBits(data=[Boolean(False)] * len(first.aggregation_bits.data))
             cleared = AggregatedAttestation(aggregation_bits=empty_bits, data=first.data)
-            signed_block.block.body.attestations = AggregatedAttestations(
-                data=[cleared, *original[1:]]
+            return signed_block.model_copy(
+                update={
+                    "block": signed_block.block.model_copy(
+                        update={
+                            "body": signed_block.block.body.model_copy(
+                                update={
+                                    "attestations": AggregatedAttestations(
+                                        data=[cleared, *original[1:]]
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
             )
-            return signed_block
 
         if operation == "corrupt_proof":
             # Replace the merged proof with a short bogus payload.
             # The verifier rejects the malformed proof bytes.
-            signed_block.proof = MultiMessageAggregate(
-                proof=ByteList512KiB(data=b"\x00\x01\x02\x03"),
+            return signed_block.model_copy(
+                update={
+                    "proof": MultiMessageAggregate(
+                        proof=ByteList512KiB(data=b"\x00\x01\x02\x03"),
+                    )
+                }
             )
-            return signed_block
 
         if operation == "append_phantom_attestation":
             # Add a body attestation with no matching proof component.
@@ -203,10 +222,21 @@ class VerifySignaturesTest(BaseConsensusFixture):
                 aggregation_bits=AggregationBits(data=[Boolean(True)]),
                 data=phantom_data,
             )
-            signed_block.block.body.attestations = AggregatedAttestations(
-                data=[*signed_block.block.body.attestations.data, phantom]
+            return signed_block.model_copy(
+                update={
+                    "block": signed_block.block.model_copy(
+                        update={
+                            "body": signed_block.block.body.model_copy(
+                                update={
+                                    "attestations": AggregatedAttestations(
+                                        data=[*signed_block.block.body.attestations.data, phantom]
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
             )
-            return signed_block
 
         if operation == "mutate_state_root":
             # Change a block field after signing so the block root differs.
@@ -214,8 +244,13 @@ class VerifySignaturesTest(BaseConsensusFixture):
             # recomputed block root, even though the signature is honest.
             # This is the repackaging vector: an honest proof reused under
             # a different message.
-            signed_block.block.state_root = Bytes32(b"\xff" * 32)
-            return signed_block
+            return signed_block.model_copy(
+                update={
+                    "block": signed_block.block.model_copy(
+                        update={"state_root": Bytes32(b"\xff" * 32)}
+                    )
+                }
+            )
 
         if operation == "swap_first_two_attestations":
             body = signed_block.block.body

--- a/packages/testing/src/consensus_testing/test_types/aggregated_attestation_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/aggregated_attestation_spec.py
@@ -202,8 +202,16 @@ class AggregatedAttestationSpec(CamelModel):
             invalid_proof = SingleMessageAggregate(participants=aggregation_bits, proof=placeholder)
 
         # Append invalid attestation to the block body.
-        block.body.attestations = AggregatedAttestations(
-            data=[*block.body.attestations.data, invalid_aggregated]
+        block = block.model_copy(
+            update={
+                "body": block.body.model_copy(
+                    update={
+                        "attestations": AggregatedAttestations(
+                            data=[*block.body.attestations.data, invalid_aggregated]
+                        )
+                    }
+                )
+            }
         )
 
         return block, invalid_proof

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -548,22 +548,30 @@ class BlockSpec(CamelModel):
                     attestation_spec.validator_indices, attestation_data
                 )
                 block_proofs.append(proof)
-                final_block.body.attestations = AggregatedAttestations(
-                    data=[
-                        *final_block.body.attestations.data,
-                        AggregatedAttestation(
-                            aggregation_bits=AggregationBits.from_indices(
-                                attestation_spec.validator_indices
-                            ),
-                            data=attestation_data,
-                        ),
-                    ]
+                final_block = final_block.model_copy(
+                    update={
+                        "body": final_block.body.model_copy(
+                            update={
+                                "attestations": AggregatedAttestations(
+                                    data=[
+                                        *final_block.body.attestations.data,
+                                        AggregatedAttestation(
+                                            aggregation_bits=AggregationBits.from_indices(
+                                                attestation_spec.validator_indices
+                                            ),
+                                            data=attestation_data,
+                                        ),
+                                    ]
+                                )
+                            }
+                        )
+                    }
                 )
 
             # Recompute state root with the modified body.
             post_state = spec.process_slots(parent_state, self.slot)
             post_state = spec.process_block(post_state, final_block)
-            final_block.state_root = hash_tree_root(post_state)
+            final_block = final_block.model_copy(update={"state_root": hash_tree_root(post_state)})
 
         signed_block = self._sign_block(
             final_block, block_proofs, proposer_index, key_manager, parent_state

--- a/src/lean_spec/spec/forks/lstar/block_production.py
+++ b/src/lean_spec/spec/forks/lstar/block_production.py
@@ -282,6 +282,6 @@ class BlockProductionMixin(LstarSpecBase):
         # Merging proofs keeps the same voters, so the post-state is unchanged.
         # Only the body's shape differs, so just the root is needed.
         post_state = self.process_block(self.process_slots(state, slot), final_block)
-        final_block.state_root = hash_tree_root(post_state)
+        final_block = final_block.model_copy(update={"state_root": hash_tree_root(post_state)})
 
         return final_block, post_state, aggregated_attestations, aggregated_signatures

--- a/src/lean_spec/spec/forks/lstar/containers/attestation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/attestation.py
@@ -31,6 +31,8 @@ class SignedAttestation(Attestation):
 class AggregatedAttestation(Container):
     """Aggregated attestation consisting of participation bits and message."""
 
+    model_config = Container.model_config | {"frozen": True}
+
     aggregation_bits: AggregationBits
     """Bitfield indicating which validators participated in the aggregation."""
 
@@ -48,6 +50,8 @@ class SignedAggregatedAttestation(Container):
 
     Contains the attestation data and the aggregated signature proof.
     """
+
+    model_config = Container.model_config | {"frozen": True}
 
     data: AttestationData
     """Combined attestation data similar to the beacon chain format."""

--- a/src/lean_spec/spec/forks/lstar/containers/block.py
+++ b/src/lean_spec/spec/forks/lstar/containers/block.py
@@ -10,6 +10,8 @@ from lean_spec.spec.ssz import Bytes32, Container
 class BlockBody(Container):
     """Payload of a block containing attestations."""
 
+    model_config = Container.model_config | {"frozen": True}
+
     attestations: AggregatedAttestations
     """Attestations in the block. Signatures are folded into the block-level proof."""
 
@@ -21,6 +23,8 @@ class BlockHeader(Container):
     Contains parent reference, state root, and body hash.
     Smaller than full blocks.
     """
+
+    model_config = Container.model_config | {"frozen": True}
 
     slot: Slot
     """The slot in which the block was proposed."""
@@ -40,6 +44,8 @@ class BlockHeader(Container):
 
 class Block(Container):
     """A complete block including header and body."""
+
+    model_config = Container.model_config | {"frozen": True}
 
     slot: Slot
     """The slot in which the block was proposed."""
@@ -64,6 +70,8 @@ class SignedBlock(Container):
     It binds every attestation in the body plus the proposer's signature
     over the block root.
     """
+
+    model_config = Container.model_config | {"frozen": True}
 
     block: Block
     """The block being signed."""

--- a/src/lean_spec/spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/spec/forks/lstar/containers/validator.py
@@ -14,12 +14,16 @@ class GenesisConfig(Container):
     in the absence of more complex mechanisms like RANDAO or deposits.
     """
 
+    model_config = Container.model_config | {"frozen": True}
+
     genesis_time: Uint64
     """The timestamp of the genesis block."""
 
 
 class Validator(Container):
     """Represents a validator's static metadata and operational interface."""
+
+    model_config = Container.model_config | {"frozen": True}
 
     attestation_public_key: Bytes52
     """XMSS public key for signing attestations."""

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -144,7 +144,9 @@ class StateTransitionMixin(LstarSpecBase):
             )
 
             if needs_state_root:
-                state.latest_block_header.state_root = cached_state_root
+                state.latest_block_header = state.latest_block_header.model_copy(
+                    update={"state_root": cached_state_root}
+                )
             state.slot = Slot(state.slot + Slot(1))
 
         # Reached the target slot. Return the advanced state.

--- a/tests/consensus/lstar/fc/test_checkpoint_sync.py
+++ b/tests/consensus/lstar/fc/test_checkpoint_sync.py
@@ -361,8 +361,7 @@ def test_store_from_anchor_rejects_mismatched_state_root(
     # mismatch below the only difference between this test and the happy path.
     assert anchor_block.state_root == hash_tree_root(anchor_state)
 
-    anchor_block.state_root = Bytes32(b"\xff" * 32)
-    bad_anchor_block = anchor_block
+    bad_anchor_block = anchor_block.model_copy(update={"state_root": Bytes32(b"\xff" * 32)})
 
     fork_choice_test(
         anchor_state=anchor_state,

--- a/tests/lean_spec/spec/forks/lstar/containers/test_attestation.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_attestation.py
@@ -1,5 +1,8 @@
 """Tests for AggregatedAttestation structure."""
 
+import pytest
+from pydantic import ValidationError
+
 from lean_spec.spec.forks import (
     AggregationBits,
     Checkpoint,
@@ -10,8 +13,10 @@ from lean_spec.spec.forks import (
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
     AttestationData,
+    SignedAggregatedAttestation,
+    SingleMessageAggregate,
 )
-from lean_spec.spec.ssz import Bytes32
+from lean_spec.spec.ssz import ByteList512KiB, Bytes32
 
 
 class TestAggregatedAttestation:
@@ -51,3 +56,55 @@ class TestAggregatedAttestation:
 
         recovered = aggregate.aggregation_bits.to_validator_indices()
         assert recovered == validator_indices
+
+
+class TestAggregatedAttestationImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_data_raises(self) -> None:
+        """Assigning new data on a constructed aggregated attestation raises."""
+        attestation_data = AttestationData(
+            slot=Slot(5),
+            head=Checkpoint(root=Bytes32.zero(), slot=Slot(4)),
+            target=Checkpoint(root=Bytes32.zero(), slot=Slot(3)),
+            source=Checkpoint(root=Bytes32.zero(), slot=Slot(2)),
+        )
+        aggregate = AggregatedAttestation(
+            aggregation_bits=AggregationBits.from_indices([ValidatorIndex(1)]),
+            data=attestation_data,
+        )
+        with pytest.raises(ValidationError, match="frozen"):
+            aggregate.data = attestation_data
+
+    def test_assigning_aggregation_bits_raises(self) -> None:
+        """Assigning new bits on a constructed aggregated attestation raises."""
+        attestation_data = AttestationData(
+            slot=Slot(5),
+            head=Checkpoint(root=Bytes32.zero(), slot=Slot(4)),
+            target=Checkpoint(root=Bytes32.zero(), slot=Slot(3)),
+            source=Checkpoint(root=Bytes32.zero(), slot=Slot(2)),
+        )
+        bits = AggregationBits.from_indices([ValidatorIndex(1)])
+        aggregate = AggregatedAttestation(aggregation_bits=bits, data=attestation_data)
+        with pytest.raises(ValidationError, match="frozen"):
+            aggregate.aggregation_bits = bits
+
+
+class TestSignedAggregatedAttestationImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_proof_raises(self) -> None:
+        """Assigning a new proof on a constructed signed aggregated attestation raises."""
+        attestation_data = AttestationData(
+            slot=Slot(5),
+            head=Checkpoint(root=Bytes32.zero(), slot=Slot(4)),
+            target=Checkpoint(root=Bytes32.zero(), slot=Slot(3)),
+            source=Checkpoint(root=Bytes32.zero(), slot=Slot(2)),
+        )
+        proof = SingleMessageAggregate(
+            participants=AggregationBits.from_indices([ValidatorIndex(1)]),
+            proof=ByteList512KiB(data=b""),
+        )
+        signed = SignedAggregatedAttestation(data=attestation_data, proof=proof)
+        with pytest.raises(ValidationError, match="frozen"):
+            signed.proof = proof

--- a/tests/lean_spec/spec/forks/lstar/containers/test_block.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_block.py
@@ -1,0 +1,84 @@
+"""Tests for the Block container family."""
+
+import pytest
+from pydantic import ValidationError
+
+from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.containers import (
+    AggregatedAttestations,
+    Block,
+    BlockBody,
+    BlockHeader,
+    MultiMessageAggregate,
+    SignedBlock,
+)
+from lean_spec.spec.ssz import ByteList512KiB, Bytes32
+
+
+def _empty_body() -> BlockBody:
+    """A block body carrying no attestations."""
+    return BlockBody(attestations=AggregatedAttestations(data=[]))
+
+
+def _block() -> Block:
+    """A minimal block with a zeroed state root and an empty body."""
+    return Block(
+        slot=Slot(1),
+        proposer_index=ValidatorIndex(0),
+        parent_root=Bytes32.zero(),
+        state_root=Bytes32.zero(),
+        body=_empty_body(),
+    )
+
+
+class TestBlockBodyImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_attestations_raises(self) -> None:
+        """Assigning new attestations on a constructed body raises."""
+        body = _empty_body()
+        with pytest.raises(ValidationError, match="frozen"):
+            body.attestations = AggregatedAttestations(data=[])
+
+
+class TestBlockHeaderImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_state_root_raises(self) -> None:
+        """Assigning a new state root on a constructed header raises."""
+        header = BlockHeader(
+            slot=Slot(1),
+            proposer_index=ValidatorIndex(0),
+            parent_root=Bytes32.zero(),
+            state_root=Bytes32.zero(),
+            body_root=Bytes32.zero(),
+        )
+        with pytest.raises(ValidationError, match="frozen"):
+            header.state_root = Bytes32(b"\xff" * 32)
+
+
+class TestBlockImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_state_root_raises(self) -> None:
+        """Assigning a new state root on a constructed block raises."""
+        block = _block()
+        with pytest.raises(ValidationError, match="frozen"):
+            block.state_root = Bytes32(b"\xff" * 32)
+
+    def test_assigning_body_raises(self) -> None:
+        """Assigning a new body on a constructed block raises."""
+        block = _block()
+        with pytest.raises(ValidationError, match="frozen"):
+            block.body = _empty_body()
+
+
+class TestSignedBlockImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_proof_raises(self) -> None:
+        """Assigning a new proof on a constructed signed block raises."""
+        proof = MultiMessageAggregate(proof=ByteList512KiB(data=b""))
+        signed_block = SignedBlock(block=_block(), proof=proof)
+        with pytest.raises(ValidationError, match="frozen"):
+            signed_block.proof = proof

--- a/tests/lean_spec/spec/forks/lstar/containers/test_validator.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_validator.py
@@ -1,0 +1,39 @@
+"""Tests for the GenesisConfig and Validator containers."""
+
+import pytest
+from pydantic import ValidationError
+
+from lean_spec.spec.forks.lstar.containers import GenesisConfig, Validator
+from lean_spec.spec.ssz import Bytes52, Uint64
+
+
+class TestGenesisConfigImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_genesis_time_raises(self) -> None:
+        """Assigning a new genesis time on a constructed config raises."""
+        config = GenesisConfig(genesis_time=Uint64(1_700_000_000))
+        with pytest.raises(ValidationError, match="frozen"):
+            config.genesis_time = Uint64(1_700_000_001)
+
+
+class TestValidatorImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_attestation_public_key_raises(self) -> None:
+        """Assigning a new attestation key on a constructed validator raises."""
+        validator = Validator(
+            attestation_public_key=Bytes52.zero(),
+            proposal_public_key=Bytes52.zero(),
+        )
+        with pytest.raises(ValidationError, match="frozen"):
+            validator.attestation_public_key = Bytes52(b"\xff" * 52)
+
+    def test_assigning_proposal_public_key_raises(self) -> None:
+        """Assigning a new proposal key on a constructed validator raises."""
+        validator = Validator(
+            attestation_public_key=Bytes52.zero(),
+            proposal_public_key=Bytes52.zero(),
+        )
+        with pytest.raises(ValidationError, match="frozen"):
+            validator.proposal_public_key = Bytes52(b"\xff" * 52)

--- a/tests/lean_spec/spec/forks/lstar/test_block_production.py
+++ b/tests/lean_spec/spec/forks/lstar/test_block_production.py
@@ -23,7 +23,9 @@ def _seal_header(state: State) -> Bytes32:
     """Write the post-state root into the header and return that header root."""
     # A child block references its parent by the parent header root.
     # That root is only final once the parent post-state root is filled in.
-    state.latest_block_header.state_root = hash_tree_root(state)
+    state.latest_block_header = state.latest_block_header.model_copy(
+        update={"state_root": hash_tree_root(state)}
+    )
     return hash_tree_root(state.latest_block_header)
 
 
@@ -127,7 +129,9 @@ def test_build_block_with_empty_pool_produces_empty_body(
         body=BlockBody(attestations=AggregatedAttestations(data=[])),
     )
     expected_post_state = spec.process_block(spec.process_slots(state, Slot(1)), expected_block)
-    expected_block.state_root = hash_tree_root(expected_post_state)
+    expected_block = expected_block.model_copy(
+        update={"state_root": hash_tree_root(expected_post_state)}
+    )
 
     assert block == expected_block
     assert post_state == expected_post_state
@@ -182,7 +186,9 @@ def test_build_block_keeps_genesis_self_vote(
         body=BlockBody(attestations=AggregatedAttestations(data=[expected_attestation])),
     )
     expected_post_state = spec.process_block(spec.process_slots(state, Slot(1)), expected_block)
-    expected_block.state_root = hash_tree_root(expected_post_state)
+    expected_block = expected_block.model_copy(
+        update={"state_root": hash_tree_root(expected_post_state)}
+    )
 
     assert block == expected_block
     assert post_state == expected_post_state
@@ -293,7 +299,9 @@ def test_build_block_skips_vote_with_unknown_head(
         body=BlockBody(attestations=AggregatedAttestations(data=[expected_attestation])),
     )
     expected_post_state = spec.process_block(spec.process_slots(state, Slot(1)), expected_block)
-    expected_block.state_root = hash_tree_root(expected_post_state)
+    expected_block = expected_block.model_copy(
+        update={"state_root": hash_tree_root(expected_post_state)}
+    )
 
     assert block == expected_block
     assert post_state == expected_post_state
@@ -340,7 +348,9 @@ def test_build_block_skips_vote_with_source_off_chain(
         body=BlockBody(attestations=AggregatedAttestations(data=[expected_attestation])),
     )
     expected_post_state = spec.process_block(spec.process_slots(state, Slot(1)), expected_block)
-    expected_block.state_root = hash_tree_root(expected_post_state)
+    expected_block = expected_block.model_copy(
+        update={"state_root": hash_tree_root(expected_post_state)}
+    )
 
     assert block == expected_block
     assert post_state == expected_post_state
@@ -399,7 +409,9 @@ def test_build_block_skips_vote_with_unjustified_source(
         body=BlockBody(attestations=AggregatedAttestations(data=[])),
     )
     expected_post_state = spec.process_block(spec.process_slots(state, Slot(3)), expected_block)
-    expected_block.state_root = hash_tree_root(expected_post_state)
+    expected_block = expected_block.model_copy(
+        update={"state_root": hash_tree_root(expected_post_state)}
+    )
 
     assert block == expected_block
     assert post_state == expected_post_state
@@ -457,7 +469,9 @@ def test_build_block_skips_vote_for_already_justified_target(
         body=BlockBody(attestations=AggregatedAttestations(data=[])),
     )
     expected_post_state = spec.process_block(spec.process_slots(state, Slot(3)), expected_block)
-    expected_block.state_root = hash_tree_root(expected_post_state)
+    expected_block = expected_block.model_copy(
+        update={"state_root": hash_tree_root(expected_post_state)}
+    )
 
     assert block == expected_block
     assert post_state == expected_post_state
@@ -526,7 +540,9 @@ def test_build_block_fixed_point_unlocks_chained_source(
         body=BlockBody(attestations=AggregatedAttestations(data=[expected_first, expected_second])),
     )
     expected_post_state = spec.process_block(spec.process_slots(state, Slot(3)), expected_block)
-    expected_block.state_root = hash_tree_root(expected_post_state)
+    expected_block = expected_block.model_copy(
+        update={"state_root": hash_tree_root(expected_post_state)}
+    )
 
     assert block == expected_block
     assert post_state == expected_post_state


### PR DESCRIPTION
## What

Set `frozen=True` on the last mutable containers in the lstar object graph apart from `State` and `Store`:

- `BlockBody`, `BlockHeader`, `Block`, `SignedBlock` (`containers/block.py`)

After this, every consensus container except the `State` accumulator and the fork-choice `Store` is immutable.

> **Stacked on #842.** This PR builds on the constructed-once freeze; until #842 merges, the diff here also shows #842's commit. Review only the second commit (`refactor(lstar): freeze the Block family`), or merge #842 first.

## Why

These four were deferred from #842 because each was patched in place after construction. Closer review showed those mutations are not blocked by the future `State` refactor — every site migrates cleanly to `model_copy(update=...)`, which is byte-identical in `hash_tree_root`. Freezing closes the last accidental-mutation gap on the block object graph, which matters because a `Block` / `Checkpoint` is routinely shared by reference across fork choice, the chain, and attestations.

## Migrated mutation sites

Production (`src/`):
- `block_production.py` — build with a zero state root, process, then rebuild the block with the real root.
- `state_transition.py` — rebuild the latest header with its cached state root and reassign it on the still-mutable `State`, instead of mutating the header in place.

Test framework + tests: the block builders, the signature-tampering helpers (`verify_signatures.py`), and the block-production unit tests now rebuild blocks and bodies through layered `model_copy`, matching the pattern the attestation-swap tamper already used.

## Deferred

`State` and `Store` stay mutable. `State` is the `copy.deepcopy` + in-place accumulator at the heart of the state transition; converting it to return a new value is a larger, separate change. `Store` is fork-choice scratch state.

## Caveat

`frozen` is an enforcement aid, not a hard immutability guarantee (`model_config` is a mutable dict; [pydantic#12361](https://github.com/pydantic/pydantic/issues/12361)).

## Tests

Adds immutability tests for the four containers in the source-mirrored path (new `test_block.py`), following the established idiom.

## Validation

- `ruff` (lint + format), `ty`, `codespell` — clean
- Full unit suite: 3139 passed, 92.77% coverage
- `uv run fill --fork=lstar --clean`: 520 passed, vectors regenerate cleanly (every migration preserves `hash_tree_root`, so fixtures are byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)