### PR TITLE
style: enforce multi-line docstring summary on second line (D213)

### DIFF
--- a/packages/testing/src/consensus_testing/genesis.py
+++ b/packages/testing/src/consensus_testing/genesis.py
@@ -47,7 +47,8 @@ def generate_pre_state(
     genesis_time: Uint64 = _DEFAULT_GENESIS_TIME,
     num_validators: int = 4,
 ) -> State:
-    """Generate a default pre-state for consensus tests.
+    """
+    Generate a default pre-state for consensus tests.
 
     Args:
         fork: Fork dispatching genesis construction. Defaults to a fresh
@@ -69,7 +70,8 @@ def build_anchor(
     fork: LstarSpec | None = None,
     genesis_time: Uint64 = _DEFAULT_GENESIS_TIME,
 ) -> tuple[State, Block]:
-    """Build a consistent non-genesis anchor by advancing the genesis state.
+    """
+    Build a consistent non-genesis anchor by advancing the genesis state.
 
     Simulates the mid-chain view that a checkpoint-synced node would have:
     a real state reached via the normal state transition from genesis,

--- a/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
@@ -33,7 +33,8 @@ def _make_genesis_block(state: State) -> Block:
 
 
 def _build_store(num_validators: int, genesis_time: int, anchor_slot: int = 0) -> Store:
-    """Build a deterministic store rooted at genesis or at an advanced anchor.
+    """
+    Build a deterministic store rooted at genesis or at an advanced anchor.
 
     At anchor_slot 0 the store is genesis-only. At higher slots the store
     is seeded with a real (state, block) pair produced by advancing an
@@ -144,7 +145,8 @@ def _aggregator_status_response(_store: Store, fixture: "ApiEndpointTest") -> di
 
 
 def _metrics_response(_store: Store, _fixture: "ApiEndpointTest") -> dict[str, Any]:
-    """Prometheus-format metrics scrape.
+    """
+    Prometheus-format metrics scrape.
 
     The body of /metrics is dynamic (counters accumulate, timestamps shift)
     so the fixture pins only the stable contract: status, content-type,
@@ -187,7 +189,8 @@ def _metrics_response(_store: Store, _fixture: "ApiEndpointTest") -> dict[str, A
 
 
 def _aggregator_toggle_response(_store: Store, fixture: "ApiEndpointTest") -> dict[str, Any]:
-    """Expected response after toggling the aggregator role.
+    """
+    Expected response after toggling the aggregator role.
 
     The fixture models a single POST against a node whose starting state is
     initial_is_aggregator. The response reflects the new value and the
@@ -223,7 +226,8 @@ _ENDPOINT_HANDLERS: dict[tuple[str, str], EndpointHandler] = {
 
 
 class ApiEndpointTest(BaseConsensusFixture):
-    """Fixture for API endpoint response conformance.
+    """
+    Fixture for API endpoint response conformance.
 
     JSON output: endpoint, genesisParams, expectedStatusCode,
     expectedContentType, expectedBody.

--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -46,7 +46,8 @@ class BaseConsensusFixture(BaseFixture):
         return value.__name__
 
     def assert_expected_outcome(self, exception_raised: Exception | None) -> None:
-        """Compare a self-verification outcome against the configured expectation.
+        """
+        Compare a self-verification outcome against the configured expectation.
 
         A fixture that self-verifies its own output catches the verifier exception.
         It then hands the caught exception here to decide pass or fail.

--- a/packages/testing/src/consensus_testing/test_fixtures/gossipsub_handler.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/gossipsub_handler.py
@@ -127,7 +127,8 @@ def _serialize_meshes(
 
 
 class GossipsubHandlerTest(BaseConsensusFixture):
-    """Fixture for gossipsub handler behavior conformance.
+    """
+    Fixture for gossipsub handler behavior conformance.
 
     Tests protocol decisions: given initial state + incoming event,
     what RPCs are sent and how does the mesh change?

--- a/packages/testing/src/consensus_testing/test_fixtures/justifiability.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/justifiability.py
@@ -1,4 +1,5 @@
-"""3SF-mini justifiability test fixture.
+"""
+3SF-mini justifiability test fixture.
 
 Generates JSON test vectors for the Slot.is_justifiable_after function
 that implements the core 3SF-mini justification rule. A slot is
@@ -18,7 +19,8 @@ from lean_spec.spec.forks import Slot
 
 
 class JustifiabilityTest(BaseConsensusFixture):
-    """Fixture for 3SF-mini justifiability conformance.
+    """
+    Fixture for 3SF-mini justifiability conformance.
 
     Tests Slot.is_justifiable_after(finalized_slot) which determines
     whether a slot can be a justification target.

--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -40,7 +40,8 @@ def _from_hex(hex_str: str) -> bytes:
 
 
 class NetworkingCodecTest(BaseConsensusFixture):
-    """Fixture for networking wire-format conformance.
+    """
+    Fixture for networking wire-format conformance.
 
     Verifies encode/decode roundtrips for networking codecs.
 
@@ -60,7 +61,8 @@ class NetworkingCodecTest(BaseConsensusFixture):
     """Computed output. Filled by make_fixture."""
 
     def make_fixture(self) -> "NetworkingCodecTest":
-        """Dispatch to the codec handler and produce computed output.
+        """
+        Dispatch to the codec handler and produce computed output.
 
         Returns:
             A copy of this fixture with output populated.
@@ -99,7 +101,8 @@ class NetworkingCodecTest(BaseConsensusFixture):
         return self
 
     def _make_decode_failure(self) -> dict[str, Any]:
-        """Assert that decoding `input.bytes` with `input.decoder` raises.
+        """
+        Assert that decoding `input.bytes` with `input.decoder` raises.
 
         Dispatches to one of the wire-format decoders and confirms that the
         expected exception (on :attribute:`expect_exception`) is raised. Used to
@@ -176,7 +179,8 @@ class NetworkingCodecTest(BaseConsensusFixture):
         return {"encoded": _to_hex(encoded), "byteLength": byte_length}
 
     def _make_gossip_topic(self) -> dict[str, Any]:
-        """Build a topic string from components, parse it back, assert roundtrip.
+        """
+        Build a topic string from components, parse it back, assert roundtrip.
 
         When the input carries `expectedForkDigest`, also run validate_fork
         against the parsed topic and report whether the network name matched.
@@ -254,7 +258,8 @@ class NetworkingCodecTest(BaseConsensusFixture):
         return {"encoded": _to_hex(encoded)}
 
     def _make_reqresp_response_stream(self) -> dict[str, Any]:
-        """Encode a sequence of response chunks as a concatenated stream.
+        """
+        Encode a sequence of response chunks as a concatenated stream.
 
         Multi-chunk responses (for example BlocksByRoot returning N blocks)
         send their chunks back-to-back on a single libp2p stream: each

--- a/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
@@ -1,4 +1,5 @@
-"""Poseidon permutation test fixture.
+"""
+Poseidon permutation test fixture.
 
 Generates JSON test vectors for the Poseidon permutation over the
 KoalaBear field at widths 16 and 24. Clients must produce identical
@@ -13,7 +14,8 @@ from lean_spec.spec.crypto.poseidon import PARAMS_16, PARAMS_24, Poseidon
 
 
 class PoseidonPermutationTest(BaseConsensusFixture):
-    """Fixture for Poseidon permutation conformance.
+    """
+    Fixture for Poseidon permutation conformance.
 
     Each vector names the permutation width and supplies an input state
     as decimal strings. The fixture runs the spec's permutation engine
@@ -35,7 +37,8 @@ class PoseidonPermutationTest(BaseConsensusFixture):
     """Computed output state. Filled by make_fixture."""
 
     def make_fixture(self) -> "PoseidonPermutationTest":
-        """Run the Poseidon permutation and produce the output state.
+        """
+        Run the Poseidon permutation and produce the output state.
 
         Returns:
             A copy of this fixture with output populated.

--- a/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
@@ -1,4 +1,5 @@
-"""Slot clock test fixture for timing conformance testing.
+"""
+Slot clock test fixture for timing conformance testing.
 
 Generates JSON test vectors that verify slot/interval computation from
 wall-clock timestamps. Every client must compute identical slot boundaries
@@ -19,7 +20,8 @@ from lean_spec.spec.ssz import Uint64
 
 
 class SlotClockTest(BaseConsensusFixture):
-    """Fixture for slot clock timing conformance.
+    """
+    Fixture for slot clock timing conformance.
 
     Tests time-to-slot and time-to-interval conversions that every
     consensus client must implement identically.

--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -13,7 +13,8 @@ from lean_spec.spec.ssz.ssz_base import SSZType
 
 
 class SSZTest(BaseConsensusFixture):
-    """Fixture for SSZ conformance testing.
+    """
+    Fixture for SSZ conformance testing.
 
     Supports two modes:
 
@@ -71,7 +72,8 @@ class SSZTest(BaseConsensusFixture):
         return str(value)
 
     def make_fixture(self) -> "SSZTest":
-        """Verify SSZ roundtrip or decode-failure and produce the reference output.
+        """
+        Verify SSZ roundtrip or decode-failure and produce the reference output.
 
         Returns:
             A copy of this fixture with `serialized` and `root` populated.
@@ -102,7 +104,8 @@ class SSZTest(BaseConsensusFixture):
         return self
 
     def _make_decode_failure(self) -> "SSZTest":
-        """Run the decode-failure path: assert decoding `raw_bytes` raises.
+        """
+        Run the decode-failure path: assert decoding `raw_bytes` raises.
 
         The class of `value` is used as the decoder. `serialized` carries
         the malformed bytes verbatim so consumers can reproduce the input.

--- a/packages/testing/src/consensus_testing/test_fixtures/sync.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/sync.py
@@ -1,4 +1,5 @@
-"""Sync layer test fixture format.
+"""
+Sync layer test fixture format.
 
 Emits JSON vectors for the client-facing sync helpers. Each vector
 pins the expected verdict on a given input so clients can align their
@@ -16,7 +17,8 @@ from lean_spec.spec.ssz import Uint64
 
 
 class SyncTest(BaseConsensusFixture):
-    """Fixture for sync-layer conformance.
+    """
+    Fixture for sync-layer conformance.
 
     Currently supports one operation:
 
@@ -39,7 +41,8 @@ class SyncTest(BaseConsensusFixture):
     """Computed output. Filled by make_fixture."""
 
     def make_fixture(self) -> "SyncTest":
-        """Dispatch to the operation handler.
+        """
+        Dispatch to the operation handler.
 
         Returns:
             A copy of this fixture with output populated.
@@ -54,7 +57,8 @@ class SyncTest(BaseConsensusFixture):
         return self
 
     def _make_verify_checkpoint(self) -> dict[str, Any]:
-        """Build a state for the given validator count and anchor slot and report the verdict.
+        """
+        Build a state for the given validator count and anchor slot and report the verdict.
 
         Input keys:
 

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_multi_message_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_multi_message_proofs.py
@@ -28,7 +28,8 @@ ALTERNATE_HEAD_ROOT: Bytes32 = Bytes32(b"\xee" * 32)
 
 
 class RebindComponentToAlternateHeadRoot(BaseModel):
-    """Rebind one component's proof to an alternate head root.
+    """
+    Rebind one component's proof to an alternate head root.
 
     The honest attestation data is still emitted for every component.
     Only the targeted component's proof bytes carry the alternate binding.
@@ -46,7 +47,8 @@ class IncrementComponentSlot(BaseModel):
 
 
 class SwapComponentParticipantPublicKey(BaseModel):
-    """Replace one participant's public key with another validator's attestation key.
+    """
+    Replace one participant's public key with another validator's attestation key.
 
     The honest proof is still emitted.
     Only the targeted component's public key layout carries the swap.
@@ -63,7 +65,8 @@ class SwapComponentParticipantPublicKey(BaseModel):
 
 
 class SwapComponentMessageBindings(BaseModel):
-    """Swap the emitted message-slot bindings of two components.
+    """
+    Swap the emitted message-slot bindings of two components.
 
     The merged proof and the per-component key layout stay honest.
     Each component's proof is then checked against the other component's binding.
@@ -78,7 +81,8 @@ class SwapComponentMessageBindings(BaseModel):
 
 
 class DropComponentMessageBinding(BaseModel):
-    """Drop one component's emitted message-slot binding while keeping its keys.
+    """
+    Drop one component's emitted message-slot binding while keeping its keys.
 
     The emitted binding list ends up shorter than the per-component key list.
     A conforming verifier rejects the length mismatch.
@@ -136,7 +140,8 @@ class VerifyMultiMessageProofsTest(BaseConsensusFixture):
     """Aggregated multi-message proof bytes for clients to verify."""
 
     def make_fixture(self) -> VerifyMultiMessageProofsTest:
-        """Generate the merged proof, optionally tamper one binding, self-verify, return self.
+        """
+        Generate the merged proof, optionally tamper one binding, self-verify, return self.
 
         Raises:
             AssertionError: If the verifier outcome disagrees with the configured expectation.

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -147,7 +147,8 @@ class VerifySignaturesTest(BaseConsensusFixture):
         return self
 
     def _apply_tamper(self, signed_block: SignedBlock) -> SignedBlock:
-        """Apply the configured post-build mutation to a signed block.
+        """
+        Apply the configured post-build mutation to a signed block.
 
         Args:
             signed_block: The validly built signed block.

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_single_message_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_single_message_proofs.py
@@ -97,7 +97,8 @@ class VerifySingleMessageProofsTest(BaseConsensusFixture):
     """Aggregated proof bytes for clients to verify."""
 
     def make_fixture(self) -> VerifySingleMessageProofsTest:
-        """Generate the proof, optionally tamper, self-verify, and return the populated copy.
+        """
+        Generate the proof, optionally tamper, self-verify, and return the populated copy.
 
         Raises:
             AssertionError: If the verifier outcome disagrees with the configured expectation.
@@ -208,7 +209,8 @@ class VerifySingleMessageProofsTest(BaseConsensusFixture):
         validator_indices: list[ValidatorIndex],
         public_keys: list[PublicKey],
     ) -> ByteList512KiB:
-        """Build a two-level proof so the verifier is exercised on the recursive path.
+        """
+        Build a two-level proof so the verifier is exercised on the recursive path.
 
         Children are leaf-only sub-proofs, so the folded tree is exactly two levels deep.
 

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -242,7 +242,8 @@ class BlockSpec(CamelModel):
         key_manager: XmssKeyManager,
         state: State,
     ) -> SignedBlock:
-        """Sign a block and assemble the final SignedBlock with the merged proof.
+        """
+        Sign a block and assemble the final SignedBlock with the merged proof.
 
         Builds a single-message aggregate wrapping the proposer's XMSS
         signature, then merges that with the per-attestation single-message

--- a/packages/testing/src/framework/pytest_plugins/filler.py
+++ b/packages/testing/src/framework/pytest_plugins/filler.py
@@ -310,7 +310,8 @@ def _check_markers_valid_for_fork(
     fork_class: type,
     get_fork_by_name: Callable[[str], type | None],
 ) -> bool:
-    """Check if test markers indicate validity for the given fork.
+    """
+    Check if test markers indicate validity for the given fork.
 
     Shared logic for both collection-time and parametrization-time fork filtering.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,9 @@ line-length = 100
 docstring-code-format = true
 
 [tool.ruff.lint]
-select = ["E", "F", "B", "W", "I", "A", "N", "D", "C", "TID"]
+# D213 is selected by exact code: the google convention would otherwise disable it.
+# It forces multi-line docstring summaries onto the second line (after the opening quotes).
+select = ["E", "F", "B", "W", "I", "A", "N", "D", "D213", "C", "TID"]
 fixable = ["I", "B", "E", "F", "W", "D", "C", "TID"]
 ignore = ["D205", "D203", "D212", "D415", "C901", "A005", "C420"]
 

--- a/src/lean_spec/base.py
+++ b/src/lean_spec/base.py
@@ -7,7 +7,8 @@ from pydantic.alias_generators import to_camel
 
 
 class CamelModel(BaseModel):
-    """Base model that serializes field names as camelCase.
+    """
+    Base model that serializes field names as camelCase.
 
     All spec types inherit from this model so that JSON test vectors
     use camelCase keys for cross-client compatibility.
@@ -46,7 +47,8 @@ class CamelModel(BaseModel):
 
 
 class StrictBaseModel(CamelModel):
-    """Strict base model for all spec types.
+    """
+    Strict base model for all spec types.
 
     Adds two constraints on top of CamelModel:
 

--- a/src/lean_spec/node/genesis/config.py
+++ b/src/lean_spec/node/genesis/config.py
@@ -1,4 +1,5 @@
-"""Genesis configuration loader.
+"""
+Genesis configuration loader.
 
 Loads genesis configuration from YAML files compatible with ream and zeam.
 

--- a/src/lean_spec/node/networking/client/event_source/live.py
+++ b/src/lean_spec/node/networking/client/event_source/live.py
@@ -580,7 +580,8 @@ class LiveNetworkEventSource:
             return None
 
     async def _ensure_quic_manager(self) -> None:
-        """Initialize QUIC manager lazily on first use.
+        """
+        Initialize QUIC manager lazily on first use.
 
         Reuses the identity key from the connection manager for consistency.
         This ensures the same peer ID is used across all connections.
@@ -593,7 +594,8 @@ class LiveNetworkEventSource:
             self.quic_manager = await QuicConnectionManager.create(identity_key)
 
     async def _dial_quic(self, multiaddr: str) -> QuicConnection:
-        """Connect to a peer using QUIC transport.
+        """
+        Connect to a peer using QUIC transport.
 
         Ensures the QUIC manager is initialized before connecting.
 
@@ -611,7 +613,8 @@ class LiveNetworkEventSource:
         return await self.quic_manager.connect(multiaddr)
 
     async def listen(self, multiaddr: str) -> None:
-        """Start listening for incoming connections.
+        """
+        Start listening for incoming connections.
 
         Automatically detects transport type from multiaddr:
 
@@ -632,7 +635,8 @@ class LiveNetworkEventSource:
             )
 
     async def _listen_quic(self, multiaddr: str) -> None:
-        """Listen for incoming QUIC connections.
+        """
+        Listen for incoming QUIC connections.
 
         Ensures the QUIC manager is initialized.
         Registers the connection callback for accepted connections.

--- a/src/lean_spec/node/networking/client/event_source/protocol.py
+++ b/src/lean_spec/node/networking/client/event_source/protocol.py
@@ -15,7 +15,8 @@ from lean_spec.node.networking.types import ProtocolId
 
 
 class EventSource(Protocol):
-    """Protocol for network event sources.
+    """
+    Protocol for network event sources.
 
     Defines the minimal interface needed by the network service.
     One implementation uses real network I/O.

--- a/src/lean_spec/node/networking/enr/enr.py
+++ b/src/lean_spec/node/networking/enr/enr.py
@@ -134,7 +134,8 @@ class ENR(StrictBaseModel):
         return Port(int.from_bytes(raw, "big")) if raw else None
 
     def multiaddr(self) -> Multiaddr | None:
-        """Construct QUIC multiaddress from endpoint info.
+        """
+        Construct QUIC multiaddress from endpoint info.
 
         Use QUIC port if available, otherwise UDP port.
         """

--- a/src/lean_spec/node/networking/gossipsub/behavior.py
+++ b/src/lean_spec/node/networking/gossipsub/behavior.py
@@ -95,7 +95,8 @@ logger = logging.getLogger(__name__)
 
 
 def _try_decompress(data: bytes) -> tuple[bytes, bytes]:
-    """Attempt Snappy decompression and return data with domain.
+    """
+    Attempt Snappy decompression and return data with domain.
 
     Decompress once upfront so that message ID computation and event delivery share the result.
 
@@ -259,7 +260,8 @@ class GossipsubBehavior:
         self._stop_event.set()
 
     def subscribe(self, topic: TopicId) -> None:
-        """Subscribe to a topic.
+        """
+        Subscribe to a topic.
 
         Joining a topic means:
 
@@ -282,7 +284,8 @@ class GossipsubBehavior:
             self._spawn_background_task(self._broadcast_subscription(topic, subscribe=True))
 
     def unsubscribe(self, topic: TopicId) -> None:
-        """Unsubscribe from a topic.
+        """
+        Unsubscribe from a topic.
 
         Leaving a topic means:
 
@@ -349,7 +352,8 @@ class GossipsubBehavior:
         *,
         inbound: bool = False,
     ) -> None:
-        """Add a connected peer and establish gossipsub session.
+        """
+        Add a connected peer and establish gossipsub session.
 
         Libp2p uses separate streams for each direction:
 
@@ -448,7 +452,8 @@ class GossipsubBehavior:
         logger.info("Removed gossipsub peer %s", peer_id)
 
     async def publish(self, topic: TopicId, data: bytes) -> None:
-        """Publish a message to a topic.
+        """
+        Publish a message to a topic.
 
         Sends the message to mesh peers, or fanout peers if not subscribed.
 
@@ -511,7 +516,8 @@ class GossipsubBehavior:
     async def get_next_event(
         self,
     ) -> GossipsubMessageEvent | GossipsubPeerEvent | None:
-        """Get the next event from the queue.
+        """
+        Get the next event from the queue.
 
         Returns None when stopped or no event available.
         """
@@ -741,7 +747,8 @@ class GossipsubBehavior:
             logger.debug("Sent %d messages in response to IWANT from %s", len(messages), peer_id)
 
     def _handle_idontwant(self, peer_id: PeerId, idontwant: ControlIDontWant) -> None:
-        """Handle an IDONTWANT message from a peer (v1.2).
+        """
+        Handle an IDONTWANT message from a peer (v1.2).
 
         Records message IDs the peer does not want so we skip
         forwarding those messages to them.
@@ -769,7 +776,8 @@ class GossipsubBehavior:
                 logger.warning("Heartbeat error: %s", exception)
 
     async def _heartbeat(self) -> None:
-        """Perform heartbeat maintenance.
+        """
+        Perform heartbeat maintenance.
 
         1. Maintain mesh sizes (GRAFT/PRUNE)
         2. Send IHAVE gossip to non-mesh peers
@@ -883,7 +891,8 @@ class GossipsubBehavior:
         )
 
     async def _send_rpc(self, peer_id: PeerId, rpc: RPC) -> None:
-        """Deliver an RPC to a peer using length-prefixed framing.
+        """
+        Deliver an RPC to a peer using length-prefixed framing.
 
         Silently skips if the peer has no outbound stream yet.
         This is normal during connection setup -- the outbound
@@ -916,7 +925,8 @@ class GossipsubBehavior:
             logger.warning("Failed to send RPC to %s: %s", peer_id, exception)
 
     async def _receive_loop(self, peer_id: PeerId, stream: QuicStreamAdapter) -> None:
-        """Process incoming RPCs from a peer for the lifetime of the connection.
+        """
+        Process incoming RPCs from a peer for the lifetime of the connection.
 
         Each RPC is length-prefixed with a varint, matching the libp2p
         framing convention: `[varint length][RPC payload] ...`
@@ -976,7 +986,8 @@ class GossipsubBehavior:
         subscribe: bool,
         prune_peers: set[PeerId] | None = None,
     ) -> None:
-        """Announce a subscription change and adjust the mesh accordingly.
+        """
+        Announce a subscription change and adjust the mesh accordingly.
 
         Every peer learns about the change so they can update their
         peer-subscription tables. Beyond that:

--- a/src/lean_spec/node/networking/gossipsub/mcache.py
+++ b/src/lean_spec/node/networking/gossipsub/mcache.py
@@ -72,7 +72,8 @@ from lean_spec.node.networking.gossipsub.types import MessageId, Timestamp, Topi
 
 @dataclass(slots=True)
 class CacheEntry:
-    """A single entry in the message cache.
+    """
+    A single entry in the message cache.
 
     Stores the message along with its topic for efficient retrieval
     during IWANT responses and topic-filtered IHAVE gossip.
@@ -90,7 +91,8 @@ class CacheEntry:
 
 @dataclass(slots=True)
 class MessageCache:
-    """Sliding window cache for gossipsub messages.
+    """
+    Sliding window cache for gossipsub messages.
 
     Maintains recent messages for:
 
@@ -133,7 +135,8 @@ class MessageCache:
         self._windows.append(set())
 
     def put(self, topic: TopicId, message: GossipsubMessage) -> bool:
-        """Add a message to the cache.
+        """
+        Add a message to the cache.
 
         Messages are added to the newest window (index 0) and
         indexed for fast retrieval. Duplicates are ignored.
@@ -155,7 +158,8 @@ class MessageCache:
         return True
 
     def get(self, message_id: MessageId) -> GossipsubMessage | None:
-        """Retrieve a message by ID.
+        """
+        Retrieve a message by ID.
 
         Used to respond to IWANT requests from peers.
 
@@ -169,7 +173,8 @@ class MessageCache:
         return entry.message if entry else None
 
     def has(self, message_id: MessageId) -> bool:
-        """Check if a message is cached.
+        """
+        Check if a message is cached.
 
         Args:
             message_id: Message ID to check.
@@ -180,7 +185,8 @@ class MessageCache:
         return message_id in self._by_id
 
     def get_gossip_ids(self, topic: TopicId) -> list[MessageId]:
-        """Get message IDs for IHAVE gossip.
+        """
+        Get message IDs for IHAVE gossip.
 
         Returns IDs from the most recent `mcache_gossip` windows
         that belong to the specified topic.
@@ -204,7 +210,8 @@ class MessageCache:
         return result
 
     def shift(self) -> int:
-        """Shift the cache window, evicting the oldest.
+        """
+        Shift the cache window, evicting the oldest.
 
         Called at each heartbeat to age the cache:
 
@@ -230,7 +237,8 @@ class MessageCache:
 
 @dataclass(slots=True)
 class SeenCache:
-    """TTL-based cache for deduplicating messages.
+    """
+    TTL-based cache for deduplicating messages.
 
     Tracks message IDs that have been seen to prevent reprocessing
     duplicates. Unlike `MessageCache`, this only stores IDs (not
@@ -262,7 +270,8 @@ class SeenCache:
     """
 
     def add(self, message_id: MessageId, timestamp: Timestamp) -> bool:
-        """Mark a message as seen.
+        """
+        Mark a message as seen.
 
         Args:
             message_id: Message ID to mark as seen.
@@ -278,7 +287,8 @@ class SeenCache:
         return True
 
     def has(self, message_id: MessageId) -> bool:
-        """Check if a message has been seen.
+        """
+        Check if a message has been seen.
 
         Args:
             message_id: Message ID to check.
@@ -289,7 +299,8 @@ class SeenCache:
         return message_id in self._timestamps
 
     def cleanup(self, current_time: float) -> int:
-        """Remove expired entries.
+        """
+        Remove expired entries.
 
         Should be called periodically (e.g., each heartbeat)
         to prevent unbounded memory growth.

--- a/src/lean_spec/node/networking/gossipsub/mesh.py
+++ b/src/lean_spec/node/networking/gossipsub/mesh.py
@@ -53,7 +53,8 @@ from lean_spec.node.networking.transport import PeerId
 
 @dataclass(slots=True)
 class FanoutEntry:
-    """Fanout state for a publish-only topic.
+    """
+    Fanout state for a publish-only topic.
 
     Tracks peers used when publishing to topics we don't subscribe to.
     Fanout entries expire after a period of inactivity (fanout_ttl).
@@ -75,7 +76,8 @@ class FanoutEntry:
     """
 
     def is_stale(self, current_time: float, ttl: float) -> bool:
-        """Check if this fanout entry has expired.
+        """
+        Check if this fanout entry has expired.
 
         Args:
             current_time: Current Unix timestamp.
@@ -89,7 +91,8 @@ class FanoutEntry:
 
 @dataclass(slots=True)
 class TopicMesh:
-    """Mesh state for a single topic.
+    """
+    Mesh state for a single topic.
 
     Represents the set of peers we exchange full messages with
     for a specific topic. Mesh membership is managed via
@@ -104,7 +107,8 @@ class TopicMesh:
     """
 
     def add_peer(self, peer_id: PeerId) -> bool:
-        """Add a peer to this topic's mesh.
+        """
+        Add a peer to this topic's mesh.
 
         Args:
             peer_id: Peer to add.
@@ -118,7 +122,8 @@ class TopicMesh:
         return True
 
     def remove_peer(self, peer_id: PeerId) -> bool:
-        """Remove a peer from this topic's mesh.
+        """
+        Remove a peer from this topic's mesh.
 
         Args:
             peer_id: Peer to remove.
@@ -134,7 +139,8 @@ class TopicMesh:
 
 @dataclass(slots=True)
 class MeshState:
-    """Complete mesh state for all subscribed topics.
+    """
+    Complete mesh state for all subscribed topics.
 
     Central data structure managing mesh topology across all topics.
     Provides operations for subscription management, peer tracking,
@@ -164,7 +170,8 @@ class MeshState:
         return set(self._fanouts)
 
     def subscribe(self, topic: TopicId) -> None:
-        """Subscribe to a topic, initializing its mesh.
+        """
+        Subscribe to a topic, initializing its mesh.
 
         If we have fanout peers for this topic, they are
         promoted to the mesh automatically.
@@ -185,7 +192,8 @@ class MeshState:
         self._meshes[topic] = mesh
 
     def unsubscribe(self, topic: TopicId) -> set[PeerId]:
-        """Unsubscribe from a topic.
+        """
+        Unsubscribe from a topic.
 
         Args:
             topic: Topic identifier to unsubscribe from.
@@ -198,7 +206,8 @@ class MeshState:
         return mesh.peers if mesh else set()
 
     def get_mesh_peers(self, topic: TopicId) -> set[PeerId]:
-        """Get mesh peers for a topic.
+        """
+        Get mesh peers for a topic.
 
         Args:
             topic: Topic identifier.
@@ -210,7 +219,8 @@ class MeshState:
         return mesh.peers.copy() if mesh else set()
 
     def add_to_mesh(self, topic: TopicId, peer_id: PeerId) -> bool:
-        """Add a peer to a topic's mesh.
+        """
+        Add a peer to a topic's mesh.
 
         Args:
             topic: Topic identifier.
@@ -226,7 +236,8 @@ class MeshState:
         return mesh.add_peer(peer_id)
 
     def remove_from_mesh(self, topic: TopicId, peer_id: PeerId) -> bool:
-        """Remove a peer from a topic's mesh.
+        """
+        Remove a peer from a topic's mesh.
 
         Args:
             topic: Topic identifier.
@@ -242,7 +253,8 @@ class MeshState:
         return mesh.remove_peer(peer_id)
 
     def get_fanout_peers(self, topic: TopicId) -> set[PeerId]:
-        """Get fanout peers for a topic.
+        """
+        Get fanout peers for a topic.
 
         Args:
             topic: Topic identifier.
@@ -254,7 +266,8 @@ class MeshState:
         return fanout.peers.copy() if fanout else set()
 
     def fill_fanout(self, topic: TopicId, available_peers: set[PeerId]) -> None:
-        """Fill fanout for a topic up to D peers without updating last_published.
+        """
+        Fill fanout for a topic up to D peers without updating last_published.
 
         Used during heartbeat to maintain fanout sizes.
 
@@ -273,7 +286,8 @@ class MeshState:
             fanout.peers.update(new_peers)
 
     def update_fanout(self, topic: TopicId, available_peers: set[PeerId]) -> set[PeerId]:
-        """Update fanout for publishing to a non-subscribed topic.
+        """
+        Update fanout for publishing to a non-subscribed topic.
 
         For subscribed topics, returns mesh peers instead.
 
@@ -304,7 +318,8 @@ class MeshState:
         return fanout.peers.copy()
 
     def cleanup_fanouts(self, ttl: float, now: float | None = None) -> int:
-        """Remove expired fanout entries.
+        """
+        Remove expired fanout entries.
 
         Args:
             ttl: Time-to-live in seconds.
@@ -320,7 +335,8 @@ class MeshState:
         return len(stale)
 
     def select_peers_for_gossip(self, topic: TopicId, all_topic_peers: set[PeerId]) -> list[PeerId]:
-        """Select non-mesh peers for IHAVE gossip.
+        """
+        Select non-mesh peers for IHAVE gossip.
 
         Randomly selects up to D_lazy peers from those not in the mesh.
         These peers receive IHAVE messages during heartbeat.

--- a/src/lean_spec/node/networking/gossipsub/message.py
+++ b/src/lean_spec/node/networking/gossipsub/message.py
@@ -63,7 +63,8 @@ from lean_spec.node.networking.gossipsub.types import MessageId
 
 @dataclass(slots=True)
 class GossipsubMessage:
-    r"""A gossipsub message with lazy ID computation.
+    r"""
+    A gossipsub message with lazy ID computation.
 
     Encapsulates topic, payload, and message ID logic. The ID is
     computed lazily on first access and cached thereafter.
@@ -99,7 +100,8 @@ class GossipsubMessage:
 
     @property
     def id(self) -> MessageId:
-        """Get the 20-byte message ID.
+        """
+        Get the 20-byte message ID.
 
         Computed lazily on first access using the Ethereum consensus
         message ID function. The result is cached.
@@ -118,7 +120,8 @@ class GossipsubMessage:
         *,
         domain: bytes | None = None,
     ) -> MessageId:
-        """Compute a 20-byte message ID from raw data.
+        """
+        Compute a 20-byte message ID from raw data.
 
         Implements the Ethereum consensus message ID function::
 
@@ -144,7 +147,8 @@ class GossipsubMessage:
         return MessageId(hashlib.sha256(preimage).digest()[:20])
 
     def __hash__(self) -> int:
-        """Hash based on message ID.
+        """
+        Hash based on message ID.
 
         Allows messages to be used in sets and as dict keys.
         """

--- a/src/lean_spec/node/networking/gossipsub/parameters.py
+++ b/src/lean_spec/node/networking/gossipsub/parameters.py
@@ -66,7 +66,8 @@ from lean_spec.spec.forks.lstar.config import JUSTIFICATION_LOOKBACK_SLOTS, SECO
 
 
 class GossipsubParameters(StrictBaseModel):
-    """Core gossipsub configuration.
+    """
+    Core gossipsub configuration.
 
     Defines the mesh topology and timing parameters.
 

--- a/src/lean_spec/node/networking/gossipsub/rpc.py
+++ b/src/lean_spec/node/networking/gossipsub/rpc.py
@@ -64,7 +64,8 @@ class ProtobufDecodeError(ValueError):
 
 
 def _decode_length_at(data: bytes, pos: int) -> tuple[int, int]:
-    """Decode a length varint and validate bounds.
+    """
+    Decode a length varint and validate bounds.
 
     Returns:
         (length, new_position) tuple.
@@ -576,7 +577,8 @@ class RPC:
 
 
 def _skip_field(data: bytes, pos: int, wire_type: int) -> int:
-    """Skip an unknown field based on wire type.
+    """
+    Skip an unknown field based on wire type.
 
     Raises:
         ProtobufDecodeError: If the wire type is unrecognized (e.g. deprecated

--- a/src/lean_spec/node/networking/gossipsub/topic.py
+++ b/src/lean_spec/node/networking/gossipsub/topic.py
@@ -111,7 +111,8 @@ Used in the topic string to identify committee's aggregation messages.
 
 
 class TopicKind(Enum):
-    """Gossip topic types.
+    """
+    Gossip topic types.
 
     Enumerates the different message types that can be gossiped.
 
@@ -135,7 +136,8 @@ class TopicKind(Enum):
 
 @dataclass(frozen=True, slots=True)
 class GossipTopic:
-    """A fully-qualified gossipsub topic.
+    """
+    A fully-qualified gossipsub topic.
 
     Immutable representation of a topic that combines the message type
     and network name. Can be converted to/from the string format.
@@ -159,7 +161,8 @@ class GossipTopic:
     """Subnet id for attestation subnet topics (required for ATTESTATION_SUBNET)."""
 
     def to_topic_id(self) -> TopicId:
-        """Return the full topic string as a TopicId.
+        """
+        Return the full topic string as a TopicId.
 
         Returns:
             Topic in format `/{prefix}/{fork}/{name}/{encoding}`
@@ -191,7 +194,8 @@ class GossipTopic:
 
     @classmethod
     def from_string(cls, topic_str: str) -> GossipTopic:
-        """Parse a topic string into a GossipTopic.
+        """
+        Parse a topic string into a GossipTopic.
 
         Args:
             topic_str: Full topic string to parse.
@@ -233,7 +237,8 @@ class GossipTopic:
 
     @classmethod
     def from_string_validated(cls, topic_str: str, expected_network_name: str) -> GossipTopic:
-        """Parse a topic string and validate fork compatibility.
+        """
+        Parse a topic string and validate fork compatibility.
 
         Combines parsing and fork validation into a single operation.
         Use this when receiving gossip messages to reject wrong-fork topics early.
@@ -255,7 +260,8 @@ class GossipTopic:
 
     @classmethod
     def block(cls, network_name: str) -> GossipTopic:
-        """Create a block topic for the given fork.
+        """
+        Create a block topic for the given fork.
 
         Args:
             network_name: Network name as hex string (no 0x prefix) string.
@@ -267,7 +273,8 @@ class GossipTopic:
 
     @classmethod
     def committee_aggregation(cls, network_name: str) -> GossipTopic:
-        """Create a committee aggregation topic for the given fork.
+        """
+        Create a committee aggregation topic for the given fork.
 
         Args:
             network_name: Network name as hex string (no 0x prefix) string.
@@ -279,7 +286,8 @@ class GossipTopic:
 
     @classmethod
     def attestation_subnet(cls, network_name: str, subnet_id: SubnetId) -> GossipTopic:
-        """Create an attestation subnet topic for the given fork and subnet.
+        """
+        Create an attestation subnet topic for the given fork and subnet.
 
         Args:
             network_name: Network name as hex string (no 0x prefix) string.
@@ -294,7 +302,8 @@ class GossipTopic:
 
 
 def parse_topic_string(topic_str: str) -> tuple[str, str, str, str]:
-    """Parse a topic string into its components.
+    """
+    Parse a topic string into its components.
 
     Low-level function for deconstructing topic strings.
     Prefer the dataclass parser for most use cases.

--- a/src/lean_spec/node/networking/gossipsub/types.py
+++ b/src/lean_spec/node/networking/gossipsub/types.py
@@ -6,7 +6,8 @@ from lean_spec.spec.ssz import Bytes20
 
 
 class MessageId(Bytes20):
-    """20-byte message identifier.
+    """
+    20-byte message identifier.
 
     Computed from message contents using SHA256::
 
@@ -19,7 +20,8 @@ class MessageId(Bytes20):
 
 
 class TopicId(str):
-    """Topic string identifier.
+    """
+    Topic string identifier.
 
     Follows the Ethereum consensus format::
 
@@ -30,7 +32,8 @@ class TopicId(str):
 
 
 class Timestamp(float):
-    """Unix timestamp in seconds since epoch.
+    """
+    Unix timestamp in seconds since epoch.
 
     Used for:
 

--- a/src/lean_spec/node/networking/reqresp/codec.py
+++ b/src/lean_spec/node/networking/reqresp/codec.py
@@ -81,7 +81,8 @@ from lean_spec.node.snappy import SnappyDecompressionError, frame_compress, fram
 
 
 class CodecError(Exception):
-    """Raised when encoding or decoding fails.
+    """
+    Raised when encoding or decoding fails.
 
     This covers all wire format errors:
       - Truncated or malformed varints

--- a/src/lean_spec/node/networking/reqresp/handler.py
+++ b/src/lean_spec/node/networking/reqresp/handler.py
@@ -90,7 +90,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class StreamResponseAdapter:
-    """Encodes responses using the wire format from codec.py and writes
+    """
+    Encodes responses using the wire format from codec.py and writes
     them to the underlying stream.
     """
 
@@ -98,7 +99,8 @@ class StreamResponseAdapter:
     """Underlying transport stream."""
 
     async def send_success(self, ssz_data: bytes) -> None:
-        """Send a SUCCESS response chunk.
+        """
+        Send a SUCCESS response chunk.
 
         Args:
             ssz_data: SSZ-encoded response payload.
@@ -108,7 +110,8 @@ class StreamResponseAdapter:
         await self._stream.drain()
 
     async def send_error(self, code: ResponseCode, message: str) -> None:
-        """Send an error response.
+        """
+        Send an error response.
 
         Args:
             code: Error code.

--- a/src/lean_spec/node/networking/transport/protocols.py
+++ b/src/lean_spec/node/networking/transport/protocols.py
@@ -1,4 +1,5 @@
-"""Shared protocol definitions for transport layer.
+"""
+Shared protocol definitions for transport layer.
 
 InboundStreamProtocol
     Used by ReqResp handler and gossip message processing. Matches
@@ -11,7 +12,8 @@ from typing import Protocol
 
 
 class InboundStreamProtocol(Protocol):
-    """Buffered stream for inbound request and gossip handling.
+    """
+    Buffered stream for inbound request and gossip handling.
 
     Matches QuicStreamAdapter and test mocks.
 

--- a/src/lean_spec/node/networking/transport/quic/connection.py
+++ b/src/lean_spec/node/networking/transport/quic/connection.py
@@ -459,7 +459,8 @@ class QuicConnectionManager:
         multiaddr: str,
         on_connection: Callable[[QuicConnection], Awaitable[None]],
     ) -> None:
-        """Listen for incoming QUIC connections.
+        """
+        Listen for incoming QUIC connections.
 
         Creates a server using aioquic with libp2p-tls authentication.
         Runs until shutdown is requested.

--- a/src/lean_spec/node/networking/transport/quic/stream.py
+++ b/src/lean_spec/node/networking/transport/quic/stream.py
@@ -15,7 +15,8 @@ class QuicTransportError(Exception):
 
 
 class QuicStreamResetError(QuicTransportError):
-    """Raised when a QUIC stream is abruptly reset by the peer (RESET_STREAM).
+    """
+    Raised when a QUIC stream is abruptly reset by the peer (RESET_STREAM).
 
     Per RFC 9000 Section 3.2, RESET_STREAM indicates the peer cannot guarantee
     delivery of stream data.  Outstanding data may be lost.
@@ -162,7 +163,8 @@ class QuicStream:
         self._read_buffer.put_nowait(b"")
 
     def _receive_reset(self, error_code: int) -> None:
-        """Internal: called when the peer sends RESET_STREAM (abrupt termination).
+        """
+        Internal: called when the peer sends RESET_STREAM (abrupt termination).
 
         Per RFC 9000 Section 3.2, RESET_STREAM indicates the sender cannot
         guarantee delivery.  Outstanding data may be lost.  This is fundamentally

--- a/src/lean_spec/node/networking/transport/quic/stream_adapter.py
+++ b/src/lean_spec/node/networking/transport/quic/stream_adapter.py
@@ -1,4 +1,5 @@
-r"""Buffered read/write adapter for QuicStream with multistream-select negotiation.
+r"""
+Buffered read/write adapter for QuicStream with multistream-select negotiation.
 
 QuicStream provides raw, unbuffered I/O — each read returns exactly one
 QUIC frame's worth of data. Higher-level protocols (multistream-select,
@@ -56,7 +57,8 @@ class NegotiationError(Exception):
 
 
 class QuicStreamAdapter:
-    """Adapts QuicStream for buffered, protocol-level I/O.
+    """
+    Adapts QuicStream for buffered, protocol-level I/O.
 
     Provides:
 
@@ -77,7 +79,8 @@ class QuicStreamAdapter:
         self._write_buffer = b""
 
     async def read(self, n: int | None = None) -> bytes:
-        """Read bytes from the stream.
+        """
+        Read bytes from the stream.
 
         - If *n* is provided, returns at most *n* bytes.
         - If *n* is None, returns all available data (no limit).
@@ -106,7 +109,8 @@ class QuicStreamAdapter:
         return data
 
     async def readexactly(self, n: int) -> bytes:
-        """Read exactly *n* bytes from the stream.
+        """
+        Read exactly *n* bytes from the stream.
 
         Raises:
             EOFError: If the stream closes before *n* bytes arrive.
@@ -136,7 +140,8 @@ class QuicStreamAdapter:
         await self._stream.close()
 
     async def finish_write(self) -> None:
-        """Half-close the stream (signal end of writing).
+        """
+        Half-close the stream (signal end of writing).
 
         Flushes any buffered data before sending FIN.
         """
@@ -150,7 +155,8 @@ class QuicStreamAdapter:
         supported: set[ProtocolId],
         timeout: float = DEFAULT_TIMEOUT,
     ) -> ProtocolId:
-        """Server-side protocol negotiation.
+        """
+        Server-side protocol negotiation.
 
         Waits for client to propose protocols, accepts first supported one.
 
@@ -193,7 +199,8 @@ class QuicStreamAdapter:
             raise NegotiationError(f"Negotiation timed out after {timeout}s") from None
 
     async def negotiate_lazy_client(self, protocol: ProtocolId) -> ProtocolId:
-        """Lazy client-side negotiation for single protocol.
+        """
+        Lazy client-side negotiation for single protocol.
 
         Sends both the multistream header and protocol proposal together,
         then waits for server to accept. Reduces round trips when we only
@@ -225,7 +232,8 @@ class QuicStreamAdapter:
             raise NegotiationError(f"Unexpected response: {response!r}")
 
     async def _write_negotiation_message(self, message: str) -> None:
-        r"""Write a multistream message.
+        r"""
+        Write a multistream message.
 
         Format: [varint length][message + '\n']
         """
@@ -235,7 +243,8 @@ class QuicStreamAdapter:
         await self.drain()
 
     async def _read_negotiation_message(self) -> str:
-        """Read a multistream message.
+        """
+        Read a multistream message.
 
         Returns:
             Message content (without newline).

--- a/src/lean_spec/node/networking/types.py
+++ b/src/lean_spec/node/networking/types.py
@@ -8,7 +8,8 @@ from lean_spec.spec.ssz import Bytes4, Bytes32, Uint16, Uint64
 
 
 class DomainType(Bytes4):
-    """4-byte domain for message-id isolation in Gossipsub.
+    """
+    4-byte domain for message-id isolation in Gossipsub.
 
     Per the Ethereum consensus spec, DomainType is 4 bytes.
     Prepended to the message hash to compute the gossip message ID.

--- a/src/lean_spec/node/snappy/__init__.py
+++ b/src/lean_spec/node/snappy/__init__.py
@@ -1,4 +1,5 @@
-"""Pure Python Snappy compression library.
+"""
+Pure Python Snappy compression library.
 
 Snappy is a fast compression/decompression algorithm developed by Google.
 It prioritizes speed over compression ratio, making it ideal for real-time

--- a/src/lean_spec/node/snappy/compress.py
+++ b/src/lean_spec/node/snappy/compress.py
@@ -76,7 +76,8 @@ from lean_spec.node.snappy.encoding import encode_copy_tag, encode_literal_tag
 
 
 def compress(data: bytes) -> bytes:
-    """Compress data using the Snappy algorithm.
+    """
+    Compress data using the Snappy algorithm.
 
     Args:
         data: Uncompressed input bytes.
@@ -124,7 +125,8 @@ def compress(data: bytes) -> bytes:
 
 
 def max_compressed_length(source_bytes: int) -> int:
-    """Calculate the maximum possible compressed length for a given input size.
+    """
+    Calculate the maximum possible compressed length for a given input size.
 
     Snappy guarantees that compressed output never exceeds this size.
     Useful for pre-allocating buffers.
@@ -147,7 +149,8 @@ def max_compressed_length(source_bytes: int) -> int:
 
 
 def _compress_block(block: bytes) -> bytes:
-    """Compress a single block (up to 64KB).
+    """
+    Compress a single block (up to 64KB).
 
     This is the heart of the compression algorithm.
 
@@ -254,7 +257,8 @@ def _compress_block(block: bytes) -> bytes:
 
 
 def _compute_table_bits(block_size: int) -> int:
-    """Compute hash table size (as power of 2) for a given block size.
+    """
+    Compute hash table size (as power of 2) for a given block size.
 
     Args:
         block_size: Size of the block being compressed.
@@ -277,7 +281,8 @@ def _compute_table_bits(block_size: int) -> int:
 
 
 def _hash_4_bytes(data: bytes, pos: int, table_bits: int) -> int:
-    """Hash 4 bytes into a table index.
+    """
+    Hash 4 bytes into a table index.
 
     Args:
         data: Input data.
@@ -337,7 +342,8 @@ def _hash_4_bytes(data: bytes, pos: int, table_bits: int) -> int:
 
 
 def _matches_at(data: bytes, pos1: int, pos2: int) -> bool:
-    """Check if 4 bytes at pos1 equal 4 bytes at pos2.
+    """
+    Check if 4 bytes at pos1 equal 4 bytes at pos2.
 
     Args:
         data: Input data.
@@ -371,7 +377,8 @@ def _matches_at(data: bytes, pos1: int, pos2: int) -> bool:
 
 
 def _extend_match(data: bytes, match_pos: int, current_pos: int) -> int:
-    """Extend a match as far as possible.
+    """
+    Extend a match as far as possible.
 
     Args:
         data: Input data.
@@ -423,7 +430,8 @@ def _extend_match(data: bytes, match_pos: int, current_pos: int) -> int:
 
 
 def _emit_literal(literal_data: bytes) -> bytes:
-    """Encode literal data (unmatched bytes).
+    """
+    Encode literal data (unmatched bytes).
 
     Args:
         literal_data: Raw bytes to emit.

--- a/src/lean_spec/node/snappy/decompress.py
+++ b/src/lean_spec/node/snappy/decompress.py
@@ -81,7 +81,8 @@ class SnappyDecompressionError(Exception):
 
 
 def decompress(data: bytes) -> bytes:
-    """Decompress Snappy-compressed data.
+    """
+    Decompress Snappy-compressed data.
 
     Args:
         data: Snappy-compressed bytes.
@@ -193,7 +194,8 @@ def decompress(data: bytes) -> bytes:
 
 
 def _execute_copy(output: bytearray, offset: int, length: int, max_length: int) -> None:
-    """Execute a copy operation, appending bytes to the output buffer.
+    """
+    Execute a copy operation, appending bytes to the output buffer.
 
     Args:
         output: The output buffer (modified in place).

--- a/src/lean_spec/node/snappy/encoding.py
+++ b/src/lean_spec/node/snappy/encoding.py
@@ -79,7 +79,8 @@ type TagType = Literal["literal", "copy"]
 
 
 def encode_literal_tag(length: int) -> bytes:
-    """Encode a literal tag for the given data length.
+    """
+    Encode a literal tag for the given data length.
 
     Returns the tag byte(s) that should precede literal data in the
     compressed stream. The actual literal bytes follow immediately.
@@ -298,7 +299,8 @@ def encode_literal_tag(length: int) -> bytes:
 
 
 def encode_copy_tag(length: int, offset: int) -> bytes:
-    """Encode a copy tag for the given length and offset.
+    """
+    Encode a copy tag for the given length and offset.
 
     Automatically selects the most compact encoding based on the
     offset and length values.
@@ -338,7 +340,8 @@ def encode_copy_tag(length: int, offset: int) -> bytes:
 
 
 def _encode_copy_1(length: int, offset: int) -> bytes:
-    """Encode a copy-1 tag (2 bytes).
+    """
+    Encode a copy-1 tag (2 bytes).
 
     Format:
       Tag byte: [offset_high (3 bits)][length-4 (3 bits)][01 (2 bits)]
@@ -361,7 +364,8 @@ def _encode_copy_1(length: int, offset: int) -> bytes:
 
 
 def _encode_copy_2(length: int, offset: int) -> bytes:
-    """Encode a copy-2 tag (3 bytes).
+    """
+    Encode a copy-2 tag (3 bytes).
 
     Format:
       Tag byte: [length-1 (6 bits)][10 (2 bits)]
@@ -372,7 +376,8 @@ def _encode_copy_2(length: int, offset: int) -> bytes:
 
 
 def _encode_copy_4(length: int, offset: int) -> bytes:
-    """Encode a copy-4 tag (5 bytes).
+    """
+    Encode a copy-4 tag (5 bytes).
 
     Format:
       Tag byte: [length-1 (6 bits)][11 (2 bits)]
@@ -458,7 +463,8 @@ def _encode_copy_4(length: int, offset: int) -> bytes:
 
 
 def decode_tag(data: bytes, offset: int = 0) -> tuple[TagType, int, int, int]:
-    """Decode a tag at the given offset in the data.
+    """
+    Decode a tag at the given offset in the data.
 
     Parses the tag byte and any following length/offset bytes to determine
     the operation type, data length, and for copies, the backward offset.

--- a/src/lean_spec/node/sync/service.py
+++ b/src/lean_spec/node/sync/service.py
@@ -226,7 +226,8 @@ class SyncService:
         return new_store
 
     def _persist_block(self, store: Store, block: Block) -> None:
-        """Persist the block, its state, indices, and chain pointers atomically.
+        """
+        Persist the block, its state, indices, and chain pointers atomically.
 
         - A crash mid-batch would leave the database inconsistent.
         - The single batch guarantees all-or-nothing persistence per block import.
@@ -510,7 +511,8 @@ class SyncService:
         store: Store,
         block: SignedBlock,
     ) -> tuple[Store, list[SignedAggregatedAttestation]]:
-        """Recover per-attestation proofs from a processed block.
+        """
+        Recover per-attestation proofs from a processed block.
 
         On block import we already trust the block-attestation participant
         bitfields via spec on_block signature verification. The block carries
@@ -658,7 +660,8 @@ class SyncService:
         return store, aggregates
 
     async def _publish_pending_block_aggregates(self) -> None:
-        """Gossip the aggregates recovered from processed blocks.
+        """
+        Gossip the aggregates recovered from processed blocks.
 
         Every processed block is deconstructed in the block wrapper, which
         writes the recovered proofs into the store and queues the combined
@@ -697,7 +700,8 @@ class SyncService:
             await self._transition_to(SyncState.SYNCED)
 
     async def _transition_to(self, new_state: SyncState) -> None:
-        """Transition to a new sync state, rejecting invalid moves.
+        """
+        Transition to a new sync state, rejecting invalid moves.
 
         Two invariants are enforced:
 

--- a/src/lean_spec/node/sync/states.py
+++ b/src/lean_spec/node/sync/states.py
@@ -6,7 +6,8 @@ from enum import Enum, auto
 
 
 class SyncState(Enum):
-    """Three-phase progression for the sync service.
+    """
+    Three-phase progression for the sync service.
 
     Lifecycle:
 

--- a/src/lean_spec/node/validator/constants.py
+++ b/src/lean_spec/node/validator/constants.py
@@ -1,4 +1,5 @@
-"""Validator duty-gate thresholds.
+"""
+Validator duty-gate thresholds.
 
 Informative, not normative:
 

--- a/src/lean_spec/node/validator/registry.py
+++ b/src/lean_spec/node/validator/registry.py
@@ -1,4 +1,5 @@
-"""Validator registry for managing validator keys.
+"""
+Validator registry for managing validator keys.
 
 Loads validator keys from YAML configuration files compatible with ream and zeam.
 
@@ -217,7 +218,8 @@ class ValidatorRegistry:
 
     @classmethod
     def from_keys_directory(cls, node_id: str, base_directory: Path | str) -> ValidatorRegistry:
-        """Load a validator registry from the ream/zeam keystore layout.
+        """
+        Load a validator registry from the ream/zeam keystore layout.
 
         Two files relative to the base directory:
 

--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -580,7 +580,8 @@ class ValidatorService:
         slot: Slot,
         duty: Literal["block", "attestation"],
     ) -> bool:
-        """Decide whether duties may run for the given slot.
+        """
+        Decide whether duties may run for the given slot.
 
         Combines local lag and local-store stall evidence with
         hysteresis. Returns False only when the local view is stale

--- a/src/lean_spec/spec/crypto/merkleization.py
+++ b/src/lean_spec/spec/crypto/merkleization.py
@@ -54,7 +54,8 @@ Depth 64 covers any chunk count the protocol uses.
 
 
 def _zero_tree_root(width: int) -> Bytes32:
-    """Root of an all-zero perfect binary tree with the given leaf count.
+    """
+    Root of an all-zero perfect binary tree with the given leaf count.
 
     The width must be a power of two.
     """
@@ -75,7 +76,8 @@ def _zero_tree_root(width: int) -> Bytes32:
 
 
 def merkleize(chunks: Sequence[Bytes32], limit: int | None = None) -> Bytes32:
-    r"""Compute the SSZ Merkle root over a chunk sequence.
+    r"""
+    Compute the SSZ Merkle root over a chunk sequence.
 
     Tree layout for three leaves with no limit:
 
@@ -138,7 +140,8 @@ def merkleize(chunks: Sequence[Bytes32], limit: int | None = None) -> Bytes32:
 
 
 def mix_in_length(root: Bytes32, length: int) -> Bytes32:
-    """Mix a length into a Merkle root via the SSZ uint256 little-endian encoding.
+    """
+    Mix a length into a Merkle root via the SSZ uint256 little-endian encoding.
 
     Variable-length types append their declared length to disambiguate roots.
     Two lists with identical elements but different lengths must produce different roots.
@@ -159,7 +162,8 @@ def mix_in_length(root: Bytes32, length: int) -> Bytes32:
 
 
 def _pack_bytes(data: bytes) -> list[Bytes32]:
-    """Right-pad serialized bytes to a chunk boundary and split into chunks.
+    """
+    Right-pad serialized bytes to a chunk boundary and split into chunks.
 
     Layout for a 5-byte payload:
 
@@ -176,7 +180,8 @@ def _pack_bytes(data: bytes) -> list[Bytes32]:
 
 
 def _pack_bits(bits: Sequence[Boolean]) -> list[Bytes32]:
-    """Pack a boolean sequence into bytes, then into chunks for merkleization.
+    """
+    Pack a boolean sequence into bytes, then into chunks for merkleization.
 
     The first input bit becomes the least significant bit of the first byte.
     Each next input bit moves up one position, wrapping to the next byte after eight.
@@ -197,7 +202,8 @@ def _pack_bits(bits: Sequence[Boolean]) -> list[Bytes32]:
 
 @singledispatch
 def hash_tree_root(value: object) -> Bytes32:
-    """Compute the SSZ Merkle root of a value.
+    """
+    Compute the SSZ Merkle root of a value.
 
     Raises:
         TypeError: If the value's type has no registered handler.

--- a/src/lean_spec/spec/crypto/poseidon.py
+++ b/src/lean_spec/spec/crypto/poseidon.py
@@ -1,4 +1,5 @@
-"""Specification of the Poseidon permutation over the KoalaBear field.
+"""
+Specification of the Poseidon permutation over the KoalaBear field.
 
 Based on "Poseidon: A New Hash Function for Zero-Knowledge Proof Systems".
 See https://eprint.iacr.org/2019/458.
@@ -1340,7 +1341,8 @@ def _permute_jit(
 
 
 class PoseidonParams(StrictBaseModel):
-    """Parameters for a specific Poseidon instance.
+    """
+    Parameters for a specific Poseidon instance.
 
     - The paper requires at least 6 full rounds for statistical-attack security.
     - Some regimes raise this bound to 10 per Eq. 2 of the paper.

--- a/src/lean_spec/spec/crypto/xmss/__init__.py
+++ b/src/lean_spec/spec/crypto/xmss/__init__.py
@@ -1,4 +1,5 @@
-"""Generalized XMSS hash-based signature scheme.
+"""
+Generalized XMSS hash-based signature scheme.
 
 References:
     - Hash-Based Multi-Signatures for Post-Quantum Ethereum.

--- a/src/lean_spec/spec/crypto/xmss/constants.py
+++ b/src/lean_spec/spec/crypto/xmss/constants.py
@@ -68,7 +68,8 @@ class XmssConfig(StrictBaseModel):
 
     @property
     def LIFETIME(self) -> Uint64:
-        """The maximum number of slots supported by this configuration.
+        """
+        The maximum number of slots supported by this configuration.
 
         An individual key pair can be active for a smaller sub-range.
         """
@@ -86,7 +87,8 @@ class XmssConfig(StrictBaseModel):
 
     @property
     def SIGNATURE_LENGTH_BYTES(self) -> int:
-        """The SSZ-encoded size of a signature in bytes.
+        """
+        The SSZ-encoded size of a signature in bytes.
 
         # Layout
 

--- a/src/lean_spec/spec/crypto/xmss/containers.py
+++ b/src/lean_spec/spec/crypto/xmss/containers.py
@@ -71,7 +71,8 @@ class Signature(HexSerializedContainer):
 
 
 class SecretKey(HexSerializedContainer):
-    """Private state of an XMSS key pair.
+    """
+    Private state of an XMSS key pair.
 
     Must be kept confidential.
 
@@ -147,7 +148,8 @@ class KeyPair(StrictBaseModel):
 
 
 class ValidatorKeyPair(StrictBaseModel):
-    """Two independent XMSS key pairs for one validator's two signing roles.
+    """
+    Two independent XMSS key pairs for one validator's two signing roles.
 
     A validator signs two messages per slot:
 

--- a/src/lean_spec/spec/crypto/xmss/encoding.py
+++ b/src/lean_spec/spec/crypto/xmss/encoding.py
@@ -1,4 +1,5 @@
-"""Message-to-codeword pipeline for the Generalized XMSS scheme.
+"""
+Message-to-codeword pipeline for the Generalized XMSS scheme.
 
 # Overview
 
@@ -56,7 +57,8 @@ from lean_spec.spec.ssz import Bytes32, Uint64
 
 
 def encode_message(config: XmssConfig, message: Bytes32) -> list[Fp]:
-    """Encode a 32-byte message into field elements via base-P decomposition.
+    """
+    Encode a 32-byte message into field elements via base-P decomposition.
 
     The bytes are read little-endian as a single integer.
     """
@@ -65,7 +67,8 @@ def encode_message(config: XmssConfig, message: Bytes32) -> list[Fp]:
 
 
 def encode_epoch(config: XmssConfig, epoch: Uint64) -> list[Fp]:
-    """Encode the epoch and the message-hash subdomain into field elements.
+    """
+    Encode the epoch and the message-hash subdomain into field elements.
 
     The 8-bit prefix separates the message-hash subdomain from the chain and tree subdomains.
     """
@@ -77,7 +80,8 @@ def encode_epoch(config: XmssConfig, epoch: Uint64) -> list[Fp]:
 
 
 def aborting_decode(config: XmssConfig, field_elements: list[Fp]) -> list[int] | None:
-    """Reject-sample each field element into base-BASE digits.
+    """
+    Reject-sample each field element into base-BASE digits.
 
     For each element A_i:
 
@@ -115,7 +119,8 @@ def message_hash(
     rho: Randomness,
     message: Bytes32,
 ) -> list[int] | None:
-    """Hash the inputs with Poseidon and decode into a candidate codeword.
+    """
+    Hash the inputs with Poseidon and decode into a candidate codeword.
 
     Args:
         poseidon: Cached Poseidon engine.
@@ -147,7 +152,8 @@ def target_sum_encode(
     rho: Randomness,
     epoch: Uint64,
 ) -> list[int] | None:
-    """Encode a message into a codeword if it meets the target sum.
+    """
+    Encode a message into a codeword if it meets the target sum.
 
     The signer retries with fresh randomness on rejection.
 

--- a/src/lean_spec/spec/crypto/xmss/interface.py
+++ b/src/lean_spec/spec/crypto/xmss/interface.py
@@ -17,7 +17,8 @@ from lean_spec.spec.ssz import Bytes32, Uint64
 def _expand_activation_time(
     log_lifetime: int, desired_activation_slot: int, desired_num_active_slots: int
 ) -> tuple[int, int]:
-    """Snap a requested slot window onto whole bottom trees.
+    """
+    Snap a requested slot window onto whole bottom trees.
 
     # Overview
 
@@ -76,7 +77,8 @@ class GeneralizedXmssScheme(StrictBaseModel):
     """Cached Poseidon engine used by every primitive in the scheme."""
 
     def key_gen(self, activation_slot: Slot, num_active_slots: Uint64) -> KeyPair:
-        """Generate a fresh key pair active for an aligned slot range.
+        """
+        Generate a fresh key pair active for an aligned slot range.
 
         # Overview
 
@@ -172,7 +174,8 @@ class GeneralizedXmssScheme(StrictBaseModel):
         return KeyPair(public_key=public_key, secret_key=secret_key)
 
     def sign(self, secret_key: SecretKey, slot: Slot, message: Bytes32) -> Signature:
-        """Produce a signature for a message at a specific slot.
+        """
+        Produce a signature for a message at a specific slot.
 
         Phase 1: enforce that the slot is inside the activation and prepared windows.
         Phase 2: search for randomness rho whose encoding lands on the target-sum layer.
@@ -278,7 +281,8 @@ class GeneralizedXmssScheme(StrictBaseModel):
     def verify(
         self, public_key: PublicKey, slot: Slot, message: Bytes32, signature: Signature
     ) -> bool:
-        """Verify a signature against a public key, message, and slot.
+        """
+        Verify a signature against a public key, message, and slot.
 
         Phase 1: bound-check the slot.
         Phase 1 rejects without raising on bad input.
@@ -340,7 +344,8 @@ class GeneralizedXmssScheme(StrictBaseModel):
         )
 
     def get_activation_interval(self, secret_key: SecretKey) -> range:
-        """Return the activation interval as a Python range.
+        """
+        Return the activation interval as a Python range.
 
         A signature is only valid for a slot inside this range.
         """
@@ -348,7 +353,8 @@ class GeneralizedXmssScheme(StrictBaseModel):
         return range(start, start + int(secret_key.num_active_slots))
 
     def get_prepared_interval(self, secret_key: SecretKey) -> range:
-        """Return the prepared interval as a Python range.
+        """
+        Return the prepared interval as a Python range.
 
         The prepared interval is the slot window covered by the two resident bottom trees.
         A signer can sign any slot in this range without paying the cost of
@@ -359,7 +365,8 @@ class GeneralizedXmssScheme(StrictBaseModel):
         return range(start, start + 2 * leaves_per_bottom_tree)
 
     def advance_preparation(self, secret_key: SecretKey) -> SecretKey:
-        """Slide the prepared window one bottom tree forward.
+        """
+        Slide the prepared window one bottom tree forward.
 
         Phase 1: bail out when the next window would exceed the activation interval.
         Phase 2: regenerate the new right bottom tree from the PRF key.

--- a/src/lean_spec/spec/crypto/xmss/merkle.py
+++ b/src/lean_spec/spec/crypto/xmss/merkle.py
@@ -248,7 +248,8 @@ class HashSubTree(Container):
         parameter: Parameter,
         bottom_tree_roots: list[HashDigestVector],
     ) -> Self:
-        """Build the top tree from bottom-tree roots up to the global root.
+        """
+        Build the top tree from bottom-tree roots up to the global root.
 
         The top tree starts at layer depth/2 and treats bottom-tree roots as its leaves.
 
@@ -424,7 +425,8 @@ class HashSubTree(Container):
         )
 
     def root(self) -> HashDigestVector:
-        """Return the single node in the highest stored layer.
+        """
+        Return the single node in the highest stored layer.
 
         Raises:
             ValueError: When the subtree is empty or the highest layer has no nodes.

--- a/src/lean_spec/spec/crypto/xmss/poseidon.py
+++ b/src/lean_spec/spec/crypto/xmss/poseidon.py
@@ -25,7 +25,8 @@ class PoseidonXmss(StrictBaseModel):
     _engines: dict[int, Poseidon] = PrivateAttr(default_factory=dict)
 
     def _get_engine(self, width: int) -> Poseidon:
-        """Return a cached Poseidon engine for the given width.
+        """
+        Return a cached Poseidon engine for the given width.
 
         Raises:
             ValueError: When the width is neither 16 nor 24.
@@ -42,7 +43,8 @@ class PoseidonXmss(StrictBaseModel):
         return self._engines[width]
 
     def compress(self, input_vec: list[Fp], width: int, output_length: int) -> list[Fp]:
-        """Poseidon in compression mode.
+        """
+        Poseidon in compression mode.
 
         Computes Truncate(Permute(padded_input) + padded_input).
         The padded input is the original vector zero-extended to the state width.
@@ -75,7 +77,8 @@ class PoseidonXmss(StrictBaseModel):
         return final_state[:output_length]
 
     def safe_domain_separator(self, lengths: list[int], capacity_length: int) -> list[Fp]:
-        """Build a capacity initialization vector for the sponge construction.
+        """
+        Build a capacity initialization vector for the sponge construction.
 
         Hashes the packed length parameters into a fixed-size capacity value.
         This prevents collisions between sponges that absorb data of different shapes.
@@ -104,7 +107,8 @@ class PoseidonXmss(StrictBaseModel):
         output_length: int,
         width: int,
     ) -> list[Fp]:
-        """Poseidon in sponge mode.
+        """
+        Poseidon in sponge mode.
 
         Phase 1: load capacity, zero-extend input to a multiple of the rate.
         Phase 2: absorb each rate-sized chunk by replacement, then permute.
@@ -156,7 +160,8 @@ class PoseidonXmss(StrictBaseModel):
         tweak: TreeTweak | ChainTweak,
         message_parts: list[HashDigestVector],
     ) -> HashDigestVector:
-        """Apply the tweakable hash to one or more digests.
+        """
+        Apply the tweakable hash to one or more digests.
 
         Mode selection:
 
@@ -231,7 +236,8 @@ class PoseidonXmss(StrictBaseModel):
         num_steps: int,
         start_digest: HashDigestVector,
     ) -> HashDigestVector:
-        """Iterate the tweakable hash along a Winternitz chain.
+        """
+        Iterate the tweakable hash along a Winternitz chain.
 
         Each iteration uses a distinct chain tweak so every step is domain-separated.
 

--- a/src/lean_spec/spec/crypto/xmss/types.py
+++ b/src/lean_spec/spec/crypto/xmss/types.py
@@ -67,7 +67,8 @@ class HashDigestList(SSZList[HashDigestVector]):
 
 
 class Parameter(SSZVector[Fp]):
-    """The public parameter P.
+    """
+    The public parameter P.
 
     - Unique, randomly generated value associated with a single key pair.
     - Mixed into every hash to personalize the function and block cross-key attacks.

--- a/src/lean_spec/spec/forks/lstar/containers/__init__.py
+++ b/src/lean_spec/spec/forks/lstar/containers/__init__.py
@@ -1,4 +1,5 @@
-"""Container types for the Lean consensus specification.
+"""
+Container types for the Lean consensus specification.
 
 This package is the public container surface for the lstar fork.
 The types are split across submodules by domain role:

--- a/src/lean_spec/spec/forks/lstar/containers/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/aggregation.py
@@ -1,7 +1,8 @@
-"""Post-quantum signature aggregation proofs wrapping the Rust prover.
+"""
+Post-quantum signature aggregation proofs wrapping the Rust prover.
 
-Single-message proofs aggregate many validators signing the same message.
-Multi-message proofs merge components over distinct messages into one blob.
+- Single-message proofs aggregate many validators signing the same message.
+- Multi-message proofs merge components over distinct messages into one blob.
 """
 
 from lean_multisig_py import (
@@ -20,7 +21,8 @@ from lean_spec.spec.forks.lstar.slot import Slot
 from lean_spec.spec.ssz import ByteList512KiB, Bytes32, Container
 
 LOG_INV_RATE: int = 1 if LEAN_ENV == "test" else 2
-"""Inverse-rate exponent forwarded to the SNARK backend.
+"""
+Inverse-rate exponent forwarded to the SNARK backend.
 
 A smaller rate trades verifier cost for prover speed.
 Test mode favors prover speed.
@@ -32,7 +34,8 @@ class AggregationError(Exception):
 
 
 class SingleMessageAggregate(Container):
-    """Single-message proof aggregating signatures from many validators.
+    """
+    Single-message proof aggregating signatures from many validators.
 
     Every validator signs the same message for the same slot.
 
@@ -56,7 +59,8 @@ class SingleMessageAggregate(Container):
         message: Bytes32,
         slot: Slot,
     ) -> "SingleMessageAggregate":
-        """Fold fresh signatures and child proofs into one single-message proof.
+        """
+        Fold fresh signatures and child proofs into one single-message proof.
 
         # Overview
 
@@ -129,7 +133,8 @@ class SingleMessageAggregate(Container):
         message: Bytes32,
         slot: Slot,
     ) -> None:
-        """Verify this single-message single-message aggregate proof against a public_key set.
+        """
+        Verify this single-message single-message aggregate proof against a public_key set.
 
         Args:
             public_keys: PublicKeys for the validators named by participants.
@@ -171,7 +176,8 @@ class SingleMessageAggregate(Container):
 
 
 class MultiMessageAggregate(Container):
-    """Merged proof covering many distinct messages.
+    """
+    Merged proof covering many distinct messages.
 
     Each component is a single-message proof over its own message.
     Merging binds the components into one proof the block can carry whole.
@@ -188,7 +194,8 @@ class MultiMessageAggregate(Container):
         parts: list[SingleMessageAggregate],
         public_keys_per_part: list[list[PublicKey]],
     ) -> "MultiMessageAggregate":
-        """Merge several single-message proofs over distinct messages into one.
+        """
+        Merge several single-message proofs over distinct messages into one.
 
         # Why the public keys are passed in
 
@@ -247,7 +254,8 @@ class MultiMessageAggregate(Container):
         public_keys_per_message: list[list[PublicKey]],
         participants: AggregationBits,
     ) -> SingleMessageAggregate:
-        """Recover the single-message aggregate proof bound to one message.
+        """
+        Recover the single-message aggregate proof bound to one message.
 
         Splits this multi-message aggregate to extract the component
         bound to the given message.
@@ -301,7 +309,8 @@ class MultiMessageAggregate(Container):
         public_keys_per_message: list[list[PublicKey]],
         messages: list[tuple[Bytes32, Slot]],
     ) -> None:
-        """Verify this multi-message proof against its per-component bindings.
+        """
+        Verify this multi-message proof against its per-component bindings.
 
         # The message bindings
 

--- a/src/lean_spec/spec/forks/lstar/containers/block.py
+++ b/src/lean_spec/spec/forks/lstar/containers/block.py
@@ -64,7 +64,8 @@ class Block(Container):
 
 
 class SignedBlock(Container):
-    """Envelope carrying a block with a single aggregated proof for all signatures.
+    """
+    Envelope carrying a block with a single aggregated proof for all signatures.
 
     The proof is a multi-message aggregate multi-message proof.
     It binds every attestation in the body plus the proposer's signature

--- a/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
+++ b/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
@@ -1,4 +1,5 @@
-"""Casper-FFG checkpoints and the attestation vote they anchor.
+"""
+Casper-FFG checkpoints and the attestation vote they anchor.
 
 A checkpoint is the (block root, slot) pair that gets justified and finalized.
 An attestation's content is three checkpoints: source, target, and head.

--- a/src/lean_spec/spec/forks/lstar/containers/identifiers.py
+++ b/src/lean_spec/spec/forks/lstar/containers/identifiers.py
@@ -14,7 +14,8 @@ class ValidatorIndex(Uint64):
 
     @classmethod
     def proposer_for_slot(cls, slot: Slot, num_validators: Uint64) -> "ValidatorIndex":
-        """Return the validator index responsible for proposing at the given slot.
+        """
+        Return the validator index responsible for proposing at the given slot.
 
         Round-robin selection: the proposer is slot modulo registry size.
         """
@@ -25,7 +26,8 @@ class ValidatorIndex(Uint64):
         return int(self) < int(num_validators)
 
     def compute_subnet_id(self, num_committees: Uint64) -> SubnetId:
-        """Compute the attestation subnet id for this validator.
+        """
+        Compute the attestation subnet id for this validator.
 
         Args:
             num_committees: Positive number of committees.

--- a/src/lean_spec/spec/forks/lstar/containers/state.py
+++ b/src/lean_spec/spec/forks/lstar/containers/state.py
@@ -166,7 +166,8 @@ class JustifiedSlots(BaseBitlist):
 
 
 class JustificationValidators(BaseBitlist):
-    """Per-root validator vote bitfields, concatenated into one flat bitlist.
+    """
+    Per-root validator vote bitfields, concatenated into one flat bitlist.
 
     Each tracked root contributes one bit per registered validator.
     The cap is the maximum tracked roots times the validator registry limit.

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -42,7 +42,8 @@ class ForkChoiceMixin(LstarSpecBase):
         anchor_block: SpecBlockType,
         validator_index: ValidatorIndex | None,
     ) -> LstarStore:
-        """Initialize a forkchoice store from an anchor state and block.
+        """
+        Initialize a forkchoice store from an anchor state and block.
 
         The anchor block and state form the starting point for fork choice.
         Both are treated as justified and finalized.
@@ -99,7 +100,8 @@ class ForkChoiceMixin(LstarSpecBase):
         )
 
     def prune_stale_attestation_data(self, store: LstarStore) -> LstarStore:
-        """Remove attestation data that can no longer influence fork choice.
+        """
+        Remove attestation data that can no longer influence fork choice.
 
         An attestation becomes stale when its head checkpoint falls at or before
         the finalized slot. Such attestations cannot affect chain selection since
@@ -133,7 +135,8 @@ class ForkChoiceMixin(LstarSpecBase):
         return store
 
     def validate_attestation(self, store: LstarStore, attestation_data: AttestationData) -> None:
-        """Validate incoming attestation before processing.
+        """
+        Validate incoming attestation before processing.
 
         Ensures the vote respects the basic laws of time and topology:
             1. The blocks voted for must exist in our store.
@@ -191,7 +194,8 @@ class ForkChoiceMixin(LstarSpecBase):
         signed_attestation: SignedAttestation,
         is_aggregator: bool = False,
     ) -> LstarStore:
-        """Process a signed attestation received via gossip network.
+        """
+        Process a signed attestation received via gossip network.
 
         This method:
 
@@ -255,7 +259,8 @@ class ForkChoiceMixin(LstarSpecBase):
         store: LstarStore,
         signed_attestation: SignedAggregatedAttestation,
     ) -> LstarStore:
-        """Process a signed aggregated attestation received via aggregation topic.
+        """
+        Process a signed aggregated attestation received via aggregation topic.
 
         This method:
         1. Verifies the aggregated attestation
@@ -314,7 +319,8 @@ class ForkChoiceMixin(LstarSpecBase):
         store: LstarStore,
         signed_block: SignedBlock,
     ) -> LstarStore:
-        """Process a new block and update the forkchoice state.
+        """
+        Process a new block and update the forkchoice state.
 
         This method integrates a block into the forkchoice store by:
 
@@ -418,7 +424,8 @@ class ForkChoiceMixin(LstarSpecBase):
         store: LstarStore,
         aggregated_payloads: dict[AttestationData, set[SingleMessageAggregate]],
     ) -> dict[ValidatorIndex, AttestationData]:
-        """Extract attestations from aggregated payloads.
+        """
+        Extract attestations from aggregated payloads.
 
         Given a mapping of aggregated signature proofs, extract the attestation data
         for each validator that participated in the aggregation.
@@ -439,7 +446,8 @@ class ForkChoiceMixin(LstarSpecBase):
         attestations: dict[ValidatorIndex, AttestationData],
         start_slot: Slot,
     ) -> dict[Bytes32, int]:
-        """Accumulate one unit of voting weight per ancestor of each head vote.
+        """
+        Accumulate one unit of voting weight per ancestor of each head vote.
 
         For every vote, follow the chosen head upward through its ancestors.
         Each visited block above the start slot accumulates one unit of weight
@@ -460,7 +468,8 @@ class ForkChoiceMixin(LstarSpecBase):
         return weights
 
     def compute_block_weights(self, store: LstarStore) -> dict[Bytes32, int]:
-        """Compute attestation-based weight for each block above the finalized slot.
+        """
+        Compute attestation-based weight for each block above the finalized slot.
 
         Walks backward from each validator's latest head vote, incrementing weight
         for every ancestor above the finalized slot.
@@ -487,7 +496,8 @@ class ForkChoiceMixin(LstarSpecBase):
         attestations: dict[ValidatorIndex, AttestationData],
         min_score: int = 0,
     ) -> Bytes32:
-        """Walk the block tree according to the LMD GHOST rule.
+        """
+        Walk the block tree according to the LMD GHOST rule.
 
         The walk starts from a chosen root.
         At each fork, the child subtree with the highest weight is taken.
@@ -544,7 +554,8 @@ class ForkChoiceMixin(LstarSpecBase):
         return head
 
     def update_head(self, store: LstarStore) -> LstarStore:
-        """Compute updated store with new canonical head.
+        """
+        Compute updated store with new canonical head.
 
         Selects the canonical chain head using:
 
@@ -576,7 +587,8 @@ class ForkChoiceMixin(LstarSpecBase):
         return store
 
     def accept_new_attestations(self, store: LstarStore) -> LstarStore:
-        """Process pending aggregated payloads and update forkchoice head.
+        """
+        Process pending aggregated payloads and update forkchoice head.
 
         Moves aggregated payloads from latest_new_aggregated_payloads to
         latest_known_aggregated_payloads, making them eligible to contribute to
@@ -605,7 +617,8 @@ class ForkChoiceMixin(LstarSpecBase):
         return self.update_head(store)
 
     def update_safe_target(self, store: LstarStore) -> LstarStore:
-        """Compute the deepest block that has 2/3+ supermajority attestation weight.
+        """
+        Compute the deepest block that has 2/3+ supermajority attestation weight.
 
         The safe target is the furthest-from-genesis block where enough validators
         agree. Validators use it to decide which block is safe to attest to.

--- a/src/lean_spec/spec/forks/lstar/slot.py
+++ b/src/lean_spec/spec/forks/lstar/slot.py
@@ -1,4 +1,5 @@
-"""Slot primitive shared by the consensus and crypto layers.
+"""
+Slot primitive shared by the consensus and crypto layers.
 
 The crypto signing scheme binds each signature to a specific slot.
 Hosting the type here lets the crypto layer name the slot without

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -31,7 +31,8 @@ def attestation_data_matches_chain(
     attestation_data: AttestationData,
     historical_block_hashes: Sequence[Bytes32],
 ) -> bool:
-    """Check that source and target checkpoints point to blocks on a chain.
+    """
+    Check that source and target checkpoints point to blocks on a chain.
 
     Args:
         attestation_data: The attestation being validated.

--- a/src/lean_spec/spec/forks/lstar/timeline.py
+++ b/src/lean_spec/spec/forks/lstar/timeline.py
@@ -19,7 +19,8 @@ class TimelineMixin(LstarSpecBase):
         has_proposal: bool,
         is_aggregator: bool = False,
     ) -> tuple[LstarStore, list[SignedAggregatedAttestation]]:
-        """Advance store time by one interval and perform interval-specific actions.
+        """
+        Advance store time by one interval and perform interval-specific actions.
 
         Different actions are performed based on interval within slot:
         - Interval 0: Process attestations if proposal exists
@@ -51,7 +52,8 @@ class TimelineMixin(LstarSpecBase):
         has_proposal: bool,
         is_aggregator: bool = False,
     ) -> tuple[LstarStore, list[SignedAggregatedAttestation]]:
-        """Advance forkchoice store time to given interval count.
+        """
+        Advance forkchoice store time to given interval count.
 
         Ticks store forward interval by interval, performing appropriate
         actions for each interval type. This method handles time progression

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -21,7 +21,8 @@ class ValidatorDutiesMixin(LstarSpecBase):
     """Validator duties for the lstar fork."""
 
     def get_proposal_head(self, store: LstarStore, slot: Slot) -> tuple[LstarStore, Bytes32]:
-        """Get the head for block proposal at given slot.
+        """
+        Get the head for block proposal at given slot.
 
         Ensures store is up-to-date and processes any pending attestations
         before returning the canonical head. This guarantees the proposer
@@ -37,7 +38,8 @@ class ValidatorDutiesMixin(LstarSpecBase):
         return store, store.head
 
     def get_attestation_target(self, store: LstarStore) -> Checkpoint:
-        """Calculate target checkpoint for validator attestations.
+        """
+        Calculate target checkpoint for validator attestations.
 
         Determines the attestation target from the head, the safe target,
         and the finalization constraints.
@@ -86,7 +88,8 @@ class ValidatorDutiesMixin(LstarSpecBase):
         return Checkpoint(root=target_block_root, slot=target_block.slot)
 
     def produce_attestation_data(self, store: LstarStore, slot: Slot) -> AttestationData:
-        """Produce attestation data for the given slot.
+        """
+        Produce attestation data for the given slot.
 
         This method constructs an AttestationData object according to the lean protocol
         specification. The attestation data represents the chain state view including
@@ -115,7 +118,8 @@ class ValidatorDutiesMixin(LstarSpecBase):
         slot: Slot,
         validator_index: ValidatorIndex,
     ) -> tuple[LstarStore, Block, list[SingleMessageAggregate]]:
-        """Produce a block for the target slot.
+        """
+        Produce a block for the target slot.
 
         Returns the block alongside its per-attestation single-message
         aggregate proofs.

--- a/src/lean_spec/spec/forks/protocol.py
+++ b/src/lean_spec/spec/forks/protocol.py
@@ -68,7 +68,8 @@ class SpecBlockType(SpecSSZType, Protocol):
 
 
 class SpecBlockBodyType(SpecSSZType, Protocol):
-    """Structural contract: any fork's BlockBody container class.
+    """
+    Structural contract: any fork's BlockBody container class.
 
     Carries the variable-size payload attached to a block — typically
     aggregated attestations and any future operation lists.
@@ -76,7 +77,8 @@ class SpecBlockBodyType(SpecSSZType, Protocol):
 
 
 class SpecBlockHeaderType(SpecSSZType, Protocol):
-    """Structural contract: any fork's BlockHeader container class.
+    """
+    Structural contract: any fork's BlockHeader container class.
 
     The fixed-shape summary of a block used in state-transition tracking
     and state-root caching. Carries slot, proposer, parent root, state
@@ -85,14 +87,16 @@ class SpecBlockHeaderType(SpecSSZType, Protocol):
 
 
 class SpecAggregatedAttestationsType(SpecSSZType, Protocol):
-    """Structural contract: any fork's AggregatedAttestations list class.
+    """
+    Structural contract: any fork's AggregatedAttestations list class.
 
     Bounded SSZ list of aggregated attestations included in a block body.
     """
 
 
 class SpecAttestationDataType(SpecSSZType, Protocol):
-    """Structural contract: any fork's AttestationData container class.
+    """
+    Structural contract: any fork's AttestationData container class.
 
     Encodes a validator's view of the chain (slot + source/target/head
     checkpoints) and is the payload that gets signed.
@@ -120,7 +124,8 @@ class SpecAttestationDataType(SpecSSZType, Protocol):
 
 
 class SpecAggregatedAttestationType(SpecSSZType, Protocol):
-    """Structural contract: any fork's AggregatedAttestation container class.
+    """
+    Structural contract: any fork's AggregatedAttestation container class.
 
     An attestation aggregated over multiple validators via a participation
     bitfield.
@@ -133,7 +138,8 @@ class SpecAggregatedAttestationType(SpecSSZType, Protocol):
 
 
 class SpecStoreType(Protocol):
-    """Structural contract: any fork's forkchoice Store.
+    """
+    Structural contract: any fork's forkchoice Store.
 
     Exposes anchor construction plus the read/write surface that sync,
     chain, and node services drive without depending on a concrete fork.

--- a/src/lean_spec/spec/ssz/ssz_base.py
+++ b/src/lean_spec/spec/ssz/ssz_base.py
@@ -19,7 +19,8 @@ class SSZType(ABC):
     @classmethod
     @abstractmethod
     def is_fixed_size(cls) -> bool:
-        """Whether every instance encodes to the same number of bytes.
+        """
+        Whether every instance encodes to the same number of bytes.
 
         Returns:
             True for fixed-size types, False for variable-size.
@@ -29,7 +30,8 @@ class SSZType(ABC):
     @classmethod
     @abstractmethod
     def get_byte_length(cls) -> int:
-        """Fixed encoded byte length of this type.
+        """
+        Fixed encoded byte length of this type.
 
         Returns:
             The constant byte width every instance encodes to.
@@ -41,7 +43,8 @@ class SSZType(ABC):
 
     @abstractmethod
     def serialize(self, stream: IO[bytes]) -> int:
-        """Write the SSZ encoding to a binary stream.
+        """
+        Write the SSZ encoding to a binary stream.
 
         Args:
             stream: Output binary stream.
@@ -54,7 +57,8 @@ class SSZType(ABC):
     @classmethod
     @abstractmethod
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
-        """Read one value from a binary stream within a bounded byte budget.
+        """
+        Read one value from a binary stream within a bounded byte budget.
 
         Args:
             stream: Source binary stream.
@@ -66,7 +70,8 @@ class SSZType(ABC):
         ...
 
     def encode_bytes(self) -> bytes:
-        """Encode this value to its SSZ byte representation.
+        """
+        Encode this value to its SSZ byte representation.
 
         Returns:
             Serialized bytes.
@@ -77,7 +82,8 @@ class SSZType(ABC):
 
     @classmethod
     def decode_bytes(cls, data: bytes) -> Self:
-        """Decode SSZ bytes into a new instance.
+        """
+        Decode SSZ bytes into a new instance.
 
         Rejects trailing bytes left over after the stream-based decoder finishes.
         A spec decoder must accept exactly one canonical encoding per value.
@@ -104,7 +110,8 @@ class SSZType(ABC):
 
 
 class SSZModel(StrictBaseModel, SSZType):
-    """Pydantic-backed SSZ base used by containers, lists, vectors, and bitfields.
+    """
+    Pydantic-backed SSZ base used by containers, lists, vectors, and bitfields.
 
     Two shapes share this base:
 

--- a/src/lean_spec/spec/ssz/uint.py
+++ b/src/lean_spec/spec/ssz/uint.py
@@ -20,7 +20,8 @@ class BaseUint(int, SSZType):
     """The number of bits in the integer (overridden by subclasses)."""
 
     def __new__(cls, value: SupportsInt) -> Self:
-        """Create and range-check a new instance.
+        """
+        Create and range-check a new instance.
 
         Raises:
             SSZTypeError: If value is not an int. Bool, string, and float are rejected.
@@ -83,7 +84,8 @@ class BaseUint(int, SSZType):
     @classmethod
     @override
     def decode_bytes(cls, data: bytes) -> Self:
-        """Deserialize from little-endian bytes.
+        """
+        Deserialize from little-endian bytes.
 
         Raises:
             SSZSerializationError: If the byte string has the wrong length.
@@ -108,7 +110,8 @@ class BaseUint(int, SSZType):
     @classmethod
     @override
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
-        """Read little-endian bytes from a stream within a fixed scope.
+        """
+        Read little-endian bytes from a stream within a fixed scope.
 
         Raises:
             SSZSerializationError: If the scope mismatches, or the stream ends early.

--- a/tests/consensus/lstar/api/test_api_post_genesis.py
+++ b/tests/consensus/lstar/api/test_api_post_genesis.py
@@ -1,4 +1,5 @@
-"""API endpoint conformance vectors after the chain has advanced past genesis.
+"""
+API endpoint conformance vectors after the chain has advanced past genesis.
 
 Existing API fixtures pin responses against a genesis-only store. This
 file pins the same endpoints after an empty-block chain has advanced,
@@ -16,7 +17,8 @@ GENESIS_4V_AT_SLOT_3 = {"numValidators": 4, "genesisTime": 0, "anchorSlot": 3}
 
 
 def test_fork_choice_tree_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
-    """Fork-choice response carries a multi-node tree once the chain advances.
+    """
+    Fork-choice response carries a multi-node tree once the chain advances.
 
     With the chain at slot 3 the store holds four blocks (genesis plus
     slots 1 through 3). The response's nodes list, head root, and
@@ -27,7 +29,8 @@ def test_fork_choice_tree_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None
 
 
 def test_finalized_state_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
-    """Finalized-state response returns the SSZ-encoded anchor state after chain advance.
+    """
+    Finalized-state response returns the SSZ-encoded anchor state after chain advance.
 
     Finalization has not yet moved past genesis (no attestations have
     been injected), but the served state now carries non-empty
@@ -38,7 +41,8 @@ def test_finalized_state_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
 
 
 def test_justified_checkpoint_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
-    """Justified-checkpoint response at a non-genesis slot pins the slot=0 root.
+    """
+    Justified-checkpoint response at a non-genesis slot pins the slot=0 root.
 
     Without attestations, justification remains at genesis even after
     the chain advances. This vector pins that the response still

--- a/tests/consensus/lstar/api/test_metrics_endpoint.py
+++ b/tests/consensus/lstar/api/test_metrics_endpoint.py
@@ -9,7 +9,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_metrics_endpoint_scrape_contract(
     api_endpoint: ApiEndpointTestFiller,
 ) -> None:
-    """GET /metrics returns the Prometheus-format scrape with the required metric names.
+    """
+    GET /metrics returns the Prometheus-format scrape with the required metric names.
 
     The endpoint body is dynamic (counters accumulate, timestamps shift),
     so the vector pins only the stable contract: status 200, the

--- a/tests/consensus/lstar/chain/test_slot_clock.py
+++ b/tests/consensus/lstar/chain/test_slot_clock.py
@@ -1,4 +1,5 @@
-"""Test vectors for slot clock timing computations.
+"""
+Test vectors for slot clock timing computations.
 
 Every consensus client must derive identical slot and interval numbers
 from wall-clock timestamps. These vectors verify the conversion logic

--- a/tests/consensus/lstar/fc/test_block_attestation_limits.py
+++ b/tests/consensus/lstar/fc/test_block_attestation_limits.py
@@ -20,7 +20,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 @pytest.fixture(autouse=True)
 def _reset_xmss_signing_state():
-    """Reset XMSS signing state around each test in this module.
+    """
+    Reset XMSS signing state around each test in this module.
 
     Tests here sign at high slots (50+). Without resetting, the advanced
     key state poisons the cache for any later test on the same

--- a/tests/consensus/lstar/fc/test_checkpoint_sync.py
+++ b/tests/consensus/lstar/fc/test_checkpoint_sync.py
@@ -29,7 +29,8 @@ NUM_VALIDATORS = 4
 def test_store_init_from_non_genesis_anchor(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Store exposes the anchor as head, justified, and finalized on startup.
+    """
+    Store exposes the anchor as head, justified, and finalized on startup.
 
     Scenario
     --------
@@ -96,7 +97,8 @@ def test_store_init_from_non_genesis_anchor(
 def test_extend_chain_from_non_genesis_anchor(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Blocks at slots above the anchor extend the canonical chain.
+    """
+    Blocks at slots above the anchor extend the canonical chain.
 
     Scenario
     --------
@@ -186,7 +188,8 @@ def test_extend_chain_from_non_genesis_anchor(
 def test_fork_off_non_genesis_anchor(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Forks rooted at a checkpoint-synced anchor are tracked and resolvable.
+    """
+    Forks rooted at a checkpoint-synced anchor are tracked and resolvable.
 
     Scenario
     --------
@@ -282,7 +285,8 @@ def test_fork_off_non_genesis_anchor(
 def test_non_genesis_anchor_is_internally_consistent(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """The helper-built anchor satisfies Store.from_anchor's preconditions.
+    """
+    The helper-built anchor satisfies Store.from_anchor's preconditions.
 
     Documents the invariants any valid non-genesis anchor must meet before
     seeding the store:
@@ -327,7 +331,8 @@ def test_non_genesis_anchor_is_internally_consistent(
 def test_store_from_anchor_rejects_mismatched_state_root(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Store.from_anchor aborts when the anchor block's state_root disagrees
+    """
+    Store.from_anchor aborts when the anchor block's state_root disagrees
     with the hash of the anchor state.
 
     Scenario

--- a/tests/consensus/lstar/fc/test_finalization_mid_processing.py
+++ b/tests/consensus/lstar/fc/test_finalization_mid_processing.py
@@ -1,4 +1,5 @@
-"""Fork Choice: Finalization advances mid-attestation processing.
+"""
+Fork Choice: Finalization advances mid-attestation processing.
 
 This test verifies that attestations see updated finalized_slot during processing,
 as required by the 3sf-mini specification.

--- a/tests/consensus/lstar/fc/test_safe_target.py
+++ b/tests/consensus/lstar/fc/test_safe_target.py
@@ -34,7 +34,8 @@ def test_safe_target_does_not_advance_below_supermajority(
     fork_choice_test: ForkChoiceTestFiller,
     num_attesters: int,
 ) -> None:
-    """Safe target stays at genesis when weight falls short of the 2/3 threshold.
+    """
+    Safe target stays at genesis when weight falls short of the 2/3 threshold.
 
     Fixture state:
 
@@ -144,7 +145,8 @@ def test_safe_target_does_not_advance_below_supermajority(
 def test_safe_target_advances_incrementally_along_the_chain(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target advances one block at a time as votes shift forward.
+    """
+    Safe target advances one block at a time as votes shift forward.
 
     4 validators, threshold = ceil(8/3) = 3.
     Chain: genesis -> block_1 -> block_2 -> block_3.
@@ -257,7 +259,8 @@ def test_safe_target_advances_incrementally_along_the_chain(
 def test_safe_target_follows_heavier_fork_on_split(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target follows the fork with supermajority support.
+    """
+    Safe target follows the fork with supermajority support.
 
     6 validators, threshold = 4.
 
@@ -330,7 +333,8 @@ def test_safe_target_follows_heavier_fork_on_split(
 def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target can be strictly shallower than the LMD-GHOST head.
+    """
+    Safe target can be strictly shallower than the LMD-GHOST head.
 
     8 validators, threshold = ceil(16/3) = 6.
     Chain: genesis -> block_1 -> block_2 -> block_3.
@@ -419,7 +423,8 @@ def test_safe_target_is_conservative_relative_to_lmd_ghost_head(
 def test_safe_target_ignores_known_pool_at_interval_3(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
-    """Safe target only uses the "new" pool at interval 3.
+    """
+    Safe target only uses the "new" pool at interval 3.
 
     6 validators, threshold = 4.
 

--- a/tests/consensus/lstar/networking/test_decode_failure_smoke.py
+++ b/tests/consensus/lstar/networking/test_decode_failure_smoke.py
@@ -1,4 +1,5 @@
-"""Smoke test for the networking_codec fixture's decode_failure dispatcher.
+"""
+Smoke test for the networking_codec fixture's decode_failure dispatcher.
 
 Exercises the new `decode_failure` codec so the framework change is covered
 independently of later negative-path content PRs.
@@ -11,7 +12,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_decode_failure_varint_truncated(networking_codec: NetworkingCodecTestFiller) -> None:
-    """A truncated varint (continuation bit set on the final byte) must fail to decode.
+    """
+    A truncated varint (continuation bit set on the final byte) must fail to decode.
 
     Pins the new `decode_failure` codec dispatch path on the
     networking_codec fixture.

--- a/tests/consensus/lstar/networking/test_enr_non_canonical.py
+++ b/tests/consensus/lstar/networking/test_enr_non_canonical.py
@@ -1,4 +1,5 @@
-"""ENR decoder: non-canonical key-order rejection vector.
+"""
+ENR decoder: non-canonical key-order rejection vector.
 
 EIP-778 requires ENR key/value pairs to be lexicographically ordered
 in the signed RLP list. A decoder that accepts unordered keys would
@@ -15,7 +16,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def _build_unsorted_enr_rlp() -> bytes:
-    """Build an RLP-encoded ENR whose key/value pairs are not sorted.
+    """
+    Build an RLP-encoded ENR whose key/value pairs are not sorted.
 
     EIP-778 mandates lexicographic key ordering. The decoder must reject
     any ENR whose on-the-wire RLP list has keys out of order.
@@ -40,7 +42,8 @@ UNSORTED_ENR_HEX: str = "0x" + _build_unsorted_enr_rlp().hex()
 def test_enr_decode_rejects_non_canonical_key_order(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """An ENR with keys outside lexicographic order must be rejected.
+    """
+    An ENR with keys outside lexicographic order must be rejected.
 
     Pins EIP-778's canonical-ordering requirement. A client that decodes
     such a record would verify a signature over bytes the signer never

--- a/tests/consensus/lstar/networking/test_enr_rejections.py
+++ b/tests/consensus/lstar/networking/test_enr_rejections.py
@@ -9,7 +9,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_enr_decode_rejects_oversize_payload(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """An ENR RLP payload above the 300-byte cap is rejected.
+    """
+    An ENR RLP payload above the 300-byte cap is rejected.
 
     EIP-778 caps the encoded ENR at 300 bytes so records can travel
     comfortably through DNS TXT records. A 301-byte input must be
@@ -26,7 +27,8 @@ def test_enr_decode_rejects_oversize_payload(
 def test_enr_decode_rejects_malformed_rlp(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """An input that cannot be parsed as an RLP list is rejected.
+    """
+    An input that cannot be parsed as an RLP list is rejected.
 
     The byte 0x00 is valid RLP for the single byte value 0x00, not for a
     list structure. The ENR decoder requires a list header, so the parse

--- a/tests/consensus/lstar/networking/test_gossip_topic_fork.py
+++ b/tests/consensus/lstar/networking/test_gossip_topic_fork.py
@@ -1,4 +1,5 @@
-"""Gossipsub topic network-name validation vectors.
+"""
+Gossipsub topic network-name validation vectors.
 
 Validates that a parsed topic carries the network name a client
 expects. A mismatch is the only mechanism preventing cross-fork mesh
@@ -15,7 +16,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_gossip_topic_network_name_matches(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """Block topic whose network name matches the expected value validates cleanly.
+    """
+    Block topic whose network name matches the expected value validates cleanly.
 
     Pins the accept branch of validate_fork: a topic built with a network
     name equal to the expected one must pass the check.
@@ -33,7 +35,8 @@ def test_gossip_topic_network_name_matches(
 def test_gossip_topic_network_name_mismatch(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """Block topic with a network name different from the expected one is rejected.
+    """
+    Block topic with a network name different from the expected one is rejected.
 
     Pins the reject branch of validate_fork: a topic built for one fork
     must not pass when validated against a different network name. The
@@ -53,7 +56,8 @@ def test_gossip_topic_network_name_mismatch(
 def test_gossip_topic_network_name_match_on_attestation_subnet(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """Attestation-subnet topic carries the subnet id and still validates its network name.
+    """
+    Attestation-subnet topic carries the subnet id and still validates its network name.
 
     Mixes a non-default kind and subnet id with the network-name check
     to confirm the validator reads network_name independent of other

--- a/tests/consensus/lstar/networking/test_gossipsub_rpc_rejections.py
+++ b/tests/consensus/lstar/networking/test_gossipsub_rpc_rejections.py
@@ -11,7 +11,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_gossipsub_rpc_decode_rejects_unknown_wire_type(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """A protobuf tag with an unrecognised wire type must be rejected.
+    """
+    A protobuf tag with an unrecognised wire type must be rejected.
 
     The tag byte 0x0e encodes field number 1 with wire type 6. Wire types
     beyond the set 0, 1, 2, 5 are unassigned; any occurrence in RPC traffic
@@ -27,7 +28,8 @@ def test_gossipsub_rpc_decode_rejects_unknown_wire_type(
 def test_gossipsub_rpc_decode_rejects_length_exceeding_data(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """A length-delimited field whose length runs past the payload is rejected.
+    """
+    A length-delimited field whose length runs past the payload is rejected.
 
     The payload starts with tag 0x0a (field 1, length-delimited wire type)
     followed by varint length 0x64 (100). The rest of the buffer carries

--- a/tests/consensus/lstar/networking/test_reqresp_error_utf8.py
+++ b/tests/consensus/lstar/networking/test_reqresp_error_utf8.py
@@ -9,7 +9,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_reqresp_error_at_max_error_message_size(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """Error response carrying a payload at the maximum error-message size roundtrips.
+    """
+    Error response carrying a payload at the maximum error-message size roundtrips.
 
     The handler truncates server-side error strings to 256 bytes before
     encoding. A payload at that boundary exercises the exact wire shape
@@ -29,7 +30,8 @@ def test_reqresp_error_at_max_error_message_size(
 def test_reqresp_error_with_multi_byte_utf8(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """Error response carrying multi-byte UTF-8 text roundtrips byte-for-byte.
+    """
+    Error response carrying multi-byte UTF-8 text roundtrips byte-for-byte.
 
     The codec treats the payload as opaque bytes. A multi-byte UTF-8
     payload verifies that compression, length framing, and decode
@@ -48,7 +50,8 @@ def test_reqresp_error_with_multi_byte_utf8(
 def test_reqresp_error_resource_unavailable_with_informational_text(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """Error code 3 response carrying a short descriptive message roundtrips.
+    """
+    Error code 3 response carrying a short descriptive message roundtrips.
 
     Pins the wire shape for the common peer-observed case of an
     informational error string alongside the RESOURCE_UNAVAILABLE code.

--- a/tests/consensus/lstar/networking/test_reqresp_rejections.py
+++ b/tests/consensus/lstar/networking/test_reqresp_rejections.py
@@ -1,4 +1,5 @@
-"""Req/resp codec: wire-level rejection vectors.
+"""
+Req/resp codec: wire-level rejection vectors.
 
 Exercises the user-reachable CodecError paths in the req/resp decoder.
 Each vector pins the exact exception class a client must raise when a
@@ -16,7 +17,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_reqresp_decode_rejects_empty_request(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """Decoding an empty request is rejected with CodecError.
+    """
+    Decoding an empty request is rejected with CodecError.
 
     The req/resp framing demands a length-prefix varint followed by a
     compressed payload. Zero input carries neither, so the decoder must
@@ -32,7 +34,8 @@ def test_reqresp_decode_rejects_empty_request(
 def test_reqresp_decode_rejects_invalid_varint_prefix(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """A request whose length prefix is a malformed varint is rejected with CodecError.
+    """
+    A request whose length prefix is a malformed varint is rejected with CodecError.
 
     Two continuation bytes with no terminator make the varint parse raise.
     The decoder wraps the underlying varint error in CodecError so clients
@@ -48,7 +51,8 @@ def test_reqresp_decode_rejects_invalid_varint_prefix(
 def test_reqresp_decode_rejects_declared_length_above_max(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """A request whose declared length exceeds the ten-mebibyte cap is rejected.
+    """
+    A request whose declared length exceeds the ten-mebibyte cap is rejected.
 
     The varint 0x81 0x80 0x80 0x05 declares 10,485,761 bytes, one over the
     ten-mebibyte protocol cap. Refusing before decompression prevents a

--- a/tests/consensus/lstar/networking/test_reqresp_response_stream.py
+++ b/tests/consensus/lstar/networking/test_reqresp_response_stream.py
@@ -1,4 +1,5 @@
-"""Req/resp multi-chunk response stream vectors.
+"""
+Req/resp multi-chunk response stream vectors.
 
 Pins the concatenated byte layout of a libp2p request/response stream
 carrying multiple chunks. Each chunk is its own [code][varint][snappy]
@@ -13,7 +14,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_stream_two_success_chunks(networking_codec: NetworkingCodecTestFiller) -> None:
-    """Stream with two SUCCESS chunks carrying distinct payload bytes.
+    """
+    Stream with two SUCCESS chunks carrying distinct payload bytes.
 
     Pins the concatenation of two independent response frames. Clients
     must read both records before signalling EOF, so a receiver that
@@ -33,7 +35,8 @@ def test_stream_two_success_chunks(networking_codec: NetworkingCodecTestFiller) 
 def test_stream_success_then_resource_unavailable(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """A SUCCESS chunk followed by a RESOURCE_UNAVAILABLE terminator.
+    """
+    A SUCCESS chunk followed by a RESOURCE_UNAVAILABLE terminator.
 
     Real servers end a multi-chunk response early when the peer asked
     for more items than the server holds. The vector pins the exact
@@ -54,7 +57,8 @@ def test_stream_success_then_resource_unavailable(
 def test_stream_three_success_chunks_with_compressible_payloads(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """Three SUCCESS chunks whose payloads compress well.
+    """
+    Three SUCCESS chunks whose payloads compress well.
 
     Exercises the N>2 case and highlights that each chunk carries its
     own snappy stream-identifier preamble inside the concatenated bytes;

--- a/tests/consensus/lstar/networking/test_snappy_codec.py
+++ b/tests/consensus/lstar/networking/test_snappy_codec.py
@@ -1,4 +1,5 @@
-"""Test vectors for standalone Snappy compression and decompression.
+"""
+Test vectors for standalone Snappy compression and decompression.
 
 Both raw block format and Ethereum framing format are tested.
 Client teams use these to verify their Snappy implementation

--- a/tests/consensus/lstar/networking/test_snappy_frame_rejections.py
+++ b/tests/consensus/lstar/networking/test_snappy_frame_rejections.py
@@ -11,7 +11,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_snappy_frame_decode_rejects_empty_input(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """Empty input is not a valid snappy frame and must be rejected.
+    """
+    Empty input is not a valid snappy frame and must be rejected.
 
     Every framed snappy stream begins with a ten-byte stream identifier.
     Zero bytes cannot satisfy that minimum so the decoder aborts early
@@ -27,7 +28,8 @@ def test_snappy_frame_decode_rejects_empty_input(
 def test_snappy_frame_decode_rejects_wrong_stream_identifier(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """A stream whose opening bytes do not spell the snappy magic is rejected.
+    """
+    A stream whose opening bytes do not spell the snappy magic is rejected.
 
     A valid framed snappy stream starts with the ten-byte sequence
     `ff 06 00 00 73 4e 61 50 70 59` ("sNaPpY"). Ten zero bytes satisfy
@@ -44,7 +46,8 @@ def test_snappy_frame_decode_rejects_wrong_stream_identifier(
 def test_snappy_frame_decode_rejects_unknown_unskippable_chunk(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """A chunk of an unassigned unskippable type is rejected.
+    """
+    A chunk of an unassigned unskippable type is rejected.
 
     The byte sequence begins with a valid stream identifier followed by a
     chunk whose type byte is `0x03` with a zero-length payload. Type

--- a/tests/consensus/lstar/networking/test_varint_invalid.py
+++ b/tests/consensus/lstar/networking/test_varint_invalid.py
@@ -11,7 +11,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_varint_truncated_mid_stream_rejected(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """A varint whose final byte still has the continuation bit set is rejected.
+    """
+    A varint whose final byte still has the continuation bit set is rejected.
 
     Two bytes (`0x80 0x80`) each carry the continuation bit but there are no
     further bytes to complete the value. The decoder must raise
@@ -27,7 +28,8 @@ def test_varint_truncated_mid_stream_rejected(
 def test_varint_longer_than_ten_bytes_rejected(
     networking_codec: NetworkingCodecTestFiller,
 ) -> None:
-    """A varint running eleven continuation bytes exceeds the 64-bit cap and is rejected.
+    """
+    A varint running eleven continuation bytes exceeds the 64-bit cap and is rejected.
 
     A uint64 fits in at most ten varint bytes (70 bits with 6 unused). Eleven
     continuation bytes means the decoder cannot represent the value and must

--- a/tests/consensus/lstar/poseidon/test_permutation_width16.py
+++ b/tests/consensus/lstar/poseidon/test_permutation_width16.py
@@ -1,4 +1,5 @@
-"""Poseidon permutation: width-16 known-answer vectors.
+"""
+Poseidon permutation: width-16 known-answer vectors.
 
 Pins the output state of the Poseidon permutation over the KoalaBear
 field at state width 16 for four structural input patterns. Clients
@@ -18,7 +19,8 @@ WIDTH: int = 16
 def test_permutation_width16_all_zero(
     poseidon_permutation: PoseidonPermutationTestFiller,
 ) -> None:
-    """Input state of all zeros pins the round-constant-only output.
+    """
+    Input state of all zeros pins the round-constant-only output.
 
     With a zero state, the only contribution to every S-box input is the
     round-constants stream. The output state therefore depends purely on
@@ -34,7 +36,8 @@ def test_permutation_width16_all_zero(
 def test_permutation_width16_all_one(
     poseidon_permutation: PoseidonPermutationTestFiller,
 ) -> None:
-    """Input state of all ones exercises uniform non-zero entries.
+    """
+    Input state of all ones exercises uniform non-zero entries.
 
     Every element begins at the smallest non-zero field value. The MDS
     multiplications see a state vector whose entries all carry the same
@@ -49,7 +52,8 @@ def test_permutation_width16_all_one(
 def test_permutation_width16_incremental_index(
     poseidon_permutation: PoseidonPermutationTestFiller,
 ) -> None:
-    """Input state filled with 0, 1, 2, ..., WIDTH - 1.
+    """
+    Input state filled with 0, 1, 2, ..., WIDTH - 1.
 
     Distinct entries per slot expose per-position behaviour: any
     off-by-one in MDS row indexing or round-constant slicing perturbs
@@ -64,7 +68,8 @@ def test_permutation_width16_incremental_index(
 def test_permutation_width16_p_minus_one_and_near_zero(
     poseidon_permutation: PoseidonPermutationTestFiller,
 ) -> None:
-    """Mix of field-boundary values P - 1 and small values across the state.
+    """
+    Mix of field-boundary values P - 1 and small values across the state.
 
     Half the slots sit at the maximum representable field element, the
     other half at small positives. This pattern stresses the reduction

--- a/tests/consensus/lstar/poseidon/test_permutation_width24.py
+++ b/tests/consensus/lstar/poseidon/test_permutation_width24.py
@@ -1,4 +1,5 @@
-"""Poseidon permutation: width-24 known-answer vectors.
+"""
+Poseidon permutation: width-24 known-answer vectors.
 
 Pins the output state of the Poseidon permutation over the KoalaBear
 field at state width 24 for four structural input patterns. Mirrors
@@ -18,7 +19,8 @@ WIDTH: int = 24
 def test_permutation_width24_all_zero(
     poseidon_permutation: PoseidonPermutationTestFiller,
 ) -> None:
-    """Input state of all zeros pins the round-constant-only output at width 24.
+    """
+    Input state of all zeros pins the round-constant-only output at width 24.
 
     With a zero state the only contribution to every S-box input is the
     round-constants stream. The output state depends purely on the

--- a/tests/consensus/lstar/ssz/test_decode_failure_smoke.py
+++ b/tests/consensus/lstar/ssz/test_decode_failure_smoke.py
@@ -1,4 +1,5 @@
-"""Smoke test for the ssz fixture's decode-failure mode.
+"""
+Smoke test for the ssz fixture's decode-failure mode.
 
 Exercises the new `raw_bytes` + `expect_exception` path so the framework
 change is covered independently of later negative-path content PRs.
@@ -21,7 +22,8 @@ class SmokeBitlist8(BaseBitlist):
 
 
 def test_ssz_decode_failure_bitlist_exceeds_limit(ssz: SSZTestFiller) -> None:
-    """Decoding a bitlist whose contents imply a length above its LIMIT raises.
+    """
+    Decoding a bitlist whose contents imply a length above its LIMIT raises.
 
     The payload `0x0010` encodes 16 bits before the sentinel. The `LIMIT`
     on the decoder type is 8, so SSZ decode must reject. This pins the new

--- a/tests/consensus/lstar/ssz/test_decode_rejections.py
+++ b/tests/consensus/lstar/ssz/test_decode_rejections.py
@@ -1,4 +1,5 @@
-"""SSZ: decode-failure vectors for malformed inputs.
+"""
+SSZ: decode-failure vectors for malformed inputs.
 
 Exercises the SSZ decoder's user-triggerable rejection paths through the
 decode-failure fixture. Each vector captures the expected exception class
@@ -30,7 +31,8 @@ class DecodeBitvector16(BaseBitvector):
 
 
 def test_bitlist_decode_rejects_empty_input(ssz: SSZTestFiller) -> None:
-    """Bitlist decoding of zero bytes has no delimiter bit and must be rejected.
+    """
+    Bitlist decoding of zero bytes has no delimiter bit and must be rejected.
 
     Every SSZ bitlist encoding ends in a sentinel set bit that signals the
     bit-length. Empty input carries no such sentinel, so the decoder cannot
@@ -45,7 +47,8 @@ def test_bitlist_decode_rejects_empty_input(ssz: SSZTestFiller) -> None:
 
 
 def test_bitlist_decode_rejects_missing_delimiter(ssz: SSZTestFiller) -> None:
-    """Bitlist bytes with no set bits carry no sentinel and must be rejected.
+    """
+    Bitlist bytes with no set bits carry no sentinel and must be rejected.
 
     A single 0x00 byte encodes eight clear bits with nothing marking the
     end of the logical bitlist. The decoder needs the sentinel to know
@@ -60,7 +63,8 @@ def test_bitlist_decode_rejects_missing_delimiter(ssz: SSZTestFiller) -> None:
 
 
 def test_bitlist_decode_rejects_length_above_limit(ssz: SSZTestFiller) -> None:
-    """Bitlist whose sentinel implies a bit-length beyond the type limit must be rejected.
+    """
+    Bitlist whose sentinel implies a bit-length beyond the type limit must be rejected.
 
     The payload 0x0002 places the sentinel at bit index nine, implying a
     nine-bit bitlist. The type caps at eight bits, so the decoder must
@@ -75,7 +79,8 @@ def test_bitlist_decode_rejects_length_above_limit(ssz: SSZTestFiller) -> None:
 
 
 def test_bitvector_decode_rejects_wrong_byte_length(ssz: SSZTestFiller) -> None:
-    """Fixed-width bitvector decoding rejects inputs whose byte count does not match LENGTH.
+    """
+    Fixed-width bitvector decoding rejects inputs whose byte count does not match LENGTH.
 
     The fixed-width bitvector here occupies exactly two bytes. A single-byte
     input underfills the vector. The fixed-size decode path requires an
@@ -90,7 +95,8 @@ def test_bitvector_decode_rejects_wrong_byte_length(ssz: SSZTestFiller) -> None:
 
 
 def test_bytes4_decode_rejects_extra_trailing_bytes(ssz: SSZTestFiller) -> None:
-    """Fixed-size byte arrays reject inputs longer than their declared LENGTH.
+    """
+    Fixed-size byte arrays reject inputs longer than their declared LENGTH.
 
     A four-byte fixed array cannot consume five input bytes. The extra
     trailing byte has no slot in the type, so the decoder must raise
@@ -105,7 +111,8 @@ def test_bytes4_decode_rejects_extra_trailing_bytes(ssz: SSZTestFiller) -> None:
 
 
 def test_uint32_decode_rejects_wrong_byte_length(ssz: SSZTestFiller) -> None:
-    """Fixed-size uint types reject input whose byte length does not match the type.
+    """
+    Fixed-size uint types reject input whose byte length does not match the type.
 
     A uint32 is always four bytes. A three-byte input underfills the slot
     and cannot be safely widened. The decoder raises rather than guessing

--- a/tests/consensus/lstar/ssz/test_merkleization_boundaries.py
+++ b/tests/consensus/lstar/ssz/test_merkleization_boundaries.py
@@ -51,7 +51,8 @@ class BoundaryBitvector257(BaseBitvector):
 
 
 class BoundaryBitlist256(BaseBitlist):
-    """Bitlist whose limit is exactly one Merkle chunk.
+    """
+    Bitlist whose limit is exactly one Merkle chunk.
 
     When filled to the limit, the sentinel bit lands in a fresh byte.
     """
@@ -115,7 +116,8 @@ def test_bitvector_length_257_all_set(ssz: SSZTestFiller) -> None:
 
 
 def test_bitlist_filled_to_chunk_boundary_limit(ssz: SSZTestFiller) -> None:
-    """Bitlist filled to a 256-bit limit places the sentinel at the start of a fresh byte.
+    """
+    Bitlist filled to a 256-bit limit places the sentinel at the start of a fresh byte.
 
     The trailing sentinel crosses into a new chunk, exercising the length-mixin
     ordering for bitlists whose limit sits on a Merkle-chunk edge.
@@ -127,7 +129,8 @@ def test_bitlist_filled_to_chunk_boundary_limit(ssz: SSZTestFiller) -> None:
 
 
 def test_uint64_list_with_misaligned_chunk_count(ssz: SSZTestFiller) -> None:
-    """Three uint64 entries occupy 24 bytes, one byte shy of a full Merkle chunk.
+    """
+    Three uint64 entries occupy 24 bytes, one byte shy of a full Merkle chunk.
 
     Pins the zero-pad / length-mixin behaviour for variable-length lists of
     fixed-size elements whose serialized length is not a multiple of 32.

--- a/tests/consensus/lstar/state_transition/test_genesis.py
+++ b/tests/consensus/lstar/state_transition/test_genesis.py
@@ -36,7 +36,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def _generate_max_registry_pre_state() -> State:
-    """Build genesis with the registry filled to capacity using placeholder public_keys.
+    """
+    Build genesis with the registry filled to capacity using placeholder public_keys.
 
     XMSS key generation is intentionally skipped: every validator carries a
     zero public_key. This is sound because the state-transition path used here

--- a/tests/consensus/lstar/state_transition/test_justifiability.py
+++ b/tests/consensus/lstar/state_transition/test_justifiability.py
@@ -1,4 +1,5 @@
-"""Test vectors for 3SF-mini slot justifiability rules.
+"""
+Test vectors for 3SF-mini slot justifiability rules.
 
 A slot is justifiable after a finalized slot if the distance (delta) is:
 1. In the immediate window (delta <= 5)

--- a/tests/consensus/lstar/sync/test_checkpoint_verify.py
+++ b/tests/consensus/lstar/sync/test_checkpoint_verify.py
@@ -1,4 +1,5 @@
-"""Checkpoint-sync state verification: known-answer vectors.
+"""
+Checkpoint-sync state verification: known-answer vectors.
 
 Pins the structural-validity verdict each client must produce when
 fetching an anchor state from a checkpoint provider. The verdict is a
@@ -15,7 +16,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_checkpoint_verify_rejects_empty_validator_set(
     sync: SyncTestFiller,
 ) -> None:
-    """A checkpoint state with zero validators is rejected.
+    """
+    A checkpoint state with zero validators is rejected.
 
     A state without validators cannot produce blocks, so seeding a
     fork-choice store with it would be useless and mask configuration
@@ -30,7 +32,8 @@ def test_checkpoint_verify_rejects_empty_validator_set(
 def test_checkpoint_verify_accepts_small_validator_set(
     sync: SyncTestFiller,
 ) -> None:
-    """A checkpoint state with a small in-range validator set is accepted.
+    """
+    A checkpoint state with a small in-range validator set is accepted.
 
     Four validators is the baseline size used throughout the consensus
     test suite. Pins the happy path of the verifier so clients observe
@@ -45,7 +48,8 @@ def test_checkpoint_verify_accepts_small_validator_set(
 def test_checkpoint_verify_accepts_eight_validator_set(
     sync: SyncTestFiller,
 ) -> None:
-    """Eight-validator anchor state is accepted at the key-manager limit.
+    """
+    Eight-validator anchor state is accepted at the key-manager limit.
 
     Matches the maximum-validator setup used by the existing fork-choice
     and signature-verification suites. Pins the verdict at the upper

--- a/tests/consensus/lstar/sync/test_checkpoint_verify_advanced.py
+++ b/tests/consensus/lstar/sync/test_checkpoint_verify_advanced.py
@@ -1,4 +1,5 @@
-"""Checkpoint-sync verification vectors at post-genesis anchor slots.
+"""
+Checkpoint-sync verification vectors at post-genesis anchor slots.
 
 Existing verify_checkpoint vectors run against fresh genesis states.
 These pin the verdict after the chain has advanced through empty
@@ -13,7 +14,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_checkpoint_verify_advanced_slot_three(sync: SyncTestFiller) -> None:
-    """Advanced anchor state at slot 3 with four validators is accepted.
+    """
+    Advanced anchor state at slot 3 with four validators is accepted.
 
     The chain walks through three empty blocks. The resulting state
     carries non-empty historical_block_hashes and a non-zero latest
@@ -26,7 +28,8 @@ def test_checkpoint_verify_advanced_slot_three(sync: SyncTestFiller) -> None:
 
 
 def test_checkpoint_verify_advanced_slot_ten(sync: SyncTestFiller) -> None:
-    """Advanced anchor state at slot 10 with four validators is accepted.
+    """
+    Advanced anchor state at slot 10 with four validators is accepted.
 
     Ten empty blocks populate historical_block_hashes and justified_slots
     with longer lists. Pins the verdict and state bytes at a larger
@@ -39,7 +42,8 @@ def test_checkpoint_verify_advanced_slot_ten(sync: SyncTestFiller) -> None:
 
 
 def test_checkpoint_verify_advanced_eight_validators(sync: SyncTestFiller) -> None:
-    """Advanced anchor state at slot 5 with eight validators is accepted.
+    """
+    Advanced anchor state at slot 5 with eight validators is accepted.
 
     Exercises the combination of larger validator set with a non-zero
     anchor slot so clients diff both axes in a single vector.

--- a/tests/consensus/lstar/verify_signatures/test_empty_aggregation_bits.py
+++ b/tests/consensus/lstar/verify_signatures/test_empty_aggregation_bits.py
@@ -16,7 +16,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_empty_aggregation_bits_rejected(
     verify_signatures_test: VerifySignaturesTestFiller,
 ) -> None:
-    """A signed block whose attestation references zero participants is rejected.
+    """
+    A signed block whose attestation references zero participants is rejected.
 
     Scenario
     --------

--- a/tests/consensus/lstar/verify_signatures/test_proposer_index_bounds.py
+++ b/tests/consensus/lstar/verify_signatures/test_proposer_index_bounds.py
@@ -15,7 +15,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_proposer_index_out_of_range_rejected(
     verify_signatures_test: VerifySignaturesTestFiller,
 ) -> None:
-    """A signed block whose proposer_index exceeds the validator registry is rejected.
+    """
+    A signed block whose proposer_index exceeds the validator registry is rejected.
 
     Scenario
     --------

--- a/tests/consensus/lstar/verify_signatures/test_structural_rejections.py
+++ b/tests/consensus/lstar/verify_signatures/test_structural_rejections.py
@@ -1,4 +1,5 @@
-"""Signature verification: structural rejection vectors for the merged proof.
+"""
+Signature verification: structural rejection vectors for the merged proof.
 
 These cover structural invariants a peer could break that the block
 builder upholds by construction:
@@ -26,7 +27,8 @@ pytestmark = pytest.mark.valid_until("Lstar")
 def test_corrupt_proof_rejected(
     verify_signatures_test: VerifySignaturesTestFiller,
 ) -> None:
-    """A signed block whose merged proof does not decode is rejected.
+    """
+    A signed block whose merged proof does not decode is rejected.
 
     Scenario
     --------
@@ -56,7 +58,8 @@ def test_corrupt_proof_rejected(
 def test_proof_component_count_mismatch_rejected(
     verify_signatures_test: VerifySignaturesTestFiller,
 ) -> None:
-    """A block whose body claims more components than the proof is rejected.
+    """
+    A block whose body claims more components than the proof is rejected.
 
     Scenario
     --------
@@ -88,7 +91,8 @@ def test_proof_component_count_mismatch_rejected(
 def test_proof_reused_under_different_message_rejected(
     verify_signatures_test: VerifySignaturesTestFiller,
 ) -> None:
-    """An honest proof reused under a different block is rejected.
+    """
+    An honest proof reused under a different block is rejected.
 
     Scenario
     --------

--- a/tests/integration/networking/gossipsub/conftest.py
+++ b/tests/integration/networking/gossipsub/conftest.py
@@ -13,7 +13,8 @@ from tests.integration.networking.gossipsub.node import GossipsubTestNode
 
 
 def fast_params(**overrides: int | float | str) -> GossipsubParameters:
-    """Create parameters tuned for fast integration tests.
+    """
+    Create parameters tuned for fast integration tests.
 
     Uses small mesh degree (D=3) so tests need fewer nodes to fill
     meshes. Short heartbeat (0.05s) keeps test duration low.
@@ -37,7 +38,8 @@ def fast_params(**overrides: int | float | str) -> GossipsubParameters:
 
 @pytest.fixture
 async def network() -> AsyncGenerator[GossipsubTestNetwork]:
-    """Provide a test network with automatic teardown.
+    """
+    Provide a test network with automatic teardown.
 
     Teardown stops all nodes, cancelling background tasks and closing
     streams. This prevents leaked coroutines between tests.

--- a/tests/integration/networking/gossipsub/network.py
+++ b/tests/integration/networking/gossipsub/network.py
@@ -1,4 +1,5 @@
-"""Test network orchestrator for multi-node gossipsub integration tests.
+"""
+Test network orchestrator for multi-node gossipsub integration tests.
 
 Manages node lifecycle and provides common topologies (full mesh, star,
 chain, ring) so individual tests focus on protocol behavior, not setup.
@@ -50,7 +51,8 @@ PEER_NAMES = [
 
 
 class GossipsubTestNetwork:
-    """Manages a network of gossipsub test nodes.
+    """
+    Manages a network of gossipsub test nodes.
 
     Provides topology creation helpers (full mesh, star, chain, ring)
     and lifecycle management for all nodes.
@@ -83,7 +85,8 @@ class GossipsubTestNetwork:
             await node.stop()
 
     async def connect_full(self) -> None:
-        """Connect all nodes in a full mesh topology.
+        """
+        Connect all nodes in a full mesh topology.
 
         Every node can reach every other node directly.
         Useful for testing gossip with maximum connectivity.
@@ -93,7 +96,8 @@ class GossipsubTestNetwork:
                 await node_a.connect_to(node_b)
 
     async def connect_chain(self) -> None:
-        """Connect nodes in a linear chain: 0-1-2-...-N.
+        """
+        Connect nodes in a linear chain: 0-1-2-...-N.
 
         Messages must hop through intermediaries. Tests multi-hop
         gossip propagation and relay behavior.
@@ -102,7 +106,8 @@ class GossipsubTestNetwork:
             await self.nodes[i].connect_to(self.nodes[i + 1])
 
     async def connect_ring(self) -> None:
-        """Connect nodes in a ring: 0-1-2-...-N-0.
+        """
+        Connect nodes in a ring: 0-1-2-...-N-0.
 
         Like a chain but with redundant path between endpoints.
         Tests that duplicate suppression works across alternate routes.
@@ -125,7 +130,8 @@ class GossipsubTestNetwork:
         await asyncio.sleep(0.05)
 
     async def stabilize_mesh(self, topic: str, rounds: int = 3, settle_time: float = 0.05) -> None:
-        """Run multiple heartbeat rounds to let meshes converge.
+        """
+        Run multiple heartbeat rounds to let meshes converge.
 
         One heartbeat is rarely enough. Each round lets nodes exchange
         GRAFT/PRUNE control messages and react to peer changes. Three

--- a/tests/integration/networking/gossipsub/node.py
+++ b/tests/integration/networking/gossipsub/node.py
@@ -1,4 +1,5 @@
-"""Test node wrapper for GossipsubBehavior integration tests.
+"""
+Test node wrapper for GossipsubBehavior integration tests.
 
 Wraps a GossipsubBehavior with connection helpers, event collection,
 and message waiting utilities.
@@ -22,7 +23,8 @@ from tests.integration.networking.gossipsub.stream import create_stream_pair
 
 @dataclass
 class GossipsubTestNode:
-    """Wraps a GossipsubBehavior for integration testing.
+    """
+    Wraps a GossipsubBehavior for integration testing.
 
     Collects received messages and peer events, and provides
     helpers for connecting to other nodes and waiting for messages.
@@ -46,7 +48,8 @@ class GossipsubTestNode:
         return cls(peer_id=peer_id, behavior=behavior)
 
     async def start(self) -> None:
-        """Start the behavior and event collector.
+        """
+        Start the behavior and event collector.
 
         The collector runs as a background task so events are captured
         continuously. Without it, the internal event queue would fill up
@@ -78,7 +81,8 @@ class GossipsubTestNode:
         await self.behavior.publish(topic, data)
 
     async def connect_to(self, other: GossipsubTestNode) -> None:
-        """Establish bidirectional gossipsub streams with another node.
+        """
+        Establish bidirectional gossipsub streams with another node.
 
         Creates two stream pairs (one per direction) and registers
         them with both behaviors. This mirrors real libp2p where
@@ -189,7 +193,8 @@ class GossipsubTestNode:
         self.received_messages.clear()
 
     async def _collect_events(self) -> None:
-        """Background task that collects events from the behavior.
+        """
+        Background task that collects events from the behavior.
 
         Runs for the lifetime of the node. Sorts events into typed lists
         so tests can query them without async boilerplate.

--- a/tests/integration/networking/gossipsub/stream.py
+++ b/tests/integration/networking/gossipsub/stream.py
@@ -1,4 +1,5 @@
-"""In-memory bidirectional stream pair for integration testing.
+"""
+In-memory bidirectional stream pair for integration testing.
 
 Provides the same interface as QuicStreamAdapter (read, write, drain, close)
 so GossipsubBehavior can exchange RPCs without a real QUIC transport.
@@ -10,7 +11,8 @@ import asyncio
 
 
 class InMemoryStream:
-    """Async bidirectional stream backed by asyncio.Queue.
+    """
+    Async bidirectional stream backed by asyncio.Queue.
 
     Matches the QuicStreamAdapter interface used by GossipsubBehavior:
 
@@ -36,7 +38,8 @@ class InMemoryStream:
         self._read_buffer = b""
 
     async def read(self, n: int | None = None) -> bytes:
-        """Read bytes from the stream.
+        """
+        Read bytes from the stream.
 
         Returns data from the internal read queue. An empty bytes
         object signals EOF (peer closed their end).
@@ -94,7 +97,8 @@ class InMemoryStream:
             self._write_buffer = b""
 
     async def close(self) -> None:
-        """Signal EOF to the peer by sending an empty sentinel.
+        """
+        Signal EOF to the peer by sending an empty sentinel.
 
         An empty bytes object travels through the same queue as data.
         This guarantees the peer processes all prior writes before seeing EOF.
@@ -104,7 +108,8 @@ class InMemoryStream:
 
 
 def create_stream_pair() -> tuple[InMemoryStream, InMemoryStream]:
-    """Create a pair of connected in-memory streams.
+    """
+    Create a pair of connected in-memory streams.
 
     Returns (stream_a, stream_b) where:
     - Writing to stream_a is readable from stream_b

--- a/tests/integration/networking/gossipsub/test_connectivity.py
+++ b/tests/integration/networking/gossipsub/test_connectivity.py
@@ -1,4 +1,5 @@
-"""Basic 2-3 peer connectivity tests.
+"""
+Basic 2-3 peer connectivity tests.
 
 Gossipsub is a mesh-based pub/sub protocol. Peers subscribe to topics,
 form a mesh overlay, and forward messages only through mesh links.

--- a/tests/integration/networking/gossipsub/test_heartbeat.py
+++ b/tests/integration/networking/gossipsub/test_heartbeat.py
@@ -1,4 +1,5 @@
-"""Heartbeat mechanics integration tests.
+"""
+Heartbeat mechanics integration tests.
 
 The heartbeat is the periodic maintenance cycle of gossipsub.
 Each tick, a node adjusts its mesh, ages its caches, and clears

--- a/tests/integration/networking/gossipsub/test_idontwant.py
+++ b/tests/integration/networking/gossipsub/test_idontwant.py
@@ -1,4 +1,5 @@
-"""IDONTWANT protocol tests.
+"""
+IDONTWANT protocol tests.
 
 IDONTWANT is a gossipsub v1.2 optimization for large messages.
 When a node receives a large message, it tells its other mesh peers

--- a/tests/integration/networking/gossipsub/test_mesh_formation.py
+++ b/tests/integration/networking/gossipsub/test_mesh_formation.py
@@ -1,4 +1,5 @@
-"""Mesh formation with multiple peers.
+"""
+Mesh formation with multiple peers.
 
 Gossipsub controls mesh size with three parameters:
 

--- a/tests/interop/helpers/node_runner.py
+++ b/tests/interop/helpers/node_runner.py
@@ -83,7 +83,8 @@ class TestNode:
 
     @property
     def peer_count(self) -> int:
-        """Number of connected peers.
+        """
+        Number of connected peers.
 
         Reads the raw connection map rather than the peer manager,
         which is updated asynchronously and may lag behind.

--- a/tests/interop/test_consensus_lifecycle.py
+++ b/tests/interop/test_consensus_lifecycle.py
@@ -1,4 +1,5 @@
-"""End-to-end consensus lifecycle test.
+"""
+End-to-end consensus lifecycle test.
 
 Tests the networking, gossip, and block production stack in a 3-node cluster.
 Phases 1-4 verify connectivity, block propagation, attestation activity,

--- a/tests/lean_spec/cli/test_bootstrap.py
+++ b/tests/lean_spec/cli/test_bootstrap.py
@@ -300,7 +300,8 @@ class TestBuildAnchor:
     async def test_checkpoint_url_calls_from_checkpoint(
         self, make_boot: Callable[..., NodeBootstrap]
     ) -> None:
-        """With a checkpoint URL the boot delegates to the asynchronous checkpoint builder.
+        """
+        With a checkpoint URL the boot delegates to the asynchronous checkpoint builder.
 
         The real checkpoint path needs a fetched state plus a constructed store.
         A dispatch-via-mock keeps the test focused on the dispatch contract.

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -445,7 +445,8 @@ def make_signed_block_from_store(
     slot: Slot,
     proposer_index: ValidatorIndex,
 ) -> tuple[Store, SignedBlock]:
-    """Produce a signed block and advance the consumer store to accept it.
+    """
+    Produce a signed block and advance the consumer store to accept it.
 
     Returns the updated store (with time advanced) and the signed block.
     The merged multi-message aggregate proof is built honestly because callers usually

--- a/tests/lean_spec/helpers/mocks.py
+++ b/tests/lean_spec/helpers/mocks.py
@@ -141,7 +141,8 @@ class _MockBlock:
 
 
 class MockForkchoiceStore:
-    """Mock forkchoice store for sync service testing.
+    """
+    Mock forkchoice store for sync service testing.
 
     Tracks blocks, attestations, and head state without running real
     forkchoice logic. Methods return self so the SyncService can assign

--- a/tests/lean_spec/node/api/test_server.py
+++ b/tests/lean_spec/node/api/test_server.py
@@ -1,4 +1,5 @@
-"""Tests for the API server implementation details.
+"""
+Tests for the API server implementation details.
 
 API contract tests (status codes, content types, response structure) are in
 tests/api/ and also run automatically with `uv run pytest`.
@@ -27,7 +28,8 @@ class _AggregatorStub:
 
 
 def _make_test_controller(initial: bool = False) -> AggregatorController:
-    """Build an AggregatorController backed by lightweight stubs.
+    """
+    Build an AggregatorController backed by lightweight stubs.
 
     Avoids pulling in the full SyncService / NetworkService dependency graph
     for endpoint-level tests that only exercise the flag-toggle contract.
@@ -336,7 +338,8 @@ class TestAggregatorAdminEndpoint:
             await server.aclose()
 
     async def test_sequential_posts_converge(self) -> None:
-        """Multiple sequential POSTs converge to the last-writer value.
+        """
+        Multiple sequential POSTs converge to the last-writer value.
 
         Posts must be issued one at a time (not via ``asyncio.gather``);
         with concurrent requests the server-side arrival order is racy and

--- a/tests/lean_spec/node/networking/client/event_source/test_gossip.py
+++ b/tests/lean_spec/node/networking/client/event_source/test_gossip.py
@@ -1,4 +1,5 @@
-"""Tests for the gossip message handler.
+"""
+Tests for the gossip message handler.
 
 This module tests the GossipHandler class, GossipMessageError exception,
 and read_gossip_message async function that handle incoming gossip messages

--- a/tests/lean_spec/node/networking/client/test_reqresp_client.py
+++ b/tests/lean_spec/node/networking/client/test_reqresp_client.py
@@ -806,7 +806,8 @@ def empty_signed_block(slot: Slot, parent_root: Bytes32, state_seed: int) -> Sig
 
 
 def build_chain(start_slot: int, count: int, root_seed: int = 0xAA) -> list[SignedBlock]:
-    """Return a chain of strictly-increasing-slot blocks starting at start_slot.
+    """
+    Return a chain of strictly-increasing-slot blocks starting at start_slot.
 
     Each child links to its predecessor via the previous block's tree-hash root.
     The root of the first slot is derived from the seed parameter.
@@ -961,7 +962,8 @@ class TestReqRespClientBlocksByRange:
     async def test_parent_root_continuity_violation_across_skipped_slot(
         self, peer_id: PeerId
     ) -> None:
-        """A wrong parent root after a skipped empty slot is rejected as a protocol violation.
+        """
+        A wrong parent root after a skipped empty slot is rejected as a protocol violation.
 
         The responder serves canonical blocks only and skips empty slots.
         So a block following an empty slot must still chain off the previous

--- a/tests/lean_spec/node/networking/enr/test_enr.py
+++ b/tests/lean_spec/node/networking/enr/test_enr.py
@@ -1,4 +1,5 @@
-"""Tests for the Ethereum Node Record (ENR) module (EIP-778).
+"""
+Tests for the Ethereum Node Record (ENR) module (EIP-778).
 
 This module tests ENR parsing, validation, and property accessors using the
 official EIP-778 test vector and additional edge cases.
@@ -113,7 +114,8 @@ class TestOfficialEIP778Vector:
         assert multiaddr == f"/ip4/{OFFICIAL_IPV4}/udp/{OFFICIAL_UDP_PORT}/quic-v1"
 
     def test_official_enr_node_id(self) -> None:
-        """Official ENR node ID matches keccak256(uncompressed_public_key).
+        """
+        Official ENR node ID matches keccak256(uncompressed_public_key).
 
         Per EIP-778 "v4" identity scheme:
             "To derive a node address, take the keccak256 hash of the

--- a/tests/lean_spec/node/networking/gossipsub/test_behavior.py
+++ b/tests/lean_spec/node/networking/gossipsub/test_behavior.py
@@ -1,4 +1,5 @@
-"""Tests for the gossipsub behavior.
+"""
+Tests for the gossipsub behavior.
 
 Covers RPC handlers, mesh maintenance and gossip emission during the
 heartbeat cycle, and message publishing with subscription broadcast.

--- a/tests/lean_spec/node/networking/gossipsub/test_rpc.py
+++ b/tests/lean_spec/node/networking/gossipsub/test_rpc.py
@@ -39,7 +39,8 @@ class TestControlMessages:
 
 
 class TestRPCProtobufEncoding:
-    """Test suite for GossipSub RPC protobuf wire format encoding/decoding.
+    """
+    Test suite for GossipSub RPC protobuf wire format encoding/decoding.
 
     These tests verify interoperability with rust-libp2p and go-libp2p by
     ensuring our encoding matches the expected protobuf wire format.
@@ -163,7 +164,8 @@ class TestRPCProtobufEncoding:
         )
 
     def test_wire_format_compatibility(self) -> None:
-        """Test wire format matches expected protobuf encoding.
+        """
+        Test wire format matches expected protobuf encoding.
 
         Verifies that our encoding produces bytes that round-trip
         correctly through decode, matching the original structure.

--- a/tests/lean_spec/node/networking/reqresp/test_codec.py
+++ b/tests/lean_spec/node/networking/reqresp/test_codec.py
@@ -1,4 +1,5 @@
-"""Tests for the req/resp codec.
+"""
+Tests for the req/resp codec.
 
 Test Vector Sources
 -------------------
@@ -176,7 +177,8 @@ class TestInteroperability:
 
 
 class TestBoundaryConditions:
-    """Tests for boundary conditions in the codec.
+    """
+    Tests for boundary conditions in the codec.
 
     Source: Ethereum P2P Interface Spec (MAX_PAYLOAD_SIZE = 10 MiB)
         https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md
@@ -253,7 +255,8 @@ class TestBoundaryConditions:
 
 
 class TestMaliciousInputs:
-    """Security-focused tests for malicious input handling.
+    """
+    Security-focused tests for malicious input handling.
 
     These tests verify that the codec rejects malformed or malicious data
     without crashing, leaking information, or consuming excessive resources.
@@ -398,7 +401,8 @@ class TestMaliciousInputs:
 
 
 class TestSnappyFramingEdgeCases:
-    """Tests for snappy framing edge cases.
+    """
+    Tests for snappy framing edge cases.
 
     These tests verify correct handling of various snappy framing scenarios
     that may occur in real-world network traffic.

--- a/tests/lean_spec/node/networking/reqresp/test_handler.py
+++ b/tests/lean_spec/node/networking/reqresp/test_handler.py
@@ -1308,7 +1308,8 @@ class TestBlocksByRangeRequestBoundaryValues:
         assert decoded.count == Uint64(0)
 
     def test_count_above_max_encodes_and_decodes(self) -> None:
-        """count > MAX_REQUEST_BLOCKS encodes/decodes at SSZ layer.
+        """
+        count > MAX_REQUEST_BLOCKS encodes/decodes at SSZ layer.
 
         Enforcement of MAX_REQUEST_BLOCKS is the handler's job, not SSZ's.
         """
@@ -1440,7 +1441,8 @@ class TestRequestHandlerBlocksByRange:
         assert decoded_slots == [Slot(4000), Slot(4002), Slot(4004)]
 
     async def test_resource_unavailable_when_start_slot_predates_window(self) -> None:
-        """RESOURCE_UNAVAILABLE when start_slot is older than the sliding window.
+        """
+        RESOURCE_UNAVAILABLE when start_slot is older than the sliding window.
 
         With current_slot=5000 and MIN_SLOTS_FOR_BLOCK_REQUESTS=3600 the floor is
         slot 1400; start_slot=0 falls outside it.

--- a/tests/lean_spec/node/networking/test_varint.py
+++ b/tests/lean_spec/node/networking/test_varint.py
@@ -1,4 +1,5 @@
-"""Tests for unsigned LEB128 varint encoding and decoding.
+"""
+Tests for unsigned LEB128 varint encoding and decoding.
 
 Test vectors sourced from:
 - Protocol Buffers Encoding Guide: https://protobuf.dev/programming-guides/encoding/
@@ -100,7 +101,8 @@ class TestVarintRoundtrip:
         ids=[f"2^{p}" for p in [7, 14, 21, 28, 35, 42, 49, 56, 63]],
     )
     def test_power_of_two_boundaries(self, power: int) -> None:
-        """Values at 7-bit group boundaries roundtrip correctly.
+        """
+        Values at 7-bit group boundaries roundtrip correctly.
 
         Each power of 7 is a byte-size boundary: values below 2^7
         fit in 1 byte, values below 2^14 fit in 2 bytes, etc.

--- a/tests/lean_spec/node/networking/transport/quic/test_connection.py
+++ b/tests/lean_spec/node/networking/transport/quic/test_connection.py
@@ -177,7 +177,8 @@ class TestAlpnProtocol:
     """Verify the ALPN protocol value per the libp2p TLS spec."""
 
     def test_alpn_is_libp2p(self) -> None:
-        """The ALPN value is 'libp2p' as mandated by the libp2p TLS spec.
+        """
+        The ALPN value is 'libp2p' as mandated by the libp2p TLS spec.
 
         Spec reference (https://github.com/libp2p/specs/blob/master/tls/tls.md):
         the ALPN extension MUST include "libp2p" as the protocol string.
@@ -398,7 +399,8 @@ class TestQuicConnectionHandleEvent:
     def test_stream_reset_signals_error_not_eof(
         self, quic_connection: QuicConnection, mock_protocol: MagicMock
     ) -> None:
-        """Per RFC 9000 Section 3.2, RESET_STREAM is an error, not clean EOF.
+        """
+        Per RFC 9000 Section 3.2, RESET_STREAM is an error, not clean EOF.
 
         The stream must surface the error code to the application, and
         subsequent reads must raise rather than returning empty bytes.
@@ -422,7 +424,8 @@ class TestQuicConnectionHandleEvent:
     def test_connection_terminated_resets_all_streams(
         self, quic_connection: QuicConnection, mock_protocol: MagicMock
     ) -> None:
-        """Per RFC 9000 Section 10, connection termination implicitly resets all streams.
+        """
+        Per RFC 9000 Section 10, connection termination implicitly resets all streams.
 
         All open streams are assumed to have lost data. Reads must raise
         an error, not return empty bytes (which would imply clean EOF).
@@ -590,7 +593,8 @@ class TestLibP2PQuicProtocol:
     def test_events_buffered_between_handshake_and_connection(
         self, protocol: LibP2PQuicProtocol
     ) -> None:
-        """Events after handshake but before connection assignment are buffered.
+        """
+        Events after handshake but before connection assignment are buffered.
 
         This addresses a real race: the peer may open streams immediately after
         TLS completes, before the application creates the connection wrapper.
@@ -660,7 +664,8 @@ class TestLibP2PQuicProtocol:
     def test_handshake_exception_sets_peer_identity_none(
         self, protocol: LibP2PQuicProtocol
     ) -> None:
-        """Handshake completes even if certificate extraction raises.
+        """
+        Handshake completes even if certificate extraction raises.
 
         The except branch is defensive — if the try block inside the
         handshake handler raises, the handshake must still complete
@@ -694,7 +699,8 @@ class TestLibP2PQuicProtocol:
 
 
 class TestQuicStreamProtocolId:
-    """Tests for the protocol_id property on QuicStream.
+    """
+    Tests for the protocol_id property on QuicStream.
 
     Each QUIC stream carries a negotiated protocol identifier set during
     multistream-select. The default is empty until negotiation completes.
@@ -715,7 +721,8 @@ class TestQuicStreamProtocolId:
 
 
 class TestQuicStreamWriteFinDetection:
-    """Tests for write detecting aioquic's internal FIN state.
+    """
+    Tests for write detecting aioquic's internal FIN state.
 
     aioquic tracks per-stream state internally. If FIN was already sent
     (e.g., due to a race between close and write), the write method must
@@ -726,7 +733,8 @@ class TestQuicStreamWriteFinDetection:
     async def test_write_detects_aioquic_fin_sent(
         self, quic_stream: QuicStream, mock_protocol: MagicMock
     ) -> None:
-        """Write raises when aioquic has already sent FIN on this stream.
+        """
+        Write raises when aioquic has already sent FIN on this stream.
 
         This catches the race where close() sends FIN but write() is
         called before our _write_closed flag is set.
@@ -759,7 +767,8 @@ class TestQuicStreamWriteFinDetection:
     async def test_write_proceeds_when_stream_not_in_map(
         self, quic_stream: QuicStream, mock_protocol: MagicMock
     ) -> None:
-        """Write succeeds when aioquic has no entry for this stream ID.
+        """
+        Write succeeds when aioquic has no entry for this stream ID.
 
         This happens for newly created streams before any data is sent.
         """
@@ -770,7 +779,8 @@ class TestQuicStreamWriteFinDetection:
 
 
 class TestQuicStreamWriteException:
-    """Tests for write wrapping exceptions from aioquic.
+    """
+    Tests for write wrapping exceptions from aioquic.
 
     When aioquic raises during a write, the error is wrapped in
     QuicTransportError. If the error message indicates a terminal
@@ -781,7 +791,8 @@ class TestQuicStreamWriteException:
     async def test_write_wraps_fin_exception_and_marks_closed(
         self, quic_stream: QuicStream, mock_protocol: MagicMock
     ) -> None:
-        """An exception mentioning 'FIN' permanently closes the write side.
+        """
+        An exception mentioning 'FIN' permanently closes the write side.
 
         This heuristic detects terminal errors from aioquic's internals.
         """
@@ -811,7 +822,8 @@ class TestQuicStreamWriteException:
     async def test_write_wraps_unrelated_exception_without_marking_closed(
         self, quic_stream: QuicStream, mock_protocol: MagicMock
     ) -> None:
-        """Transient errors keep the write side open for retry.
+        """
+        Transient errors keep the write side open for retry.
 
         Only terminal conditions (FIN, closed) should permanently close.
         A buffer overflow or similar transient error should not.
@@ -828,7 +840,8 @@ class TestQuicStreamWriteException:
 
 
 class TestQuicConnectionProperties:
-    """Tests for QuicConnection read-only property accessors.
+    """
+    Tests for QuicConnection read-only property accessors.
 
     These properties expose the peer identity and address that were
     established during connection setup.
@@ -846,7 +859,8 @@ class TestQuicConnectionProperties:
 
 
 class TestQuicConnectionOpenStreamHappyPath:
-    """Tests for opening a stream with successful protocol negotiation.
+    """
+    Tests for opening a stream with successful protocol negotiation.
 
     Opening a stream involves three steps:
 
@@ -864,7 +878,8 @@ class TestQuicConnectionOpenStreamHappyPath:
         quic_connection: QuicConnection,
         mock_protocol: MagicMock,
     ) -> None:
-        """Full stream opening flow: allocate ID, negotiate, return stream.
+        """
+        Full stream opening flow: allocate ID, negotiate, return stream.
 
         The adapter wraps the raw QUIC stream for multistream-select.
         After negotiation, the protocol ID is stored on the stream.
@@ -891,7 +906,8 @@ class TestQuicConnectionOpenStreamHappyPath:
 
 
 class TestLibP2PQuicProtocolInit:
-    """Tests for LibP2PQuicProtocol construction.
+    """
+    Tests for LibP2PQuicProtocol construction.
 
     The parent class (aioquic's QuicConnectionProtocol) requires real
     QUIC internals. Patching the parent constructor lets us verify
@@ -899,7 +915,8 @@ class TestLibP2PQuicProtocolInit:
     """
 
     def test_init_with_mocked_quic_config(self) -> None:
-        """All custom attributes start in their expected initial state.
+        """
+        All custom attributes start in their expected initial state.
 
         Connection and peer identity are None until handshake completes.
         The handshake event is unset. No events are buffered yet.
@@ -916,7 +933,8 @@ class TestLibP2PQuicProtocolInit:
 
 
 class TestQuicConnectionManagerCreate:
-    """Tests for QuicConnectionManager.create factory method.
+    """
+    Tests for QuicConnectionManager.create factory method.
 
     Creation generates a libp2p-TLS certificate, writes it to temp files
     (aioquic requires file paths), and configures QUIC with the libp2p
@@ -928,7 +946,8 @@ class TestQuicConnectionManagerCreate:
     async def test_create_generates_certificate_and_configures_quic(
         self, mock_gen_certificate: MagicMock
     ) -> None:
-        """Full creation flow: generate certificate, write to disk, configure QUIC.
+        """
+        Full creation flow: generate certificate, write to disk, configure QUIC.
 
         The certificate is written to temp files because aioquic only
         accepts file paths for TLS configuration.
@@ -968,7 +987,8 @@ class TestQuicConnectionManagerCreate:
 
 
 class TestQuicConnectionManagerConnect:
-    """Tests for outbound QUIC connection establishment.
+    """
+    Tests for outbound QUIC connection establishment.
 
     Connecting parses the multiaddr, creates a QUIC session via aioquic,
     waits for the TLS handshake, and wraps the result in a QuicConnection.
@@ -999,7 +1019,8 @@ class TestQuicConnectionManagerConnect:
     async def test_connect_happy_path_with_peer_id(
         self, mock_quic_connect: MagicMock, manager: QuicConnectionManager
     ) -> None:
-        """When the multiaddr includes a p2p component, that peer ID is used.
+        """
+        When the multiaddr includes a p2p component, that peer ID is used.
 
         This is the normal case — the caller knows who they're connecting to.
         """
@@ -1036,7 +1057,8 @@ class TestQuicConnectionManagerConnect:
         mock_identity_cls: MagicMock,
         manager: QuicConnectionManager,
     ) -> None:
-        """Without a p2p component, a temporary peer ID is generated.
+        """
+        Without a p2p component, a temporary peer ID is generated.
 
         Full peer certificate verification is not yet implemented.
         This fallback allows connections to proceed during development.
@@ -1071,7 +1093,8 @@ class TestQuicConnectionManagerConnect:
     async def test_connect_wraps_exception(
         self, mock_quic_connect: MagicMock, manager: QuicConnectionManager
     ) -> None:
-        """Connection failures are wrapped in QuicTransportError.
+        """
+        Connection failures are wrapped in QuicTransportError.
 
         The original exception is preserved as the cause.
         """
@@ -1086,7 +1109,8 @@ class TestQuicConnectionManagerConnect:
 
 
 class TestQuicConnectionManagerListen:
-    """Tests for inbound QUIC connection acceptance.
+    """
+    Tests for inbound QUIC connection acceptance.
 
     The listener creates a server-side QUIC configuration, starts
     quic_serve, and installs a protocol factory. Each new connection
@@ -1095,7 +1119,8 @@ class TestQuicConnectionManagerListen:
 
     @pytest.fixture
     def manager_with_temp_directory(self, tmp_path: Path) -> QuicConnectionManager:
-        """A manager with a real temp dir containing certificate files.
+        """
+        A manager with a real temp dir containing certificate files.
 
         Uses tmp_path so certificate files exist on disk for load_cert_chain.
         """
@@ -1130,7 +1155,8 @@ class TestQuicConnectionManagerListen:
         mock_config_cls: MagicMock,
         manager_with_temp_directory: QuicConnectionManager,
     ) -> None:
-        """Server uses is_client=False, CERT_NONE, and the libp2p ALPN.
+        """
+        Server uses is_client=False, CERT_NONE, and the libp2p ALPN.
 
         CERT_NONE is correct because peer verification happens via
         the libp2p certificate extension, not a CA chain.
@@ -1175,7 +1201,8 @@ class TestQuicConnectionManagerListen:
         mock_config_cls: MagicMock,
         manager_with_temp_directory: QuicConnectionManager,
     ) -> None:
-        """The handshake callback creates and registers a QuicConnection.
+        """
+        The handshake callback creates and registers a QuicConnection.
 
         This test captures the protocol factory that listen() passes to
         quic_serve, then invokes the handshake callback to verify that
@@ -1246,7 +1273,8 @@ class TestQuicConnectionManagerListen:
         mock_quic_serve: MagicMock,
         mock_config_cls: MagicMock,
     ) -> None:
-        """Without a temp directory, certificate loading is skipped gracefully.
+        """
+        Without a temp directory, certificate loading is skipped gracefully.
 
         This guards against a crash if the manager was not constructed
         via the normal create() factory.

--- a/tests/lean_spec/node/networking/transport/quic/test_stream_adapter.py
+++ b/tests/lean_spec/node/networking/transport/quic/test_stream_adapter.py
@@ -576,7 +576,8 @@ class TestReadNegotiationMessage:
 
 @dataclass
 class _MockStream:
-    """In-memory stream for testing.
+    """
+    In-memory stream for testing.
 
     Two instances cross-connected via asyncio queues simulate a
     bidirectional QUIC stream pair.
@@ -618,7 +619,8 @@ class TestClose:
 
 
 def _create_stream_pair() -> tuple[QuicStreamAdapter, QuicStreamAdapter]:
-    """Create a cross-connected pair of QuicStreamAdapters for testing.
+    """
+    Create a cross-connected pair of QuicStreamAdapters for testing.
 
     Data written to one adapter is readable from the other.
     """

--- a/tests/lean_spec/node/networking/transport/quic/test_tls.py
+++ b/tests/lean_spec/node/networking/transport/quic/test_tls.py
@@ -1,4 +1,5 @@
-"""Tests for libp2p TLS certificate generation and ASN.1 encoding.
+"""
+Tests for libp2p TLS certificate generation and ASN.1 encoding.
 
 Tests verify behavior against the libp2p TLS spec:
     https://github.com/libp2p/specs/blob/master/tls/tls.md

--- a/tests/lean_spec/node/networking/transport/test_peer_id.py
+++ b/tests/lean_spec/node/networking/transport/test_peer_id.py
@@ -126,7 +126,8 @@ class TestMultihash:
 
 
 class TestEncodePublicKey:
-    """Tests for public key encoding.
+    """
+    Tests for public key encoding.
 
     Protobuf wire format from libp2p-crypto:
         message PublicKey {
@@ -172,7 +173,8 @@ class TestEncodePublicKey:
         assert secp256k1[1] == KeyType.SECP256K1  # 2
 
     def test_ed25519_encoding_matches_spec(self) -> None:
-        """Test ED25519 encoding matches libp2p spec test vector.
+        """
+        Test ED25519 encoding matches libp2p spec test vector.
 
         From: https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#test-vectors
         """
@@ -190,7 +192,8 @@ class TestEncodePublicKey:
         assert encoded == full_encoded
 
     def test_secp256k1_encoding_matches_spec(self) -> None:
-        """Test secp256k1 encoding matches libp2p spec test vector.
+        """
+        Test secp256k1 encoding matches libp2p spec test vector.
 
         From: https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#test-vectors
         """
@@ -207,7 +210,8 @@ class TestEncodePublicKey:
         assert encoded == full_encoded
 
     def test_ecdsa_encoding_matches_spec(self) -> None:
-        """Test ECDSA encoding matches libp2p spec test vector.
+        """
+        Test ECDSA encoding matches libp2p spec test vector.
 
         From: https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#test-vectors
         """
@@ -295,7 +299,8 @@ class TestPeerIdFormat:
 
 
 class TestKnownVectors:
-    """Tests against known test vectors from the libp2p spec.
+    """
+    Tests against known test vectors from the libp2p spec.
 
     Test vectors from:
     https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#test-vectors
@@ -313,7 +318,8 @@ class TestKnownVectors:
     """
 
     def test_ed25519_from_spec_test_vector(self) -> None:
-        """Test ED25519 key from libp2p spec test vectors.
+        """
+        Test ED25519 key from libp2p spec test vectors.
 
         Spec test vector (encoded public key):
             080112201ed1e8fae2c4a144b8be8fd4b47bf3d3b34b871c3cacf6010f0e42d474fce27e
@@ -351,7 +357,8 @@ class TestKnownVectors:
         assert decoded == multihash
 
     def test_secp256k1_from_spec_test_vector(self) -> None:
-        """Test secp256k1 key from libp2p spec test vectors.
+        """
+        Test secp256k1 key from libp2p spec test vectors.
 
         Spec test vector (encoded public key):
             08021221037777e994e452c21604f91de093ce415f5432f701dd8cd1a7a6fea0e630bfca99
@@ -389,7 +396,8 @@ class TestKnownVectors:
         assert decoded == multihash
 
     def test_ecdsa_from_spec_test_vector(self) -> None:
-        """Test ECDSA key from libp2p spec test vectors.
+        """
+        Test ECDSA key from libp2p spec test vectors.
 
         Spec test vector (encoded public key):
             0803125b3059301306072a8648ce3d020106082a8648ce3d030107034200
@@ -459,7 +467,8 @@ class TestKnownVectors:
         assert peer_id.startswith("16Uiu2")
 
     def test_known_secp256k1_peer_id(self) -> None:
-        """Test against a known secp256k1-derived PeerId.
+        """
+        Test against a known secp256k1-derived PeerId.
 
         This matches the libp2p spec test vector.
         """

--- a/tests/lean_spec/node/sync/test_backfill_sync.py
+++ b/tests/lean_spec/node/sync/test_backfill_sync.py
@@ -26,7 +26,8 @@ from tests.lean_spec.helpers import MockNetworkRequester, make_signed_block
 
 @dataclass
 class FakeStoreView:
-    """In-memory StoreView used to drive backfill tests.
+    """
+    In-memory StoreView used to drive backfill tests.
 
     Concrete implementation. Avoids MagicMock so tests fail loudly when
     fields drift. Tests mutate `known_roots` and `head` directly.
@@ -107,7 +108,8 @@ class TestBackfillChainResolution:
         peer_id: PeerId,
         network: MockNetworkRequester,
     ) -> None:
-        """Backfill recursively fetches missing parents up the chain.
+        """
+        Backfill recursively fetches missing parents up the chain.
 
         No store view is supplied, so backfill resolves missing parents purely
         by root recursion (the gap-detection path requires a view).
@@ -392,7 +394,8 @@ class TestBackfillOptimizations:
         store_view: FakeStoreView,
         peer_id: PeerId,
     ) -> None:
-        """A large gap above head triggers a single range request to fill it.
+        """
+        A large gap above head triggers a single range request to fill it.
 
         Floor is the head slot, not the finalized slot: slots above finalized
         but at or below head are already canonical for us and are not refetched.

--- a/tests/lean_spec/node/sync/test_checkpoint_sync.py
+++ b/tests/lean_spec/node/sync/test_checkpoint_sync.py
@@ -20,7 +20,8 @@ from lean_spec.spec.forks.lstar.containers import Validators
 
 
 class _MockTransport(httpx.AsyncBaseTransport):
-    """Injects a canned HTTP response or error without a real network.
+    """
+    Injects a canned HTTP response or error without a real network.
 
     Used by fetch_finalized_state tests to exercise error-handling paths
     through real httpx machinery rather than patching context managers.
@@ -85,7 +86,8 @@ class TestStateVerification:
     async def test_exception_during_hash_tree_root_returns_false(
         self, genesis_state: State
     ) -> None:
-        """Verification never crashes the caller on unexpected hashing errors.
+        """
+        Verification never crashes the caller on unexpected hashing errors.
 
         Any exception from the state root computation is caught and treated
         as a verification failure so startup can abort cleanly.
@@ -100,7 +102,8 @@ class TestStateVerification:
 
 
 class TestFetchFinalizedState:
-    """Tests for error handling when fetching checkpoint state over HTTP.
+    """
+    Tests for error handling when fetching checkpoint state over HTTP.
 
     Each test injects failures via _MockTransport so the real httpx client
     runs unchanged. This exercises the actual error-wrapping logic without
@@ -108,7 +111,8 @@ class TestFetchFinalizedState:
     """
 
     async def test_network_error_raises_checkpoint_sync_error(self) -> None:
-        """TCP-level failure surfaces as CheckpointSyncError with the URL.
+        """
+        TCP-level failure surfaces as CheckpointSyncError with the URL.
 
         Operators need the URL in the error message to diagnose which endpoint
         is unreachable (DNS failure, firewall block, wrong host).
@@ -139,7 +143,8 @@ class TestFetchFinalizedState:
     async def test_http_error_response_raises_checkpoint_sync_error(
         self, status_code: int, status_text: str
     ) -> None:
-        """Non-success HTTP status surfaces as CheckpointSyncError with the code.
+        """
+        Non-success HTTP status surfaces as CheckpointSyncError with the code.
 
         Covers both misconfigured endpoints (404) and server-side failures (500).
         The status code in the message helps operators identify the failure tier.
@@ -156,7 +161,8 @@ class TestFetchFinalizedState:
             await fetch_finalized_state("http://example.com", State)
 
     async def test_corrupt_ssz_raises_checkpoint_sync_error(self) -> None:
-        """Corrupt response body surfaces as CheckpointSyncError.
+        """
+        Corrupt response body surfaces as CheckpointSyncError.
 
         A 200 response with malformed SSZ bytes fails at deserialization.
         This catches truncated downloads or servers that return JSON instead
@@ -174,7 +180,8 @@ class TestFetchFinalizedState:
             await fetch_finalized_state("http://example.com", State)
 
     async def test_trailing_slash_stripped_from_url(self) -> None:
-        """Trailing slash on base URL does not produce a double slash in the request.
+        """
+        Trailing slash on base URL does not produce a double slash in the request.
 
         Operators commonly configure base URLs with trailing slashes.
         The endpoint must be appended cleanly regardless of input format.

--- a/tests/lean_spec/node/sync/test_head_sync.py
+++ b/tests/lean_spec/node/sync/test_head_sync.py
@@ -427,7 +427,8 @@ class TestReentrantGuard:
 
 @dataclass
 class _RecordingBackfill:
-    """Backfill stub recording range and root-recursion requests.
+    """
+    Backfill stub recording range and root-recursion requests.
 
     Used as the I/O boundary mock for head sync's backfill dependency.
     Each method appends its arguments verbatim and performs no real work.
@@ -459,7 +460,8 @@ def _store_with_head(
     finalized_slot: int,
     head_slot: int,
 ) -> tuple[Store, Bytes32]:
-    """Build a mock forkchoice store with a finalized slot and a head block.
+    """
+    Build a mock forkchoice store with a finalized slot and a head block.
 
     Returns the typed store and the head root. The head block carries the
     requested head slot so subsequent gap math sees the configured value.

--- a/tests/lean_spec/node/sync/test_service.py
+++ b/tests/lean_spec/node/sync/test_service.py
@@ -769,7 +769,8 @@ def _setup(
     *,
     block_participants: list[ValidatorIndex],
 ):
-    """Build a two-block chain and a signed block carrying an attestation.
+    """
+    Build a two-block chain and a signed block carrying an attestation.
 
     The chain block sits at slot 1. The returned signed block sits at slot
     2 and carries one attestation whose target is the slot-1 block, ahead
@@ -814,7 +815,8 @@ def _service(peer_id: PeerId):
 def test_skips_when_target_not_ahead_of_justified(
     peer_id: PeerId, key_manager: XmssKeyManager
 ) -> None:
-    """Target at or behind the justified checkpoint -> no aggregates.
+    """
+    Target at or behind the justified checkpoint -> no aggregates.
 
     The block's attestation cannot move justification, so the expensive
     split is never attempted and the store is returned unchanged.
@@ -836,7 +838,8 @@ def test_skips_when_target_not_ahead_of_justified(
 def test_skips_when_block_adds_no_new_validators(
     peer_id: PeerId, key_manager: XmssKeyManager
 ) -> None:
-    """Block participants are a subset of the local union -> no aggregates.
+    """
+    Block participants are a subset of the local union -> no aggregates.
 
     The target is ahead of justified, so the only thing stopping the split
     is that the block adds no new participant. The store is unchanged.

--- a/tests/lean_spec/node/test_node.py
+++ b/tests/lean_spec/node/test_node.py
@@ -95,7 +95,8 @@ def _make_populated_db(
 
 
 def _make_mock_db_with_partial_data() -> MagicMock:
-    """Build a mock database pre-populated with valid data for negative-path tests.
+    """
+    Build a mock database pre-populated with valid data for negative-path tests.
 
     Returns a MagicMock so individual methods can be overridden to return None,
     simulating partial DB corruption.
@@ -387,7 +388,8 @@ class TestDatabaseGenesisTimeFallback:
     """Tests for genesis_time fallback to database."""
 
     def test_falls_back_to_database_genesis_time(self) -> None:
-        """When genesis_time is None, loads it from the database.
+        """
+        When genesis_time is None, loads it from the database.
 
         The store time should be computed using the database-provided
         genesis time, identical to passing it explicitly.
@@ -453,7 +455,8 @@ class TestDatabaseResumeFromGenesis:
 
 
 class TestValidatorPublishWrappers:
-    """Tests for the publish wrappers created when a validator registry is provided.
+    """
+    Tests for the publish wrappers created when a validator registry is provided.
 
     The wrappers fan out each locally-produced block/attestation to both the
     network layer (gossip) and the local sync service (so forkchoice sees the
@@ -485,7 +488,8 @@ class TestValidatorPublishWrappers:
     async def test_attestation_publish_wrapper_calls_both_services(
         self, node_with_validator: Node
     ) -> None:
-        """Attestation wrapper publishes to network with computed subnet_id.
+        """
+        Attestation wrapper publishes to network with computed subnet_id.
 
         The subnet_id is derived from the attestation's validator index via
         `compute_subnet_id(ATTESTATION_COMMITTEE_COUNT)`. This test
@@ -564,7 +568,8 @@ class TestSignalHandlers:
 
 
 class TestPeriodicLogging:
-    """Tests for the periodic logging task.
+    """
+    Tests for the periodic logging task.
 
     These tests call `_log_justified_finalized_periodically` directly
     rather than through `run()`, isolating the logging loop from the
@@ -585,7 +590,8 @@ class TestPeriodicLogging:
         await node._log_justified_finalized_periodically()
 
     async def test_logging_reports_metrics(self, node_config: NodeConfig) -> None:
-        """Periodic logging updates Prometheus gauges at least once.
+        """
+        Periodic logging updates Prometheus gauges at least once.
 
         Initializes the metric registry with a test collector, runs one
         full iteration of the loop, then asserts each gauge was set with
@@ -630,7 +636,8 @@ class TestPeriodicLogging:
     async def test_logging_reports_zero_validators_without_service(
         self, node_config: NodeConfig
     ) -> None:
-        """Validator count gauge is set to 0 when no validator service exists.
+        """
+        Validator count gauge is set to 0 when no validator service exists.
 
         This verifies the `len(self.validator_service.registry)` fallback
         path that returns 0 when `validator_service is None`.

--- a/tests/lean_spec/node/validator/test_service.py
+++ b/tests/lean_spec/node/validator/test_service.py
@@ -1267,7 +1267,8 @@ class TestValidatorServiceIntegration:
 
 
 def _replace_head_at_slot(sync_service: SyncService, head_slot: Slot) -> None:
-    """Rewrite the head block at the given slot, preserving the map invariant.
+    """
+    Rewrite the head block at the given slot, preserving the map invariant.
 
     Preserves
     ---------
@@ -1296,7 +1297,8 @@ def _replace_head_at_slot(sync_service: SyncService, head_slot: Slot) -> None:
 
 
 def _add_block_at_slot(sync_service: SyncService, slot: Slot) -> Bytes32:
-    """Add a non-head block at the given slot, returning its root.
+    """
+    Add a non-head block at the given slot, returning its root.
 
     Why
     ---
@@ -1318,7 +1320,8 @@ def _add_block_at_slot(sync_service: SyncService, slot: Slot) -> Bytes32:
 
 
 def _build_gate_service(sync_service: SyncService) -> ValidatorService:
-    """Build a service for gate-only tests with an empty registry.
+    """
+    Build a service for gate-only tests with an empty registry.
 
     The gate logic never consults the registry, so emptying it keeps
     the focus on the predicate under test.
@@ -1331,7 +1334,8 @@ def _build_gate_service(sync_service: SyncService) -> ValidatorService:
 
 
 class TestSyncLagGate:
-    """Sync-lag duty gate.
+    """
+    Sync-lag duty gate.
 
     Decision matrix
     ---------------
@@ -1422,7 +1426,8 @@ class TestSyncLagGate:
         assert not service._is_synced_for_duties(Slot(10 + SYNC_LAG_THRESHOLD + 1), "block")
 
     def test_hysteresis_prevents_flap(self, sync_service: SyncService) -> None:
-        """Closed gate stays closed near the threshold.
+        """
+        Closed gate stays closed near the threshold.
 
         Lag sequence
         ------------
@@ -1492,7 +1497,8 @@ class TestSyncLagGate:
     async def test_run_loop_skips_attestation_when_gated(
         self, sync_service: SyncService, key_manager: XmssKeyManager
     ) -> None:
-        """Closed gate at interval 1 skips attestation and leaves the slot retryable.
+        """
+        Closed gate at interval 1 skips attestation and leaves the slot retryable.
 
         Why
         ---
@@ -1532,7 +1538,8 @@ class TestSyncLagGate:
     def test_gate_logs_only_on_transition(
         self, sync_service: SyncService, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """One INFO record per state change, not one per query.
+        """
+        One INFO record per state change, not one per query.
 
         Fields recorded
         ---------------

--- a/tests/lean_spec/spec/crypto/test_poseidon.py
+++ b/tests/lean_spec/spec/crypto/test_poseidon.py
@@ -1,4 +1,5 @@
-"""Tests for the Poseidon permutation for widths 16 and 24.
+"""
+Tests for the Poseidon permutation for widths 16 and 24.
 
 Test vectors are taken from Plonky3 (koala-bear/src/poseidon1.rs).
 To verify independently, run `cargo test` in the Plonky3 koala-bear crate.

--- a/tests/lean_spec/spec/crypto/xmss/test_constants.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_constants.py
@@ -112,7 +112,8 @@ def test_prod_config_matches_reference(param_name: str, value: int) -> None:
 
 
 def _calculate_layer_size(w: int, v: int, d: int) -> int:
-    """Count a hypercube layer's size using inclusion-exclusion.
+    """
+    Count a hypercube layer's size using inclusion-exclusion.
 
     Counts integer solutions to x_1 + ... + x_v = k with 0 <= x_i <= w-1,
     where k = v*(w-1) - d.
@@ -125,7 +126,8 @@ def _calculate_layer_size(w: int, v: int, d: int) -> int:
 
 
 def _compute_security_levels(config: XmssConfig) -> dict[str, float]:
-    """Compute classical and quantum security levels for a configuration.
+    """
+    Compute classical and quantum security levels for a configuration.
 
     Returns a dict with keys:
 

--- a/tests/lean_spec/spec/crypto/xmss/test_encoding.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_encoding.py
@@ -128,7 +128,8 @@ def test_target_sum_encode_rejects_codeword_off_target_layer() -> None:
 def test_target_sum_encode_propagates_aborting_decode_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An aborting message hash makes the encode return None before the sum check.
+    """
+    An aborting message hash makes the encode return None before the sum check.
 
     The aborting decode rejects only the prime-minus-one field element.
     That event has probability near one in two billion per element.

--- a/tests/lean_spec/spec/crypto/xmss/test_interface.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_interface.py
@@ -250,7 +250,8 @@ def test_sign_rejects_slot_outside_activation() -> None:
 
 
 def test_sign_raises_when_no_encoding_found(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An encoding search that never succeeds raises after exhausting the attempts.
+    """
+    An encoding search that never succeeds raises after exhausting the attempts.
 
     The encoding is forced to always reject so the retry loop runs to its limit.
     """
@@ -264,7 +265,8 @@ def test_sign_raises_when_no_encoding_found(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_sign_raises_on_wrong_codeword_dimension(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An encoding returning the wrong number of digits raises.
+    """
+    An encoding returning the wrong number of digits raises.
 
     The encoding is forced to return one digit too few for the scheme dimension.
     """

--- a/tests/lean_spec/spec/forks/lstar/containers/test_aggregation.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_aggregation.py
@@ -300,7 +300,8 @@ def test_single_message_aggregate_verify_rejects_public_key_count_mismatch(
 def test_multi_message_aggregate_split_by_message_rejected_under_test_prover(
     key_manager: XmssKeyManager,
 ) -> None:
-    """Splitting a merged proof aborts under the reduced test-config prover.
+    """
+    Splitting a merged proof aborts under the reduced test-config prover.
 
     The split branch is functional only under the production prover.
     The test-config build aborts it with an in-circuit assertion.
@@ -536,7 +537,8 @@ def test_multi_message_aggregate_verify_round_trip(key_manager: XmssKeyManager) 
 
 
 def test_multi_message_aggregate_verify_rejects_message_swap(key_manager: XmssKeyManager) -> None:
-    """Swapping the parallel message bindings causes verification to fail.
+    """
+    Swapping the parallel message bindings causes verification to fail.
 
     Without per-component message binding a proposer could pair honest
     signatures with attacker-chosen attestation data.

--- a/tests/lean_spec/spec/forks/lstar/test_aggregation.py
+++ b/tests/lean_spec/spec/forks/lstar/test_aggregation.py
@@ -25,7 +25,8 @@ from tests.lean_spec.helpers import (
 
 
 def _proof(validator_indices: list[int], distinguishing_bytes: bytes) -> SingleMessageAggregate:
-    """Build a proof covering the given validators.
+    """
+    Build a proof covering the given validators.
 
     Args:
         validator_indices: Validators this proof attests for.

--- a/tests/lean_spec/spec/forks/lstar/test_block_production.py
+++ b/tests/lean_spec/spec/forks/lstar/test_block_production.py
@@ -45,7 +45,8 @@ def _chain_through_slot_two(
     *,
     justify_slot_one: bool = False,
 ) -> tuple[State, Bytes32, Bytes32, Bytes32]:
-    """Apply a three-block chain and return the slot-two state with its roots.
+    """
+    Apply a three-block chain and return the slot-two state with its roots.
 
     The chain runs genesis, then a slot-one block, then a slot-two block.
 
@@ -141,7 +142,8 @@ def test_build_block_keeps_genesis_self_vote(
     key_manager: XmssKeyManager,
     spec: LstarSpec,
 ) -> None:
-    """A vote anchored entirely at genesis is carried into the body unchanged.
+    """
+    A vote anchored entirely at genesis is carried into the body unchanged.
 
     - Source and target both sit at slot zero.
     - The state transition discards such a vote for justification.
@@ -206,7 +208,8 @@ def test_build_block_merges_split_proofs_into_one_attestation(
     key_manager: XmssKeyManager,
     spec: LstarSpec,
 ) -> None:
-    """Two proofs for the same data collapse into one attestation over their union.
+    """
+    Two proofs for the same data collapse into one attestation over their union.
 
     - One subset arrives as a gossip-derived proof.
     - A second disjoint subset arrives as a separate proof.
@@ -361,7 +364,8 @@ def test_build_block_skips_vote_with_unjustified_source(
     key_manager: XmssKeyManager,
     spec: LstarSpec,
 ) -> None:
-    """A vote whose source slot is not yet justified is excluded.
+    """
+    A vote whose source slot is not yet justified is excluded.
 
     Fixture state:
 
@@ -421,7 +425,8 @@ def test_build_block_skips_vote_for_already_justified_target(
     key_manager: XmssKeyManager,
     spec: LstarSpec,
 ) -> None:
-    """A vote whose target slot is already justified adds nothing and is excluded.
+    """
+    A vote whose target slot is already justified adds nothing and is excluded.
 
     Fixture state:
 
@@ -482,7 +487,8 @@ def test_build_block_fixed_point_unlocks_chained_source(
     key_manager: XmssKeyManager,
     spec: LstarSpec,
 ) -> None:
-    """Justifying one target unlocks a second vote whose source was that target.
+    """
+    Justifying one target unlocks a second vote whose source was that target.
 
     Fixture state:
 

--- a/tests/lean_spec/spec/ssz/test_ssz_base.py
+++ b/tests/lean_spec/spec/ssz/test_ssz_base.py
@@ -35,7 +35,8 @@ class SmallBitlist(BaseBitlist):
 
 
 class TestSSZModelLength:
-    """Tests for SSZModel.__len__() on both collection and container models.
+    """
+    Tests for SSZModel.__len__() on both collection and container models.
 
     Uses BaseBitlist (not SSZList) for the data-path because SSZList overrides
     __len__ with its own implementation. BaseBitlist inherits SSZModel's version.
@@ -83,7 +84,8 @@ class TestSSZModelRepr:
 
 
 class TestSSZTypeEncodeDecode:
-    """Tests for encode_bytes/decode_bytes on SSZType.
+    """
+    Tests for encode_bytes/decode_bytes on SSZType.
 
     These methods wrap the stream-based serialize/deserialize interface
     so callers can work with plain byte strings instead.

--- a/tests/lean_spec/test_base.py
+++ b/tests/lean_spec/test_base.py
@@ -21,7 +21,8 @@ class SampleStrictModel(StrictBaseModel):
 
 
 class TestCamelModelToJson:
-    """Tests for CamelModel.to_json() camelCase serialization.
+    """
+    Tests for CamelModel.to_json() camelCase serialization.
 
     Test vectors use camelCase keys in their JSON output. This method
     is the single point where that conversion happens. A bug here
@@ -29,7 +30,8 @@ class TestCamelModelToJson:
     """
 
     def test_to_json_converts_snake_case_to_camel(self) -> None:
-        """Snake_case field names become camelCase in JSON output.
+        """
+        Snake_case field names become camelCase in JSON output.
 
         This is the core behavior that all test vector serialization
         depends on.
@@ -55,7 +57,8 @@ class TestCamelModelToJson:
             model.to_json(by_alias=False)
 
     def test_to_json_forwards_extra_kwargs(self) -> None:
-        """Other kwargs (e.g., exclude_defaults) pass through to model_dump.
+        """
+        Other kwargs (e.g., exclude_defaults) pass through to model_dump.
 
         Only mode and by_alias are stripped. Everything else is forwarded.
         """
@@ -69,14 +72,16 @@ class TestCamelModelToJson:
 
 
 class TestStrictBaseModel:
-    """Tests for StrictBaseModel constraints.
+    """
+    Tests for StrictBaseModel constraints.
 
     StrictBaseModel is the foundation for all spec types. Its constraints
     (extra-forbidden, strict) catch typos and silent type coercion.
     """
 
     def test_extra_fields_forbidden(self) -> None:
-        """Unknown fields are rejected at construction time.
+        """
+        Unknown fields are rejected at construction time.
 
         This catches typos and schema mismatches early.
         """
@@ -88,7 +93,8 @@ class TestStrictBaseModel:
             )
 
     def test_strict_rejects_type_coercion(self) -> None:
-        """Strict mode rejects values that would require type coercion.
+        """
+        Strict mode rejects values that would require type coercion.
 
         Without strict mode, Pydantic would silently convert "5" to 5.
         In spec code, this kind of silent coercion hides bugs.
@@ -97,7 +103,8 @@ class TestStrictBaseModel:
             SampleStrictModel(slot_number="5", block_root="0xabc")  # type: ignore[arg-type]
 
     def test_inherits_camel_serialization(self) -> None:
-        """StrictBaseModel inherits camelCase serialization from CamelModel.
+        """
+        StrictBaseModel inherits camelCase serialization from CamelModel.
 
         Verifies the inheritance chain works end-to-end.
         """


### PR DESCRIPTION
## Motivation

Multi-line docstrings across the codebase were inconsistent: some started the summary on the same line as the opening quotes, others on the line after. Neither pydocstyle rule governing this was enforced — `D212` (summary on first line) was in the `ignore` list, and `D213` (summary on second line) is disabled by the `google` convention — so the two styles had drifted into a mix.

## Changes

- **`pyproject.toml`**: select `D213` by exact code in the ruff lint config. The exact-code selection is required because `convention = "google"` would otherwise disable it; `D212` was already ignored, so there is no conflict. From now on, ruff enforces the second-line style on every multi-line docstring.
- **Auto-fix all 454 existing violations** (232 in `src/`, 222 in `tests/` and `packages/`) so the entire codebase uses one homogeneous layout:

```python
"""
Merge several single-message proofs over distinct messages into one.

...
"""
```

The fixes in `tests/` and `packages/` were applied with a one-off run overriding the `tests/** = ["D"]` per-file ignore, so existing test docstrings match too.

`ruff format` does not fight the new layout, and the full `just check` suite (lint, format, ty, codespell, mdformat) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)