### PR TITLE
refactor: enforce frozen natively in StrictBaseModel

### DIFF
--- a/.claude/rules/ssz-patterns.md
+++ b/.claude/rules/ssz-patterns.md
@@ -29,7 +29,7 @@ When creating SSZ types, follow these established patterns:
 - These use Pydantic models with a `data` field for contents
 - Example: `MyList(data=[1, 2, 3])` *has* a list of data with SSZ serialization
 
-**Key principle**: If the type conceptually *holds* or *contains* other data, use SSZModel for consistent validation and SSZ encoding.
+**Key principle**: If the type conceptually *holds* or *contains* other data, use SSZModel for consistent validation and immutability.
 
 ## Modular Architecture
 

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -243,7 +243,9 @@ class ForkChoiceTest(BaseConsensusFixture):
 
         # Updating validators changes the state root.
         # We must also update the anchor block to match.
-        self.anchor_state.validators = Validators(data=updated_validators)
+        self.anchor_state = self.anchor_state.model_copy(
+            update={"validators": Validators(data=updated_validators)}
+        )
         self.anchor_block = self.anchor_block.model_copy(
             update={"state_root": hash_tree_root(self.anchor_state)}
         )

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -540,8 +540,7 @@ class BlockSpec(CamelModel):
         }
         for attestation_data, proofs in merged_store.latest_known_aggregated_payloads.items():
             merged_known.setdefault(attestation_data, set()).update(proofs)
-        caller_store.latest_known_aggregated_payloads = merged_known
-        store = caller_store
+        store = caller_store.model_copy(update={"latest_known_aggregated_payloads": merged_known})
 
         # Append forced attestations that bypass the builder's MAX cap.
         # Each entry is signed and aggregated so the block carries valid proofs.

--- a/src/lean_spec/base.py
+++ b/src/lean_spec/base.py
@@ -48,15 +48,17 @@ class CamelModel(BaseModel):
 
 class StrictBaseModel(CamelModel):
     """
-    Strict base model for all spec types.
+    Immutable, strict base model for all spec types.
 
-    Adds two constraints on top of CamelModel:
+    Adds three constraints on top of CamelModel:
 
+    - Frozen: attribute assignment after construction raises
     - Extra forbidden: unknown fields rejected at construction
     - Strict: no implicit type coercion
     """
 
     model_config = CamelModel.model_config | {
         "extra": "forbid",
+        "frozen": True,
         "strict": True,
     }

--- a/src/lean_spec/node/chain/service.py
+++ b/src/lean_spec/node/chain/service.py
@@ -110,7 +110,9 @@ class ChainService:
         # Acceptance for the jumped slots waits for the final slot's tick.
         # That is safe: acceptance is a monotone pool merge, and the head recomputes from scratch.
         if target_interval - store.time > Interval(INTERVALS_PER_SLOT):
-            store.time = target_interval - Interval(INTERVALS_PER_SLOT)
+            store = store.model_copy(
+                update={"time": target_interval - Interval(INTERVALS_PER_SLOT)}
+            )
 
         # Tick remaining intervals one at a time.
         while store.time < target_interval:

--- a/src/lean_spec/node/networking/enr/enr.py
+++ b/src/lean_spec/node/networking/enr/enr.py
@@ -373,7 +373,7 @@ class ENR(StrictBaseModel):
         # Compute and store node_id for routing/identification.
         node_id = enr.compute_node_id()
         if node_id is not None:
-            enr.node_id = node_id
+            enr = enr.model_copy(update={"node_id": node_id})
 
         return enr
 

--- a/src/lean_spec/node/networking/enr/eth2.py
+++ b/src/lean_spec/node/networking/enr/eth2.py
@@ -35,8 +35,6 @@ class Eth2Data(StrictBaseModel):
     SSZ: fork_digest (4) + next_fork_version (4) + next_fork_epoch (8)
     """
 
-    model_config = StrictBaseModel.model_config | {"frozen": True}
-
     fork_digest: ForkDigest
     """Current active fork identifier (4 bytes)."""
 

--- a/src/lean_spec/node/sync/service.py
+++ b/src/lean_spec/node/sync/service.py
@@ -656,7 +656,7 @@ class SyncService:
             aggregates.append(SignedAggregatedAttestation(data=attestation_data, proof=combined))
 
         if aggregates:
-            store.latest_new_aggregated_payloads = new_payloads
+            store = store.model_copy(update={"latest_new_aggregated_payloads": new_payloads})
 
         return store, aggregates
 

--- a/src/lean_spec/spec/crypto/xmss/containers.py
+++ b/src/lean_spec/spec/crypto/xmss/containers.py
@@ -42,8 +42,6 @@ class PublicKey(HexSerializedContainer):
 class Signature(HexSerializedContainer):
     """A single XMSS signature for one slot and message under one public key."""
 
-    model_config = Container.model_config | {"frozen": True}
-
     path: HashTreeOpening
     """Authentication path from the one-time key up to the Merkle root."""
 
@@ -138,8 +136,6 @@ class SecretKey(HexSerializedContainer):
 class KeyPair(StrictBaseModel):
     """A single XMSS public/secret pair returned by key generation."""
 
-    model_config = StrictBaseModel.model_config | {"frozen": True}
-
     public_key: PublicKey
     """Public key."""
 
@@ -160,8 +156,6 @@ class ValidatorKeyPair(StrictBaseModel):
     So one key cannot cover both roles in the same slot.
     Two independent pairs let each role sign from its own Winternitz chains.
     """
-
-    model_config = StrictBaseModel.model_config | {"frozen": True}
 
     attestation_keypair: KeyPair
     """Key pair used to sign attestation data."""

--- a/src/lean_spec/spec/crypto/xmss/interface.py
+++ b/src/lean_spec/spec/crypto/xmss/interface.py
@@ -398,10 +398,13 @@ class GeneralizedXmssScheme(StrictBaseModel):
         )
 
         # Phase 3: rotate the right tree into the left slot, advance the index.
-        secret_key.left_bottom_tree = secret_key.right_bottom_tree
-        secret_key.right_bottom_tree = new_right_bottom_tree
-        secret_key.left_bottom_tree_index = Uint64(left_index + 1)
-        return secret_key
+        return secret_key.model_copy(
+            update={
+                "left_bottom_tree": secret_key.right_bottom_tree,
+                "right_bottom_tree": new_right_bottom_tree,
+                "left_bottom_tree_index": Uint64(left_index + 1),
+            }
+        )
 
 
 PROD_SIGNATURE_SCHEME = GeneralizedXmssScheme(config=PROD_CONFIG, poseidon=POSEIDON)

--- a/src/lean_spec/spec/forks/lstar/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/aggregation.py
@@ -189,13 +189,21 @@ class AggregationMixin(LstarSpecBase):
 
         # Replace the new-payload pool with this round's proofs, keyed by attestation data.
         # Future rounds reuse these as building blocks.
-        store.latest_new_aggregated_payloads = {
+        new_aggregated_payloads = {
             signed_attestation.data: {signed_attestation.proof}
             for signed_attestation in new_aggregates
         }
 
         # Those proofs absorbed their gossip signatures, so drop the raw copies.
-        for attestation_data in store.latest_new_aggregated_payloads:
-            store.attestation_signatures.pop(attestation_data, None)
+        remaining_attestation_signatures = {
+            attestation_data: signatures
+            for attestation_data, signatures in store.attestation_signatures.items()
+            if attestation_data not in new_aggregated_payloads
+        }
 
-        return store, new_aggregates
+        return store.model_copy(
+            update={
+                "latest_new_aggregated_payloads": new_aggregated_payloads,
+                "attestation_signatures": remaining_attestation_signatures,
+            }
+        ), new_aggregates

--- a/src/lean_spec/spec/forks/lstar/containers/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/aggregation.py
@@ -43,8 +43,6 @@ class SingleMessageAggregate(Container):
     The verifier rederives them from the block body it already trusts.
     """
 
-    model_config = Container.model_config | {"frozen": True}
-
     participants: AggregationBits
     """Bitfield indicating which validators contributed signatures."""
 
@@ -182,8 +180,6 @@ class MultiMessageAggregate(Container):
     Each component is a single-message proof over its own message.
     Merging binds the components into one proof the block can carry whole.
     """
-
-    model_config = Container.model_config | {"frozen": True}
 
     proof: ByteList512KiB
     """Compact public-key-free serialized multi-message aggregate proof bytes."""

--- a/src/lean_spec/spec/forks/lstar/containers/attestation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/attestation.py
@@ -12,8 +12,6 @@ from lean_spec.spec.ssz import Container, SSZList
 class Attestation(Container):
     """Validator specific attestation wrapping shared attestation data."""
 
-    model_config = Container.model_config | {"frozen": True}
-
     validator_index: ValidatorIndex
     """The index of the validator making the attestation."""
 
@@ -30,8 +28,6 @@ class SignedAttestation(Attestation):
 
 class AggregatedAttestation(Container):
     """Aggregated attestation consisting of participation bits and message."""
-
-    model_config = Container.model_config | {"frozen": True}
 
     aggregation_bits: AggregationBits
     """Bitfield indicating which validators participated in the aggregation."""
@@ -50,8 +46,6 @@ class SignedAggregatedAttestation(Container):
 
     Contains the attestation data and the aggregated signature proof.
     """
-
-    model_config = Container.model_config | {"frozen": True}
 
     data: AttestationData
     """Combined attestation data similar to the beacon chain format."""

--- a/src/lean_spec/spec/forks/lstar/containers/block.py
+++ b/src/lean_spec/spec/forks/lstar/containers/block.py
@@ -10,8 +10,6 @@ from lean_spec.spec.ssz import Bytes32, Container
 class BlockBody(Container):
     """Payload of a block containing attestations."""
 
-    model_config = Container.model_config | {"frozen": True}
-
     attestations: AggregatedAttestations
     """Attestations in the block. Signatures are folded into the block-level proof."""
 
@@ -23,8 +21,6 @@ class BlockHeader(Container):
     Contains parent reference, state root, and body hash.
     Smaller than full blocks.
     """
-
-    model_config = Container.model_config | {"frozen": True}
 
     slot: Slot
     """The slot in which the block was proposed."""
@@ -44,8 +40,6 @@ class BlockHeader(Container):
 
 class Block(Container):
     """A complete block including header and body."""
-
-    model_config = Container.model_config | {"frozen": True}
 
     slot: Slot
     """The slot in which the block was proposed."""
@@ -71,8 +65,6 @@ class SignedBlock(Container):
     It binds every attestation in the body plus the proposer's signature
     over the block root.
     """
-
-    model_config = Container.model_config | {"frozen": True}
 
     block: Block
     """The block being signed."""

--- a/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
+++ b/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
@@ -20,8 +20,6 @@ class Checkpoint(Container):
     Checkpoints are used for justification and finalization.
     """
 
-    model_config = Container.model_config | {"frozen": True}
-
     root: Bytes32
     """The root hash of the checkpoint's block."""
 
@@ -41,8 +39,6 @@ class Checkpoint(Container):
 
 class AttestationData(Container):
     """Attestation content describing the validator's observed chain view."""
-
-    model_config = Container.model_config | {"frozen": True}
 
     slot: Slot
     """The slot for which the attestation is made."""

--- a/src/lean_spec/spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/spec/forks/lstar/containers/validator.py
@@ -14,16 +14,12 @@ class GenesisConfig(Container):
     in the absence of more complex mechanisms like RANDAO or deposits.
     """
 
-    model_config = Container.model_config | {"frozen": True}
-
     genesis_time: Uint64
     """The timestamp of the genesis block."""
 
 
 class Validator(Container):
     """Represents a validator's static metadata and operational interface."""
-
-    model_config = Container.model_config | {"frozen": True}
 
     attestation_public_key: Bytes52
     """XMSS public key for signing attestations."""

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -117,22 +117,25 @@ class ForkChoiceMixin(LstarSpecBase):
         #
         # Each mapping is keyed by attestation data, so we check the attested
         # head slot against the finalized slot.
-        store.attestation_signatures = {
-            attestation_data: signatures
-            for attestation_data, signatures in store.attestation_signatures.items()
-            if attestation_data.head.slot > store.latest_finalized.slot
-        }
-        store.latest_new_aggregated_payloads = {
-            attestation_data: proofs
-            for attestation_data, proofs in store.latest_new_aggregated_payloads.items()
-            if attestation_data.head.slot > store.latest_finalized.slot
-        }
-        store.latest_known_aggregated_payloads = {
-            attestation_data: proofs
-            for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
-            if attestation_data.head.slot > store.latest_finalized.slot
-        }
-        return store
+        return store.model_copy(
+            update={
+                "attestation_signatures": {
+                    attestation_data: signatures
+                    for attestation_data, signatures in store.attestation_signatures.items()
+                    if attestation_data.head.slot > store.latest_finalized.slot
+                },
+                "latest_new_aggregated_payloads": {
+                    attestation_data: proofs
+                    for attestation_data, proofs in store.latest_new_aggregated_payloads.items()
+                    if attestation_data.head.slot > store.latest_finalized.slot
+                },
+                "latest_known_aggregated_payloads": {
+                    attestation_data: proofs
+                    for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
+                    if attestation_data.head.slot > store.latest_finalized.slot
+                },
+            }
+        )
 
     def validate_attestation(self, store: LstarStore, attestation_data: AttestationData) -> None:
         """
@@ -255,16 +258,22 @@ class ForkChoiceMixin(LstarSpecBase):
                 public_key, attestation_data.slot, hash_tree_root(attestation_data), signature
             ), "Signature verification failed"
 
+            # Non-aggregator nodes validate and drop — they never store gossip signatures.
+            if not is_aggregator:
+                return store
+
             # Aggregators store all received gossip signatures.
             # The p2p layer only delivers attestations from subscribed subnets,
             # so subnet filtering happens at subscription time, not here.
-            # Non-aggregator nodes validate and drop — they never store gossip signatures.
-            if is_aggregator:
-                store.attestation_signatures.setdefault(attestation_data, set()).add(
-                    AttestationSignatureEntry(validator_index, signature)
-                )
+            # Copy the inner sets so the caller's store is left untouched.
+            new_attestation_signatures = {
+                data: set(signatures) for data, signatures in store.attestation_signatures.items()
+            }
+            new_attestation_signatures.setdefault(attestation_data, set()).add(
+                AttestationSignatureEntry(validator_index, signature)
+            )
 
-            return store
+            return store.model_copy(update={"attestation_signatures": new_attestation_signatures})
 
     def on_gossip_aggregated_attestation(
         self,
@@ -323,11 +332,14 @@ class ForkChoiceMixin(LstarSpecBase):
                 f"Committee aggregation signature verification failed: {exception}"
             ) from exception
 
-        store.latest_new_aggregated_payloads.setdefault(attestation_data, set()).add(
-            aggregated_proof
-        )
+        # Copy the inner sets so the caller's store is left untouched.
+        new_aggregated_payloads = {
+            pooled_data: set(pooled_proofs)
+            for pooled_data, pooled_proofs in store.latest_new_aggregated_payloads.items()
+        }
+        new_aggregated_payloads.setdefault(attestation_data, set()).add(aggregated_proof)
 
-        return store
+        return store.model_copy(update={"latest_new_aggregated_payloads": new_aggregated_payloads})
 
     def on_block(
         self,
@@ -401,11 +413,6 @@ class ForkChoiceMixin(LstarSpecBase):
             latest_justified = store.latest_justified.advance_to(post_state.latest_justified)
             latest_finalized = store.latest_finalized.advance_to(post_state.latest_finalized)
 
-            store.blocks = store.blocks | {block_root: block}
-            store.states = store.states | {block_root: post_state}
-            store.latest_justified = latest_justified
-            store.latest_finalized = latest_finalized
-
             # Register each block attestation's data in the known pool.
             #
             # Only the data key is recorded here, with an empty proof set.
@@ -420,10 +427,23 @@ class ForkChoiceMixin(LstarSpecBase):
             # the known pool at the next acceptance tick.
             # Head weight from block-imported votes is therefore deferred
             # by up to one slot.
+            # Copy the inner sets so the caller's store is left untouched.
+            new_known_aggregated_payloads = {
+                attestation_data: set(proofs)
+                for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
+            }
             for aggregated_attestation in aggregated_attestations:
-                store.latest_known_aggregated_payloads.setdefault(
-                    aggregated_attestation.data, set()
-                )
+                new_known_aggregated_payloads.setdefault(aggregated_attestation.data, set())
+
+            store = store.model_copy(
+                update={
+                    "blocks": store.blocks | {block_root: block},
+                    "states": store.states | {block_root: post_state},
+                    "latest_justified": latest_justified,
+                    "latest_finalized": latest_finalized,
+                    "latest_known_aggregated_payloads": new_known_aggregated_payloads,
+                }
+            )
 
             # Update forkchoice head based on new block and attestations.
             store = self.update_head(store)
@@ -594,12 +614,12 @@ class ForkChoiceMixin(LstarSpecBase):
         # Starts from the justified root and greedily descends to the heaviest
         # leaf. The result is always a descendant of the justified root by
         # construction: the walk only follows child edges within the subtree.
-        store.head = self._compute_lmd_ghost_head(
+        new_head = self._compute_lmd_ghost_head(
             store,
             start_root=store.latest_justified.root,
             attestations=attestations,
         )
-        return store
+        return store.model_copy(update={"head": new_head})
 
     def accept_new_attestations(self, store: LstarStore) -> LstarStore:
         """
@@ -621,12 +641,21 @@ class ForkChoiceMixin(LstarSpecBase):
         This staged progression ensures proper timing and prevents premature
         influence on fork choice decisions.
         """
-        # Merge new aggregated payloads into known aggregated payloads
+        # Merge new aggregated payloads into known aggregated payloads.
+        # Copy the inner sets so the caller's store is left untouched.
+        merged_aggregated_payloads = {
+            attestation_data: set(proofs)
+            for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
+        }
         for attestation_data, proofs in store.latest_new_aggregated_payloads.items():
-            store.latest_known_aggregated_payloads.setdefault(attestation_data, set()).update(
-                proofs
-            )
-        store.latest_new_aggregated_payloads = {}
+            merged_aggregated_payloads.setdefault(attestation_data, set()).update(proofs)
+
+        store = store.model_copy(
+            update={
+                "latest_known_aggregated_payloads": merged_aggregated_payloads,
+                "latest_new_aggregated_payloads": {},
+            }
+        )
 
         # Update head with newly accepted aggregated payloads
         return self.update_head(store)
@@ -701,5 +730,4 @@ class ForkChoiceMixin(LstarSpecBase):
         # Return a new Store with only the safe target updated.
         #
         # The head and attestation pools remain unchanged.
-        store.safe_target = safe_target
-        return store
+        return store.model_copy(update={"safe_target": safe_target})

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -1,6 +1,5 @@
 """Lstar fork — state transition: slots, header, body, finalization."""
 
-import copy
 from collections.abc import Iterable, Sequence
 from typing import Any
 
@@ -129,9 +128,6 @@ class StateTransitionMixin(LstarSpecBase):
         # The target must be strictly greater than the current slot.
         assert state.slot < target_slot, "Target slot must be in the future"
 
-        # Work on a copy so the caller's state is untouched.
-        state = copy.deepcopy(state)
-
         # Step through each missing slot.
         while state.slot < target_slot:
             # Cache the pre-block state root into the latest header, then bump the slot.
@@ -144,11 +140,14 @@ class StateTransitionMixin(LstarSpecBase):
                 hash_tree_root(state) if needs_state_root else state.latest_block_header.state_root
             )
 
-            if needs_state_root:
-                state.latest_block_header = state.latest_block_header.model_copy(
-                    update={"state_root": cached_state_root}
-                )
-            state.slot = Slot(state.slot + Slot(1))
+            state = state.model_copy(
+                update={
+                    "latest_block_header": state.latest_block_header.model_copy(
+                        update={"state_root": cached_state_root}
+                    ),
+                    "slot": Slot(state.slot + Slot(1)),
+                }
+            )
 
         # Reached the target slot. Return the advanced state.
         return state
@@ -223,8 +222,11 @@ class StateTransitionMixin(LstarSpecBase):
         #   updates rely entirely on validator attestations which are processed
         #   later in the block body.
         if is_genesis_parent:
-            state.latest_justified = Checkpoint(slot=Slot(0), root=parent_root)
-            state.latest_finalized = Checkpoint(slot=Slot(0), root=parent_root)
+            new_latest_justified = Checkpoint(slot=Slot(0), root=parent_root)
+            new_latest_finalized = Checkpoint(slot=Slot(0), root=parent_root)
+        else:
+            new_latest_justified = state.latest_justified
+            new_latest_finalized = state.latest_finalized
 
         # Historical Data Management
 
@@ -238,7 +240,7 @@ class StateTransitionMixin(LstarSpecBase):
         # Update the list of historical block roots.
         #
         # Structure: [Existing history] + [Parent root] + [Zero hash for gaps]
-        state.historical_block_hashes = (
+        new_historical_block_hashes = (
             state.historical_block_hashes + [parent_root] + [ZERO_HASH] * num_empty_slots
         )
 
@@ -254,8 +256,8 @@ class StateTransitionMixin(LstarSpecBase):
         # and addressable. The current block's slot is not materialized until
         # its header is fully processed, so we stop at slot (block.slot - 1).
         last_materialized_slot = block.slot - Slot(1)
-        state.justified_slots = state.justified_slots.extend_to_slot(
-            state.latest_finalized.slot,
+        new_justified_slots = state.justified_slots.extend_to_slot(
+            new_latest_finalized.slot,
             last_materialized_slot,
         )
 
@@ -265,7 +267,7 @@ class StateTransitionMixin(LstarSpecBase):
         #
         # Leave state root empty.
         # It is not computed until the block body is fully processed or the next slot begins.
-        state.latest_block_header = self.block_header_class(
+        new_latest_block_header = self.block_header_class(
             slot=block.slot,
             proposer_index=block.proposer_index,
             parent_root=block.parent_root,
@@ -273,7 +275,16 @@ class StateTransitionMixin(LstarSpecBase):
             state_root=Bytes32.zero(),
         )
 
-        return state
+        # Apply all calculated updates atomically in one new state.
+        return state.model_copy(
+            update={
+                "latest_justified": new_latest_justified,
+                "latest_finalized": new_latest_finalized,
+                "historical_block_hashes": new_historical_block_hashes,
+                "justified_slots": new_justified_slots,
+                "latest_block_header": new_latest_block_header,
+            }
+        )
 
     def process_block(self, state: State, block: Block) -> State:
         """
@@ -509,15 +520,18 @@ class StateTransitionMixin(LstarSpecBase):
         # Sorting ensures that every node produces identical state representation.
         sorted_roots = sorted(justifications.keys())
 
-        # Apply the updated state
-        state.justifications_roots = JustificationRoots(data=sorted_roots)
-        state.justifications_validators = JustificationValidators(
-            data=[vote for root in sorted_roots for vote in justifications[root]]
+        # Construct and return the updated state.
+        return state.model_copy(
+            update={
+                "justifications_roots": JustificationRoots(data=sorted_roots),
+                "justifications_validators": JustificationValidators(
+                    data=[vote for root in sorted_roots for vote in justifications[root]]
+                ),
+                "justified_slots": justified_slots,
+                "latest_justified": latest_justified,
+                "latest_finalized": latest_finalized,
+            }
         )
-        state.justified_slots = justified_slots
-        state.latest_justified = latest_justified
-        state.latest_finalized = latest_finalized
-        return state
 
     def state_transition(
         self,

--- a/src/lean_spec/spec/forks/lstar/timeline.py
+++ b/src/lean_spec/spec/forks/lstar/timeline.py
@@ -30,7 +30,7 @@ class TimelineMixin(LstarSpecBase):
         - Interval 4: Process accumulated attestations
         """
         # Advance time by one interval
-        store.time = store.time + Interval(1)
+        store = store.model_copy(update={"time": store.time + Interval(1)})
         current_interval = Interval(int(store.time) % int(INTERVALS_PER_SLOT))
         new_aggregates: list[SignedAggregatedAttestation] = []
 

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -205,10 +205,14 @@ class ValidatorDutiesMixin(LstarSpecBase):
 
         # Persist block and state.
         previous_finalized_slot = store.latest_finalized.slot
-        store.blocks = store.blocks | {block_hash: final_block}
-        store.states = store.states | {block_hash: final_post_state}
-        store.latest_justified = latest_justified
-        store.latest_finalized = latest_finalized
+        store = store.model_copy(
+            update={
+                "blocks": store.blocks | {block_hash: final_block},
+                "states": store.states | {block_hash: final_post_state},
+                "latest_justified": latest_justified,
+                "latest_finalized": latest_finalized,
+            }
+        )
 
         # Prune stale attestation data when finalization advances
         if store.latest_finalized.slot > previous_finalized_slot:

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -338,7 +338,7 @@ def make_store_with_attestation_data(
         validator_index=validator_index,
         key_manager=key_manager,
     )
-    store.time = Interval.from_slot(attestation_slot)
+    store = store.model_copy(update={"time": Interval.from_slot(attestation_slot)})
     attestation_data = LstarSpec().produce_attestation_data(store, attestation_slot)
     return store, attestation_data
 
@@ -357,15 +357,19 @@ def make_store_with_attestation_signatures(
         validator_index,
         attestation_slot,
     )
-    store.attestation_signatures = {
-        attestation_data: {
-            AttestationSignatureEntry(
-                validator_index,
-                key_manager.sign_attestation_data(validator_index, attestation_data),
-            )
-            for validator_index in attesting_validators
-        },
-    }
+    store = store.model_copy(
+        update={
+            "attestation_signatures": {
+                attestation_data: {
+                    AttestationSignatureEntry(
+                        validator_index,
+                        key_manager.sign_attestation_data(validator_index, attestation_data),
+                    )
+                    for validator_index in attesting_validators
+                },
+            }
+        }
+    )
     return store, attestation_data
 
 

--- a/tests/lean_spec/node/chain/test_service.py
+++ b/tests/lean_spec/node/chain/test_service.py
@@ -178,7 +178,9 @@ class TestCatchUp:
     async def test_rejects_a_target_before_the_current_time(self) -> None:
         """Catch-up refuses a target earlier than where the store already sits."""
         service = make_service(ProbeSpec())
-        service.sync_service.store.time = Interval(5)
+        service.sync_service.store = service.sync_service.store.model_copy(
+            update={"time": Interval(5)}
+        )
         with pytest.raises(AssertionError):
             await service._tick_to(Interval(3))
 
@@ -188,8 +190,10 @@ class TestCatchUp:
 
         # Stand in for a gossip handler that processes a block during the yield.
         # It installs a fresh store object, which the driver must continue from.
-        swapped = make_store(genesis_time=1000)
-        swapped.time = Interval(1)
+        #
+        # The swapped store carries a distinctive genesis time so the final store
+        # can be traced back to it rather than to the stale original object.
+        swapped = make_store(genesis_time=2000).model_copy(update={"time": Interval(1)})
         swap = {"done": False}
 
         async def swap_store_once(duration: float) -> None:
@@ -200,9 +204,11 @@ class TestCatchUp:
         with patch("asyncio.sleep", new=swap_store_once):
             await service._tick_to(Interval(3))
 
-        # Reaching the target on the swapped object proves the post-yield re-read.
-        assert service.sync_service.store is swapped
-        assert int(swapped.time) == 3
+        # The final store descends from the swapped object, proving the post-yield
+        # re-read: it carries the swapped genesis time and reaches the target time.
+        final_store = service.sync_service.store
+        assert final_store.config.genesis_time == Uint64(2000)
+        assert int(final_store.time) == 3
 
 
 class TestStartupTick:

--- a/tests/lean_spec/node/sync/test_service.py
+++ b/tests/lean_spec/node/sync/test_service.py
@@ -799,7 +799,9 @@ def _setup(
     )
 
     block_proof = make_aggregated_proof(key_manager, block_participants, attestation_data)
-    chain_store.latest_known_aggregated_payloads = {attestation_data: {block_proof}}
+    chain_store = chain_store.model_copy(
+        update={"latest_known_aggregated_payloads": {attestation_data: {block_proof}}}
+    )
     producer_store = chain_store
     _, signed_block = make_signed_block_from_store(
         producer_store, key_manager, BLOCK_SLOT, BLOCK_PROPOSER
@@ -825,8 +827,7 @@ def test_skips_when_target_not_ahead_of_justified(
         key_manager, block_participants=[ValidatorIndex(1), ValidatorIndex(2)]
     )
     # Justified now sits at the attestation's target slot.
-    chain_store.latest_justified = attestation_data.target
-    store = chain_store
+    store = chain_store.model_copy(update={"latest_justified": attestation_data.target})
     service = _service(peer_id)
 
     new_store, aggregates = service._deconstruct_block_into_store(store, signed_block)
@@ -854,8 +855,9 @@ def test_skips_when_block_adds_no_new_validators(
         [ValidatorIndex(1), ValidatorIndex(2), ValidatorIndex(3)],
         attestation_data,
     )
-    chain_store.latest_new_aggregated_payloads = {attestation_data: {local_partial}}
-    store = chain_store
+    store = chain_store.model_copy(
+        update={"latest_new_aggregated_payloads": {attestation_data: {local_partial}}}
+    )
     service = _service(peer_id)
 
     new_store, aggregates = service._deconstruct_block_into_store(store, signed_block)
@@ -869,8 +871,7 @@ def test_noop_when_parent_state_missing(peer_id: PeerId, key_manager: XmssKeyMan
     chain_store, signed_block, _ = _setup(
         key_manager, block_participants=[ValidatorIndex(1), ValidatorIndex(2)]
     )
-    chain_store.states = {}
-    store = chain_store
+    store = chain_store.model_copy(update={"states": {}})
     service = _service(peer_id)
 
     new_store, aggregates = service._deconstruct_block_into_store(store, signed_block)

--- a/tests/lean_spec/node/validator/test_service.py
+++ b/tests/lean_spec/node/validator/test_service.py
@@ -595,7 +595,9 @@ class TestProduceAttestationsAdvanced:
                     state_root=Bytes32.zero(),
                 )
                 root = hash_tree_root(sb.block)
-                sync_service.store.blocks = {**sync_service.store.blocks, root: sb.block}
+                sync_service.store = sync_service.store.model_copy(
+                    update={"blocks": {**sync_service.store.blocks, root: sb.block}}
+                )
 
         with patch("asyncio.sleep", new=mock_sleep):
             await service._produce_attestations(target_slot)
@@ -1088,8 +1090,9 @@ class TestValidatorServiceIntegration:
             slot=attestation_data.slot,
         )
 
-        store.latest_known_aggregated_payloads = {attestation_data: {proof}}
-        updated_store = store
+        updated_store = store.model_copy(
+            update={"latest_known_aggregated_payloads": {attestation_data: {proof}}}
+        )
         real_sync_service.store = updated_store
 
         blocks_produced: list[SignedBlock] = []
@@ -1294,8 +1297,7 @@ def _replace_head_at_slot(sync_service: SyncService, head_slot: Slot) -> None:
     )
     new_root = hash_tree_root(new_head_block)
     blocks[new_root] = new_head_block
-    sync_service.store.blocks = blocks
-    sync_service.store.head = new_root
+    sync_service.store = sync_service.store.model_copy(update={"blocks": blocks, "head": new_root})
 
 
 def _add_block_at_slot(sync_service: SyncService, slot: Slot) -> Bytes32:
@@ -1317,7 +1319,7 @@ def _add_block_at_slot(sync_service: SyncService, slot: Slot) -> Bytes32:
     )
     new_root = hash_tree_root(new_block)
     new_blocks = {**sync_service.store.blocks, new_root: new_block}
-    sync_service.store.blocks = new_blocks
+    sync_service.store = sync_service.store.model_copy(update={"blocks": new_blocks})
     return new_root
 
 

--- a/tests/lean_spec/spec/forks/lstar/conftest.py
+++ b/tests/lean_spec/spec/forks/lstar/conftest.py
@@ -25,8 +25,7 @@ def pruning_store() -> Store:
 def sample_store(store_factory):
     """Store with 8 validators, genesis_time=1000, time=100."""
     store = store_factory(num_validators=8, genesis_time=1000)
-    store.time = Interval(100)
-    return store
+    return store.model_copy(update={"time": Interval(100)})
 
 
 @pytest.fixture

--- a/tests/lean_spec/spec/forks/lstar/containers/test_state.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from lean_spec.spec.forks import Slot
 from tests.lean_spec.helpers import make_genesis_state
@@ -13,3 +14,13 @@ def test_is_slot_justified_raises_on_out_of_bounds() -> None:
     # If it is not, this indicates an inconsistent state and should fail fast.
     with pytest.raises(IndexError):
         make_genesis_state(num_validators=1).justified_slots.is_slot_justified(Slot(0), Slot(1))
+
+
+class TestStateImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_slot_raises(self) -> None:
+        """Assigning a new slot on a constructed state raises."""
+        genesis_state = make_genesis_state(num_validators=1)
+        with pytest.raises(ValidationError, match="frozen"):
+            genesis_state.slot = Slot(1)

--- a/tests/lean_spec/spec/forks/lstar/containers/test_store.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_store.py
@@ -1,0 +1,19 @@
+"""Tests for the lstar forkchoice Store container."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from lean_spec.spec.forks.lstar.containers import Interval
+from tests.lean_spec.helpers import make_store
+
+
+class TestStoreImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_time_raises(self) -> None:
+        """Assigning a new time on a constructed store raises."""
+        store = make_store(num_validators=1)
+        with pytest.raises(ValidationError, match="frozen"):
+            store.time = Interval(1)

--- a/tests/lean_spec/spec/forks/lstar/test_aggregation.py
+++ b/tests/lean_spec/spec/forks/lstar/test_aggregation.py
@@ -254,8 +254,7 @@ class TestAggregateCommitteeSignatures:
             attestation_data_2: {AttestationSignatureEntry(ValidatorIndex(2), signature_2)},
         }
 
-        base_store.attestation_signatures = attestation_signatures
-        store = base_store
+        store = base_store.model_copy(update={"attestation_signatures": attestation_signatures})
 
         updated_store, _ = spec.aggregate(store)
 
@@ -293,7 +292,7 @@ class TestTickIntervalAggregation:
         # Set time to interval 1 (so next tick goes to interval 2)
         # time % INTERVALS_PER_SLOT determines current interval
         # We want to end up at interval 2 after tick
-        store.time = Interval(1)
+        store = store.model_copy(update={"time": Interval(1)})
 
         # Tick to interval 2 as aggregator
         updated_store, _ = spec.tick_interval(store, has_proposal=False, is_aggregator=True)
@@ -321,7 +320,7 @@ class TestTickIntervalAggregation:
         )
 
         # Set time to interval 1
-        store.time = Interval(1)
+        store = store.model_copy(update={"time": Interval(1)})
 
         # Tick to interval 2 as NON-aggregator
         updated_store, _ = spec.tick_interval(store, has_proposal=False, is_aggregator=False)
@@ -357,8 +356,7 @@ class TestTickIntervalAggregation:
             # So we need time+1 % 5 == target_interval
             # Therefore time = target_interval - 1 (mod 5)
             pre_tick_time = (target_interval - 1) % int(INTERVALS_PER_SLOT)
-            store.time = Interval(pre_tick_time)
-            test_store = store
+            test_store = store.model_copy(update={"time": Interval(pre_tick_time)})
 
             updated_store, _ = spec.tick_interval(
                 test_store, has_proposal=False, is_aggregator=True
@@ -382,7 +380,7 @@ class TestTickIntervalAggregation:
         )
 
         # Set time to interval 4 (so next tick wraps to interval 0)
-        store.time = Interval(4)
+        store = store.model_copy(update={"time": Interval(4)})
 
         # Tick to interval 0 with proposal
         updated_store, _ = spec.tick_interval(store, has_proposal=True, is_aggregator=True)
@@ -420,7 +418,7 @@ class TestEndToEndAggregationFlow:
             num_validators=num_validators, key_manager=key_manager, validator_index=aggregator_id
         )
         # Advance the clock to slot 1 so the attestation's slot has begun.
-        store.time = Interval.from_slot(Slot(1))
+        store = store.model_copy(update={"time": Interval.from_slot(Slot(1))})
 
         attestation_data = spec.produce_attestation_data(store, Slot(1))
 
@@ -449,7 +447,7 @@ class TestEndToEndAggregationFlow:
             )
 
         # Step 2: Advance to interval 2 (aggregation interval)
-        store.time = Interval(1)
+        store = store.model_copy(update={"time": Interval(1)})
         store, _ = spec.tick_interval(store, has_proposal=False, is_aggregator=True)
 
         # Step 3: Verify aggregated proofs were created
@@ -492,7 +490,7 @@ def test_aggregated_signatures_prefers_full_gossip_payload(
         }
     }
 
-    store.attestation_signatures = attestation_signatures
+    store = store.model_copy(update={"attestation_signatures": attestation_signatures})
     _, aggregated_attestations = spec.aggregate(store)
 
     assert len(aggregated_attestations) == 1
@@ -559,7 +557,7 @@ def test_aggregated_signatures_with_multiple_data_groups(
         },
     }
 
-    store.attestation_signatures = attestation_signatures
+    store = store.model_copy(update={"attestation_signatures": attestation_signatures})
     _, aggregated_attestations = spec.aggregate(store)
 
     assert len(aggregated_attestations) == 2

--- a/tests/lean_spec/spec/forks/lstar/test_block_production.py
+++ b/tests/lean_spec/spec/forks/lstar/test_block_production.py
@@ -19,14 +19,15 @@ from lean_spec.spec.ssz import Bytes32
 from tests.lean_spec.helpers import make_aggregated_proof, make_keyed_genesis_state
 
 
-def _seal_header(state: State) -> Bytes32:
-    """Write the post-state root into the header and return that header root."""
+def _seal_header(state: State) -> tuple[State, Bytes32]:
+    """Write the post-state root into the header and return the sealed state and its root."""
     # A child block references its parent by the parent header root.
     # That root is only final once the parent post-state root is filled in.
-    state.latest_block_header = state.latest_block_header.model_copy(
+    sealed_header = state.latest_block_header.model_copy(
         update={"state_root": hash_tree_root(state)}
     )
-    return hash_tree_root(state.latest_block_header)
+    sealed_state = state.model_copy(update={"latest_block_header": sealed_header})
+    return sealed_state, hash_tree_root(sealed_state.latest_block_header)
 
 
 def _genesis_with_parent(
@@ -35,7 +36,7 @@ def _genesis_with_parent(
 ) -> tuple[State, Bytes32]:
     """Build a keyed genesis state and seal its header for use as a parent."""
     state = make_keyed_genesis_state(num_validators, key_manager)
-    return state, _seal_header(state)
+    return _seal_header(state)
 
 
 def _chain_through_slot_two(
@@ -67,7 +68,7 @@ def _chain_through_slot_two(
         body=BlockBody(attestations=AggregatedAttestations(data=[])),
     )
     state = spec.process_block(spec.process_slots(state, Slot(1)), block_one)
-    block_one_root = _seal_header(state)
+    state, block_one_root = _seal_header(state)
 
     # The slot-two body stays empty unless a caller needs slot one justified.
     # A full vote for slot one inside the body crosses the supermajority.
@@ -93,7 +94,7 @@ def _chain_through_slot_two(
         body=BlockBody(attestations=slot_two_body),
     )
     state = spec.process_block(spec.process_slots(state, Slot(2)), block_two)
-    block_two_root = _seal_header(state)
+    state, block_two_root = _seal_header(state)
 
     return state, genesis_root, block_one_root, block_two_root
 

--- a/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
+++ b/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
@@ -52,7 +52,7 @@ def _make_empty_proof(participants: list[ValidatorIndex]) -> SingleMessageAggreg
     )
 
 
-def _add_two_block_chain(base_store: Store) -> tuple[Bytes32, Bytes32, Bytes32]:
+def _add_two_block_chain(base_store: Store) -> tuple[Store, Bytes32, Bytes32, Bytes32]:
     genesis_root = base_store.head
 
     block1 = make_signed_block(
@@ -71,23 +71,27 @@ def _add_two_block_chain(base_store: Store) -> tuple[Bytes32, Bytes32, Bytes32]:
     )
     block2_root = hash_tree_root(block2.block)
 
-    base_store.blocks = {
-        **base_store.blocks,
-        block1_root: block1.block,
-        block2_root: block2.block,
-    }
     genesis_state = base_store.states[genesis_root]
-    base_store.states = {
-        **base_store.states,
-        block1_root: genesis_state,
-        block2_root: genesis_state,
-    }
-    base_store.head = block2_root
+    base_store = base_store.model_copy(
+        update={
+            "blocks": {
+                **base_store.blocks,
+                block1_root: block1.block,
+                block2_root: block2.block,
+            },
+            "states": {
+                **base_store.states,
+                block1_root: genesis_state,
+                block2_root: genesis_state,
+            },
+            "head": block2_root,
+        }
+    )
 
-    return genesis_root, block1_root, block2_root
+    return base_store, genesis_root, block1_root, block2_root
 
 
-def _add_finalized_fork(base_store: Store) -> tuple[Bytes32, Bytes32, Bytes32, Bytes32]:
+def _add_finalized_fork(base_store: Store) -> tuple[Store, Bytes32, Bytes32, Bytes32, Bytes32]:
     genesis_root = base_store.head
 
     block1 = make_signed_block(
@@ -117,22 +121,26 @@ def _add_finalized_fork(base_store: Store) -> tuple[Bytes32, Bytes32, Bytes32, B
     voted_root, tie_break_root = sorted([child_a_root, child_b_root])
 
     genesis_state = base_store.states[genesis_root]
-    base_store.blocks = {
-        **base_store.blocks,
-        block1_root: block1.block,
-        child_a_root: child_a.block,
-        child_b_root: child_b.block,
-    }
-    base_store.states = {
-        **base_store.states,
-        block1_root: genesis_state,
-        child_a_root: genesis_state,
-        child_b_root: genesis_state,
-    }
-    base_store.head = tie_break_root
+    base_store = base_store.model_copy(
+        update={
+            "blocks": {
+                **base_store.blocks,
+                block1_root: block1.block,
+                child_a_root: child_a.block,
+                child_b_root: child_b.block,
+            },
+            "states": {
+                **base_store.states,
+                block1_root: genesis_state,
+                child_a_root: genesis_state,
+                child_b_root: genesis_state,
+            },
+            "head": tie_break_root,
+        }
+    )
     assert tie_break_root > voted_root
 
-    return genesis_root, block1_root, voted_root, tie_break_root
+    return base_store, genesis_root, block1_root, voted_root, tie_break_root
 
 
 def test_genesis_only_store_returns_empty_weights(spec: LstarSpec, base_store: Store) -> None:
@@ -180,11 +188,14 @@ def test_linear_chain_weight_accumulates_upward(spec: LstarSpec, base_store: Sto
         attestation_data: {proof},
     }
 
-    base_store.blocks = new_blocks
-    base_store.states = new_states
-    base_store.head = block2_root
-    base_store.latest_known_aggregated_payloads = aggregated_payloads
-    store = base_store
+    store = base_store.model_copy(
+        update={
+            "blocks": new_blocks,
+            "states": new_states,
+            "head": block2_root,
+            "latest_known_aggregated_payloads": aggregated_payloads,
+        }
+    )
 
     weights = spec.compute_block_weights(store)
 
@@ -216,19 +227,23 @@ def test_stale_latest_message_does_not_mask_fresh_weight(
     )
     block2_root = hash_tree_root(block2.block)
 
-    base_store.blocks = {
-        **base_store.blocks,
-        block1_root: block1.block,
-        block2_root: block2.block,
-    }
     genesis_state = base_store.states[genesis_root]
-    base_store.states = {
-        **base_store.states,
-        block1_root: genesis_state,
-        block2_root: genesis_state,
-    }
-    base_store.head = block2_root
-    base_store.latest_finalized = Checkpoint(root=block1_root, slot=Slot(1))
+    base_store = base_store.model_copy(
+        update={
+            "blocks": {
+                **base_store.blocks,
+                block1_root: block1.block,
+                block2_root: block2.block,
+            },
+            "states": {
+                **base_store.states,
+                block1_root: genesis_state,
+                block2_root: genesis_state,
+            },
+            "head": block2_root,
+            "latest_finalized": Checkpoint(root=block1_root, slot=Slot(1)),
+        }
+    )
 
     fresh_vote = AttestationData(
         slot=Slot(2),
@@ -243,10 +258,14 @@ def test_stale_latest_message_does_not_mask_fresh_weight(
         source=Checkpoint(root=genesis_root, slot=Slot(0)),
     )
 
-    base_store.latest_known_aggregated_payloads = {
-        fresh_vote: {_make_empty_proof([ValidatorIndex(0)])},
-        stale_vote: {_make_empty_proof([ValidatorIndex(0)])},
-    }
+    base_store = base_store.model_copy(
+        update={
+            "latest_known_aggregated_payloads": {
+                fresh_vote: {_make_empty_proof([ValidatorIndex(0)])},
+                stale_vote: {_make_empty_proof([ValidatorIndex(0)])},
+            }
+        }
+    )
 
     weights = spec.compute_block_weights(base_store)
 
@@ -255,8 +274,7 @@ def test_stale_latest_message_does_not_mask_fresh_weight(
 
 def test_fresh_head_with_finalized_target_still_counts(spec: LstarSpec, base_store: Store) -> None:
     """A vote with head above finalization still counts when its target is finalized."""
-    genesis_root, block1_root, block2_root = _add_two_block_chain(base_store)
-    base_store.latest_finalized = Checkpoint(root=block1_root, slot=Slot(1))
+    base_store, genesis_root, block1_root, block2_root = _add_two_block_chain(base_store)
 
     fresh_vote_with_finalized_target = AttestationData(
         slot=Slot(2),
@@ -264,9 +282,14 @@ def test_fresh_head_with_finalized_target_still_counts(spec: LstarSpec, base_sto
         target=Checkpoint(root=block1_root, slot=Slot(1)),
         source=Checkpoint(root=genesis_root, slot=Slot(0)),
     )
-    base_store.latest_known_aggregated_payloads = {
-        fresh_vote_with_finalized_target: {_make_empty_proof([ValidatorIndex(0)])},
-    }
+    base_store = base_store.model_copy(
+        update={
+            "latest_finalized": Checkpoint(root=block1_root, slot=Slot(1)),
+            "latest_known_aggregated_payloads": {
+                fresh_vote_with_finalized_target: {_make_empty_proof([ValidatorIndex(0)])},
+            },
+        }
+    )
 
     weights = spec.compute_block_weights(base_store)
 
@@ -275,10 +298,10 @@ def test_fresh_head_with_finalized_target_still_counts(spec: LstarSpec, base_sto
 
 def test_finalized_target_vote_can_drive_head_selection(spec: LstarSpec, base_store: Store) -> None:
     """A weighted head above finalization wins over the zero-weight tie break branch."""
-    genesis_root, block1_root, voted_root, tie_break_root = _add_finalized_fork(base_store)
+    base_store, genesis_root, block1_root, voted_root, tie_break_root = _add_finalized_fork(
+        base_store
+    )
     finalized = Checkpoint(root=block1_root, slot=Slot(1))
-    base_store.latest_justified = finalized
-    base_store.latest_finalized = finalized
 
     vote = AttestationData(
         slot=Slot(2),
@@ -286,9 +309,15 @@ def test_finalized_target_vote_can_drive_head_selection(spec: LstarSpec, base_st
         target=finalized,
         source=Checkpoint(root=genesis_root, slot=Slot(0)),
     )
-    base_store.latest_known_aggregated_payloads = {
-        vote: {_make_empty_proof([ValidatorIndex(0)])},
-    }
+    base_store = base_store.model_copy(
+        update={
+            "latest_justified": finalized,
+            "latest_finalized": finalized,
+            "latest_known_aggregated_payloads": {
+                vote: {_make_empty_proof([ValidatorIndex(0)])},
+            },
+        }
+    )
 
     store = spec.update_head(base_store)
 
@@ -298,11 +327,8 @@ def test_finalized_target_vote_can_drive_head_selection(spec: LstarSpec, base_st
 
 def test_finalized_target_vote_can_advance_safe_target(spec: LstarSpec, base_store: Store) -> None:
     """Safe target counts new-pool votes whose head is above finalization."""
-    genesis_root, block1_root, block2_root = _add_two_block_chain(base_store)
+    base_store, genesis_root, block1_root, block2_root = _add_two_block_chain(base_store)
     finalized = Checkpoint(root=block1_root, slot=Slot(1))
-    base_store.latest_justified = finalized
-    base_store.latest_finalized = finalized
-    base_store.safe_target = block1_root
 
     vote = AttestationData(
         slot=Slot(2),
@@ -310,9 +336,16 @@ def test_finalized_target_vote_can_advance_safe_target(spec: LstarSpec, base_sto
         target=finalized,
         source=Checkpoint(root=genesis_root, slot=Slot(0)),
     )
-    base_store.latest_new_aggregated_payloads = {
-        vote: {_make_empty_proof([ValidatorIndex(0), ValidatorIndex(1)])},
-    }
+    base_store = base_store.model_copy(
+        update={
+            "latest_justified": finalized,
+            "latest_finalized": finalized,
+            "safe_target": block1_root,
+            "latest_new_aggregated_payloads": {
+                vote: {_make_empty_proof([ValidatorIndex(0), ValidatorIndex(1)])},
+            },
+        }
+    )
 
     store = spec.update_safe_target(base_store)
 
@@ -349,11 +382,14 @@ def test_multiple_attestations_accumulate(spec: LstarSpec, base_store: Store) ->
         attestation_data: {proof},
     }
 
-    base_store.blocks = new_blocks
-    base_store.states = new_states
-    base_store.head = block1_root
-    base_store.latest_known_aggregated_payloads = aggregated_payloads
-    store = base_store
+    store = base_store.model_copy(
+        update={
+            "blocks": new_blocks,
+            "states": new_states,
+            "head": block1_root,
+            "latest_known_aggregated_payloads": aggregated_payloads,
+        }
+    )
 
     weights = spec.compute_block_weights(store)
 
@@ -598,8 +634,7 @@ class TestValidateAttestationTimeCheck:
 
         # Sweep every interval in the attestation's slot.
         for offset in range(int(INTERVALS_PER_SLOT)):
-            store.time = ATTESTATION_START_INTERVAL + Interval(offset)
-            local = store
+            local = store.model_copy(update={"time": ATTESTATION_START_INTERVAL + Interval(offset)})
             spec.validate_attestation(local, attestation_data)
 
     def test_attestation_in_past_passes(self, spec: LstarSpec, observer_store: Store) -> None:
@@ -608,7 +643,7 @@ class TestValidateAttestationTimeCheck:
 
         # Place the local clock several slots ahead.
         far_future = ATTESTATION_START_INTERVAL + Interval(int(INTERVALS_PER_SLOT) * 10)
-        store.time = far_future
+        store = store.model_copy(update={"time": far_future})
         spec.validate_attestation(store, attestation_data)
 
     def test_attestation_at_disparity_boundary_passes(
@@ -617,7 +652,7 @@ class TestValidateAttestationTimeCheck:
         """At the disparity boundary the attestation is still accepted."""
         store, attestation_data = self._build_two_block_chain(spec, observer_store)
 
-        store.time = DISPARITY_BOUNDARY_INTERVAL
+        store = store.model_copy(update={"time": DISPARITY_BOUNDARY_INTERVAL})
         spec.validate_attestation(store, attestation_data)
 
     def test_attestation_just_beyond_disparity_boundary_rejected(
@@ -626,7 +661,7 @@ class TestValidateAttestationTimeCheck:
         """One interval past the disparity boundary the attestation is rejected."""
         store, attestation_data = self._build_two_block_chain(spec, observer_store)
 
-        store.time = JUST_BEYOND_DISPARITY_BOUNDARY_INTERVAL
+        store = store.model_copy(update={"time": JUST_BEYOND_DISPARITY_BOUNDARY_INTERVAL})
 
         with pytest.raises(AssertionError, match="Attestation too far in future"):
             spec.validate_attestation(store, attestation_data)
@@ -643,7 +678,7 @@ class TestValidateAttestationTimeCheck:
         """
         store, attestation_data = self._build_two_block_chain(spec, observer_store)
 
-        store.time = ONE_FULL_SLOT_BEHIND_INTERVAL
+        store = store.model_copy(update={"time": ONE_FULL_SLOT_BEHIND_INTERVAL})
 
         with pytest.raises(AssertionError, match="Attestation too far in future"):
             spec.validate_attestation(store, attestation_data)
@@ -663,10 +698,16 @@ def test_prunes_entries_with_head_at_finalized(spec: LstarSpec, pruning_store: S
     )
 
     # Set up store with attestation data and finalized slot at 5
-    store.attestation_signatures = {
-        attestation_data: {AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())},
-    }
-    store.latest_finalized = make_checkpoint(root_seed=255, slot=5)
+    store = store.model_copy(
+        update={
+            "attestation_signatures": {
+                attestation_data: {
+                    AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+                },
+            },
+            "latest_finalized": make_checkpoint(root_seed=255, slot=5),
+        }
+    )
 
     # Verify data exists before pruning
     assert attestation_data in store.attestation_signatures
@@ -691,10 +732,16 @@ def test_prunes_entries_with_head_before_finalized(spec: LstarSpec, pruning_stor
     )
 
     # Set up store with finalized slot at 5 (greater than head.slot)
-    store.attestation_signatures = {
-        attestation_data: {AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())},
-    }
-    store.latest_finalized = make_checkpoint(root_seed=255, slot=5)
+    store = store.model_copy(
+        update={
+            "attestation_signatures": {
+                attestation_data: {
+                    AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+                },
+            },
+            "latest_finalized": make_checkpoint(root_seed=255, slot=5),
+        }
+    )
 
     # Verify data exists before pruning
     assert attestation_data in store.attestation_signatures
@@ -719,10 +766,16 @@ def test_keeps_entries_with_head_after_finalized(spec: LstarSpec, pruning_store:
     )
 
     # Set up store with finalized slot at 5 (less than head.slot)
-    store.attestation_signatures = {
-        attestation_data: {AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())},
-    }
-    store.latest_finalized = make_checkpoint(root_seed=255, slot=5)
+    store = store.model_copy(
+        update={
+            "attestation_signatures": {
+                attestation_data: {
+                    AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+                },
+            },
+            "latest_finalized": make_checkpoint(root_seed=255, slot=5),
+        }
+    )
 
     # Verify data exists before pruning
     assert attestation_data in store.attestation_signatures
@@ -754,10 +807,14 @@ def test_keeps_finalized_target_when_head_after_finalized(
     )
     signature = AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
 
-    store.attestation_signatures = {attestation_data: {signature}}
-    store.latest_new_aggregated_payloads = {attestation_data: {mock_proof}}
-    store.latest_known_aggregated_payloads = {attestation_data: {mock_proof}}
-    store.latest_finalized = finalized
+    store = store.model_copy(
+        update={
+            "attestation_signatures": {attestation_data: {signature}},
+            "latest_new_aggregated_payloads": {attestation_data: {mock_proof}},
+            "latest_known_aggregated_payloads": {attestation_data: {mock_proof}},
+            "latest_finalized": finalized,
+        }
+    )
 
     pruned_store = spec.prune_stale_attestation_data(store)
 
@@ -796,19 +853,27 @@ def test_prunes_related_structures_together(spec: LstarSpec, pruning_store: Stor
     )
 
     # Set up store with both stale and fresh entries in all structures
-    store.attestation_signatures = {
-        stale_attestation: {AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())},
-        fresh_attestation: {AttestationSignatureEntry(ValidatorIndex(2), make_mock_signature())},
-    }
-    store.latest_new_aggregated_payloads = {
-        stale_attestation: {mock_proof},
-        fresh_attestation: {mock_proof},
-    }
-    store.latest_known_aggregated_payloads = {
-        stale_attestation: {mock_proof},
-        fresh_attestation: {mock_proof},
-    }
-    store.latest_finalized = make_checkpoint(root_seed=255, slot=5)
+    store = store.model_copy(
+        update={
+            "attestation_signatures": {
+                stale_attestation: {
+                    AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature())
+                },
+                fresh_attestation: {
+                    AttestationSignatureEntry(ValidatorIndex(2), make_mock_signature())
+                },
+            },
+            "latest_new_aggregated_payloads": {
+                stale_attestation: {mock_proof},
+                fresh_attestation: {mock_proof},
+            },
+            "latest_known_aggregated_payloads": {
+                stale_attestation: {mock_proof},
+                fresh_attestation: {mock_proof},
+            },
+            "latest_finalized": make_checkpoint(root_seed=255, slot=5),
+        }
+    )
 
     # Verify all data exists before pruning
     assert stale_attestation in store.attestation_signatures
@@ -860,13 +925,17 @@ def test_prunes_multiple_validators_same_attestation_data(
     )
 
     # Multiple validators signed the same attestation data
-    store.attestation_signatures = {
-        stale_attestation: {
-            AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature()),
-            AttestationSignatureEntry(ValidatorIndex(2), make_mock_signature()),
-        },
-    }
-    store.latest_finalized = make_checkpoint(root_seed=255, slot=5)
+    store = store.model_copy(
+        update={
+            "attestation_signatures": {
+                stale_attestation: {
+                    AttestationSignatureEntry(ValidatorIndex(1), make_mock_signature()),
+                    AttestationSignatureEntry(ValidatorIndex(2), make_mock_signature()),
+                },
+            },
+            "latest_finalized": make_checkpoint(root_seed=255, slot=5),
+        }
+    )
 
     # Verify data exists before pruning
     assert stale_attestation in store.attestation_signatures
@@ -900,8 +969,12 @@ def test_mixed_stale_and_fresh_entries(spec: LstarSpec, pruning_store: Store) ->
     }
 
     # Finalized at slot 5 means slots 1-5 are stale, 6-10 are fresh
-    store.attestation_signatures = gossip_signatures
-    store.latest_finalized = make_checkpoint(root_seed=255, slot=5)
+    store = store.model_copy(
+        update={
+            "attestation_signatures": gossip_signatures,
+            "latest_finalized": make_checkpoint(root_seed=255, slot=5),
+        }
+    )
 
     # Verify all data exists before pruning
     for attestation in attestations:
@@ -1420,8 +1493,9 @@ def test_on_block_processes_multi_validator_aggregations(
 
     aggregated_payloads = {attestation_data: {proof}}
 
-    base_store.latest_known_aggregated_payloads = aggregated_payloads
-    producer_store = base_store
+    producer_store = base_store.model_copy(
+        update={"latest_known_aggregated_payloads": aggregated_payloads}
+    )
 
     proposer_index = ValidatorIndex(1)
     consumer_store, signed_block = make_signed_block_from_store(
@@ -1463,8 +1537,7 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
         },
     }
 
-    base_store.attestation_signatures = gossip_signatures_1
-    producer_store_1 = base_store
+    producer_store_1 = base_store.model_copy(update={"attestation_signatures": gossip_signatures_1})
 
     consumer_store_1, signed_block_1 = make_signed_block_from_store(
         producer_store_1, key_manager, attestation_slot_1, ValidatorIndex(1)
@@ -1485,8 +1558,9 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
         },
     }
 
-    store_after_block_1.attestation_signatures = gossip_signatures_2
-    producer_store_2 = store_after_block_1
+    producer_store_2 = store_after_block_1.model_copy(
+        update={"attestation_signatures": gossip_signatures_2}
+    )
 
     store_before_block_2, signed_block_2 = make_signed_block_from_store(
         producer_store_2, key_manager, attestation_slot_2, ValidatorIndex(2)

--- a/tests/lean_spec/spec/forks/lstar/test_state_transition.py
+++ b/tests/lean_spec/spec/forks/lstar/test_state_transition.py
@@ -59,16 +59,21 @@ class TestProcessAttestationsBoundsCheck:
         # extended, but historical hashes were not fully populated.
         # This can happen with certain block arrival patterns.
         source_root = make_bytes32(1)
-        state.slot = Slot(5)
         # History covers indices 0-4 only.
-        state.historical_block_hashes = HistoricalBlockHashes(
-            data=[source_root] + [make_bytes32(i) for i in range(2, 6)]
-        )
+        #
         # Extend justified_slots to avoid is_slot_justified throwing.
         #
         # Index calculation: slot - finalized_slot - 1 = 10 - 0 - 1 = 9
         # Need at least 10 entries to cover slot 10.
-        state.justified_slots = JustifiedSlots(data=[Boolean(False)] * 10)
+        state = state.model_copy(
+            update={
+                "slot": Slot(5),
+                "historical_block_hashes": HistoricalBlockHashes(
+                    data=[source_root] + [make_bytes32(i) for i in range(2, 6)]
+                ),
+                "justified_slots": JustifiedSlots(data=[Boolean(False)] * 10),
+            }
+        )
 
         # Verify the history length matches our setup.
         assert len(state.historical_block_hashes) == 5
@@ -144,13 +149,18 @@ class TestProcessAttestationsBoundsCheck:
         # Build a state with very limited history.
         #
         # Only 3 entries in historical_block_hashes (indices 0-2).
-        state.slot = Slot(5)
         # Minimal history: only 3 blocks recorded.
-        state.historical_block_hashes = HistoricalBlockHashes(
-            data=[make_bytes32(i) for i in range(3)]
-        )
+        #
         # Extend justified_slots to cover target slot.
-        state.justified_slots = JustifiedSlots(data=[Boolean(False)] * 10)
+        state = state.model_copy(
+            update={
+                "slot": Slot(5),
+                "historical_block_hashes": HistoricalBlockHashes(
+                    data=[make_bytes32(i) for i in range(3)]
+                ),
+                "justified_slots": JustifiedSlots(data=[Boolean(False)] * 10),
+            }
+        )
 
         # Create attestation with target beyond history.
         #
@@ -324,8 +334,12 @@ def test_pruning_keeps_pending_justifications(spec: LstarSpec) -> None:
     # comes after the finalized boundary.
     pending_votes = [Boolean(True), Boolean(False), Boolean(False)]
 
-    state.justifications_roots = JustificationRoots(data=[slot_3_root])
-    state.justifications_validators = JustificationValidators(data=pending_votes)
+    state = state.model_copy(
+        update={
+            "justifications_roots": JustificationRoots(data=[slot_3_root]),
+            "justifications_validators": JustificationValidators(data=pending_votes),
+        }
+    )
 
     # Sanity check: slot 3 root is present in history.
     assert state.historical_block_hashes[3] == slot_3_root

--- a/tests/lean_spec/spec/forks/lstar/test_timeline.py
+++ b/tests/lean_spec/spec/forks/lstar/test_timeline.py
@@ -88,7 +88,7 @@ class TestIntervalTicking:
         """Test different actions performed based on interval phase."""
         # Reset store to known state
         initial_time = Interval(0)
-        object.__setattr__(sample_store, "time", initial_time)
+        sample_store = sample_store.model_copy(update={"time": initial_time})
 
         # Tick through a complete slot cycle
         for interval in range(int(INTERVALS_PER_SLOT)):

--- a/tests/lean_spec/spec/forks/lstar/test_validator_duties.py
+++ b/tests/lean_spec/spec/forks/lstar/test_validator_duties.py
@@ -120,8 +120,9 @@ class TestGetAttestationTarget:
             roots[slot] = hash_tree_root(block)
 
         finalized = Checkpoint(root=roots[Slot(4)], slot=Slot(4))
-        store.latest_justified = finalized
-        store.latest_finalized = finalized
+        store = store.model_copy(
+            update={"latest_justified": finalized, "latest_finalized": finalized}
+        )
         assert store.blocks[store.safe_target].slot == Slot(0)
 
         target = spec.get_attestation_target(store)
@@ -172,10 +173,14 @@ class TestGetAttestationTarget:
 
         # Fixture state: finalized at slot 1, safe target at slot 3, head at slot 4.
         # The safe target leads finalization, so it sets the lower bound at slot 3.
-        store.safe_target = roots[Slot(3)]
         finalized = Checkpoint(root=roots[Slot(1)], slot=Slot(1))
-        store.latest_justified = finalized
-        store.latest_finalized = finalized
+        store = store.model_copy(
+            update={
+                "safe_target": roots[Slot(3)],
+                "latest_justified": finalized,
+                "latest_finalized": finalized,
+            }
+        )
 
         target = spec.get_attestation_target(store)
 
@@ -292,8 +297,12 @@ class TestBlockProduction:
             AttestationSignatureEntry(ValidatorIndex(6), signed_6.signature)
         )
 
-        sample_store.latest_known_aggregated_payloads = known_payloads
-        sample_store.attestation_signatures = gossip_signatures
+        sample_store = sample_store.model_copy(
+            update={
+                "latest_known_aggregated_payloads": known_payloads,
+                "attestation_signatures": gossip_signatures,
+            }
+        )
 
         slot = Slot(2)
         validator_index = ValidatorIndex(2)  # Proposer for slot 2
@@ -375,7 +384,7 @@ class TestBlockProduction:
         validator_index = ValidatorIndex(3)
 
         # Ensure no attestations in store (clear aggregated payloads)
-        sample_store.latest_known_aggregated_payloads = {}
+        sample_store = sample_store.model_copy(update={"latest_known_aggregated_payloads": {}})
 
         store, block, _signatures = spec.produce_block_with_signatures(
             sample_store,
@@ -413,10 +422,16 @@ class TestBlockProduction:
 
         proof_7 = make_aggregated_proof(key_manager, [ValidatorIndex(7)], signed_7.data)
 
-        sample_store.latest_known_aggregated_payloads = {signed_7.data: {proof_7}}
-        sample_store.attestation_signatures = {
-            signed_7.data: {AttestationSignatureEntry(ValidatorIndex(7), signed_7.signature)},
-        }
+        sample_store = sample_store.model_copy(
+            update={
+                "latest_known_aggregated_payloads": {signed_7.data: {proof_7}},
+                "attestation_signatures": {
+                    signed_7.data: {
+                        AttestationSignatureEntry(ValidatorIndex(7), signed_7.signature)
+                    },
+                },
+            }
+        )
 
         store, block, signatures = spec.produce_block_with_signatures(
             sample_store,
@@ -643,8 +658,7 @@ class TestProposalHeadTiming:
         # Use immutable update to add block
         new_blocks = dict(sample_store.blocks)
         new_blocks[genesis_hash] = genesis_block
-        sample_store.blocks = new_blocks
-        sample_store.head = genesis_hash
+        sample_store = sample_store.model_copy(update={"blocks": new_blocks, "head": genesis_hash})
 
         # Get proposal head for slot 0
         store, head = spec.get_proposal_head(sample_store, Slot(0))

--- a/tests/lean_spec/test_base.py
+++ b/tests/lean_spec/test_base.py
@@ -76,8 +76,20 @@ class TestStrictBaseModel:
     Tests for StrictBaseModel constraints.
 
     StrictBaseModel is the foundation for all spec types. Its constraints
-    (extra-forbidden, strict) catch typos and silent type coercion.
+    (frozen, extra-forbidden, strict) prevent accidental mutations and
+    type coercion that could silently corrupt spec state.
     """
+
+    def test_frozen_rejects_assignment(self) -> None:
+        """Attribute assignment after construction raises an error.
+
+        Spec types must be immutable. A mutable state object would
+        break forkchoice assumptions.
+        """
+        model = SampleStrictModel(slot_number=5, block_root="0xabc")
+
+        with pytest.raises(ValidationError):
+            model.slot_number = 10
 
     def test_extra_fields_forbidden(self) -> None:
         """


### PR DESCRIPTION
cc @alexanderlhicks

## What

Enforce immutability once, in the base model, instead of per class:

- `StrictBaseModel` now carries `"frozen": True` natively (restoring the pre-#789 constraint and docstring).
- The 17 per-class `model_config = Container.model_config | {"frozen": True}` overrides from #842/#843 are deleted — subclasses inherit the constraint.
- **No mutable opt-outs.** `State` and `Store` are frozen too, and every remaining in-place mutation site is converted back to the `model_copy(update=...)` functional style.

Follow-up to #842/#843, as discussed in the #843 review thread.

## Why

Immutability is groundwork for formal verification: a block, checkpoint, state, or store never changes once it exists, so instances are safe to share by reference across fork choice, the chain, and attestations. Enforcing it in the base keeps the spec legible — the constraint lives in one place rather than being repeated on every container.

## Migrated mutation sites

Spec (`src/lean_spec/spec/`):

- `state_transition.py` — `process_slots` rebinds through `model_copy` (the `deepcopy` barrier is no longer needed), `process_block_header` applies its updates atomically in one final copy, `process_attestations` returns a new state.
- `fork_choice.py`, `timeline.py`, `validator_duties.py`, `aggregation.py` — every store update flows through `model_copy`; dicts and inner sets are shallow-copied before growing so the caller's store is left untouched.
- `xmss/interface.py` — `advance_preparation` returns a rebuilt secret key instead of rotating the bottom trees in place.

Node (`src/lean_spec/node/`):

- `chain/service.py`, `sync/service.py` — rebind the store instead of patching it in place.
- `networking/enr/enr.py` — `from_rlp` rebuilds the record with the computed node id.

Test framework + tests:

- `packages/testing` fixtures and ~110 test-side fixture-setup mutations converted to `model_copy` rebinding; helpers that mutated arguments now return the new instance.
- Restores `test_frozen_rejects_assignment` (dropped in #789) and the immutability wording in the SSZ patterns rule; adds mirrored immutability tests for `State` and the new `containers/test_store.py`.

## Caveat

Unchanged from #842/#843: `frozen` is an enforcement aid, not a hard immutability guarantee ([pydantic#12361](https://github.com/pydantic/pydantic/issues/12361)).

## Validation

- `just check` — clean (ruff lint + format, ty, codespell, mdformat, lock)
- Unit suites: lstar spec 257 passed, node 1682 passed, crypto/ssz/enr/containers/base 1660 passed
- Every migration preserves `hash_tree_root`, so generated fixtures should be byte-identical; CI's `fill` run will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)