### PR TITLE
refactor: rename vague locals to descriptive, self-documenting names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,17 @@ subspecifications that the Lean Ethereum protocol relies on.
   still vague is NOT acceptable. This applies to source, tests, and `packages/`.
   - BAN vague placeholder names that describe nothing: `selected`, `result`, `data`, `value`,
     `item`, `temp`, `obj`, `info`, `payload` (when unqualified), `current`, `entry`, `thing`,
-    `out`, `ret`, single-letter names (except a conventional math index `i`/`j` in a tight numeric
-    loop). Name the THING, not its role: `selected` → `selected_proofs`, `result` →
+    `out`, `ret`, `expected`, `actual`, `part`/`parts`, single-letter names (except a conventional
+    math index `i`/`j` in a tight numeric loop, or notation mirroring a cited formula). Name the
+    THING, not its role: `selected` → `selected_proofs`, `result` →
     `post_state` / `merged_signature`, `current` → `current_justified_checkpoint`.
+  - `expected` and `actual` must name WHAT is expected: `expected` →
+    `expected_public_key_count` / `expected_state_root` / `expected_encoding`; `actual` →
+    `actual_field_value`. This applies everywhere, including next to a test assert.
+  - `index` alone is banned when what it indexes is not obvious; say what it walks:
+    `validator_index`, `aggregate_index`, `byte_index`, `chunk_index`.
+  - Never shadow-alias a well-named value into a vague one (`data = attestation_data` is banned);
+    use the descriptive name directly, even if lines must wrap.
   - Encode the type or domain meaning when a bare word is ambiguous. A variable holding a
     `Checkpoint` is `justified_checkpoint`, not `justified`; a bitfield of justified slots is
     `justified_slots`, not `slots`; a boolean is a predicate phrase (`found_new_entries`,

--- a/packages/testing/src/consensus_testing/genesis.py
+++ b/packages/testing/src/consensus_testing/genesis.py
@@ -28,14 +28,14 @@ def _build_validators(num_validators: int) -> Validators:
         )
 
     validators = []
-    for i in range(num_validators):
-        index = ValidatorIndex(i)
-        attestation_public_key, proposal_public_key = key_manager.get_public_keys(index)
+    for validator_position in range(num_validators):
+        validator_index = ValidatorIndex(validator_position)
+        attestation_public_key, proposal_public_key = key_manager.get_public_keys(validator_index)
         validators.append(
             Validator(
                 attestation_public_key=Bytes52(attestation_public_key.encode_bytes()),
                 proposal_public_key=Bytes52(proposal_public_key.encode_bytes()),
-                index=index,
+                index=validator_index,
             )
         )
 

--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -289,7 +289,8 @@ class XmssKeyManager:
 
             # Each JSON file is named by its validator index (e.g. "0.json").
             self._available_indices = {
-                ValidatorIndex(int(f.stem)) for f in self._keys_directory.glob("*.json")
+                ValidatorIndex(int(key_file.stem))
+                for key_file in self._keys_directory.glob("*.json")
             }
 
             # An empty directory is as bad as a missing one.
@@ -320,8 +321,8 @@ class XmssKeyManager:
             # Resolve the per-validator JSON file path.
             key_file = self._keys_directory / f"{index}.json"
             try:
-                with key_file.open() as f:
-                    self._json_cache[index] = json.load(f)
+                with key_file.open() as key_file_handle:
+                    self._json_cache[index] = json.load(key_file_handle)
             except FileNotFoundError:
                 raise KeyError(f"Key file not found: {key_file}") from None
         return self._json_cache[index]
@@ -690,11 +691,14 @@ def _generate_keys(lean_env: str, count: int, max_slot: int) -> None:
     gen_start = time.monotonic()
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
         worker_func = partial(_generate_single_keypair, scheme, num_slots)
-        for index, key_pair in enumerate(executor.map(worker_func, range(count))):
+        for validator_index, key_pair in enumerate(executor.map(worker_func, range(count))):
             elapsed = time.monotonic() - gen_start
-            print(f"[{index + 1}/{count}] saved key #{index} ({elapsed:.0f}s elapsed)")
+            print(
+                f"[{validator_index + 1}/{count}] saved key #{validator_index} "
+                f"({elapsed:.0f}s elapsed)"
+            )
 
-            key_file = keys_directory / f"{index}.json"
+            key_file = keys_directory / f"{validator_index}.json"
             key_file.write_text(key_pair.model_dump_json(indent=2))
 
     total = time.monotonic() - gen_start

--- a/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
@@ -286,6 +286,6 @@ class ApiEndpointTest(BaseConsensusFixture):
             genesis_time=self.genesis_params.get("genesisTime", 0),
             anchor_slot=self.genesis_params.get("anchorSlot", 0),
         )
-        for k, v in handler(store, self).items():
-            setattr(self, k, v)
+        for field_name, field_value in handler(store, self).items():
+            setattr(self, field_name, field_value)
         return self

--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -39,11 +39,11 @@ class BaseConsensusFixture(BaseFixture):
             BaseConsensusFixture.formats[cls.format_name] = cls
 
     @field_serializer("expect_exception", when_used="json")
-    def serialize_exception(self, value: type[Exception] | None) -> str | None:
+    def serialize_exception(self, exception_type: type[Exception] | None) -> str | None:
         """Serialize exception type to its class name for JSON output."""
-        if value is None:
+        if exception_type is None:
             return None
-        return value.__name__
+        return exception_type.__name__
 
     def assert_expected_outcome(self, exception_raised: Exception | None) -> None:
         """

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -200,15 +200,15 @@ class ForkChoiceTest(BaseConsensusFixture):
                     self.anchor_block,
                     validator_index=ValidatorIndex(0),
                 )
-            except AssertionError as e:
+            except AssertionError as exception:
                 if self.expected_anchor_error is not None and self.expected_anchor_error not in str(
-                    e
+                    exception
                 ):
                     raise AssertionError(
                         "Store.from_anchor failed with wrong error.\n"
                         f"  Expected error containing: {self.expected_anchor_error!r}\n"
-                        f"  Actual error: {e!r}"
-                    ) from e
+                        f"  Actual error: {exception!r}"
+                    ) from exception
                 return self
 
             raise AssertionError("Store.from_anchor was expected to fail but succeeded")
@@ -226,9 +226,11 @@ class ForkChoiceTest(BaseConsensusFixture):
         # We must replace them with the key manager's actual keys.
         # Otherwise signature verification will fail.
         updated_validators = []
-        for i, validator in enumerate(self.anchor_state.validators):
-            index = ValidatorIndex(i)
-            attestation_public_key, proposal_public_key = key_manager.get_public_keys(index)
+        for validator_position, validator in enumerate(self.anchor_state.validators):
+            validator_index = ValidatorIndex(validator_position)
+            attestation_public_key, proposal_public_key = key_manager.get_public_keys(
+                validator_index
+            )
             updated_validators.append(
                 validator.model_copy(
                     update={
@@ -266,7 +268,7 @@ class ForkChoiceTest(BaseConsensusFixture):
         #
         # Process each step against the Store.
         # Store follows immutable pattern: each method returns a new Store.
-        for i, step in enumerate(self.steps):
+        for step_index, step in enumerate(self.steps):
             old_head = store.head
             try:
                 match step:
@@ -309,7 +311,7 @@ class ForkChoiceTest(BaseConsensusFixture):
                         if step.block.label is not None:
                             if step.block.label in self._block_registry:
                                 raise ValueError(
-                                    f"Step {i}: duplicate label '{step.block.label}' - "
+                                    f"Step {step_index}: duplicate label '{step.block.label}' - "
                                     f"labels must be unique within a test"
                                 )
                             self._block_registry[step.block.label] = block
@@ -355,34 +357,37 @@ class ForkChoiceTest(BaseConsensusFixture):
                         store = spec.on_gossip_aggregated_attestation(store, signed_aggregated)
 
                     case _:
-                        raise ValueError(f"Step {i}: unknown step type {type(step).__name__}")
+                        raise ValueError(
+                            f"Step {step_index}: unknown step type {type(step).__name__}"
+                        )
 
                 # Validate Store state if checks are provided.
                 if step.checks is not None:
                     filled_block = step._filled_block if isinstance(step, BlockStep) else None
                     step.checks.validate_against_store(
                         store,
-                        step_index=i,
+                        step_index=step_index,
                         block_registry=self._block_registry,
                         filled_block=filled_block,
                         old_head=old_head,
                     )
 
-            except Exception as e:
+            except Exception as exception:
                 # Handle expected failures.
                 # Steps marked valid=False should raise exceptions.
                 if step.valid:
                     raise AssertionError(
-                        f"Step {i} ({type(step).__name__}) failed unexpectedly: {e}"
-                    ) from e
+                        f"Step {step_index} ({type(step).__name__}) "
+                        f"failed unexpectedly: {exception}"
+                    ) from exception
 
                 # Verify the failure reason matches when specified.
-                if step.expected_error is not None and step.expected_error not in str(e):
+                if step.expected_error is not None and step.expected_error not in str(exception):
                     raise AssertionError(
-                        f"Step {i} ({type(step).__name__}) failed with wrong error.\n"
+                        f"Step {step_index} ({type(step).__name__}) failed with wrong error.\n"
                         f"  Expected error containing: {step.expected_error!r}\n"
-                        f"  Actual error: {e!r}"
-                    ) from e
+                        f"  Actual error: {exception!r}"
+                    ) from exception
 
                 continue
 
@@ -390,7 +395,7 @@ class ForkChoiceTest(BaseConsensusFixture):
             # If we expected failure but the step succeeded, that's a test bug.
             if not step.valid:
                 raise AssertionError(
-                    f"Step {i} ({type(step).__name__}) succeeded but expected failure"
+                    f"Step {step_index} ({type(step).__name__}) succeeded but expected failure"
                 )
 
         # Return self (fixture is already complete)

--- a/packages/testing/src/consensus_testing/test_fixtures/gossipsub_handler.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/gossipsub_handler.py
@@ -71,44 +71,53 @@ def _serialize_rpcs(
 
     Fixture consumers use this to assert exact outbound behavior.
     """
-    result = []
-    for pid, rpc in sent:
-        name = peer_names.get(pid, str(pid))
-        entry: dict[str, Any] = {"toPeer": name}
+    serialized_rpcs = []
+    for recipient_peer_id, rpc in sent:
+        recipient_name = peer_names.get(recipient_peer_id, str(recipient_peer_id))
+        serialized_rpc: dict[str, Any] = {"toPeer": recipient_name}
 
         if rpc.subscriptions:
-            entry["subscriptions"] = [
-                {"subscribe": s.subscribe, "topicId": str(s.topic_id)} for s in rpc.subscriptions
+            serialized_rpc["subscriptions"] = [
+                {"subscribe": subscription.subscribe, "topicId": str(subscription.topic_id)}
+                for subscription in rpc.subscriptions
             ]
 
         if rpc.publish:
-            entry["publish"] = [
-                {"topic": str(m.topic), "data": "0x" + m.data.hex()} for m in rpc.publish
+            serialized_rpc["publish"] = [
+                {"topic": str(message.topic), "data": "0x" + message.data.hex()}
+                for message in rpc.publish
             ]
 
         # Only include control fields that carry sub-messages.
         if rpc.control and not rpc.control.is_empty():
-            ctrl: dict[str, Any] = {}
+            serialized_control: dict[str, Any] = {}
             if rpc.control.graft:
-                ctrl["graft"] = [{"topicId": str(g.topic_id)} for g in rpc.control.graft]
+                serialized_control["graft"] = [
+                    {"topicId": str(graft.topic_id)} for graft in rpc.control.graft
+                ]
             if rpc.control.prune:
-                ctrl["prune"] = [
-                    {"topicId": str(p.topic_id), "backoff": p.backoff} for p in rpc.control.prune
+                serialized_control["prune"] = [
+                    {"topicId": str(prune.topic_id), "backoff": prune.backoff}
+                    for prune in rpc.control.prune
                 ]
             if rpc.control.iwant:
-                ctrl["iwant"] = [
-                    {"messageIds": ["0x" + mid.hex() for mid in w.message_ids]}
-                    for w in rpc.control.iwant
+                serialized_control["iwant"] = [
+                    {"messageIds": ["0x" + message_id.hex() for message_id in iwant.message_ids]}
+                    for iwant in rpc.control.iwant
                 ]
             if rpc.control.idontwant:
-                ctrl["idontwant"] = [
-                    {"messageIds": ["0x" + mid.hex() for mid in d.message_ids]}
-                    for d in rpc.control.idontwant
+                serialized_control["idontwant"] = [
+                    {
+                        "messageIds": [
+                            "0x" + message_id.hex() for message_id in idontwant.message_ids
+                        ]
+                    }
+                    for idontwant in rpc.control.idontwant
                 ]
-            entry["control"] = ctrl
+            serialized_rpc["control"] = serialized_control
 
-        result.append(entry)
-    return result
+        serialized_rpcs.append(serialized_rpc)
+    return serialized_rpcs
 
 
 def _serialize_meshes(
@@ -121,7 +130,9 @@ def _serialize_meshes(
     Sorting ensures deterministic output for fixture comparison.
     """
     return {
-        str(topic): sorted(peer_names.get(p, str(p)) for p in behavior.mesh.get_mesh_peers(topic))
+        str(topic): sorted(
+            peer_names.get(peer_id, str(peer_id)) for peer_id in behavior.mesh.get_mesh_peers(topic)
+        )
         for topic in behavior.mesh.subscriptions
     }
 
@@ -194,51 +205,53 @@ class GossipsubHandlerTest(BaseConsensusFixture):
         #
         # Peer properties like backoff timers and IDONTWANT sets directly
         # influence handler decisions (e.g., reject GRAFTs, skip forwarding).
-        for name, info in self.initial_state.get("peers", {}).items():
-            pid = _peer_id(name)
-            peer_names[pid] = name
-            state = PeerState(
-                peer_id=pid,
-                subscriptions={TopicId(t) for t in info.get("subscriptions", [])},
-                outbound_stream=_FAKE_STREAM if info.get("withStream", True) else None,
+        for peer_name, peer_config in self.initial_state.get("peers", {}).items():
+            peer_id = _peer_id(peer_name)
+            peer_names[peer_id] = peer_name
+            peer_state = PeerState(
+                peer_id=peer_id,
+                subscriptions={
+                    TopicId(topic_str) for topic_str in peer_config.get("subscriptions", [])
+                },
+                outbound_stream=_FAKE_STREAM if peer_config.get("withStream", True) else None,
             )
 
             # Backoff prevents re-GRAFTing a recently-pruned peer.
-            for topic_str, expiry in info.get("backoff", {}).items():
-                state.backoff[TopicId(topic_str)] = expiry
+            for topic_str, expiry in peer_config.get("backoff", {}).items():
+                peer_state.backoff[TopicId(topic_str)] = expiry
 
             # IDONTWANT suppresses forwarding to peers that already have the message.
-            for mid_hex in info.get("dontWantIds", []):
-                state.dont_want_ids.add(MessageId(_unhex(mid_hex)))
-            behavior._peers[pid] = state
+            for message_id_hex in peer_config.get("dontWantIds", []):
+                peer_state.dont_want_ids.add(MessageId(_unhex(message_id_hex)))
+            behavior._peers[peer_id] = peer_state
 
         # Mesh topology determines who receives forwarded messages.
         #
         # Handlers check mesh membership for GRAFT acceptance, PRUNE removal,
         # and message forwarding decisions.
-        for topic_str, peer_list in self.initial_state.get("meshes", {}).items():
+        for topic_str, mesh_peer_names in self.initial_state.get("meshes", {}).items():
             topic = TopicId(topic_str)
-            for name in peer_list:
-                behavior.mesh.add_to_mesh(topic, _peer_id(name))
+            for peer_name in mesh_peer_names:
+                behavior.mesh.add_to_mesh(topic, _peer_id(peer_name))
 
         # Seen cache tracks previously-received message IDs.
         #
         # Duplicate messages are silently dropped; IHAVE for seen IDs
         # does not trigger an IWANT response.
-        for mid_hex in self.initial_state.get("seenMessageIds", []):
-            behavior.seen_cache.add(MessageId(_unhex(mid_hex)), Timestamp(self.now))
+        for message_id_hex in self.initial_state.get("seenMessageIds", []):
+            behavior.seen_cache.add(MessageId(_unhex(message_id_hex)), Timestamp(self.now))
 
         # Message cache holds full message payloads for IWANT responses.
         #
         # When a peer requests a message via IWANT, the handler looks it up
         # here and sends the payload back.
-        for entry in self.initial_state.get("cachedMessages", []):
+        for cached_message in self.initial_state.get("cachedMessages", []):
             message = GossipsubMessage(
-                topic=entry["topic"].encode("utf-8"),
-                raw_data=_unhex(entry["data"]),
+                topic=cached_message["topic"].encode("utf-8"),
+                raw_data=_unhex(cached_message["data"]),
             )
-            message._cached_id = MessageId(_unhex(entry["messageId"]))
-            behavior.message_cache.put(TopicId(entry["topic"]), message)
+            message._cached_id = MessageId(_unhex(cached_message["messageId"]))
+            behavior.message_cache.put(TopicId(cached_message["topic"]), message)
 
         # Build the incoming RPC from the event.
         from_peer = _peer_id(self.event["fromPeer"])
@@ -272,43 +285,53 @@ def _build_event_rpc(event: dict[str, Any]) -> RPC:
     - idontwant: list of dicts with hex messageIds
     - publish: list of dicts with topic and hex data
     """
-    control_parts: dict[str, list[Any]] = {}
+    control_components: dict[str, list[Any]] = {}
 
     if "graft" in event:
-        control_parts["graft"] = [
-            ControlGraft(topic_id=TopicId(g["topicId"])) for g in event["graft"]
+        control_components["graft"] = [
+            ControlGraft(topic_id=TopicId(graft["topicId"])) for graft in event["graft"]
         ]
     if "prune" in event:
-        control_parts["prune"] = [
-            ControlPrune(topic_id=TopicId(p["topicId"]), backoff=p.get("backoff", 0))
-            for p in event["prune"]
+        control_components["prune"] = [
+            ControlPrune(topic_id=TopicId(prune["topicId"]), backoff=prune.get("backoff", 0))
+            for prune in event["prune"]
         ]
     if "ihave" in event:
-        control_parts["ihave"] = [
+        control_components["ihave"] = [
             ControlIHave(
-                topic_id=TopicId(ih["topicId"]),
-                message_ids=[_unhex(m) for m in ih.get("messageIds", [])],
+                topic_id=TopicId(ihave["topicId"]),
+                message_ids=[
+                    _unhex(message_id_hex) for message_id_hex in ihave.get("messageIds", [])
+                ],
             )
-            for ih in event["ihave"]
+            for ihave in event["ihave"]
         ]
     if "iwant" in event:
-        control_parts["iwant"] = [
-            ControlIWant(message_ids=[_unhex(m) for m in iw.get("messageIds", [])])
-            for iw in event["iwant"]
+        control_components["iwant"] = [
+            ControlIWant(
+                message_ids=[
+                    _unhex(message_id_hex) for message_id_hex in iwant.get("messageIds", [])
+                ]
+            )
+            for iwant in event["iwant"]
         ]
     if "idontwant" in event:
-        control_parts["idontwant"] = [
-            ControlIDontWant(message_ids=[_unhex(m) for m in idw.get("messageIds", [])])
-            for idw in event["idontwant"]
+        control_components["idontwant"] = [
+            ControlIDontWant(
+                message_ids=[
+                    _unhex(message_id_hex) for message_id_hex in idontwant.get("messageIds", [])
+                ]
+            )
+            for idontwant in event["idontwant"]
         ]
 
     return RPC(
         publish=[
             Message(
-                topic=TopicId(m.get("topic", "")),
-                data=_unhex(m["data"]) if m.get("data") else b"",
+                topic=TopicId(message.get("topic", "")),
+                data=_unhex(message["data"]) if message.get("data") else b"",
             )
-            for m in event.get("publish", [])
+            for message in event.get("publish", [])
         ],
-        control=ControlMessage(**control_parts) if control_parts else None,
+        control=ControlMessage(**control_components) if control_components else None,
     )

--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -168,12 +168,14 @@ class NetworkingCodecTest(BaseConsensusFixture):
 
     def _make_varint(self) -> dict[str, Any]:
         """Encode a value as LEB128, decode it back, assert roundtrip."""
-        value = self.input["value"]
-        encoded = encode_varint(value)
+        varint_value = self.input["value"]
+        encoded = encode_varint(varint_value)
 
         # Decode must recover the original value and consume all bytes.
         decoded, byte_length = decode_varint(encoded)
-        assert decoded == value, f"Varint roundtrip: {value} -> {encoded.hex()} -> {decoded}"
+        assert decoded == varint_value, (
+            f"Varint roundtrip: {varint_value} -> {encoded.hex()} -> {decoded}"
+        )
         assert byte_length == len(encoded), f"Length: {byte_length} != {len(encoded)}"
 
         return {"encoded": _to_hex(encoded), "byteLength": byte_length}
@@ -281,9 +283,9 @@ class NetworkingCodecTest(BaseConsensusFixture):
         """
         raw_chunks = self.input["chunks"]
         buffer = bytearray()
-        for entry in raw_chunks:
-            code = ResponseCode(entry["responseCode"])
-            ssz_data = _from_hex(entry["sszData"])
+        for chunk in raw_chunks:
+            code = ResponseCode(chunk["responseCode"])
+            ssz_data = _from_hex(chunk["sszData"])
             buffer.extend(code.encode(ssz_data))
         return {
             "encoded": _to_hex(bytes(buffer)),
@@ -292,30 +294,30 @@ class NetworkingCodecTest(BaseConsensusFixture):
 
     def _make_snappy_block(self) -> dict[str, Any]:
         """Compress with raw Snappy block format, decompress, assert roundtrip."""
-        data = _from_hex(self.input["data"])
-        compressed = compress(data)
+        uncompressed_bytes = _from_hex(self.input["data"])
+        compressed = compress(uncompressed_bytes)
 
         decompressed = decompress(compressed)
-        assert decompressed == data, "Snappy block roundtrip produced different bytes"
+        assert decompressed == uncompressed_bytes, "Snappy block roundtrip produced different bytes"
 
         return {
             "compressed": _to_hex(compressed),
             "compressedLength": len(compressed),
-            "uncompressedLength": len(data),
+            "uncompressedLength": len(uncompressed_bytes),
         }
 
     def _make_snappy_frame(self) -> dict[str, Any]:
         """Compress with Snappy framing format (Ethereum wire format), decompress, roundtrip."""
-        data = _from_hex(self.input["data"])
-        framed = frame_compress(data)
+        uncompressed_bytes = _from_hex(self.input["data"])
+        framed = frame_compress(uncompressed_bytes)
 
         decompressed = frame_decompress(framed)
-        assert decompressed == data, "Snappy frame roundtrip produced different bytes"
+        assert decompressed == uncompressed_bytes, "Snappy frame roundtrip produced different bytes"
 
         return {
             "framed": _to_hex(framed),
             "framedLength": len(framed),
-            "uncompressedLength": len(data),
+            "uncompressedLength": len(uncompressed_bytes),
         }
 
     def _make_enr(self) -> dict[str, Any]:
@@ -356,7 +358,9 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 "nextForkEpoch": int(eth2.next_fork_epoch),
             }
         if (subnets := enr.attestation_subnets) is not None:
-            output["attestationSubnets"] = [int(s) for s in subnets.subscribed_subnets()]
+            output["attestationSubnets"] = [
+                int(subnet_id) for subnet_id in subnets.subscribed_subnets()
+            ]
         output["isAggregator"] = enr.is_aggregator
         output["signatureValid"] = enr.verify_signature()
         output["isValid"] = enr.is_valid()
@@ -389,63 +393,81 @@ class NetworkingCodecTest(BaseConsensusFixture):
         }
 
 
-def _build_rpc(d: dict[str, Any]) -> RPC:
+def _build_rpc(rpc_dict: dict[str, Any]) -> RPC:
     """Build an RPC from a JSON-friendly dict."""
-    subs = [_build_sub_opts(s) for s in d.get("subscriptions", [])]
-    messages = [_build_message(m) for m in d.get("publish", [])]
-    ctrl = _build_control(d["control"]) if d.get("control") else None
-    return RPC(subscriptions=subs, publish=messages, control=ctrl)
+    subscriptions = [
+        _build_sub_opts(subscription_dict)
+        for subscription_dict in rpc_dict.get("subscriptions", [])
+    ]
+    messages = [_build_message(message_dict) for message_dict in rpc_dict.get("publish", [])]
+    control = _build_control(rpc_dict["control"]) if rpc_dict.get("control") else None
+    return RPC(subscriptions=subscriptions, publish=messages, control=control)
 
 
-def _build_sub_opts(d: dict[str, Any]) -> SubOpts:
+def _build_sub_opts(sub_opts_dict: dict[str, Any]) -> SubOpts:
     """Build a SubOpts from a dict."""
-    return SubOpts(subscribe=d["subscribe"], topic_id=TopicId(d["topicId"]))
+    return SubOpts(subscribe=sub_opts_dict["subscribe"], topic_id=TopicId(sub_opts_dict["topicId"]))
 
 
-def _build_message(d: dict[str, Any]) -> Message:
+def _build_message(message_dict: dict[str, Any]) -> Message:
     """Build a Message from a dict. Bytes fields are hex-encoded."""
     return Message(
-        from_peer=_from_hex(d["fromPeer"]) if d.get("fromPeer") else b"",
-        data=_from_hex(d["data"]) if d.get("data") else b"",
-        seqno=_from_hex(d["seqno"]) if d.get("seqno") else b"",
-        topic=TopicId(d.get("topic", "")),
-        signature=_from_hex(d["signature"]) if d.get("signature") else b"",
-        key=_from_hex(d["key"]) if d.get("key") else b"",
+        from_peer=_from_hex(message_dict["fromPeer"]) if message_dict.get("fromPeer") else b"",
+        data=_from_hex(message_dict["data"]) if message_dict.get("data") else b"",
+        seqno=_from_hex(message_dict["seqno"]) if message_dict.get("seqno") else b"",
+        topic=TopicId(message_dict.get("topic", "")),
+        signature=_from_hex(message_dict["signature"]) if message_dict.get("signature") else b"",
+        key=_from_hex(message_dict["key"]) if message_dict.get("key") else b"",
     )
 
 
-def _build_control(d: dict[str, Any]) -> ControlMessage:
+def _build_control(control_dict: dict[str, Any]) -> ControlMessage:
     """Build a ControlMessage from a dict."""
     return ControlMessage(
-        ihave=[_build_ihave(x) for x in d.get("ihave", [])],
-        iwant=[_build_iwant(x) for x in d.get("iwant", [])],
-        graft=[ControlGraft(topic_id=TopicId(x["topicId"])) for x in d.get("graft", [])],
-        prune=[_build_prune(x) for x in d.get("prune", [])],
-        idontwant=[_build_idontwant(x) for x in d.get("idontwant", [])],
+        ihave=[_build_ihave(ihave_dict) for ihave_dict in control_dict.get("ihave", [])],
+        iwant=[_build_iwant(iwant_dict) for iwant_dict in control_dict.get("iwant", [])],
+        graft=[
+            ControlGraft(topic_id=TopicId(graft_dict["topicId"]))
+            for graft_dict in control_dict.get("graft", [])
+        ],
+        prune=[_build_prune(prune_dict) for prune_dict in control_dict.get("prune", [])],
+        idontwant=[
+            _build_idontwant(idontwant_dict) for idontwant_dict in control_dict.get("idontwant", [])
+        ],
     )
 
 
-def _build_ihave(d: dict[str, Any]) -> ControlIHave:
+def _build_ihave(ihave_dict: dict[str, Any]) -> ControlIHave:
     """Build a ControlIHave from a dict."""
     return ControlIHave(
-        topic_id=TopicId(d.get("topicId", "")),
-        message_ids=[_from_hex(mid) for mid in d.get("messageIds", [])],
+        topic_id=TopicId(ihave_dict.get("topicId", "")),
+        message_ids=[
+            _from_hex(message_id_hex) for message_id_hex in ihave_dict.get("messageIds", [])
+        ],
     )
 
 
-def _build_iwant(d: dict[str, Any]) -> ControlIWant:
+def _build_iwant(iwant_dict: dict[str, Any]) -> ControlIWant:
     """Build a ControlIWant from a dict."""
-    return ControlIWant(message_ids=[_from_hex(mid) for mid in d.get("messageIds", [])])
+    return ControlIWant(
+        message_ids=[
+            _from_hex(message_id_hex) for message_id_hex in iwant_dict.get("messageIds", [])
+        ]
+    )
 
 
-def _build_prune(d: dict[str, Any]) -> ControlPrune:
+def _build_prune(prune_dict: dict[str, Any]) -> ControlPrune:
     """Build a ControlPrune from a dict."""
     return ControlPrune(
-        topic_id=TopicId(d.get("topicId", "")),
-        backoff=d.get("backoff", 0),
+        topic_id=TopicId(prune_dict.get("topicId", "")),
+        backoff=prune_dict.get("backoff", 0),
     )
 
 
-def _build_idontwant(d: dict[str, Any]) -> ControlIDontWant:
+def _build_idontwant(idontwant_dict: dict[str, Any]) -> ControlIDontWant:
     """Build a ControlIDontWant from a dict."""
-    return ControlIDontWant(message_ids=[_from_hex(mid) for mid in d.get("messageIds", [])])
+    return ControlIDontWant(
+        message_ids=[
+            _from_hex(message_id_hex) for message_id_hex in idontwant_dict.get("messageIds", [])
+        ]
+    )

--- a/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
@@ -53,13 +53,13 @@ class PoseidonPermutationTest(BaseConsensusFixture):
         else:
             raise ValueError(f"Unsupported Poseidon width: {self.width}")
 
-        state_ints = [int(x) for x in self.input["inputState"]]
+        state_ints = [int(raw_element) for raw_element in self.input["inputState"]]
         if len(state_ints) != self.width:
             raise ValueError(
                 f"Input state length {len(state_ints)} does not match width {self.width}"
             )
 
-        input_state = [Fp(v) for v in state_ints]
+        input_state = [Fp(state_int) for state_int in state_ints]
         output_state = engine.permute(input_state)
 
         self.output = {"outputState": [str(int(fp)) for fp in output_state]}

--- a/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
@@ -51,18 +51,18 @@ class SlotClockTest(BaseConsensusFixture):
         }
         match self.operation:
             case "from_unix_time":
-                result = self._make_from_unix_time()
+                computed_output = self._make_from_unix_time()
             case "from_slot":
-                result = self._make_from_slot()
+                computed_output = self._make_from_slot()
             case "current_slot":
-                result = self._make_current_slot()
+                computed_output = self._make_current_slot()
             case "current_interval":
-                result = self._make_current_interval()
+                computed_output = self._make_current_interval()
             case "total_intervals":
-                result = self._make_total_intervals()
+                computed_output = self._make_total_intervals()
             case _:
                 raise ValueError(f"Unknown operation: {self.operation}")
-        self.output = {"config": config, **result}
+        self.output = {"config": config, **computed_output}
         return self
 
     def _make_from_unix_time(self) -> dict[str, Any]:

--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -56,20 +56,20 @@ class SSZTest(BaseConsensusFixture):
     """Hex hash_tree_root. Empty in decode-failure mode."""
 
     @field_serializer("value", when_used="json")
-    def serialize_value(self, value: SSZType) -> Any:
+    def serialize_value(self, ssz_value: SSZType) -> Any:
         """Convert an SSZ value to a JSON-safe representation."""
-        if isinstance(value, CamelModel):
-            return value.to_json()
+        if isinstance(ssz_value, CamelModel):
+            return ssz_value.to_json()
         # Boolean before int — Boolean subclasses int.
-        if isinstance(value, Boolean):
-            return bool(value)
-        if isinstance(value, bytes):
-            return "0x" + value.hex()
-        if isinstance(value, int):
-            return str(value)
-        if isinstance(value, Fp):
-            return str(value.value)
-        return str(value)
+        if isinstance(ssz_value, Boolean):
+            return bool(ssz_value)
+        if isinstance(ssz_value, bytes):
+            return "0x" + ssz_value.hex()
+        if isinstance(ssz_value, int):
+            return str(ssz_value)
+        if isinstance(ssz_value, Fp):
+            return str(ssz_value.value)
+        return str(ssz_value)
 
     def make_fixture(self) -> "SSZTest":
         """

--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -87,19 +87,19 @@ class StateTransitionTest(BaseConsensusFixture):
     """Expected exception message for invalid tests."""
 
     @field_serializer("blocks", when_used="json")
-    def serialize_blocks(self, value: list[BlockSpec]) -> list[dict[str, Any]]:
+    def serialize_blocks(self, block_specs: list[BlockSpec]) -> list[dict[str, Any]]:
         """
         Serialize filled blocks instead of the input specs.
 
         Ensures fixture output contains complete blocks, not partial specs.
 
         Args:
-            value: The BlockSpec list (ignored; filled blocks are used instead).
+            block_specs: The BlockSpec list (ignored; filled blocks are used instead).
 
         Returns:
             The serialized blocks.
         """
-        del value
+        del block_specs
         return [block.to_json() for block in self._filled_blocks]
 
     def make_fixture(self) -> "StateTransitionTest":
@@ -147,12 +147,14 @@ class StateTransitionTest(BaseConsensusFixture):
                     state = spec.state_transition(state, block=block)
 
             actual_post_state = state
-        except (AssertionError, ValueError) as e:
-            exception_raised = e
+        except (AssertionError, ValueError) as exception:
+            exception_raised = exception
             # If we expect an exception, this is fine
             if self.expect_exception is None:
                 # Unexpected failure
-                raise AssertionError(f"Unexpected error processing blocks: {e}") from e
+                raise AssertionError(
+                    f"Unexpected error processing blocks: {exception}"
+                ) from exception
         finally:
             # Always store filled blocks for serialization, even if an exception occurred
             # This ensures the test fixture includes all blocks that were attempted
@@ -256,7 +258,9 @@ class StateTransitionTest(BaseConsensusFixture):
                     spec.attestations, state, block_registry
                 )
 
-            known_block_roots = frozenset(hash_tree_root(b) for b in block_registry.values())
+            known_block_roots = frozenset(
+                hash_tree_root(block) for block in block_registry.values()
+            )
 
             block, post_state, _, _ = LstarSpec().build_block(
                 state,

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_multi_message_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_multi_message_proofs.py
@@ -183,7 +183,7 @@ class VerifyMultiMessageProofsTest(BaseConsensusFixture):
         # Phase 2: honest merge.
         merged = MultiMessageAggregate.aggregate(
             components,
-            public_keys_per_part=public_keys_per_message,
+            public_keys_per_aggregate=public_keys_per_message,
         )
 
         # Phase 3: optionally mutate exactly one binding of the bundle.
@@ -208,7 +208,7 @@ class VerifyMultiMessageProofsTest(BaseConsensusFixture):
                 )
                 merged = MultiMessageAggregate.aggregate(
                     components,
-                    public_keys_per_part=public_keys_per_message,
+                    public_keys_per_aggregate=public_keys_per_message,
                 )
 
             case IncrementComponentSlot(component_index=component_index):

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -121,12 +121,14 @@ class VerifySignaturesTest(BaseConsensusFixture):
         # Verify signatures
         try:
             LstarSpec().verify_signatures(signed_block, self.anchor_state.validators)
-        except AssertionError as e:
-            exception_raised = e
+        except AssertionError as exception:
+            exception_raised = exception
             # If we expect an exception, this is fine
             if self.expect_exception is None:
                 # Unexpected failure
-                raise AssertionError(f"Unexpected error verifying block signature(s): {e}") from e
+                raise AssertionError(
+                    f"Unexpected error verifying block signature(s): {exception}"
+                ) from exception
         finally:
             # Always store filled block for serialization, even if an exception occurred
             # This ensures the test fixture contains the signed block that consumer can test with
@@ -163,24 +165,28 @@ class VerifySignaturesTest(BaseConsensusFixture):
         operation = self.tamper.get("operation")
 
         if operation == "set_proposer_index":
-            value = self.tamper.get("value")
-            if value is None:
+            new_proposer_index = self.tamper.get("value")
+            if new_proposer_index is None:
                 raise ValueError("set_proposer_index requires a value")
             return signed_block.model_copy(
                 update={
                     "block": signed_block.block.model_copy(
-                        update={"proposer_index": ValidatorIndex(int(value))}
+                        update={"proposer_index": ValidatorIndex(int(new_proposer_index))}
                     )
                 }
             )
 
         if operation == "clear_first_attestation_bits":
-            original = signed_block.block.body.attestations.data
-            if not original:
+            attestations = signed_block.block.body.attestations.data
+            if not attestations:
                 raise ValueError("clear_first_attestation_bits requires at least one attestation")
-            first = original[0]
-            empty_bits = AggregationBits(data=[Boolean(False)] * len(first.aggregation_bits.data))
-            cleared = AggregatedAttestation(aggregation_bits=empty_bits, data=first.data)
+            first_attestation = attestations[0]
+            empty_bits = AggregationBits(
+                data=[Boolean(False)] * len(first_attestation.aggregation_bits.data)
+            )
+            cleared = AggregatedAttestation(
+                aggregation_bits=empty_bits, data=first_attestation.data
+            )
             return signed_block.model_copy(
                 update={
                     "block": signed_block.block.model_copy(
@@ -188,7 +194,7 @@ class VerifySignaturesTest(BaseConsensusFixture):
                             "body": signed_block.block.body.model_copy(
                                 update={
                                     "attestations": AggregatedAttestations(
-                                        data=[cleared, *original[1:]]
+                                        data=[cleared, *attestations[1:]]
                                     )
                                 }
                             )
@@ -255,8 +261,8 @@ class VerifySignaturesTest(BaseConsensusFixture):
 
         if operation == "swap_first_two_attestations":
             body = signed_block.block.body
-            original = body.attestations.data
-            if len(original) < 2:
+            attestations = body.attestations.data
+            if len(attestations) < 2:
                 raise ValueError("swap_first_two_attestations requires at least two attestations")
             assert self.anchor_state is not None
 
@@ -266,13 +272,13 @@ class VerifySignaturesTest(BaseConsensusFixture):
                     list(attestation.aggregation_bits.to_validator_indices()),
                     attestation.data,
                 )
-                for attestation in original
+                for attestation in attestations
             ]
 
             swapped_body = body.model_copy(
                 update={
                     "attestations": AggregatedAttestations(
-                        data=[original[1], original[0], *original[2:]]
+                        data=[attestations[1], attestations[0], *attestations[2:]]
                     )
                 }
             )

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -295,25 +295,25 @@ class BlockSpec(CamelModel):
                 slot=self.slot,
             )
 
-            public_keys_per_part: list[list] = [
+            public_keys_per_aggregate: list[list] = [
                 [
                     state.validators[validator_index].get_attestation_public_key()
-                    for validator_index in proof.participants.to_validator_indices()
+                    for validator_index in attestation_proof.participants.to_validator_indices()
                 ]
-                for proof in attestation_proofs
+                for attestation_proof in attestation_proofs
             ]
-            public_keys_per_part.append([proposer_public_key])
+            public_keys_per_aggregate.append([proposer_public_key])
 
-            proof = MultiMessageAggregate.aggregate(
+            block_proof = MultiMessageAggregate.aggregate(
                 [*attestation_proofs, proposer_single_message_aggregate],
-                public_keys_per_part=public_keys_per_part,
+                public_keys_per_aggregate=public_keys_per_aggregate,
             )
         else:
-            proof = MultiMessageAggregate(proof=ByteList512KiB(data=b""))
+            block_proof = MultiMessageAggregate(proof=ByteList512KiB(data=b""))
 
         return SignedBlock(
             block=final_block,
-            proof=proof,
+            proof=block_proof,
         )
 
     def build_signed_block(
@@ -391,9 +391,9 @@ class BlockSpec(CamelModel):
         aggregated_attestations = [
             AggregatedAttestation(
                 aggregation_bits=AggregationBits.from_indices(validator_indices),
-                data=data,
+                data=attestation_data,
             )
-            for data, validator_indices in data_to_validator_indices.items()
+            for attestation_data, validator_indices in data_to_validator_indices.items()
         ]
         attestation_signatures = key_manager.build_attestation_proofs(
             AggregatedAttestations(data=aggregated_attestations),
@@ -532,9 +532,12 @@ class BlockSpec(CamelModel):
 
         # Merge new known payloads (built locally) back into the caller's
         # store while leaving every other field untouched.
-        merged_known = {k: set(v) for k, v in caller_store.latest_known_aggregated_payloads.items()}
-        for data, proofs in merged_store.latest_known_aggregated_payloads.items():
-            merged_known.setdefault(data, set()).update(proofs)
+        merged_known = {
+            attestation_data: set(proofs)
+            for attestation_data, proofs in caller_store.latest_known_aggregated_payloads.items()
+        }
+        for attestation_data, proofs in merged_store.latest_known_aggregated_payloads.items():
+            merged_known.setdefault(attestation_data, set()).update(proofs)
         caller_store.latest_known_aggregated_payloads = merged_known
         store = caller_store
 

--- a/packages/testing/src/consensus_testing/test_types/state_expectation.py
+++ b/packages/testing/src/consensus_testing/test_types/state_expectation.py
@@ -166,29 +166,30 @@ class StateExpectation(CamelModel):
 
         for field_name in fields & self._ACCESSORS.keys():
             accessor = self._ACCESSORS[field_name]
-            expected = getattr(self, field_name)
-            actual = accessor(state)
-            if actual != expected:
+            expected_field_value = getattr(self, field_name)
+            actual_field_value = accessor(state)
+            if actual_field_value != expected_field_value:
                 raise AssertionError(
-                    f"State validation failed: {field_name} = {actual}, expected {expected}"
+                    f"State validation failed: {field_name} = {actual_field_value}, "
+                    f"expected {expected_field_value}"
                 )
 
         if "latest_justified_root_label" in fields:
             assert self.latest_justified_root_label is not None
-            expected = _resolve(self.latest_justified_root_label)
-            if state.latest_justified.root != expected:
+            expected_justified_root = _resolve(self.latest_justified_root_label)
+            if state.latest_justified.root != expected_justified_root:
                 raise AssertionError(
                     f"State validation failed: latest_justified.root = "
-                    f"{state.latest_justified.root}, expected {expected}"
+                    f"{state.latest_justified.root}, expected {expected_justified_root}"
                 )
 
         if "latest_finalized_root_label" in fields:
             assert self.latest_finalized_root_label is not None
-            expected = _resolve(self.latest_finalized_root_label)
-            if state.latest_finalized.root != expected:
+            expected_finalized_root = _resolve(self.latest_finalized_root_label)
+            if state.latest_finalized.root != expected_finalized_root:
                 raise AssertionError(
                     f"State validation failed: latest_finalized.root = "
-                    f"{state.latest_finalized.root}, expected {expected}"
+                    f"{state.latest_finalized.root}, expected {expected_finalized_root}"
                 )
 
         if "justifications_roots_labels" in fields:

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -109,7 +109,7 @@ class BlockStep(BaseForkChoiceStep):
     """The filled Block, processed through the spec."""
 
     @field_serializer("block", when_used="json")
-    def serialize_block(self, value: BlockSpec) -> dict[str, Any]:
+    def serialize_block(self, block_spec: BlockSpec) -> dict[str, Any]:
         """
         Serialize the filled Block instead of the BlockSpec.
 
@@ -118,7 +118,7 @@ class BlockStep(BaseForkChoiceStep):
 
         Parameters:
         ----------
-        value : BlockSpec
+        block_spec : BlockSpec
             The BlockSpec field value (ignored, we use _filled_block instead).
 
         Returns:
@@ -136,10 +136,10 @@ class BlockStep(BaseForkChoiceStep):
                 "Block not filled yet - make_fixture() must be called before serialization. "
                 "This BlockStep should only be serialized after the fixture has been processed."
             )
-        result = self._filled_block.to_json()
-        if value.label:
-            result["blockRootLabel"] = value.label
-        return result
+        serialized_block = self._filled_block.to_json()
+        if block_spec.label:
+            serialized_block["blockRootLabel"] = block_spec.label
+        return serialized_block
 
 
 class AttestationStep(BaseForkChoiceStep):
@@ -177,7 +177,9 @@ class AttestationStep(BaseForkChoiceStep):
     """The filled SignedAttestation, processed through the spec."""
 
     @field_serializer("attestation", when_used="json")
-    def serialize_gossip_attestation(self, value: GossipAttestationSpec) -> dict[str, Any]:
+    def serialize_gossip_attestation(
+        self, attestation_spec: GossipAttestationSpec
+    ) -> dict[str, Any]:
         """
         Serialize the filled SignedAttestation instead of the spec.
 
@@ -186,7 +188,7 @@ class AttestationStep(BaseForkChoiceStep):
 
         Parameters:
         ----------
-        value : GossipAttestationSpec
+        attestation_spec : GossipAttestationSpec
             The spec field value (ignored, we use _filled_attestation instead).
 
         Returns:

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -79,38 +79,38 @@ class AttestationCheck(CamelModel):
         fields_to_check = self.model_fields_set - {"validator", "location"}
 
         for field_name in fields_to_check:
-            expected = getattr(self, field_name)
+            expected_slot = getattr(self, field_name)
 
             if field_name == "attestation_slot":
-                actual = attestation.slot
-                if actual != expected:
+                actual_slot = attestation.slot
+                if actual_slot != expected_slot:
                     raise AssertionError(
                         f"Step {step_index}: validator {self.validator} {location} "
-                        f"attestation slot = {actual}, expected {expected}"
+                        f"attestation slot = {actual_slot}, expected {expected_slot}"
                     )
 
             elif field_name == "head_slot":
-                actual = attestation.head.slot
-                if actual != expected:
+                actual_slot = attestation.head.slot
+                if actual_slot != expected_slot:
                     raise AssertionError(
                         f"Step {step_index}: validator {self.validator} {location} "
-                        f"head slot = {actual}, expected {expected}"
+                        f"head slot = {actual_slot}, expected {expected_slot}"
                     )
 
             elif field_name == "source_slot":
-                actual = attestation.source.slot
-                if actual != expected:
+                actual_slot = attestation.source.slot
+                if actual_slot != expected_slot:
                     raise AssertionError(
                         f"Step {step_index}: validator {self.validator} {location} "
-                        f"source slot = {actual}, expected {expected}"
+                        f"source slot = {actual_slot}, expected {expected_slot}"
                     )
 
             elif field_name == "target_slot":
-                actual = attestation.target.slot
-                if actual != expected:
+                actual_slot = attestation.target.slot
+                if actual_slot != expected_slot:
                     raise AssertionError(
                         f"Step {step_index}: validator {self.validator} {location} "
-                        f"target slot = {actual}, expected {expected}"
+                        f"target slot = {actual_slot}, expected {expected_slot}"
                     )
 
 
@@ -338,8 +338,8 @@ class StoreChecks(CamelModel):
         # Label-based root checks (resolve label -> root, then compare)
         if "head_root_label" in fields:
             assert self.head_root_label is not None
-            expected = _resolve(self.head_root_label)
-            _check("head.root", store.head, expected)
+            expected_head_root = _resolve(self.head_root_label)
+            _check("head.root", store.head, expected_head_root)
         if "filled_block_root_label" in fields:
             if filled_block is None:
                 raise ValueError(
@@ -347,81 +347,105 @@ class StoreChecks(CamelModel):
                     f"filled_block not provided"
                 )
             assert self.filled_block_root_label is not None
-            expected = _resolve(self.filled_block_root_label)
-            _check("filled_block.root", hash_tree_root(filled_block), expected)
+            expected_filled_block_root = _resolve(self.filled_block_root_label)
+            _check("filled_block.root", hash_tree_root(filled_block), expected_filled_block_root)
         if "latest_justified_root_label" in fields:
             assert self.latest_justified_root_label is not None
-            expected = _resolve(self.latest_justified_root_label)
-            _check("latest_justified.root", store.latest_justified.root, expected)
+            expected_justified_root = _resolve(self.latest_justified_root_label)
+            _check("latest_justified.root", store.latest_justified.root, expected_justified_root)
         if "latest_finalized_root_label" in fields:
             assert self.latest_finalized_root_label is not None
-            expected = _resolve(self.latest_finalized_root_label)
-            _check("latest_finalized.root", store.latest_finalized.root, expected)
+            expected_finalized_root = _resolve(self.latest_finalized_root_label)
+            _check("latest_finalized.root", store.latest_finalized.root, expected_finalized_root)
         if "safe_target_root_label" in fields:
             assert self.safe_target_root_label is not None
-            expected = _resolve(self.safe_target_root_label)
-            _check("safe_target", store.safe_target, expected)
+            expected_safe_target_root = _resolve(self.safe_target_root_label)
+            _check("safe_target", store.safe_target, expected_safe_target_root)
 
         # Attestation target checkpoint (slot + root consistency)
         if "attestation_target_slot" in fields:
-            target = LstarSpec().get_attestation_target(store)
-            _check("attestation_target.slot", target.slot, self.attestation_target_slot)
+            attestation_target = LstarSpec().get_attestation_target(store)
+            _check("attestation_target.slot", attestation_target.slot, self.attestation_target_slot)
 
             block_found = any(
-                b.slot == self.attestation_target_slot and r == target.root
-                for r, b in store.blocks.items()
+                block.slot == self.attestation_target_slot and block_root == attestation_target.root
+                for block_root, block in store.blocks.items()
             )
             if not block_found:
-                available = [
-                    f"0x{r.hex()}"
-                    for r, b in store.blocks.items()
-                    if b.slot == self.attestation_target_slot
+                block_roots_at_target_slot = [
+                    f"0x{block_root.hex()}"
+                    for block_root, block in store.blocks.items()
+                    if block.slot == self.attestation_target_slot
                 ]
                 raise AssertionError(
                     f"Step {step_index}: attestation_target.root = "
-                    f"0x{target.root.hex()} does not match any "
+                    f"0x{attestation_target.root.hex()} does not match any "
                     f"block at slot {self.attestation_target_slot}. "
-                    f"Available blocks: {available}"
+                    f"Available blocks: {block_roots_at_target_slot}"
                 )
 
         # Per-validator attestation content checks
         if "attestation_checks" in fields:
             assert self.attestation_checks is not None
-            for check in self.attestation_checks:
-                if check.location == "new":
+            for attestation_check in self.attestation_checks:
+                if attestation_check.location == "new":
                     payloads = store.latest_new_aggregated_payloads
                     label = "in latest_new"
                 else:
                     payloads = store.latest_known_aggregated_payloads
                     label = "in latest_known"
 
-                extracted = LstarSpec().extract_attestations_from_aggregated_payloads(
+                extracted_attestations = LstarSpec().extract_attestations_from_aggregated_payloads(
                     store, payloads
                 )
-                if check.validator not in extracted:
+                if attestation_check.validator not in extracted_attestations:
                     raise AssertionError(
-                        f"Step {step_index}: validator {check.validator} not found "
+                        f"Step {step_index}: validator {attestation_check.validator} not found "
                         f"{label}_aggregated_payloads"
                     )
-                check.validate_attestation(extracted[check.validator], label, step_index)
+                attestation_check.validate_attestation(
+                    extracted_attestations[attestation_check.validator], label, step_index
+                )
 
         if "attestation_signature_target_slots" in fields:
             assert self.attestation_signature_target_slots is not None
-            actual = sorted({data.target.slot for data in store.attestation_signatures})
-            expected = sorted(self.attestation_signature_target_slots)
-            _check("attestation_signatures.target_slots", actual, expected)
+            actual_target_slots = sorted(
+                {attestation_data.target.slot for attestation_data in store.attestation_signatures}
+            )
+            expected_target_slots = sorted(self.attestation_signature_target_slots)
+            _check(
+                "attestation_signatures.target_slots", actual_target_slots, expected_target_slots
+            )
 
         if "latest_new_aggregated_target_slots" in fields:
             assert self.latest_new_aggregated_target_slots is not None
-            actual = sorted({data.target.slot for data in store.latest_new_aggregated_payloads})
-            expected = sorted(self.latest_new_aggregated_target_slots)
-            _check("latest_new_aggregated_payloads.target_slots", actual, expected)
+            actual_target_slots = sorted(
+                {
+                    attestation_data.target.slot
+                    for attestation_data in store.latest_new_aggregated_payloads
+                }
+            )
+            expected_target_slots = sorted(self.latest_new_aggregated_target_slots)
+            _check(
+                "latest_new_aggregated_payloads.target_slots",
+                actual_target_slots,
+                expected_target_slots,
+            )
 
         if "latest_known_aggregated_target_slots" in fields:
             assert self.latest_known_aggregated_target_slots is not None
-            actual = sorted({data.target.slot for data in store.latest_known_aggregated_payloads})
-            expected = sorted(self.latest_known_aggregated_target_slots)
-            _check("latest_known_aggregated_payloads.target_slots", actual, expected)
+            actual_target_slots = sorted(
+                {
+                    attestation_data.target.slot
+                    for attestation_data in store.latest_known_aggregated_payloads
+                }
+            )
+            expected_target_slots = sorted(self.latest_known_aggregated_target_slots)
+            _check(
+                "latest_known_aggregated_payloads.target_slots",
+                actual_target_slots,
+                expected_target_slots,
+            )
 
         # Block body attestation count
         if "block_attestation_count" in fields:
@@ -497,44 +521,49 @@ class StoreChecks(CamelModel):
         """Validate detailed attestation structure in the block body."""
         actual_attestations = filled_block.body.attestations.data
         actual_participants_list = [
-            {int(v) for v in attestation.aggregation_bits.to_validator_indices()}
+            {
+                int(validator_index)
+                for validator_index in attestation.aggregation_bits.to_validator_indices()
+            }
             for attestation in actual_attestations
         ]
 
-        for check in expected_checks:
+        for attestation_check in expected_checks:
             matching_attestation = None
             matching_index = None
-            for index, attestation in enumerate(actual_attestations):
+            for attestation_index, attestation in enumerate(actual_attestations):
                 actual_participants = {
-                    int(v) for v in attestation.aggregation_bits.to_validator_indices()
+                    int(validator_index)
+                    for validator_index in attestation.aggregation_bits.to_validator_indices()
                 }
-                if actual_participants == check.participants:
+                if actual_participants == attestation_check.participants:
                     matching_attestation = attestation
-                    matching_index = index
+                    matching_index = attestation_index
                     break
 
             if matching_attestation is None:
                 raise AssertionError(
                     f"Step {step_index}: no aggregated attestation found with "
-                    f"participants={check.participants}\n"
+                    f"participants={attestation_check.participants}\n"
                     f"Available attestations: {actual_participants_list}"
                 )
 
-            if check.attestation_slot is not None:
-                if matching_attestation.data.slot != check.attestation_slot:
+            if attestation_check.attestation_slot is not None:
+                if matching_attestation.data.slot != attestation_check.attestation_slot:
                     raise AssertionError(
                         f"Step {step_index}: attestation[{matching_index}] with "
-                        f"participants={check.participants} has "
-                        f"slot={matching_attestation.data.slot}, expected {check.attestation_slot}"
+                        f"participants={attestation_check.participants} has "
+                        f"slot={matching_attestation.data.slot}, "
+                        f"expected {attestation_check.attestation_slot}"
                     )
 
-            if check.target_slot is not None:
-                if matching_attestation.data.target.slot != check.target_slot:
+            if attestation_check.target_slot is not None:
+                if matching_attestation.data.target.slot != attestation_check.target_slot:
                     raise AssertionError(
                         f"Step {step_index}: attestation[{matching_index}] with "
-                        f"participants={check.participants} has "
+                        f"participants={attestation_check.participants} has "
                         f"target_slot={matching_attestation.data.target.slot}, "
-                        f"expected {check.target_slot}"
+                        f"expected {attestation_check.target_slot}"
                     )
 
     @staticmethod
@@ -574,13 +603,13 @@ class StoreChecks(CamelModel):
                 if attestation_head_root == root:
                     weight += 1
                 elif attestation_head_root in store.blocks:
-                    current = attestation_head_root
-                    while current in store.blocks and store.blocks[current].slot > slot:
-                        parent = store.blocks[current].parent_root
+                    ancestor_root = attestation_head_root
+                    while ancestor_root in store.blocks and store.blocks[ancestor_root].slot > slot:
+                        parent = store.blocks[ancestor_root].parent_root
                         if parent == root:
                             weight += 1
                             break
-                        current = parent
+                        ancestor_root = parent
 
             fork_data[label] = (root, slot, weight)
 

--- a/packages/testing/src/framework/forks/registry.py
+++ b/packages/testing/src/framework/forks/registry.py
@@ -11,10 +11,14 @@ class ForkRegistry:
     def __init__(self, forks_module: ModuleType) -> None:
         """Scan a forks module and build the name index."""
         discovered: set[type[BaseFork]] = set()
-        for name in dir(forks_module):
-            obj = getattr(forks_module, name)
-            if isinstance(obj, type) and issubclass(obj, BaseFork) and obj is not BaseFork:
-                discovered.add(obj)
+        for attribute_name in dir(forks_module):
+            module_attribute = getattr(forks_module, attribute_name)
+            if (
+                isinstance(module_attribute, type)
+                and issubclass(module_attribute, BaseFork)
+                and module_attribute is not BaseFork
+            ):
+                discovered.add(module_attribute)
 
         self._forks = frozenset(fork for fork in discovered if not fork.ignore())
         self._by_name: dict[str, type[BaseFork]] = {

--- a/packages/testing/src/framework/pytest_plugins/filler.py
+++ b/packages/testing/src/framework/pytest_plugins/filler.py
@@ -116,8 +116,8 @@ class FixtureCollector:
                 fixture_dict = fixture.json_dict_with_info()
                 all_tests[test_id] = fixture_dict
 
-            with open(output_file, "w") as f:
-                json.dump(all_tests, f, indent=4)
+            with open(output_file, "w") as output_handle:
+                json.dump(all_tests, output_handle, indent=4)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -173,11 +173,11 @@ def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool 
         return None
 
     # Check if it's a different layer directory or unit tests
-    parts = relative_path.parts
-    if parts:
+    path_components = relative_path.parts
+    if path_components:
         # Known layer directories
         known_layers = {"consensus", "execution"}
-        if parts[0] in known_layers:
+        if path_components[0] in known_layers:
             # It's a different layer, ignore it
             return True
         # It's probably unit tests (tests/lean_spec), ignore during fill
@@ -204,9 +204,9 @@ def pytest_configure(config: pytest.Config) -> None:
     try:
         layer_module = importlib.import_module(f"{layer}_testing")
         config.layer_module = layer_module  # type: ignore[attribute-defined]
-    except ImportError as e:
+    except ImportError as exception:
         pytest.exit(
-            f"Failed to import {layer}_testing module: {e}",
+            f"Failed to import {layer}_testing module: {exception}",
             returncode=pytest.ExitCode.USAGE_ERROR,
         )
 
@@ -260,13 +260,15 @@ def pytest_configure(config: pytest.Config) -> None:
     # Check output directory
     if output_directory.exists() and any(output_directory.iterdir()):
         if not clean:
-            contents = list(output_directory.iterdir())
-            summary = ", ".join(item.name for item in contents[:5])
-            if len(contents) > 5:
-                summary += ", ..."
+            leftover_fixture_paths = list(output_directory.iterdir())
+            leftover_names_preview = ", ".join(
+                leftover_path.name for leftover_path in leftover_fixture_paths[:5]
+            )
+            if len(leftover_fixture_paths) > 5:
+                leftover_names_preview += ", ..."
             pytest.exit(
                 f"Output directory '{output_directory}' is not empty. "
-                f"Contains: {summary}. Use --clean to remove all existing files "
+                f"Contains: {leftover_names_preview}. Use --clean to remove all existing files "
                 "or specify a different output directory.",
                 returncode=pytest.ExitCode.USAGE_ERROR,
             )
@@ -288,21 +290,21 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     layer_module = config.layer_module
     registry = layer_module.forks.registry
     verbose = config.getoption("verbose")
-    deselected = []
-    selected = []
+    deselected_items = []
+    selected_items = []
 
-    for item in items:
-        if not _is_test_item_valid_for_fork(item, fork_class, registry.get_fork_by_name):
+    for test_item in items:
+        if not _is_test_item_valid_for_fork(test_item, fork_class, registry.get_fork_by_name):
             if verbose < 2:
-                deselected.append(item)
+                deselected_items.append(test_item)
             else:
-                selected.append(item)
+                selected_items.append(test_item)
         else:
-            selected.append(item)
+            selected_items.append(test_item)
 
-    if deselected:
-        items[:] = selected
-        config.hook.pytest_deselected(items=deselected)
+    if deselected_items:
+        items[:] = selected_items
+        config.hook.pytest_deselected(items=deselected_items)
 
 
 def _check_markers_valid_for_fork(
@@ -568,8 +570,8 @@ def _register_layer_fixtures(config: pytest.Config, layer: str) -> None:
             fixture_func = base_spec_filler_parametrizer(fixture_class)
             # Add to module globals so pytest can discover them
             globals()[format_name] = fixture_func
-    except (ImportError, AttributeError) as e:
+    except (ImportError, AttributeError) as exception:
         pytest.exit(
-            f"Failed to load {layer} layer test fixtures: {e}",
+            f"Failed to load {layer} layer test fixtures: {exception}",
             returncode=pytest.ExitCode.USAGE_ERROR,
         )

--- a/src/lean_spec/node/api/endpoints/aggregator.py
+++ b/src/lean_spec/node/api/endpoints/aggregator.py
@@ -57,22 +57,22 @@ async def handle_toggle(request: web.Request) -> web.Response:
         raise web.HTTPServiceUnavailable(reason="Aggregator controller not available")
 
     try:
-        payload = await request.json()
+        request_body = await request.json()
     except json.JSONDecodeError as exception:
         raise web.HTTPBadRequest(reason="Invalid JSON body") from exception
 
-    if not isinstance(payload, dict) or "enabled" not in payload:
+    if not isinstance(request_body, dict) or "enabled" not in request_body:
         raise web.HTTPBadRequest(reason="Missing 'enabled' field in body")
 
-    enabled = payload["enabled"]
+    enabled = request_body["enabled"]
     # Explicit bool check rejects ints like 0/1, which JSON does not distinguish
     # from booleans in loose parsers but Python does.
     if not isinstance(enabled, bool):
         raise web.HTTPBadRequest(reason="'enabled' must be a boolean")
 
-    previous = await controller.set_enabled(enabled)
+    previous_aggregator_state = await controller.set_enabled(enabled)
 
     return web.Response(
-        body=json.dumps({"is_aggregator": enabled, "previous": previous}),
+        body=json.dumps({"is_aggregator": enabled, "previous": previous_aggregator_state}),
         content_type="application/json",
     )

--- a/src/lean_spec/node/genesis/config.py
+++ b/src/lean_spec/node/genesis/config.py
@@ -104,11 +104,11 @@ class GenesisConfig(StrictBaseModel):
         return Validators(
             data=[
                 Validator(
-                    attestation_public_key=entry.attestation_public_key,
-                    proposal_public_key=entry.proposal_public_key,
-                    index=ValidatorIndex(i),
+                    attestation_public_key=genesis_validator.attestation_public_key,
+                    proposal_public_key=genesis_validator.proposal_public_key,
+                    index=ValidatorIndex(validator_index),
                 )
-                for i, entry in enumerate(self.genesis_validators)
+                for validator_index, genesis_validator in enumerate(self.genesis_validators)
             ]
         )
 
@@ -126,6 +126,6 @@ class GenesisConfig(StrictBaseModel):
             pydantic.ValidationError: If the data fails validation.
         """
         path = Path(path)
-        with path.open(encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-        return cls.model_validate(data)
+        with path.open(encoding="utf-8") as yaml_file:
+            parsed_yaml = yaml.safe_load(yaml_file)
+        return cls.model_validate(parsed_yaml)

--- a/src/lean_spec/node/networking/enr/enr.py
+++ b/src/lean_spec/node/networking/enr/enr.py
@@ -224,9 +224,9 @@ class ENR(StrictBaseModel):
         try:
             # Hash the content (excludes signature).
             content = self._content_rlp()
-            k = keccak.new(digest_bits=256)
-            k.update(content)
-            digest = k.digest()
+            keccak_hasher = keccak.new(digest_bits=256)
+            keccak_hasher.update(content)
+            digest = keccak_hasher.digest()
 
             # Load the compressed public key.
             public_key = ec.EllipticCurvePublicKey.from_encoded_point(
@@ -266,9 +266,9 @@ class ENR(StrictBaseModel):
             )
 
             # Hash the 64-byte x||y (excluding 0x04 prefix).
-            k = keccak.new(digest_bits=256)
-            k.update(uncompressed[1:])
-            return NodeId(k.digest())
+            keccak_hasher = keccak.new(digest_bits=256)
+            keccak_hasher.update(uncompressed[1:])
+            return NodeId(keccak_hasher.digest())
         except (ValueError, TypeError):
             return None
 
@@ -279,8 +279,8 @@ class ENR(StrictBaseModel):
         Format: [signature, seq, k1, v1, k2, v2, ...]
         Keys are sorted lexicographically per EIP-778.
         """
-        items = [bytes(self.signature)] + self._build_content_items()
-        return encode_rlp(items)
+        rlp_items = [bytes(self.signature)] + self._build_content_items()
+        return encode_rlp(rlp_items)
 
     def to_string(self) -> str:
         """
@@ -294,16 +294,16 @@ class ENR(StrictBaseModel):
 
     def __str__(self) -> str:
         """Human-readable summary."""
-        parts = [f"ENR(seq={self.seq}"]
+        summary_fields = [f"ENR(seq={self.seq}"]
         if self.ip4:
-            parts.append(f"ip={self.ip4}")
+            summary_fields.append(f"ip={self.ip4}")
         if self.udp_port:
-            parts.append(f"udp={self.udp_port}")
+            summary_fields.append(f"udp={self.udp_port}")
         if self.quic_port:
-            parts.append(f"quic={self.quic_port}")
+            summary_fields.append(f"quic={self.quic_port}")
         if eth2 := self.eth2_data:
-            parts.append(f"fork={eth2.fork_digest.hex()}")
-        return ", ".join(parts) + ")"
+            summary_fields.append(f"fork={eth2.fork_digest.hex()}")
+        return ", ".join(summary_fields) + ")"
 
     @classmethod
     def from_rlp(cls, rlp_data: bytes) -> Self:
@@ -329,22 +329,22 @@ class ENR(StrictBaseModel):
 
         # RLP decode: [signature, seq, k1, v1, k2, v2, ...]
         try:
-            items = decode_rlp_list(rlp_data)
+            rlp_items = decode_rlp_list(rlp_data)
         except RLPDecodingError as exception:
             raise ValueError(f"Invalid RLP encoding: {exception}") from exception
 
-        if len(items) < 2:
+        if len(rlp_items) < 2:
             raise ValueError("ENR must have at least signature and seq")
 
-        if len(items) % 2 != 0:
+        if len(rlp_items) % 2 != 0:
             raise ValueError("ENR key/value pairs must be even")
 
-        signature_raw = items[0]
+        signature_raw = rlp_items[0]
         if len(signature_raw) != 64:
             raise ValueError(f"ENR signature must be 64 bytes, got {len(signature_raw)}")
         signature = Bytes64(signature_raw)
 
-        seq_bytes = items[1]
+        seq_bytes = rlp_items[1]
         seq = int.from_bytes(seq_bytes, "big") if seq_bytes else 0
 
         # Parse key/value pairs.
@@ -353,15 +353,15 @@ class ENR(StrictBaseModel):
         # EIP-778 requires keys to be lexicographically sorted.
         pairs: dict[EnrKey, bytes] = {}
         previous_key: EnrKey | None = None
-        for i in range(2, len(items), 2):
-            key = EnrKey(items[i].decode("utf-8"))
+        for i in range(2, len(rlp_items), 2):
+            key = EnrKey(rlp_items[i].decode("utf-8"))
             if previous_key is not None and key <= previous_key:
                 raise ValueError(
                     f"ENR keys must be lexicographically sorted per EIP-778: "
                     f"'{key}' follows '{previous_key}'"
                 )
-            value = items[i + 1]
-            pairs[key] = value
+            entry_value = rlp_items[i + 1]
+            pairs[key] = entry_value
             previous_key = key
 
         enr = cls(

--- a/src/lean_spec/node/networking/enr/rlp.py
+++ b/src/lean_spec/node/networking/enr/rlp.py
@@ -61,12 +61,12 @@ class RLPDecodingError(Exception):
     """Raised when RLP input is malformed or non-canonical."""
 
 
-def encode_rlp(item: RLPItem) -> bytes:
+def encode_rlp(rlp_item: RLPItem) -> bytes:
     """
     Encode bytes or a nested list of bytes to RLP.
 
     Args:
-        item: A byte string or a list of items (lists may nest arbitrarily).
+        rlp_item: A byte string or a list of items (lists may nest arbitrarily).
 
     Returns:
         The RLP encoding of the input.
@@ -85,10 +85,10 @@ def encode_rlp(item: RLPItem) -> bytes:
     #   b"\x80"   ->  81 80            (length-prefixed: single byte at or above 0x80)
     #   b""       ->  80               (empty string is the length-zero short form)
     #   b"dog"    ->  83 64 6f 67      (short string of length 3)
-    if isinstance(item, bytes):
-        if len(item) == 1 and item[0] < STRING_BASE:
-            return item
-        return _with_length_prefix(item, base=STRING_BASE)
+    if isinstance(rlp_item, bytes):
+        if len(rlp_item) == 1 and rlp_item[0] < STRING_BASE:
+            return rlp_item
+        return _with_length_prefix(rlp_item, base=STRING_BASE)
 
     # List branch: encode each element, concatenate, then wrap with a list prefix.
     #
@@ -100,11 +100,11 @@ def encode_rlp(item: RLPItem) -> bytes:
     #   []                ->  c0                                    (empty list)
     #   [b"a", b"b"]      ->  c2 61 62                              (short list, payload "a" "b")
     #   [b"dog", b"god"]  ->  c8 83 64 6f 67 83 67 6f 64            (two short strings inside)
-    if isinstance(item, list):
-        payload = b"".join(encode_rlp(element) for element in item)
-        return _with_length_prefix(payload, base=LIST_BASE)
+    if isinstance(rlp_item, list):
+        encoded_elements = b"".join(encode_rlp(element) for element in rlp_item)
+        return _with_length_prefix(encoded_elements, base=LIST_BASE)
 
-    raise TypeError(f"Cannot RLP encode type: {type(item).__name__}")
+    raise TypeError(f"Cannot RLP encode type: {type(rlp_item).__name__}")
 
 
 def _with_length_prefix(payload: bytes, base: int) -> bytes:
@@ -173,13 +173,13 @@ def decode_rlp(data: bytes) -> RLPItem:
     if len(data) == 0:
         raise RLPDecodingError("Empty RLP data")
 
-    item, consumed = _decode_item(data, 0)
+    decoded_item, consumed = _decode_item(data, 0)
 
     # Reject trailing data so each input maps to exactly one item.
     if consumed != len(data):
         raise RLPDecodingError(f"Trailing data: decoded {consumed} of {len(data)} bytes")
 
-    return item
+    return decoded_item
 
 
 def decode_rlp_list(data: bytes) -> list[bytes]:
@@ -197,22 +197,22 @@ def decode_rlp_list(data: bytes) -> list[bytes]:
     Raises:
         RLPDecodingError: If the input is not a flat list of byte strings.
     """
-    item = decode_rlp(data)
+    decoded = decode_rlp(data)
 
     # Top-level must be a list, not a bare byte string.
-    if not isinstance(item, list):
+    if not isinstance(decoded, list):
         raise RLPDecodingError("Expected RLP list")
 
     # Validate every element while building the narrowed result.
     #
     # Each iteration proves the element is bytes before appending.
     # The new list carries the precise element type without needing a cast.
-    result: list[bytes] = []
-    for index, element in enumerate(item):
+    byte_strings: list[bytes] = []
+    for index, element in enumerate(decoded):
         if not isinstance(element, bytes):
             raise RLPDecodingError(f"Element {index} is not bytes")
-        result.append(element)
-    return result
+        byte_strings.append(element)
+    return byte_strings
 
 
 def _decode_item(data: bytes, offset: int) -> tuple[RLPItem, int]:
@@ -279,14 +279,14 @@ def _decode_item(data: bytes, offset: int) -> tuple[RLPItem, int]:
     #   payload range   =  [1, 9)
     #   cursor walk     =  1 -> 5 -> 9   (two short strings consumed in turn)
     #   items           =  [b"dog", b"god"]
-    items: list[RLPItem] = []
+    decoded_items: list[RLPItem] = []
     cursor = payload_start
     while cursor < payload_end:
-        inner, cursor = _decode_item(data, cursor)
-        items.append(inner)
+        inner_item, cursor = _decode_item(data, cursor)
+        decoded_items.append(inner_item)
     if cursor != payload_end:
         raise RLPDecodingError("List payload length mismatch")
-    return items, payload_end
+    return decoded_items, payload_end
 
 
 def _decode_length(data: bytes, offset: int, base: int) -> tuple[int, int]:

--- a/src/lean_spec/node/networking/gossipsub/behavior.py
+++ b/src/lean_spec/node/networking/gossipsub/behavior.py
@@ -898,18 +898,18 @@ class GossipsubBehavior:
         This is normal during connection setup -- the outbound
         stream arrives shortly after the inbound one.
         """
-        state = self._peers.get(peer_id)
-        if state is None or state.outbound_stream is None:
+        peer_state = self._peers.get(peer_id)
+        if peer_state is None or peer_state.outbound_stream is None:
             logger.debug("Cannot send RPC to %s: no outbound stream yet", peer_id)
             return
 
         try:
-            data = rpc.encode()
+            encoded_rpc = rpc.encode()
 
             # Libp2p frames each RPC with a varint length prefix.
             # The receiver uses this to know where one message ends
             # and the next begins on the multiplexed stream.
-            frame = encode_varint(len(data)) + data
+            frame = encode_varint(len(encoded_rpc)) + encoded_rpc
             logger.debug(
                 "Sending RPC to %s: %d bytes (subs=%d, msgs=%d)",
                 peer_id,
@@ -917,10 +917,10 @@ class GossipsubBehavior:
                 len(rpc.subscriptions),
                 len(rpc.publish),
             )
-            state.outbound_stream.write(frame)
-            await state.outbound_stream.drain()
+            peer_state.outbound_stream.write(frame)
+            await peer_state.outbound_stream.drain()
 
-            state.last_rpc_time = time.time()
+            peer_state.last_rpc_time = time.time()
         except Exception as exception:
             logger.warning("Failed to send RPC to %s: %s", peer_id, exception)
 

--- a/src/lean_spec/node/networking/gossipsub/mcache.py
+++ b/src/lean_spec/node/networking/gossipsub/mcache.py
@@ -169,8 +169,8 @@ class MessageCache:
         Returns:
             The cached message, or None if not found/evicted.
         """
-        entry = self._by_id.get(message_id)
-        return entry.message if entry else None
+        cache_entry = self._by_id.get(message_id)
+        return cache_entry.message if cache_entry else None
 
     def has(self, message_id: MessageId) -> bool:
         """
@@ -197,17 +197,17 @@ class MessageCache:
         Returns:
             List of message IDs for IHAVE advertisement.
         """
-        result: list[MessageId] = []
+        gossip_message_ids: list[MessageId] = []
 
         windows_to_check = min(self.mcache_gossip, len(self._windows))
 
         for window in islice(self._windows, windows_to_check):
             for message_id in window:
-                entry = self._by_id.get(message_id)
-                if entry and entry.topic == topic:
-                    result.append(message_id)
+                cache_entry = self._by_id.get(message_id)
+                if cache_entry and cache_entry.topic == topic:
+                    gossip_message_ids.append(message_id)
 
-        return result
+        return gossip_message_ids
 
     def shift(self) -> int:
         """

--- a/src/lean_spec/node/networking/gossipsub/rpc.py
+++ b/src/lean_spec/node/networking/gossipsub/rpc.py
@@ -135,10 +135,10 @@ class SubOpts:
 
     def encode(self) -> bytes:
         """Encode as protobuf."""
-        result = bytearray()
-        result.extend(encode_bool(1, self.subscribe))
-        result.extend(encode_string(2, self.topic_id))
-        return bytes(result)
+        encoded = bytearray()
+        encoded.extend(encode_bool(1, self.subscribe))
+        encoded.extend(encode_string(2, self.topic_id))
+        return bytes(encoded)
 
     @classmethod
     def decode(cls, data: bytes) -> SubOpts:
@@ -151,9 +151,9 @@ class SubOpts:
             field_num, wire_type, pos = decode_tag(data, pos)
 
             if field_num == 1 and wire_type == WIRE_TYPE_VARINT:
-                value, consumed = decode_varint(data, pos)
+                subscribe_flag, consumed = decode_varint(data, pos)
                 pos += consumed
-                subscribe = value != 0
+                subscribe = subscribe_flag != 0
             elif field_num == 2 and wire_type == WIRE_TYPE_LENGTH_DELIMITED:
                 length, pos = _decode_length_at(data, pos)
                 topic_id = TopicId(data[pos : pos + length].decode("utf-8"))
@@ -188,20 +188,20 @@ class Message:
 
     def encode(self) -> bytes:
         """Encode as protobuf."""
-        result = bytearray()
+        encoded = bytearray()
         if self.from_peer:
-            result.extend(encode_bytes(1, self.from_peer))
+            encoded.extend(encode_bytes(1, self.from_peer))
         if self.data:
-            result.extend(encode_bytes(2, self.data))
+            encoded.extend(encode_bytes(2, self.data))
         if self.seqno:
-            result.extend(encode_bytes(3, self.seqno))
+            encoded.extend(encode_bytes(3, self.seqno))
         if self.topic:
-            result.extend(encode_string(4, self.topic))
+            encoded.extend(encode_string(4, self.topic))
         if self.signature:
-            result.extend(encode_bytes(5, self.signature))
+            encoded.extend(encode_bytes(5, self.signature))
         if self.key:
-            result.extend(encode_bytes(6, self.key))
-        return bytes(result)
+            encoded.extend(encode_bytes(6, self.key))
+        return bytes(encoded)
 
     @classmethod
     def decode(cls, data: bytes) -> Message:
@@ -247,12 +247,12 @@ class ControlIHave:
 
     def encode(self) -> bytes:
         """Encode as protobuf."""
-        result = bytearray()
+        encoded = bytearray()
         if self.topic_id:
-            result.extend(encode_string(1, self.topic_id))
+            encoded.extend(encode_string(1, self.topic_id))
         for message_id in self.message_ids:
-            result.extend(encode_bytes(2, message_id))
-        return bytes(result)
+            encoded.extend(encode_bytes(2, message_id))
+        return bytes(encoded)
 
     @classmethod
     def decode(cls, data: bytes) -> ControlIHave:
@@ -288,10 +288,10 @@ class ControlIWant:
 
     def encode(self) -> bytes:
         """Encode as protobuf."""
-        result = bytearray()
+        encoded = bytearray()
         for message_id in self.message_ids:
-            result.extend(encode_bytes(1, message_id))
-        return bytes(result)
+            encoded.extend(encode_bytes(1, message_id))
+        return bytes(encoded)
 
     @classmethod
     def decode(cls, data: bytes) -> ControlIWant:
@@ -321,10 +321,10 @@ class ControlGraft:
 
     def encode(self) -> bytes:
         """Encode as protobuf."""
-        result = bytearray()
+        encoded = bytearray()
         if self.topic_id:
-            result.extend(encode_string(1, self.topic_id))
-        return bytes(result)
+            encoded.extend(encode_string(1, self.topic_id))
+        return bytes(encoded)
 
     @classmethod
     def decode(cls, data: bytes) -> ControlGraft:
@@ -357,12 +357,12 @@ class ControlPrune:
 
     def encode(self) -> bytes:
         """Encode as protobuf."""
-        result = bytearray()
+        encoded = bytearray()
         if self.topic_id:
-            result.extend(encode_string(1, self.topic_id))
+            encoded.extend(encode_string(1, self.topic_id))
         if self.backoff > 0:
-            result.extend(encode_uint64(3, self.backoff))
-        return bytes(result)
+            encoded.extend(encode_uint64(3, self.backoff))
+        return bytes(encoded)
 
     @classmethod
     def decode(cls, data: bytes) -> ControlPrune:
@@ -396,10 +396,10 @@ class ControlIDontWant:
 
     def encode(self) -> bytes:
         """Encode as protobuf."""
-        result = bytearray()
+        encoded = bytearray()
         for message_id in self.message_ids:
-            result.extend(encode_bytes(1, message_id))
-        return bytes(result)
+            encoded.extend(encode_bytes(1, message_id))
+        return bytes(encoded)
 
     @classmethod
     def decode(cls, data: bytes) -> ControlIDontWant:
@@ -441,18 +441,18 @@ class ControlMessage:
 
     def encode(self) -> bytes:
         """Encode as protobuf."""
-        result = bytearray()
+        encoded = bytearray()
         for ihave in self.ihave:
-            result.extend(encode_length_delimited(1, ihave.encode()))
+            encoded.extend(encode_length_delimited(1, ihave.encode()))
         for iwant in self.iwant:
-            result.extend(encode_length_delimited(2, iwant.encode()))
+            encoded.extend(encode_length_delimited(2, iwant.encode()))
         for graft in self.graft:
-            result.extend(encode_length_delimited(3, graft.encode()))
+            encoded.extend(encode_length_delimited(3, graft.encode()))
         for prune in self.prune:
-            result.extend(encode_length_delimited(4, prune.encode()))
-        for idw in self.idontwant:
-            result.extend(encode_length_delimited(5, idw.encode()))
-        return bytes(result)
+            encoded.extend(encode_length_delimited(4, prune.encode()))
+        for idontwant in self.idontwant:
+            encoded.extend(encode_length_delimited(5, idontwant.encode()))
+        return bytes(encoded)
 
     @classmethod
     def decode(cls, data: bytes) -> ControlMessage:
@@ -516,18 +516,18 @@ class RPC:
             field 2: repeated Message publish
             field 3: optional ControlMessage control
         """
-        result = bytearray()
+        encoded = bytearray()
 
-        for sub in self.subscriptions:
-            result.extend(encode_length_delimited(1, sub.encode()))
+        for subscription in self.subscriptions:
+            encoded.extend(encode_length_delimited(1, subscription.encode()))
 
         for message in self.publish:
-            result.extend(encode_length_delimited(2, message.encode()))
+            encoded.extend(encode_length_delimited(2, message.encode()))
 
         if self.control and not self.control.is_empty():
-            result.extend(encode_length_delimited(3, self.control.encode()))
+            encoded.extend(encode_length_delimited(3, self.control.encode()))
 
-        return bytes(result)
+        return bytes(encoded)
 
     @classmethod
     def decode(cls, data: bytes) -> RPC:

--- a/src/lean_spec/node/networking/gossipsub/topic.py
+++ b/src/lean_spec/node/networking/gossipsub/topic.py
@@ -317,9 +317,14 @@ def parse_topic_string(topic_str: str) -> tuple[str, str, str, str]:
     Raises:
         ValueError: If the topic string is malformed.
     """
-    parts = topic_str.lstrip("/").split("/")
+    topic_components = topic_str.lstrip("/").split("/")
 
-    if len(parts) != 4:
-        raise ValueError(f"Invalid topic format: expected 4 parts, got {len(parts)}")
+    if len(topic_components) != 4:
+        raise ValueError(f"Invalid topic format: expected 4 parts, got {len(topic_components)}")
 
-    return (parts[0], parts[1], parts[2], parts[3])
+    return (
+        topic_components[0],
+        topic_components[1],
+        topic_components[2],
+        topic_components[3],
+    )

--- a/src/lean_spec/node/networking/transport/peer_id.py
+++ b/src/lean_spec/node/networking/transport/peer_id.py
@@ -147,14 +147,14 @@ class Base58:
         return "".join(reversed(result))
 
     @classmethod
-    def decode(cls, s: str) -> bytes:
+    def decode(cls, encoded: str) -> bytes:
         """
         Decode Base58 string to bytes.
 
         Leading '1' characters become leading zero bytes.
 
         Args:
-            s: Base58-encoded string.
+            encoded: Base58-encoded string.
 
         Returns:
             Decoded bytes.
@@ -163,23 +163,23 @@ class Base58:
             ValueError: If string contains invalid characters.
         """
         # Count leading '1's (they represent leading zeros)
-        leading_ones = len(s) - len(s.lstrip("1"))
+        leading_ones = len(encoded) - len(encoded.lstrip("1"))
 
         # Convert from base58 to integer
         num = 0
-        for character in s:
-            index = cls.ALPHABET.find(character)
-            if index < 0:
+        for character in encoded:
+            alphabet_position = cls.ALPHABET.find(character)
+            if alphabet_position < 0:
                 raise ValueError(f"Invalid Base58 character: {character!r}")
-            num = num * 58 + index
+            num = num * 58 + alphabet_position
 
         # Convert to bytes
         if num == 0:
-            result = b""
+            decoded_bytes = b""
         else:
-            result = num.to_bytes((num.bit_length() + 7) // 8, "big")
+            decoded_bytes = num.to_bytes((num.bit_length() + 7) // 8, "big")
 
-        return b"\x00" * leading_ones + result
+        return b"\x00" * leading_ones + decoded_bytes
 
 
 _IDENTITY_THRESHOLD: Final[int] = 42

--- a/src/lean_spec/node/networking/transport/quic/connection.py
+++ b/src/lean_spec/node/networking/transport/quic/connection.py
@@ -266,8 +266,8 @@ def is_quic_multiaddr(multiaddr: str) -> bool:
     """
     # Multiaddr protocol names are case-sensitive per the multiaddr spec.
     # Valid QUIC components are lowercase "quic" and "quic-v1".
-    parts = multiaddr.split("/")
-    return "quic" in parts or "quic-v1" in parts
+    multiaddr_components = multiaddr.split("/")
+    return "quic" in multiaddr_components or "quic-v1" in multiaddr_components
 
 
 def parse_multiaddr(multiaddr: str) -> tuple[str, int, str | None, PeerId | None]:
@@ -281,7 +281,7 @@ def parse_multiaddr(multiaddr: str) -> tuple[str, int, str | None, PeerId | None
         (host, port, transport, peer_id) tuple.
         transport is "quic", peer_id may be None.
     """
-    parts = multiaddr.strip("/").split("/")
+    multiaddr_components = multiaddr.strip("/").split("/")
 
     host = None
     port = None
@@ -289,18 +289,18 @@ def parse_multiaddr(multiaddr: str) -> tuple[str, int, str | None, PeerId | None
     peer_id = None
 
     i = 0
-    while i < len(parts):
-        if parts[i] == "ip4" and i + 1 < len(parts):
-            host = parts[i + 1]
+    while i < len(multiaddr_components):
+        if multiaddr_components[i] == "ip4" and i + 1 < len(multiaddr_components):
+            host = multiaddr_components[i + 1]
             i += 2
-        elif parts[i] == "udp" and i + 1 < len(parts):
-            port = int(parts[i + 1])
+        elif multiaddr_components[i] == "udp" and i + 1 < len(multiaddr_components):
+            port = int(multiaddr_components[i + 1])
             i += 2
-        elif parts[i] in ("quic", "quic-v1"):
+        elif multiaddr_components[i] in ("quic", "quic-v1"):
             transport = "quic"
             i += 1
-        elif parts[i] == "p2p" and i + 1 < len(parts):
-            peer_id = PeerId.from_base58(parts[i + 1])
+        elif multiaddr_components[i] == "p2p" and i + 1 < len(multiaddr_components):
+            peer_id = PeerId.from_base58(multiaddr_components[i + 1])
             i += 2
         else:
             i += 1

--- a/src/lean_spec/node/networking/transport/quic/stream_adapter.py
+++ b/src/lean_spec/node/networking/transport/quic/stream_adapter.py
@@ -89,24 +89,24 @@ class QuicStreamAdapter:
         """
         if n is None:
             if self._buffer:
-                result = self._buffer
+                buffered_bytes = self._buffer
                 self._buffer = b""
-                return result
+                return buffered_bytes
             return await self._stream.read()
 
         if self._buffer:
-            result = self._buffer[:n]
+            buffered_bytes = self._buffer[:n]
             self._buffer = self._buffer[n:]
-            return result
+            return buffered_bytes
 
-        data = await self._stream.read()
-        if not data:
+        stream_bytes = await self._stream.read()
+        if not stream_bytes:
             return b""
 
-        if len(data) > n:
-            self._buffer = data[n:]
-            return data[:n]
-        return data
+        if len(stream_bytes) > n:
+            self._buffer = stream_bytes[n:]
+            return stream_bytes[:n]
+        return stream_bytes
 
     async def readexactly(self, n: int) -> bytes:
         """
@@ -121,9 +121,9 @@ class QuicStreamAdapter:
                 raise EOFError("Stream closed before enough data received")
             self._buffer += chunk
 
-        result = self._buffer[:n]
+        buffered_bytes = self._buffer[:n]
         self._buffer = self._buffer[n:]
-        return result
+        return buffered_bytes
 
     def write(self, data: bytes) -> None:
         """Buffer data for writing (synchronous for StreamWriter compatibility)."""
@@ -237,9 +237,9 @@ class QuicStreamAdapter:
 
         Format: [varint length][message + '\n']
         """
-        payload = message.encode("utf-8") + b"\n"
-        length_prefix = encode_varint(len(payload))
-        self.write(length_prefix + payload)
+        message_bytes = message.encode("utf-8") + b"\n"
+        length_prefix = encode_varint(len(message_bytes))
+        self.write(length_prefix + message_bytes)
         await self.drain()
 
     async def _read_negotiation_message(self) -> str:
@@ -278,9 +278,9 @@ class QuicStreamAdapter:
         if length == 0:
             raise NegotiationError("Empty message")
 
-        payload = await self.readexactly(length)
+        message_bytes = await self.readexactly(length)
 
-        if not payload.endswith(b"\n"):
+        if not message_bytes.endswith(b"\n"):
             raise NegotiationError("Message must end with newline")
 
-        return payload[:-1].decode("utf-8")
+        return message_bytes[:-1].decode("utf-8")

--- a/src/lean_spec/node/networking/varint.py
+++ b/src/lean_spec/node/networking/varint.py
@@ -148,7 +148,7 @@ def encode_varint(value: int, max_bytes: int = 10) -> bytes:
     if value >> (7 * max_bytes):
         raise ValueError(f"Varint value does not fit in {max_bytes} bytes")
 
-    result = bytearray()
+    encoded = bytearray()
 
     # Process 7 bits at a time until the value fits in 7 bits.
     #
@@ -158,16 +158,16 @@ def encode_varint(value: int, max_bytes: int = 10) -> bytes:
     #   - Set continuation bit (| 0x80) to signal more bytes follow
     #   - Shift right by 7 to process next group
     while value >= 0x80:
-        result.append((value & 0x7F) | 0x80)
+        encoded.append((value & 0x7F) | 0x80)
         value >>= 7
 
     # Emit final byte without continuation bit.
     #
     # At this point, value < 128, so it fits in 7 bits.
     # The missing continuation bit (MSB = 0) signals "end of varint".
-    result.append(value)
+    encoded.append(value)
 
-    return bytes(result)
+    return bytes(encoded)
 
 
 def decode_varint(data: bytes, offset: int = 0, max_bytes: int = 10) -> tuple[int, int]:
@@ -195,7 +195,7 @@ def decode_varint(data: bytes, offset: int = 0, max_bytes: int = 10) -> tuple[in
             before finding the final byte) or exceeds max_bytes
             (would overflow the declared range).
     """
-    result = 0
+    decoded_value = 0
     shift = 0
     pos = offset
 
@@ -214,7 +214,7 @@ def decode_varint(data: bytes, offset: int = 0, max_bytes: int = 10) -> tuple[in
         #
         # The shift accumulates: byte 0 contributes bits 0-6,
         # byte 1 contributes bits 7-13, byte 2 contributes bits 14-20, etc.
-        result |= (byte & 0x7F) << shift
+        decoded_value |= (byte & 0x7F) << shift
         shift += 7
 
         # Check the continuation bit (MSB).
@@ -231,4 +231,4 @@ def decode_varint(data: bytes, offset: int = 0, max_bytes: int = 10) -> tuple[in
         if pos - offset >= max_bytes:
             raise VarintError(f"Varint exceeds {max_bytes} bytes")
 
-    return result, pos - offset
+    return decoded_value, pos - offset

--- a/src/lean_spec/node/snappy/compress.py
+++ b/src/lean_spec/node/snappy/compress.py
@@ -322,15 +322,17 @@ def _hash_4_bytes(data: bytes, pos: int, table_bits: int) -> int:
     #   data[1] = 0x42 (B)
     #   data[2] = 0x43 (C)
     #   data[3] = 0x44 (D)
-    #   value = 0x44434241 (D C B A in memory order)
-    value = data[pos] | (data[pos + 1] << 8) | (data[pos + 2] << 16) | (data[pos + 3] << 24)
+    #   little_endian_word = 0x44434241 (D C B A in memory order)
+    little_endian_word = (
+        data[pos] | (data[pos + 1] << 8) | (data[pos + 2] << 16) | (data[pos + 3] << 24)
+    )
 
     # Multiply and mask to 32 bits.
     #
     # The magic constant (0x1e35a7bd) is chosen to spread input bits
     # across the output. This reduces collisions for similar inputs.
     # We mask to 32 bits because Python integers are arbitrary precision.
-    hash_value = (value * HASH_MULTIPLIER) & 0xFFFFFFFF
+    hash_value = (little_endian_word * HASH_MULTIPLIER) & 0xFFFFFFFF
 
     # Take top bits.
     #

--- a/src/lean_spec/node/snappy/framing.py
+++ b/src/lean_spec/node/snappy/framing.py
@@ -283,20 +283,20 @@ def frame_compress(data: bytes) -> bytes:
         # This ensures the framed output is never larger than necessary.
         if len(compressed) < len(chunk):
             chunk_type = CHUNK_TYPE_COMPRESSED
-            payload = compressed
+            chunk_body = compressed
         else:
             chunk_type = CHUNK_TYPE_UNCOMPRESSED
-            payload = chunk
+            chunk_body = chunk
 
         # Build chunk: [type: 1][length: 3 LE][crc: 4 LE][payload].
         #
         # The length field includes CRC (4 bytes) + payload.
         # It does NOT include the 4-byte header (type + length).
-        chunk_length = 4 + len(payload)
+        chunk_length = 4 + len(chunk_body)
         output.append(chunk_type)
         output.extend(chunk_length.to_bytes(3, "little"))
         output.extend(crc.to_bytes(4, "little"))
-        output.extend(payload)
+        output.extend(chunk_body)
 
     return bytes(output)
 

--- a/src/lean_spec/node/sync/peer_manager.py
+++ b/src/lean_spec/node/sync/peer_manager.py
@@ -98,14 +98,14 @@ class PeerManager:
         """Check if a peer is being tracked."""
         return peer_id in self.peers
 
-    def add_peer(self, info: PeerInfo) -> SyncPeer:
+    def add_peer(self, peer_info: PeerInfo) -> SyncPeer:
         """Register a new peer or update existing."""
-        if info.peer_id in self.peers:
-            self.peers[info.peer_id].info = info
-            return self.peers[info.peer_id]
+        if peer_info.peer_id in self.peers:
+            self.peers[peer_info.peer_id].info = peer_info
+            return self.peers[peer_info.peer_id]
 
-        sync_peer = SyncPeer(info=info)
-        self.peers[info.peer_id] = sync_peer
+        sync_peer = SyncPeer(info=peer_info)
+        self.peers[peer_info.peer_id] = sync_peer
         return sync_peer
 
     def remove_peer(self, peer_id: PeerId) -> SyncPeer | None:

--- a/src/lean_spec/node/sync/service.py
+++ b/src/lean_spec/node/sync/service.py
@@ -183,9 +183,9 @@ class SyncService:
             def ancestors(start: Bytes32) -> set[Bytes32]:
                 seen: set[Bytes32] = set()
                 root = start
-                while (b := new_store.blocks.get(root)) is not None:
+                while (block := new_store.blocks.get(root)) is not None:
                     seen.add(root)
-                    root = b.parent_root
+                    root = block.parent_root
                 return seen
 
             # Reorg depth = blocks that lived on the old chain but not on the new one.
@@ -349,7 +349,7 @@ class SyncService:
             raise RuntimeError("HeadSync not initialized")
 
         # Head-sync either processes the block now or caches it pending backfill.
-        result, new_store = await self._head_sync.on_gossip_block(
+        gossip_block_outcome, new_store = await self._head_sync.on_gossip_block(
             block=block,
             peer_id=peer_id,
             store=self.store,
@@ -358,7 +358,7 @@ class SyncService:
         # Only update our store if the block was actually processed.
         #
         # A block may be cached instead of processed if its parent is unknown.
-        if result.processed:
+        if gossip_block_outcome.processed:
             block_root = hash_tree_root(block.block)
             logger.info(
                 "Block processed slot=%s root=%s from peer %s",
@@ -570,28 +570,29 @@ class SyncService:
         # AttestationData instances from different code paths may not share a
         # dict key, so match on the hash tree root instead.
         local_proofs_by_root: dict[Bytes32, list[SingleMessageAggregate]] = {}
-        for data, proofs in store.latest_new_aggregated_payloads.items():
-            local_proofs_by_root.setdefault(hash_tree_root(data), []).extend(proofs)
+        for attestation_data, proofs in store.latest_new_aggregated_payloads.items():
+            local_proofs_by_root.setdefault(hash_tree_root(attestation_data), []).extend(proofs)
 
         # Working copy of the pending pool.
         # The combined proof is retained locally so the block-sourced
         # aggregate survives without depending on gossip loopback. Shallow
         # copy the dict and its inner sets to preserve store immutability.
         new_payloads: dict[AttestationData, set[SingleMessageAggregate]] = {
-            k: set(v) for k, v in store.latest_new_aggregated_payloads.items()
+            pending_data: set(pending_proofs)
+            for pending_data, pending_proofs in store.latest_new_aggregated_payloads.items()
         }
         aggregates: list[SignedAggregatedAttestation] = []
 
         for attestation in block_attestations:
-            data = attestation.data
+            attestation_data = attestation.data
 
             # Only spend a split on attestations that can still move
             # justification forward. A target at or behind the store's
             # justified checkpoint cannot, so skip it.
-            if data.target.slot <= store.latest_justified.slot:
+            if attestation_data.target.slot <= store.latest_justified.slot:
                 continue
 
-            data_root = hash_tree_root(data)
+            data_root = hash_tree_root(attestation_data)
             block_participants = set(attestation.aggregation_bits.to_validator_indices())
 
             local_proofs = local_proofs_by_root.get(data_root, [])
@@ -627,7 +628,7 @@ class SyncService:
                         ],
                         raw_xmss=[],
                         message=data_root,
-                        slot=data.slot,
+                        slot=attestation_data.slot,
                     )
                 else:
                     # Data unseen locally: nothing to merge, use as-is.
@@ -651,8 +652,8 @@ class SyncService:
                     else:
                         del new_payloads[key]
 
-            new_payloads.setdefault(data, set()).add(combined)
-            aggregates.append(SignedAggregatedAttestation(data=data, proof=combined))
+            new_payloads.setdefault(attestation_data, set()).add(combined)
+            aggregates.append(SignedAggregatedAttestation(data=attestation_data, proof=combined))
 
         if aggregates:
             store.latest_new_aggregated_payloads = new_payloads

--- a/src/lean_spec/node/validator/registry.py
+++ b/src/lean_spec/node/validator/registry.py
@@ -122,10 +122,10 @@ def load_node_validator_mapping(path: Path) -> NodeValidatorMapping:
         Mapping from node ID to list of validator indices.
         Empty dict if file is empty.
     """
-    with path.open() as f:
-        data = yaml.safe_load(f)
+    with path.open() as yaml_file:
+        parsed_yaml = yaml.safe_load(yaml_file)
     # YAML returns None for empty file
-    return data or {}
+    return parsed_yaml or {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -287,26 +287,29 @@ class ValidatorRegistry:
         manifest = ValidatorManifest.from_yaml_file(manifest_path)
 
         # Build index lookup from manifest.
-        manifest_by_index = {v.index: v for v in manifest.validators}
+        manifest_by_index = {
+            manifest_validator.index: manifest_validator
+            for manifest_validator in manifest.validators
+        }
 
         # Load keys for assigned validators.
         registry = cls()
         manifest_directory = manifest_path.parent
 
-        for index in assigned_indices:
-            entry = manifest_by_index.get(ValidatorIndex(index))
-            if entry is None:
+        for validator_index in assigned_indices:
+            manifest_entry = manifest_by_index.get(ValidatorIndex(validator_index))
+            if manifest_entry is None:
                 # Validator index in validators.yaml but missing from manifest.
                 # This can happen if the manifest was regenerated with fewer validators.
                 logger.warning(
                     "Validator index %d assigned to node %s but not found in manifest",
-                    index,
+                    validator_index,
                     node_id,
                 )
                 continue
 
             # Load attestation secret key from SSZ file.
-            attestation_key_path = manifest_directory / entry.attestation_private_key_file
+            attestation_key_path = manifest_directory / manifest_entry.attestation_private_key_file
             try:
                 attestation_secret_key = SecretKey.decode_bytes(attestation_key_path.read_bytes())
             except FileNotFoundError as exception:
@@ -315,23 +318,23 @@ class ValidatorRegistry:
                 ) from exception
             except Exception as exception:
                 raise ValueError(
-                    f"Failed to load attestation key for validator {index}: {exception}"
+                    f"Failed to load attestation key for validator {validator_index}: {exception}"
                 ) from exception
 
             # Load proposal secret key from SSZ file.
-            proposal_key_path = manifest_directory / entry.proposal_private_key_file
+            proposal_key_path = manifest_directory / manifest_entry.proposal_private_key_file
             try:
                 proposal_secret_key = SecretKey.decode_bytes(proposal_key_path.read_bytes())
             except FileNotFoundError as exception:
                 raise ValueError(f"Proposal key file not found: {proposal_key_path}") from exception
             except Exception as exception:
                 raise ValueError(
-                    f"Failed to load proposal key for validator {index}: {exception}"
+                    f"Failed to load proposal key for validator {validator_index}: {exception}"
                 ) from exception
 
             registry.add(
                 ValidatorEntry(
-                    index=ValidatorIndex(index),
+                    index=ValidatorIndex(validator_index),
                     attestation_secret_key=attestation_secret_key,
                     proposal_secret_key=proposal_secret_key,
                 )

--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -427,14 +427,14 @@ class ValidatorService:
         Returns:
             Signed block ready for publishing.
         """
-        entry = self.registry.get(validator_index)
-        if entry is None:
+        validator_entry = self.registry.get(validator_index)
+        if validator_entry is None:
             raise ValueError(f"No secret key for validator {validator_index}")
 
         # Sign the block root with the proposal key.
         block_root = hash_tree_root(block)
         _, proposer_signature = self._sign_with_key(
-            entry,
+            validator_entry,
             block.slot,
             block_root,
             "proposal_secret_key",
@@ -471,27 +471,29 @@ class ValidatorService:
         # A stale partial aggregate would otherwise blow up deep inside
         # the aggregator with an opaque KeyError.
         num_validators = Uint64(len(validators))
-        public_keys_per_part: list[list[PublicKey]] = []
-        for proof in attestation_proofs:
-            part_public_keys: list[PublicKey] = []
-            for validator_index in proof.participants.to_validator_indices():
+        public_keys_per_aggregate: list[list[PublicKey]] = []
+        for attestation_proof in attestation_proofs:
+            participant_public_keys: list[PublicKey] = []
+            for validator_index in attestation_proof.participants.to_validator_indices():
                 if not validator_index.is_within_registry(num_validators):
                     raise ValueError(
                         f"Attestation proof references validator {validator_index}; "
                         f"active set has {num_validators} validators"
                     )
-                part_public_keys.append(validators[validator_index].get_attestation_public_key())
-            public_keys_per_part.append(part_public_keys)
-        public_keys_per_part.append([proposer_public_key])
+                participant_public_keys.append(
+                    validators[validator_index].get_attestation_public_key()
+                )
+            public_keys_per_aggregate.append(participant_public_keys)
+        public_keys_per_aggregate.append([proposer_public_key])
 
-        merged = MultiMessageAggregate.aggregate(
+        merged_block_proof = MultiMessageAggregate.aggregate(
             [*attestation_proofs, proposer_single_message_aggregate],
-            public_keys_per_part=public_keys_per_part,
+            public_keys_per_aggregate=public_keys_per_aggregate,
         )
 
         return SignedBlock(
             block=block,
-            proof=merged,
+            proof=merged_block_proof,
         )
 
     def _sign_attestation(
@@ -512,13 +514,13 @@ class ValidatorService:
             Signed attestation ready for publishing.
         """
         # Get the secret key for this validator.
-        entry = self.registry.get(validator_index)
-        if entry is None:
+        validator_entry = self.registry.get(validator_index)
+        if validator_entry is None:
             raise ValueError(f"No secret key for validator {validator_index}")
 
         # Sign the attestation data root with the attestation key.
         _, signature = self._sign_with_key(
-            entry,
+            validator_entry,
             attestation_data.slot,
             hash_tree_root(attestation_data),
             "attestation_secret_key",
@@ -532,7 +534,7 @@ class ValidatorService:
 
     def _sign_with_key(
         self,
-        entry: ValidatorEntry,
+        validator_entry: ValidatorEntry,
         slot: Slot,
         message: Bytes32,
         key_field: Literal["attestation_secret_key", "proposal_secret_key"],
@@ -547,7 +549,7 @@ class ValidatorService:
         3. Persist the updated key state in the registry
 
         Args:
-            entry: Validator entry containing the secret keys.
+            validator_entry: Validator entry containing the secret keys.
             slot: The slot to sign for.
             message: The message bytes to sign.
             key_field: Which secret key field to use and advance.
@@ -556,7 +558,7 @@ class ValidatorService:
             Tuple of (updated entry, signature).
         """
         scheme = TARGET_SIGNATURE_SCHEME
-        secret_key = getattr(entry, key_field)
+        secret_key = getattr(validator_entry, key_field)
 
         slot_int = int(slot)
         while slot_int not in scheme.get_prepared_interval(secret_key):
@@ -565,10 +567,10 @@ class ValidatorService:
         signature = scheme.sign(secret_key, slot, message)
 
         updated_entry = ValidatorEntry(
-            index=entry.index,
+            index=validator_entry.index,
             **{
-                "attestation_secret_key": entry.attestation_secret_key,
-                "proposal_secret_key": entry.proposal_secret_key,
+                "attestation_secret_key": validator_entry.attestation_secret_key,
+                "proposal_secret_key": validator_entry.proposal_secret_key,
                 key_field: secret_key,
             },
         )

--- a/src/lean_spec/spec/crypto/koalabear.py
+++ b/src/lean_spec/spec/crypto/koalabear.py
@@ -99,13 +99,15 @@ class Fp(int, SSZType):
         """Deserialize a field element from a binary stream."""
         if scope != P_BYTES:
             raise SSZSerializationError(f"Expected {P_BYTES} bytes for Fp, got {scope}")
-        data = stream.read(P_BYTES)
-        if len(data) != P_BYTES:
-            raise SSZSerializationError(f"Expected {P_BYTES} bytes for Fp, got {len(data)}")
-        value = int.from_bytes(data, byteorder="little")
-        if value >= P:
-            raise SSZValueError(f"Value {value} exceeds field modulus {P}")
-        return cls(value)
+        serialized_bytes = stream.read(P_BYTES)
+        if len(serialized_bytes) != P_BYTES:
+            raise SSZSerializationError(
+                f"Expected {P_BYTES} bytes for Fp, got {len(serialized_bytes)}"
+            )
+        decoded_integer = int.from_bytes(serialized_bytes, byteorder="little")
+        if decoded_integer >= P:
+            raise SSZValueError(f"Value {decoded_integer} exceeds field modulus {P}")
+        return cls(decoded_integer)
 
     def _reject(self, other: Any, op: str) -> NoReturn:
         """Raise a consistent TypeError for a non-Fp operand."""

--- a/src/lean_spec/spec/crypto/merkleization.py
+++ b/src/lean_spec/spec/crypto/merkleization.py
@@ -101,12 +101,12 @@ def merkleize(chunks: Sequence[Bytes32], limit: int | None = None) -> Bytes32:
     Raises:
         ValueError: If the chunk count exceeds the limit.
     """
-    n = len(chunks)
-    if n == 0:
+    chunk_count = len(chunks)
+    if chunk_count == 0:
         return _zero_tree_root(_next_pow2(limit)) if limit is not None else ZERO_HASH
     if limit is None:
-        width = _next_pow2(n)
-    elif limit < n:
+        width = _next_pow2(chunk_count)
+    elif limit < chunk_count:
         raise ValueError("merkleize: input exceeds limit")
     else:
         width = _next_pow2(limit)
@@ -196,8 +196,8 @@ def _pack_bits(bits: Sequence[Boolean]) -> list[Bytes32]:
     The SSZ serialization delimiter and the length-mix are separate steps,
     handled by the caller when needed.
     """
-    value = sum(1 << i for i, bit in enumerate(bits) if bit)
-    return _pack_bytes(value.to_bytes(math.ceil(len(bits) / 8), "little"))
+    packed_bits = sum(1 << i for i, bit in enumerate(bits) if bit)
+    return _pack_bytes(packed_bits.to_bytes(math.ceil(len(bits) / 8), "little"))
 
 
 @singledispatch
@@ -248,9 +248,11 @@ def _htr_bytevector(value: BaseBytes) -> Bytes32:
 
 @hash_tree_root.register
 def _htr_bytelist(value: BaseByteList) -> Bytes32:
-    data = value.encode_bytes()
+    serialized_bytes = value.encode_bytes()
     limit_chunks = math.ceil(type(value).LIMIT / BYTES_PER_CHUNK)
-    return mix_in_length(merkleize(_pack_bytes(data), limit=limit_chunks), len(data))
+    return mix_in_length(
+        merkleize(_pack_bytes(serialized_bytes), limit=limit_chunks), len(serialized_bytes)
+    )
 
 
 @hash_tree_root.register

--- a/src/lean_spec/spec/crypto/poseidon.py
+++ b/src/lean_spec/spec/crypto/poseidon.py
@@ -1228,10 +1228,10 @@ _RAW_CONSTANTS_24: list[int] = [
 ]
 
 # For width 16 (needs (8 + 20) * 16 = 448 constants).
-ROUND_CONSTANTS_16: list[Fp] = [Fp(value=v) for v in _RAW_CONSTANTS_16]
+ROUND_CONSTANTS_16: list[Fp] = [Fp(value=raw_constant) for raw_constant in _RAW_CONSTANTS_16]
 
 # For width 24 (needs (8 + 23) * 24 = 744 constants).
-ROUND_CONSTANTS_24: list[Fp] = [Fp(value=v) for v in _RAW_CONSTANTS_24]
+ROUND_CONSTANTS_24: list[Fp] = [Fp(value=raw_constant) for raw_constant in _RAW_CONSTANTS_24]
 
 
 @njit(cache=True)
@@ -1245,26 +1245,26 @@ def _mds_multiply_jit(
     Each product is reduced mod p before accumulation to prevent overflow.
     """
     # State length doubles as the matrix dimension since MDS is square.
-    n = state.shape[0]
+    dimension = state.shape[0]
 
     # Output buffer, written in place by the inner loop.
-    result = np.empty(n, dtype=np.int64)
+    product = np.empty(dimension, dtype=np.int64)
 
     # One iteration computes a single row of the matrix-vector product.
-    for i in range(n):
+    for i in range(dimension):
         # Accumulator collects n pre-reduced contributions before the final fold.
-        s = np.int64(0)
+        row_sum = np.int64(0)
 
-        for j in range(n):
+        for j in range(dimension):
             # Each factor sits below p, so the product fits in 62 bits.
             #
             # Without per-product reduction, summing n products would risk int64 overflow.
-            s += (mds[i, j] * state[j]) % p
+            row_sum += (mds[i, j] * state[j]) % p
 
         # Final fold back into the field after n already-reduced terms.
-        result[i] = s % p
+        product[i] = row_sum % p
 
-    return result
+    return product
 
 
 @njit(cache=True)
@@ -1457,7 +1457,7 @@ class Poseidon:
             P,
         )
 
-        return [Fp(value=int(x)) for x in state]
+        return [Fp(value=int(state_element)) for state_element in state]
 
 
 _MDS_FIRST_ROW_16: list[int] = [1, 1, 51, 1, 11, 17, 2, 1, 101, 63, 15, 2, 67, 22, 13, 3]
@@ -1505,7 +1505,7 @@ PARAMS_16 = PoseidonParams(
     width=16,
     rounds_f=8,
     rounds_p=20,
-    mds_first_row=[Fp(value=v) for v in _MDS_FIRST_ROW_16],
+    mds_first_row=[Fp(value=row_entry) for row_entry in _MDS_FIRST_ROW_16],
     round_constants=ROUND_CONSTANTS_16,
 )
 """Poseidon parameters for width-16 permutation (8 full rounds, 20 partial)."""
@@ -1514,7 +1514,7 @@ PARAMS_24 = PoseidonParams(
     width=24,
     rounds_f=8,
     rounds_p=23,
-    mds_first_row=[Fp(value=v) for v in _MDS_FIRST_ROW_24],
+    mds_first_row=[Fp(value=row_entry) for row_entry in _MDS_FIRST_ROW_24],
     round_constants=ROUND_CONSTANTS_24,
 )
 """Poseidon parameters for width-24 permutation (8 full rounds, 23 partial)."""

--- a/src/lean_spec/spec/crypto/xmss/merkle.py
+++ b/src/lean_spec/spec/crypto/xmss/merkle.py
@@ -214,12 +214,12 @@ class HashSubTree(Container):
 
         # Phase 1: pad the input layer.
         layers: list[HashTreeLayer] = []
-        current = HashTreeLayer.padded(config, lowest_layer_nodes, start_index)
-        layers.append(current)
+        current_layer = HashTreeLayer.padded(config, lowest_layer_nodes, start_index)
+        layers.append(current_layer)
 
         # Phases 2 + 3: hash sibling pairs, pad, repeat.
         for level in range(lowest_layer, highest_layer):
-            parent_start = current.start_index // Uint64(2)
+            parent_start = current_layer.start_index // Uint64(2)
             parents = [
                 poseidon.tweak_hash(
                     config,
@@ -227,10 +227,10 @@ class HashSubTree(Container):
                     TreeTweak(level=level + 1, index=parent_start + Uint64(i)),
                     [left, right],
                 )
-                for i, (left, right) in enumerate(batched(current.nodes, 2))
+                for i, (left, right) in enumerate(batched(current_layer.nodes, 2))
             ]
-            current = HashTreeLayer.padded(config, parents, parent_start)
-            layers.append(current)
+            current_layer = HashTreeLayer.padded(config, parents, parent_start)
+            layers.append(current_layer)
 
         return cls(
             depth=depth,
@@ -589,25 +589,27 @@ def verify_path(
         return False
 
     # Phase 1: hash the leaf parts to derive the starting node.
-    current = poseidon.tweak_hash(
+    current_node = poseidon.tweak_hash(
         config,
         parameter,
         TreeTweak(level=0, index=Uint64(position)),
         leaf_parts,
     )
-    pos = int(position)
+    current_position = int(position)
 
     # Phase 2: hash with each sibling, climbing one layer per iteration.
     for level, sibling in enumerate(opening.siblings):
         # The current node sits on the left when its position is even.
-        left, right = (current, sibling) if pos % 2 == 0 else (sibling, current)
-        pos //= 2
-        current = poseidon.tweak_hash(
+        left, right = (
+            (current_node, sibling) if current_position % 2 == 0 else (sibling, current_node)
+        )
+        current_position //= 2
+        current_node = poseidon.tweak_hash(
             config,
             parameter,
-            TreeTweak(level=level + 1, index=Uint64(pos)),
+            TreeTweak(level=level + 1, index=Uint64(current_position)),
             [left, right],
         )
 
     # Phase 3: compare against the trusted root.
-    return current == root
+    return current_node == root

--- a/src/lean_spec/spec/crypto/xmss/poseidon.py
+++ b/src/lean_spec/spec/crypto/xmss/poseidon.py
@@ -141,8 +141,8 @@ class PoseidonXmss(StrictBaseModel):
 
         # Phase 2: absorb each chunk by overwriting the rate slots.
         for chunk in batched(padded_input, rate):
-            for j, value in enumerate(chunk):
-                state[cap_length + j] = value
+            for j, chunk_element in enumerate(chunk):
+                state[cap_length + j] = chunk_element
             state = engine.permute(state)
 
         # Phase 3: squeeze rate slots, permuting until enough output is available.
@@ -197,7 +197,7 @@ class PoseidonXmss(StrictBaseModel):
         if len(message_parts) == 1:
             # Hash chain step: width-16 compression of (digest || parameter || tweak).
             input_vec = message_parts[0].elements + parameter.elements + encoded_tweak
-            result = self.compress(input_vec, 16, config.HASH_LENGTH_FIELD_ELEMENTS)
+            digest = self.compress(input_vec, 16, config.HASH_LENGTH_FIELD_ELEMENTS)
 
         elif len(message_parts) == 2:
             # Merkle node: width-24 compression of (parameter || tweak || left || right).
@@ -207,11 +207,13 @@ class PoseidonXmss(StrictBaseModel):
                 + message_parts[0].elements
                 + message_parts[1].elements
             )
-            result = self.compress(input_vec, 24, config.HASH_LENGTH_FIELD_ELEMENTS)
+            digest = self.compress(input_vec, 24, config.HASH_LENGTH_FIELD_ELEMENTS)
 
         else:
             # Merkle leaf: sponge mode over many concatenated digests.
-            flattened_message = [element for part in message_parts for element in part.elements]
+            flattened_message = [
+                element for message_part in message_parts for element in message_part.elements
+            ]
             input_vec = parameter.elements + encoded_tweak + flattened_message
 
             # The domain separator binds the sponge to this hashing task shape.
@@ -222,9 +224,9 @@ class PoseidonXmss(StrictBaseModel):
                 config.HASH_LENGTH_FIELD_ELEMENTS,
             ]
             capacity_value = self.safe_domain_separator(lengths, config.CAPACITY)
-            result = self.sponge(input_vec, capacity_value, config.HASH_LENGTH_FIELD_ELEMENTS, 24)
+            digest = self.sponge(input_vec, capacity_value, config.HASH_LENGTH_FIELD_ELEMENTS, 24)
 
-        return HashDigestVector(data=result)
+        return HashDigestVector(data=digest)
 
     def hash_chain(
         self,

--- a/src/lean_spec/spec/forks/lstar/containers/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/aggregation.py
@@ -148,11 +148,11 @@ class SingleMessageAggregate(Container):
         # The bitfield names one validator per set bit.
         # The caller must supply exactly that many keys, in the same order.
         # A miscount would otherwise fail deep in the verifier with an opaque error.
-        expected = len(self.participants.to_validator_indices())
-        if len(public_keys) != expected:
+        expected_public_key_count = len(self.participants.to_validator_indices())
+        if len(public_keys) != expected_public_key_count:
             raise AggregationError(
-                f"single-message aggregate verify expected {expected} pubkeys for participants, "
-                f"got {len(public_keys)}"
+                f"single-message aggregate verify expected {expected_public_key_count} pubkeys "
+                f"for participants, got {len(public_keys)}"
             )
 
         # Hand the resolved keys, message, and slot to the Rust verifier.
@@ -191,8 +191,8 @@ class MultiMessageAggregate(Container):
     @classmethod
     def aggregate(
         cls,
-        parts: list[SingleMessageAggregate],
-        public_keys_per_part: list[list[PublicKey]],
+        single_message_aggregates: list[SingleMessageAggregate],
+        public_keys_per_aggregate: list[list[PublicKey]],
     ) -> "MultiMessageAggregate":
         """
         Merge several single-message proofs over distinct messages into one.
@@ -204,8 +204,10 @@ class MultiMessageAggregate(Container):
         - They cannot be recovered from the proofs, so the caller supplies them.
 
         Args:
-            parts: The single-message proofs to merge, one per distinct message.
-            public_keys_per_part: Public keys for each component, in the same order as the proofs.
+            single_message_aggregates: The single-message proofs to merge,
+                one per distinct message.
+            public_keys_per_aggregate: Public keys for each component,
+                in the same order as the proofs.
 
         Returns:
             A merged proof binding every component to its own message.
@@ -214,7 +216,7 @@ class MultiMessageAggregate(Container):
             AggregationError: When no proofs are given, a public_key list disagrees
                 with its participant count, or the prover rejects the inputs.
         """
-        if not parts:
+        if not single_message_aggregates:
             raise AggregationError(
                 "multi-message aggregate requires at least one single-message aggregate input"
             )
@@ -223,15 +225,22 @@ class MultiMessageAggregate(Container):
         #
         # A miscount would otherwise fail deep in the prover with an opaque error.
         single_message_aggregate_entries: list[tuple[list[bytes], bytes]] = []
-        for index, (part, public_keys) in enumerate(zip(parts, public_keys_per_part, strict=True)):
-            expected = len(part.participants.to_validator_indices())
-            if len(public_keys) != expected:
+        for aggregate_index, (single_message_aggregate, public_keys) in enumerate(
+            zip(single_message_aggregates, public_keys_per_aggregate, strict=True)
+        ):
+            expected_public_key_count = len(
+                single_message_aggregate.participants.to_validator_indices()
+            )
+            if len(public_keys) != expected_public_key_count:
                 raise AggregationError(
-                    f"multi-message aggregate entry {index} "
-                    f"expected {expected} pubkeys, got {len(public_keys)}"
+                    f"multi-message aggregate entry {aggregate_index} "
+                    f"expected {expected_public_key_count} pubkeys, got {len(public_keys)}"
                 )
             single_message_aggregate_entries.append(
-                ([public_key.encode_bytes() for public_key in public_keys], bytes(part.proof.data))
+                (
+                    [public_key.encode_bytes() for public_key in public_keys],
+                    bytes(single_message_aggregate.proof.data),
+                )
             )
 
         # Hand the per-component keys and proof bytes to the Rust prover.

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -148,31 +148,43 @@ class ForkChoiceMixin(LstarSpecBase):
         Raises:
             AssertionError: If attestation fails validation.
         """
-        data = attestation_data
+        source_checkpoint = attestation_data.source
+        target_checkpoint = attestation_data.target
+        head_checkpoint = attestation_data.head
 
         # Availability Check
         #
         # We cannot count a vote if we haven't seen the blocks involved.
-        assert data.source.root in store.blocks, f"Unknown source block: {data.source.root.hex()}"
-        assert data.target.root in store.blocks, f"Unknown target block: {data.target.root.hex()}"
-        assert data.head.root in store.blocks, f"Unknown head block: {data.head.root.hex()}"
+        assert source_checkpoint.root in store.blocks, (
+            f"Unknown source block: {source_checkpoint.root.hex()}"
+        )
+        assert target_checkpoint.root in store.blocks, (
+            f"Unknown target block: {target_checkpoint.root.hex()}"
+        )
+        assert head_checkpoint.root in store.blocks, (
+            f"Unknown head block: {head_checkpoint.root.hex()}"
+        )
 
         # Topology Check
         #
         # History is linear and monotonic: source <= target <= head.
         # The second check implies head >= source by transitivity.
-        assert data.source.slot <= data.target.slot, "Source checkpoint slot must not exceed target"
-        assert data.head.slot >= data.target.slot, "Head checkpoint must not be older than target"
+        assert source_checkpoint.slot <= target_checkpoint.slot, (
+            "Source checkpoint slot must not exceed target"
+        )
+        assert head_checkpoint.slot >= target_checkpoint.slot, (
+            "Head checkpoint must not be older than target"
+        )
 
         # Consistency Check
         #
         # Validate checkpoint slots match block slots.
-        source_block = store.blocks[data.source.root]
-        target_block = store.blocks[data.target.root]
-        head_block = store.blocks[data.head.root]
-        assert source_block.slot == data.source.slot, "Source checkpoint slot mismatch"
-        assert target_block.slot == data.target.slot, "Target checkpoint slot mismatch"
-        assert head_block.slot == data.head.slot, "Head checkpoint slot mismatch"
+        source_block = store.blocks[source_checkpoint.root]
+        target_block = store.blocks[target_checkpoint.root]
+        head_block = store.blocks[head_checkpoint.root]
+        assert source_block.slot == source_checkpoint.slot, "Source checkpoint slot mismatch"
+        assert target_block.slot == target_checkpoint.slot, "Target checkpoint slot mismatch"
+        assert head_block.slot == head_checkpoint.slot, "Head checkpoint slot mismatch"
 
         # Time Check
         #
@@ -182,7 +194,7 @@ class ForkChoiceMixin(LstarSpecBase):
         # The bound is in intervals, not slots: a whole-slot margin would
         # let an adversary pre-publish next-slot aggregates ahead of any
         # honest validator.
-        attestation_start_interval = Interval.from_slot(data.slot)
+        attestation_start_interval = Interval.from_slot(attestation_data.slot)
         gossip_disparity = Interval(int(GOSSIP_DISPARITY_INTERVALS))
         assert attestation_start_interval <= store.time + gossip_disparity, (
             "Attestation too far in future"
@@ -270,26 +282,27 @@ class ForkChoiceMixin(LstarSpecBase):
             ValueError: If validator not found in state.
             AssertionError: If signature verification fails.
         """
-        data = signed_attestation.data
-        proof = signed_attestation.proof
+        attestation_data = signed_attestation.data
+        aggregated_proof = signed_attestation.proof
 
-        self.validate_attestation(store, data)
+        self.validate_attestation(store, attestation_data)
 
         # Get validator IDs who participated in this aggregation
-        validator_indices = proof.participants.to_validator_indices()
+        validator_indices = aggregated_proof.participants.to_validator_indices()
 
         # Retrieve the relevant state to look up public keys for verification.
-        key_state = store.states.get(data.target.root)
+        key_state = store.states.get(attestation_data.target.root)
         assert key_state is not None, (
             f"No state available to verify committee aggregation for target "
-            f"{data.target.root.hex()}"
+            f"{attestation_data.target.root.hex()}"
         )
 
         # Ensure all participants exist in the active set
         validators = key_state.validators
         for validator_index in validator_indices:
             assert validator_index.is_within_registry(Uint64(len(validators))), (
-                f"Validator {validator_index} not found in state {data.target.root.hex()}"
+                f"Validator {validator_index} not found in state "
+                f"{attestation_data.target.root.hex()}"
             )
 
         # Prepare public keys for verification
@@ -300,17 +313,19 @@ class ForkChoiceMixin(LstarSpecBase):
 
         # Verify the single-message aggregate single-message aggregated proof.
         try:
-            proof.verify(
+            aggregated_proof.verify(
                 public_keys=public_keys,
-                message=hash_tree_root(data),
-                slot=data.slot,
+                message=hash_tree_root(attestation_data),
+                slot=attestation_data.slot,
             )
         except AggregationError as exception:
             raise AssertionError(
                 f"Committee aggregation signature verification failed: {exception}"
             ) from exception
 
-        store.latest_new_aggregated_payloads.setdefault(data, set()).add(proof)
+        store.latest_new_aggregated_payloads.setdefault(attestation_data, set()).add(
+            aggregated_proof
+        )
 
         return store
 

--- a/src/lean_spec/spec/ssz/bitfields.py
+++ b/src/lean_spec/spec/ssz/bitfields.py
@@ -60,24 +60,24 @@ class BaseBitvector(SSZModel):
 
     @field_validator("data", mode="before")
     @classmethod
-    def _coerce_and_validate(cls, v: Any) -> tuple[Boolean, ...]:
+    def _coerce_and_validate(cls, bits_input: Any) -> tuple[Boolean, ...]:
         """Enforce the exact bit count and coerce inputs into booleans."""
         # Subclasses must declare LENGTH before any instances can be validated.
         if not hasattr(cls, "LENGTH"):
             raise SSZTypeError(f"{cls.__name__} must define LENGTH")
 
         # Materialize generic iterables into a tuple so the length check works.
-        if not isinstance(v, (list, tuple)):
-            v = tuple(v)
+        if not isinstance(bits_input, (list, tuple)):
+            bits_input = tuple(bits_input)
 
         # Fixed-length type: the input must contain exactly LENGTH elements.
-        if len(v) != cls.LENGTH:
+        if len(bits_input) != cls.LENGTH:
             raise SSZValueError(
-                f"{cls.__name__} requires exactly {cls.LENGTH} elements, got {len(v)}"
+                f"{cls.__name__} requires exactly {cls.LENGTH} elements, got {len(bits_input)}"
             )
 
         # Wrap each value in Boolean — the constructor rejects anything outside 0 or 1.
-        return tuple(Boolean(bit) for bit in v)
+        return tuple(Boolean(bit) for bit in bits_input)
 
     @classmethod
     @override
@@ -107,10 +107,12 @@ class BaseBitvector(SSZModel):
             raise SSZSerializationError(
                 f"{cls.__name__}: expected {expected_byte_count} bytes, got {scope}"
             )
-        data = stream.read(scope)
-        if len(data) != scope:
-            raise SSZSerializationError(f"{cls.__name__}: expected {scope} bytes, got {len(data)}")
-        return cls.decode_bytes(data)
+        serialized_bytes = stream.read(scope)
+        if len(serialized_bytes) != scope:
+            raise SSZSerializationError(
+                f"{cls.__name__}: expected {scope} bytes, got {len(serialized_bytes)}"
+            )
+        return cls.decode_bytes(serialized_bytes)
 
     @override
     def encode_bytes(self) -> bytes:
@@ -124,8 +126,8 @@ class BaseBitvector(SSZModel):
             ceil(N / 8) bytes containing the packed bits.
         """
         # Build the packed bits as one integer, then split into little-endian bytes.
-        value = sum(1 << i for i, bit in enumerate(self.data) if bit)
-        return value.to_bytes(math.ceil(self.LENGTH / 8), "little")
+        packed_bits = sum(1 << i for i, bit in enumerate(self.data) if bit)
+        return packed_bits.to_bytes(math.ceil(self.LENGTH / 8), "little")
 
     @classmethod
     @override
@@ -208,7 +210,7 @@ class BaseBitlist(SSZModel):
 
     @field_validator("data", mode="before")
     @classmethod
-    def _coerce_and_validate(cls, v: Any) -> tuple[Boolean, ...]:
+    def _coerce_and_validate(cls, bits_input: Any) -> tuple[Boolean, ...]:
         """Enforce the maximum bit count and coerce inputs into booleans."""
         # Subclasses must declare LIMIT before any instances can be validated.
         if not hasattr(cls, "LIMIT"):
@@ -219,12 +221,12 @@ class BaseBitlist(SSZModel):
         #   - list or tuple    pass through directly.
         #   - other iterables  materialize into a list so length is known.
         #   - str or bytes     rejected — iterable but elements are not booleans.
-        if isinstance(v, (list, tuple)):
-            elements = v
-        elif hasattr(v, "__iter__") and not isinstance(v, (str, bytes)):
-            elements = list(v)
+        if isinstance(bits_input, (list, tuple)):
+            elements = bits_input
+        elif hasattr(bits_input, "__iter__") and not isinstance(bits_input, (str, bytes)):
+            elements = list(bits_input)
         else:
-            raise SSZTypeError(f"Expected iterable, got {type(v).__name__}")
+            raise SSZTypeError(f"Expected iterable, got {type(bits_input).__name__}")
 
         # Variable-length type: any count is fine, up to LIMIT.
         if len(elements) > cls.LIMIT:
@@ -283,10 +285,12 @@ class BaseBitlist(SSZModel):
     @override
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
         """Read SSZ bytes from a stream and return an instance."""
-        data = stream.read(scope)
-        if len(data) != scope:
-            raise SSZSerializationError(f"{cls.__name__}: expected {scope} bytes, got {len(data)}")
-        return cls.decode_bytes(data)
+        serialized_bytes = stream.read(scope)
+        if len(serialized_bytes) != scope:
+            raise SSZSerializationError(
+                f"{cls.__name__}: expected {scope} bytes, got {len(serialized_bytes)}"
+            )
+        return cls.decode_bytes(serialized_bytes)
 
     @override
     def encode_bytes(self) -> bytes:
@@ -325,8 +329,8 @@ class BaseBitlist(SSZModel):
         # It is what lets the decoder recover the original bit count.
         # Converting an integer to bytes runs the bit-to-byte split in C.
         # That avoids a Python loop over every bit.
-        value = sum(1 << i for i, bit in enumerate(self.data) if bit) | (1 << num_bits)
-        return value.to_bytes(math.ceil((num_bits + 1) / 8), "little")
+        packed_bits = sum(1 << i for i, bit in enumerate(self.data) if bit) | (1 << num_bits)
+        return packed_bits.to_bytes(math.ceil((num_bits + 1) / 8), "little")
 
     @classmethod
     @override

--- a/src/lean_spec/spec/ssz/byte_arrays.py
+++ b/src/lean_spec/spec/ssz/byte_arrays.py
@@ -85,10 +85,12 @@ class BaseBytes(bytes, SSZType):
         if not hasattr(cls, "LENGTH"):
             raise SSZTypeError(f"{cls.__name__} must define LENGTH")
 
-        b = cls._coerce_to_bytes(value)
-        if len(b) != cls.LENGTH:
-            raise SSZValueError(f"{cls.__name__} requires exactly {cls.LENGTH} bytes, got {len(b)}")
-        return super().__new__(cls, b)
+        coerced_bytes = cls._coerce_to_bytes(value)
+        if len(coerced_bytes) != cls.LENGTH:
+            raise SSZValueError(
+                f"{cls.__name__} requires exactly {cls.LENGTH} bytes, got {len(coerced_bytes)}"
+            )
+        return super().__new__(cls, coerced_bytes)
 
     @classmethod
     def zero(cls) -> Self:
@@ -133,11 +135,13 @@ class BaseBytes(bytes, SSZType):
         """
         if scope != cls.LENGTH:
             raise SSZSerializationError(f"{cls.__name__}: expected {cls.LENGTH} bytes, got {scope}")
-        data = stream.read(scope)
-        if len(data) != scope:
-            raise SSZSerializationError(f"{cls.__name__}: expected {scope} bytes, got {len(data)}")
+        serialized_bytes = stream.read(scope)
+        if len(serialized_bytes) != scope:
+            raise SSZSerializationError(
+                f"{cls.__name__}: expected {scope} bytes, got {len(serialized_bytes)}"
+            )
         # Length already verified — bypass __new__'s coerce + revalidation.
-        return bytes.__new__(cls, data)
+        return bytes.__new__(cls, serialized_bytes)
 
     @override
     def encode_bytes(self) -> bytes:
@@ -365,10 +369,12 @@ class BaseByteList(SSZModel):
             raise SSZSerializationError(f"{cls.__name__}: negative scope")
         if scope > cls.LIMIT:
             raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {scope}")
-        data = stream.read(scope)
-        if len(data) != scope:
-            raise SSZSerializationError(f"{cls.__name__}: expected {scope} bytes, got {len(data)}")
-        return cls(data=data)
+        serialized_bytes = stream.read(scope)
+        if len(serialized_bytes) != scope:
+            raise SSZSerializationError(
+                f"{cls.__name__}: expected {scope} bytes, got {len(serialized_bytes)}"
+            )
+        return cls(data=serialized_bytes)
 
     @override
     def encode_bytes(self) -> bytes:

--- a/src/lean_spec/spec/ssz/collections.py
+++ b/src/lean_spec/spec/ssz/collections.py
@@ -70,10 +70,11 @@ def _validate_offsets(offsets: list[int], scope: int, type_name: str) -> None:
         return
 
     # Pairwise comparison catches any decreasing step in the table.
-    for previous, current in pairwise(offsets):
-        if current < previous:
+    for previous_offset, current_offset in pairwise(offsets):
+        if current_offset < previous_offset:
             raise SSZSerializationError(
-                f"{type_name}: offsets not monotonically increasing: {previous} -> {current}"
+                f"{type_name}: offsets not monotonically increasing: "
+                f"{previous_offset} -> {current_offset}"
             )
 
     # The final boundary is the scope appended by the decoder.
@@ -84,7 +85,7 @@ def _validate_offsets(offsets: list[int], scope: int, type_name: str) -> None:
         )
 
 
-def _coerce_elements(element_type: type[SSZType], items: Sequence[Any]) -> tuple[SSZType, ...]:
+def _coerce_elements(element_type: type[SSZType], elements: Sequence[Any]) -> tuple[SSZType, ...]:
     """
     Coerce every element of an already-shaped sequence into the declared type.
 
@@ -94,15 +95,15 @@ def _coerce_elements(element_type: type[SSZType], items: Sequence[Any]) -> tuple
     - The chained cause preserves the underlying coercion detail.
     """
     coerced: list[SSZType] = []
-    for item in items:
-        if isinstance(item, element_type):
-            coerced.append(item)
+    for element in elements:
+        if isinstance(element, element_type):
+            coerced.append(element)
             continue
         try:
-            coerced.append(cast(Any, element_type)(item))
+            coerced.append(cast(Any, element_type)(element))
         except (SSZTypeError, SSZValueError, TypeError, ValueError) as exception:
             raise SSZTypeError(
-                f"Expected {element_type.__name__}, got {type(item).__name__}: {exception}"
+                f"Expected {element_type.__name__}, got {type(element).__name__}: {exception}"
             ) from exception
     return tuple(coerced)
 
@@ -186,24 +187,24 @@ class _SSZSequence[T: SSZType](SSZModel):
         """
         # Pydantic does not auto-flatten SSZ leaf types into JSON primitives.
         # Each element is inspected and rewritten according to the rules below.
-        result: list[Any] = []
-        for item in value:
+        serialized_elements: list[Any] = []
+        for element in value:
             # Byte-array leaves render as 0x-prefixed hex strings.
             # This matches how every other byte value appears in spec output.
-            if isinstance(item, BaseBytes):
-                result.append("0x" + item.hex())
+            if isinstance(element, BaseBytes):
+                serialized_elements.append("0x" + element.hex())
 
             # Integer leaves (uints, field elements) flatten to a plain int.
             # Bool also subclasses int.
             # It is excluded so True and False survive in JSON unchanged.
-            elif isinstance(item, int) and not isinstance(item, bool):
-                result.append(int(item))
+            elif isinstance(element, int) and not isinstance(element, bool):
+                serialized_elements.append(int(element))
 
             # Anything else passes through for Pydantic's downstream serializers.
             # Nested containers, booleans, strings, and primitive values land here.
             else:
-                result.append(item)
-        return result
+                serialized_elements.append(element)
+        return serialized_elements
 
     def _write_variable_payload(self, stream: IO[bytes], offset_count: int) -> int:
         """
@@ -325,24 +326,24 @@ class SSZVector[T: SSZType](_SSZSequence[T]):
         #   - other iterables  materialize into a list so the length check works.
         #   - str or bytes     rejected — iterating yields characters or ints.
         if isinstance(v, (list, tuple)):
-            items: Sequence[Any] = v
+            input_elements: Sequence[Any] = v
         elif isinstance(v, (str, bytes, bytearray)):
             raise SSZTypeError(
                 f"{cls.__name__}: Expected iterable of {cls.ELEMENT_TYPE.__name__}, "
                 f"got {type(v).__name__}"
             )
         elif hasattr(v, "__iter__"):
-            items = list(v)
+            input_elements = list(v)
         else:
             raise SSZTypeError(f"{cls.__name__}: Expected iterable, got {type(v).__name__}")
 
         # Fixed-length type: the input must contain exactly LENGTH elements.
-        if len(items) != cls.LENGTH:
+        if len(input_elements) != cls.LENGTH:
             raise SSZValueError(
-                f"{cls.__name__} requires exactly {cls.LENGTH} elements, got {len(items)}"
+                f"{cls.__name__} requires exactly {cls.LENGTH} elements, got {len(input_elements)}"
             )
 
-        return _coerce_elements(cls.ELEMENT_TYPE, items)
+        return _coerce_elements(cls.ELEMENT_TYPE, input_elements)
 
     @classmethod
     @override
@@ -489,22 +490,24 @@ class SSZList[T: SSZType](_SSZSequence[T]):
         #   - other iterables  materialize into a list so the length check works.
         #   - str or bytes     rejected — iterating yields characters or ints.
         if isinstance(v, (list, tuple)):
-            items: Sequence[Any] = v
+            input_elements: Sequence[Any] = v
         elif isinstance(v, (str, bytes, bytearray)):
             raise SSZTypeError(
                 f"{cls.__name__}: Expected iterable of {cls.ELEMENT_TYPE.__name__}, "
                 f"got {type(v).__name__}"
             )
         elif hasattr(v, "__iter__"):
-            items = list(v)
+            input_elements = list(v)
         else:
             raise SSZTypeError(f"{cls.__name__}: Expected iterable, got {type(v).__name__}")
 
         # Variable-length type: any count is fine, up to LIMIT.
-        if len(items) > cls.LIMIT:
-            raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {len(items)}")
+        if len(input_elements) > cls.LIMIT:
+            raise SSZValueError(
+                f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {len(input_elements)}"
+            )
 
-        return _coerce_elements(cls.ELEMENT_TYPE, items)
+        return _coerce_elements(cls.ELEMENT_TYPE, input_elements)
 
     def __add__(self, other: Any) -> Self:
         """

--- a/src/lean_spec/spec/ssz/container.py
+++ b/src/lean_spec/spec/ssz/container.py
@@ -48,22 +48,22 @@ class Container(SSZModel):
     @override
     def serialize(self, stream: IO[bytes]) -> int:
         """Write the fixed part with offsets, then the variable payloads."""
-        values = [getattr(self, name) for name in type(self).model_fields]
+        field_values = [getattr(self, name) for name in type(self).model_fields]
 
         # Leading-part width: each slot is either the field's byte length or one offset.
         offset = sum(
             type(v).get_byte_length() if type(v).is_fixed_size() else BYTES_PER_LENGTH_OFFSET
-            for v in values
+            for v in field_values
         )
 
         # Variable payloads stage in a buffer while the output takes the fixed part.
         tail = io.BytesIO()
-        for value in values:
-            if type(value).is_fixed_size():
-                value.serialize(stream)
+        for field_value in field_values:
+            if type(field_value).is_fixed_size():
+                field_value.serialize(stream)
             else:
                 Uint32(offset).serialize(stream)
-                offset += value.serialize(tail)
+                offset += field_value.serialize(tail)
         stream.write(tail.getvalue())
         return offset
 
@@ -76,8 +76,8 @@ class Container(SSZModel):
         bytes_read = 0
 
         # Phase 1: each slot is either the field itself or an offset to its tail payload.
-        for name, info in cls.model_fields.items():
-            ftype: type[SSZType] = info.annotation
+        for name, field_definition in cls.model_fields.items():
+            ftype: type[SSZType] = field_definition.annotation
             if ftype.is_fixed_size():
                 width = ftype.get_byte_length()
                 fields[name] = ftype.deserialize(stream, width)

--- a/src/lean_spec/spec/ssz/ssz_base.py
+++ b/src/lean_spec/spec/ssz/ssz_base.py
@@ -123,16 +123,16 @@ class SSZModel(StrictBaseModel, SSZType):
 
     def __len__(self) -> int:
         """Element count for collections, field count for containers."""
-        data = getattr(self, "data", None)
-        if data is not None:
-            return len(data)
+        data_field = getattr(self, "data", None)
+        if data_field is not None:
+            return len(data_field)
         return len(type(self).model_fields)
 
     def __repr__(self) -> str:
         """Show collection contents as data=[...] or container fields as name=value pairs."""
         cls_name = type(self).__name__
-        data = getattr(self, "data", None)
-        if data is not None:
-            return f"{cls_name}(data={list(data)!r})"
+        data_field = getattr(self, "data", None)
+        if data_field is not None:
+            return f"{cls_name}(data={list(data_field)!r})"
         field_strs = [f"{name}={getattr(self, name)!r}" for name in type(self).model_fields]
         return f"{cls_name}({' '.join(field_strs)})"

--- a/src/lean_spec/spec/ssz/uint.py
+++ b/src/lean_spec/spec/ssz/uint.py
@@ -122,14 +122,14 @@ class BaseUint(int, SSZType):
                 f"{cls.__name__}: invalid scope, expected {byte_length} bytes, got {scope}"
             )
         # Read the required number of bytes from the stream.
-        data = stream.read(byte_length)
+        serialized_bytes = stream.read(byte_length)
         # Ensure the correct number of bytes was read.
-        if len(data) != byte_length:
+        if len(serialized_bytes) != byte_length:
             raise SSZSerializationError(
-                f"{cls.__name__}: expected {byte_length} bytes, got {len(data)}"
+                f"{cls.__name__}: expected {byte_length} bytes, got {len(serialized_bytes)}"
             )
         # Decode the bytes into a new instance.
-        return cls.decode_bytes(data)
+        return cls.decode_bytes(serialized_bytes)
 
     @classmethod
     def max_value(cls) -> Self:
@@ -217,8 +217,8 @@ class BaseUint(int, SSZType):
             self._raise_type_error(value, "**")
         if mod is not None and type(mod) is not type(self):
             self._raise_type_error(mod, "**")
-        result = pow(int(self), int(value), int(mod) if mod is not None else None)
-        return type(self)(result)
+        power = pow(int(self), int(value), int(mod) if mod is not None else None)
+        return type(self)(power)
 
     def __rpow__(self, base: int, modulo: int | None = None, /) -> Self:
         """Reverse exponentiation and three-argument pow."""
@@ -226,22 +226,22 @@ class BaseUint(int, SSZType):
             self._raise_type_error(base, "**")
         if modulo is not None and type(modulo) is not type(self):
             self._raise_type_error(modulo, "**")
-        result = pow(int(base), int(self), int(modulo) if modulo is not None else None)
-        return type(self)(result)
+        power = pow(int(base), int(self), int(modulo) if modulo is not None else None)
+        return type(self)(power)
 
     def __divmod__(self, other: Any) -> tuple[Self, Self]:
         """Forward divmod."""
         if type(other) is not type(self):
             self._raise_type_error(other, "divmod")
-        q, r = super().__divmod__(other)
-        return type(self)(q), type(self)(r)
+        quotient, remainder = super().__divmod__(other)
+        return type(self)(quotient), type(self)(remainder)
 
     def __rdivmod__(self, other: Any) -> tuple[Self, Self]:
         """Reverse divmod."""
         if type(other) is not type(self):
             self._raise_type_error(other, "divmod")
-        q, r = super().__rdivmod__(other)
-        return type(self)(q), type(self)(r)
+        quotient, remainder = super().__rdivmod__(other)
+        return type(self)(quotient), type(self)(remainder)
 
     def __and__(self, other: Any) -> Self:
         """Forward bitwise AND."""

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -56,8 +56,8 @@ class _ServerThread(threading.Thread):
 
             self.loop.run_forever()
 
-        except Exception as e:
-            self.error = e
+        except Exception as exception:
+            self.error = exception
             self.ready.set()
         finally:
             if self.loop:

--- a/tests/api/endpoints/test_aggregator.py
+++ b/tests/api/endpoints/test_aggregator.py
@@ -26,9 +26,9 @@ class TestAggregatorStatus:
     def test_response_has_is_aggregator_field(self, server_url: str) -> None:
         """GET response contains the is_aggregator boolean field."""
         response = httpx.get(f"{server_url}/lean/v0/admin/aggregator")
-        data = response.json()
-        assert "is_aggregator" in data
-        assert isinstance(data["is_aggregator"], bool)
+        response_body = response.json()
+        assert "is_aggregator" in response_body
+        assert isinstance(response_body["is_aggregator"], bool)
 
 
 class TestAggregatorToggle:
@@ -56,11 +56,11 @@ class TestAggregatorToggle:
             f"{server_url}/lean/v0/admin/aggregator",
             json={"enabled": True},
         )
-        data = response.json()
-        assert "is_aggregator" in data
-        assert "previous" in data
-        assert isinstance(data["is_aggregator"], bool)
-        assert isinstance(data["previous"], bool)
+        response_body = response.json()
+        assert "is_aggregator" in response_body
+        assert "previous" in response_body
+        assert isinstance(response_body["is_aggregator"], bool)
+        assert isinstance(response_body["previous"], bool)
 
     def test_toggle_reflects_requested_value(self, server_url: str) -> None:
         """POST response reflects the requested enabled value."""

--- a/tests/api/endpoints/test_checkpoints.py
+++ b/tests/api/endpoints/test_checkpoints.py
@@ -28,19 +28,19 @@ class TestJustifiedCheckpoint:
     def test_has_slot(self, server_url: str) -> None:
         """Justified checkpoint response has a slot field."""
         response = get_justified_checkpoint(server_url)
-        data = response.json()
+        response_body = response.json()
 
-        assert "slot" in data
-        assert isinstance(data["slot"], int)
-        assert data["slot"] >= 0
+        assert "slot" in response_body
+        assert isinstance(response_body["slot"], int)
+        assert response_body["slot"] >= 0
 
     def test_has_root(self, server_url: str) -> None:
         """Justified checkpoint response has a valid root field."""
         response = get_justified_checkpoint(server_url)
-        data = response.json()
+        response_body = response.json()
 
-        assert "root" in data
-        root = data["root"]
+        assert "root" in response_body
+        root = response_body["root"]
 
         # Root should be a 0x-prefixed hex string (32 bytes = 66 characters with prefix)
         assert isinstance(root, str)

--- a/tests/api/endpoints/test_fork_choice.py
+++ b/tests/api/endpoints/test_fork_choice.py
@@ -31,10 +31,10 @@ class TestForkChoice:
 
     def test_fork_choice_response(self, server_url: str) -> None:
         """Fork choice response matches expected genesis-only tree structure."""
-        data = get_fork_choice(server_url).json()
-        genesis_root = data["head"]
+        response_body = get_fork_choice(server_url).json()
+        genesis_root = response_body["head"]
 
-        assert data == {
+        assert response_body == {
             "nodes": [
                 {
                     "root": genesis_root,

--- a/tests/api/endpoints/test_health.py
+++ b/tests/api/endpoints/test_health.py
@@ -28,10 +28,10 @@ def test_health_content_type_is_json(server_url: str) -> None:
 def test_health_response_structure(server_url: str) -> None:
     """Health endpoint returns expected JSON structure."""
     response = get_health(server_url)
-    data = response.json()
+    response_body = response.json()
 
-    assert "status" in data
-    assert data["status"] == health.STATUS_HEALTHY
+    assert "status" in response_body
+    assert response_body["status"] == health.STATUS_HEALTHY
 
-    assert "service" in data
-    assert data["service"] == health.SERVICE_NAME
+    assert "service" in response_body
+    assert response_body["service"] == health.SERVICE_NAME

--- a/tests/interop/helpers/node_runner.py
+++ b/tests/interop/helpers/node_runner.py
@@ -361,8 +361,10 @@ class NodeCluster:
         if listener_task.done():
             try:
                 listener_task.result()
-            except OSError as e:
-                raise RuntimeError(f"Failed to start listener on {listen_address}: {e}") from e
+            except OSError as exception:
+                raise RuntimeError(
+                    f"Failed to start listener on {listen_address}: {exception}"
+                ) from exception
 
         test_node._listener_task = listener_task
 

--- a/tests/interop/test_consensus_lifecycle.py
+++ b/tests/interop/test_consensus_lifecycle.py
@@ -136,13 +136,14 @@ async def test_consensus_lifecycle(node_cluster: NodeCluster) -> None:
         store = node._store
         head_block = store.blocks[store.head]
         visited = 0
-        current = head_block
-        while current.parent_root in store.blocks:
-            parent = store.blocks[current.parent_root]
-            assert current.slot > parent.slot, (
-                f"Node {node.index}: block at slot {current.slot} has parent at slot {parent.slot}"
+        current_block = head_block
+        while current_block.parent_root in store.blocks:
+            parent = store.blocks[current_block.parent_root]
+            assert current_block.slot > parent.slot, (
+                f"Node {node.index}: block at slot {current_block.slot} "
+                f"has parent at slot {parent.slot}"
             )
-            current = parent
+            current_block = parent
             visited += 1
 
         logger.info(

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -227,7 +227,7 @@ def make_aggregated_attestation(
 
     Head checkpoint uses the target's root and slot.
     """
-    data = AttestationData(
+    attestation_data = AttestationData(
         slot=attestation_slot,
         head=Checkpoint(root=target.root, slot=target.slot),
         target=target,
@@ -236,7 +236,7 @@ def make_aggregated_attestation(
 
     return AggregatedAttestation(
         aggregation_bits=AggregationBits.from_indices(participant_ids),
-        data=data,
+        data=attestation_data,
     )
 
 
@@ -435,8 +435,8 @@ def make_signed_aggregated_attestation(
             target=Checkpoint(root=Bytes32.zero(), slot=Slot(1)),
             source=Checkpoint(root=Bytes32.zero(), slot=Slot(0)),
         )
-    proof = make_aggregated_proof(key_manager, participants, attestation_data)
-    return SignedAggregatedAttestation(data=attestation_data, proof=proof)
+    aggregated_proof = make_aggregated_proof(key_manager, participants, attestation_data)
+    return SignedAggregatedAttestation(data=attestation_data, proof=aggregated_proof)
 
 
 def make_signed_block_from_store(
@@ -459,15 +459,15 @@ def make_signed_block_from_store(
     block_root = hash_tree_root(block)
 
     head_state = new_store.states[new_store.head]
-    public_keys_per_part: list[list] = [
+    public_keys_per_aggregate: list[list] = [
         [
             head_state.validators[validator_index].get_attestation_public_key()
-            for validator_index in proof.participants.to_validator_indices()
+            for validator_index in attestation_proof.participants.to_validator_indices()
         ]
-        for proof in attestation_proofs
+        for attestation_proof in attestation_proofs
     ]
     proposer_public_key = head_state.validators[proposer_index].get_proposal_public_key()
-    public_keys_per_part.append([proposer_public_key])
+    public_keys_per_aggregate.append([proposer_public_key])
 
     proposer_signature = key_manager.sign_block_root(proposer_index, slot, block_root)
     proposer_single_message_aggregate = SingleMessageAggregate.aggregate(
@@ -477,14 +477,14 @@ def make_signed_block_from_store(
         slot=slot,
     )
 
-    merged = MultiMessageAggregate.aggregate(
+    merged_proof = MultiMessageAggregate.aggregate(
         [*attestation_proofs, proposer_single_message_aggregate],
-        public_keys_per_part=public_keys_per_part,
+        public_keys_per_aggregate=public_keys_per_aggregate,
     )
 
     signed_block = SignedBlock(
         block=block,
-        proof=merged,
+        proof=merged_proof,
     )
 
     target_interval = Interval.from_slot(block.slot)

--- a/tests/lean_spec/node/api/test_aggregator_controller.py
+++ b/tests/lean_spec/node/api/test_aggregator_controller.py
@@ -84,7 +84,7 @@ class TestAggregatorControllerWrite:
         """Sequential toggles each see the prior state and converge to the last value."""
         controller, sync_service, network_service = _make_controller(peer_id, initial=False)
 
-        results = await asyncio.gather(
+        previous_states = await asyncio.gather(
             controller.set_enabled(True),
             controller.set_enabled(False),
             controller.set_enabled(True),
@@ -92,7 +92,7 @@ class TestAggregatorControllerWrite:
 
         # asyncio.gather on a single-threaded event loop preserves order.
         # Each toggle sees the previous state correctly.
-        assert results == [False, True, False]
+        assert previous_states == [False, True, False]
         assert controller.is_enabled() is True
         assert sync_service.is_aggregator is True
         assert network_service.is_aggregator is True

--- a/tests/lean_spec/node/api/test_server.py
+++ b/tests/lean_spec/node/api/test_server.py
@@ -155,9 +155,9 @@ class TestForkChoiceEndpoint:
                 assert response.status_code == 200
                 assert response.headers["content-type"] == "application/json"
 
-                data = response.json()
+                response_body = response.json()
 
-                assert set(data.keys()) == {
+                assert set(response_body.keys()) == {
                     "nodes",
                     "head",
                     "justified",
@@ -168,19 +168,19 @@ class TestForkChoiceEndpoint:
 
                 head_root = "0x" + base_store.head.hex()
 
-                assert data["head"] == head_root
-                assert data["validator_count"] == 3
-                assert data["justified"] == {
+                assert response_body["head"] == head_root
+                assert response_body["validator_count"] == 3
+                assert response_body["justified"] == {
                     "slot": int(base_store.latest_justified.slot),
                     "root": "0x" + base_store.latest_justified.root.hex(),
                 }
-                assert data["finalized"] == {
+                assert response_body["finalized"] == {
                     "slot": int(base_store.latest_finalized.slot),
                     "root": "0x" + base_store.latest_finalized.root.hex(),
                 }
 
-                assert len(data["nodes"]) == 1
-                node = data["nodes"][0]
+                assert len(response_body["nodes"]) == 1
+                node = response_body["nodes"][0]
                 assert node["root"] == head_root
                 assert node["slot"] == 0
                 assert node["weight"] == 0

--- a/tests/lean_spec/node/chain/test_clock.py
+++ b/tests/lean_spec/node/chain/test_clock.py
@@ -159,8 +159,8 @@ class TestSecondsUntilNextInterval:
     )
     def test_time_until_boundary(self, genesis: int, now: float, expected_seconds: float) -> None:
         """Returns the seconds remaining until the next interval boundary."""
-        result = clock_at(genesis, now).seconds_until_next_interval()
-        assert result == pytest.approx(expected_seconds, abs=1e-3)
+        seconds_until_next_interval = clock_at(genesis, now).seconds_until_next_interval()
+        assert seconds_until_next_interval == pytest.approx(expected_seconds, abs=1e-3)
 
 
 class TestSleepUntilNextInterval:

--- a/tests/lean_spec/node/chain/test_service.py
+++ b/tests/lean_spec/node/chain/test_service.py
@@ -209,7 +209,7 @@ class TestStartupTick:
     """Tests for the one-shot catch-up performed at startup."""
 
     @pytest.mark.parametrize(
-        ("intervals_elapsed", "expected_result", "expected_tick_times"),
+        ("intervals_elapsed", "expected_interval", "expected_tick_times"),
         [
             # Before genesis: nothing ticks, the caller waits.
             (-0.5, None, []),
@@ -224,15 +224,15 @@ class TestStartupTick:
     async def test_catches_store_up_to_wall_clock(
         self,
         intervals_elapsed: float,
-        expected_result: Interval | None,
+        expected_interval: Interval | None,
         expected_tick_times: list[int],
     ) -> None:
         """Startup ticks the store to the current interval, or reports waiting if pre-genesis."""
         spec = ProbeSpec()
         now = 1000 + intervals_elapsed * INTERVAL_SECONDS
         service = make_service(spec, time_fn=lambda: now)
-        result = await service._initial_tick()
-        assert result == expected_result
+        initial_tick_interval = await service._initial_tick()
+        assert initial_tick_interval == expected_interval
         assert [time for time, _, _ in spec.ticks] == expected_tick_times
 
     async def test_discards_aggregates_produced_during_catch_up(self) -> None:

--- a/tests/lean_spec/node/genesis/test_config.py
+++ b/tests/lean_spec/node/genesis/test_config.py
@@ -83,11 +83,11 @@ class TestGenesisConfigYamlLoading:
         """PublicKeys are converted to Bytes52 instances."""
         config = _load(SAMPLE_YAML)
 
-        for entry in config.genesis_validators:
-            assert isinstance(entry.attestation_public_key, Bytes52)
-            assert len(entry.attestation_public_key) == 52
-            assert isinstance(entry.proposal_public_key, Bytes52)
-            assert len(entry.proposal_public_key) == 52
+        for genesis_validator in config.genesis_validators:
+            assert isinstance(genesis_validator.attestation_public_key, Bytes52)
+            assert len(genesis_validator.attestation_public_key) == 52
+            assert isinstance(genesis_validator.proposal_public_key, Bytes52)
+            assert len(genesis_validator.proposal_public_key) == 52
 
     def test_public_key_without_0x_prefix(self) -> None:
         """Handles public_keys without 0x prefix (zeam format)."""
@@ -251,5 +251,7 @@ class TestCrossClientFormat:
                 )
             ),
         ]
-        for entry, expected in zip(config.genesis_validators, expected_public_keys, strict=True):
-            assert entry.attestation_public_key == expected
+        for genesis_validator, expected_public_key in zip(
+            config.genesis_validators, expected_public_keys, strict=True
+        ):
+            assert genesis_validator.attestation_public_key == expected_public_key

--- a/tests/lean_spec/node/networking/client/event_source/test_gossip.py
+++ b/tests/lean_spec/node/networking/client/event_source/test_gossip.py
@@ -145,9 +145,9 @@ class MockStream:
         """Return next chunk of data, or empty bytes if exhausted."""
         if self.offset >= len(self.data):
             return b""
-        end = min(self.offset + self.chunk_size, len(self.data))
-        chunk = self.data[self.offset : end]
-        self.offset = end
+        chunk_end = min(self.offset + self.chunk_size, len(self.data))
+        chunk = self.data[self.offset : chunk_end]
+        self.offset = chunk_end
         return chunk
 
     def write(self, data: bytes) -> None:
@@ -304,9 +304,9 @@ class TestGossipHandlerDecodeMessage:
         compressed = compress(ssz_bytes)
         topic_str = make_block_topic()
 
-        result = handler.decode_message(topic_str, compressed)
+        decoded_message = handler.decode_message(topic_str, compressed)
 
-        assert isinstance(result, SignedBlock)
+        assert isinstance(decoded_message, SignedBlock)
 
     def test_decode_valid_attestation_message(self) -> None:
         """Decodes valid attestation message correctly."""
@@ -316,9 +316,9 @@ class TestGossipHandlerDecodeMessage:
         compressed = compress(ssz_bytes)
         topic_str = make_attestation_topic()
 
-        result = handler.decode_message(topic_str, compressed)
+        decoded_message = handler.decode_message(topic_str, compressed)
 
-        assert isinstance(result, SignedAttestation)
+        assert isinstance(decoded_message, SignedAttestation)
 
     def test_decode_invalid_topic_format(self) -> None:
         """Raises GossipMessageError for invalid topic format."""
@@ -431,8 +431,8 @@ class TestReadGossipMessage:
         topic = make_block_topic()
         topic_bytes = topic.encode("utf-8")
         # Complete topic but incomplete data length varint
-        data = encode_varint(len(topic_bytes)) + topic_bytes + b"\x80"
-        stream = MockStream(data)
+        gossip_wire = encode_varint(len(topic_bytes)) + topic_bytes + b"\x80"
+        stream = MockStream(gossip_wire)
 
         with pytest.raises(GossipMessageError, match="Truncated gossip message"):
             await read_gossip_message(stream)
@@ -443,8 +443,10 @@ class TestReadGossipMessage:
         topic_bytes = topic.encode("utf-8")
         compressed = compress(b"test data")
         # Claim data is 1000 bytes but only provide partial
-        data = encode_varint(len(topic_bytes)) + topic_bytes + encode_varint(1000) + compressed[:5]
-        stream = MockStream(data)
+        gossip_wire = (
+            encode_varint(len(topic_bytes)) + topic_bytes + encode_varint(1000) + compressed[:5]
+        )
+        stream = MockStream(gossip_wire)
 
         with pytest.raises(GossipMessageError, match="Truncated gossip message"):
             await read_gossip_message(stream)
@@ -453,10 +455,10 @@ class TestReadGossipMessage:
         """Raises GossipMessageError for invalid UTF-8 in topic."""
         # Invalid UTF-8 sequence
         invalid_utf8 = b"\xff\xfe"
-        data = encode_varint(len(invalid_utf8)) + invalid_utf8
+        gossip_wire = encode_varint(len(invalid_utf8)) + invalid_utf8
         # Add data portion
-        data += encode_varint(4) + b"test"
-        stream = MockStream(data)
+        gossip_wire += encode_varint(4) + b"test"
+        stream = MockStream(gossip_wire)
 
         with pytest.raises(GossipMessageError, match="Invalid topic encoding"):
             await read_gossip_message(stream)
@@ -594,12 +596,12 @@ class TestGossipReceptionEdgeCases:
         topic = make_block_topic()
         topic_bytes = topic.encode("utf-8")
         # Zero-length data
-        data = encode_varint(len(topic_bytes)) + topic_bytes + encode_varint(0)
-        stream = MockStream(data)
+        gossip_wire = encode_varint(len(topic_bytes)) + topic_bytes + encode_varint(0)
+        stream = MockStream(gossip_wire)
 
-        topic_result, compressed = await read_gossip_message(stream)
+        parsed_topic, compressed = await read_gossip_message(stream)
 
-        assert topic_result == topic
+        assert parsed_topic == topic
         assert compressed == b""
 
     def test_decode_corrupted_snappy_data(self) -> None:
@@ -622,10 +624,10 @@ class TestGossipReceptionEdgeCases:
         topic_bytes = topic.encode("utf-8")
         compressed = compress(b"test")
 
-        data = encode_varint(len(topic_bytes)) + topic_bytes
-        data += encode_varint(len(compressed)) + compressed
+        gossip_wire = encode_varint(len(topic_bytes)) + topic_bytes
+        gossip_wire += encode_varint(len(compressed)) + compressed
 
-        stream = MockStream(data)
+        stream = MockStream(gossip_wire)
         parsed_topic, _ = await read_gossip_message(stream)
 
         expected_topic = f"/{TOPIC_PREFIX}/{long_digest}/block/{ENCODING_POSTFIX}"
@@ -651,8 +653,8 @@ class TestGossipReceptionEdgeCases:
         topic = make_block_topic()
         topic_bytes = topic.encode("utf-8")
         # Only topic, no data length or data
-        data = encode_varint(len(topic_bytes)) + topic_bytes
-        stream = MockStream(data)
+        gossip_wire = encode_varint(len(topic_bytes)) + topic_bytes
+        stream = MockStream(gossip_wire)
 
         with pytest.raises(GossipMessageError, match="Truncated gossip message"):
             await read_gossip_message(stream)
@@ -685,10 +687,10 @@ class TestGossipHandlerForkMismatch:
 
     def test_fork_mismatch_error_attributes(self) -> None:
         """ForkMismatchError exposes expected and actual digests."""
-        err = ForkMismatchError(expected=FORK_DIGEST, actual=WRONG_FORK_DIGEST)
+        error = ForkMismatchError(expected=FORK_DIGEST, actual=WRONG_FORK_DIGEST)
 
-        assert err.expected == FORK_DIGEST
-        assert err.actual == WRONG_FORK_DIGEST
+        assert error.expected == FORK_DIGEST
+        assert error.actual == WRONG_FORK_DIGEST
 
     def test_fork_mismatch_is_value_error(self) -> None:
         """ForkMismatchError inherits from ValueError."""
@@ -799,8 +801,12 @@ class TestReadGossipMessageChunked:
         attestation = _make_attestation()
         wire = _build_gossip_wire(_attestation_topic(), attestation.encode_bytes())
 
-        third = len(wire) // 3
-        chunks = [wire[:third], wire[third : 2 * third], wire[2 * third :]]
+        third_length = len(wire) // 3
+        chunks = [
+            wire[:third_length],
+            wire[third_length : 2 * third_length],
+            wire[2 * third_length :],
+        ]
         stream = ChunkedMockStream(chunks)
         topic, _ = await read_gossip_message(stream)
 
@@ -822,13 +828,13 @@ class TestGossipHandlerDecodeRoundtrip:
         block = _make_block()
         original_bytes = block.encode_bytes()
 
-        result = handler.decode_message(
+        decoded_message = handler.decode_message(
             _block_topic(),
             compress(original_bytes),
         )
 
-        assert isinstance(result, SignedBlock)
-        assert result.encode_bytes() == original_bytes
+        assert isinstance(decoded_message, SignedBlock)
+        assert decoded_message.encode_bytes() == original_bytes
 
     def test_attestation_roundtrip_preserves_ssz(self) -> None:
         """Attestation SSZ bytes are identical after decode."""
@@ -836,13 +842,13 @@ class TestGossipHandlerDecodeRoundtrip:
         attestation = _make_attestation()
         original_bytes = attestation.encode_bytes()
 
-        result = handler.decode_message(
+        decoded_message = handler.decode_message(
             _attestation_topic(),
             compress(original_bytes),
         )
 
-        assert isinstance(result, SignedAttestation)
-        assert result.encode_bytes() == original_bytes
+        assert isinstance(decoded_message, SignedAttestation)
+        assert decoded_message.encode_bytes() == original_bytes
 
 
 class TestGossipHandlerForkValidation:

--- a/tests/lean_spec/node/networking/client/event_source/test_protocol.py
+++ b/tests/lean_spec/node/networking/client/event_source/test_protocol.py
@@ -37,6 +37,6 @@ class TestSupportedProtocols:
 
     def test_exact_composition(self) -> None:
         """Equals the union of gossipsub and reqresp protocol IDs."""
-        expected = frozenset({GOSSIPSUB_DEFAULT_PROTOCOL_ID, GOSSIPSUB_PROTOCOL_ID_V12})
-        expected |= REQRESP_PROTOCOL_IDS
-        assert SUPPORTED_PROTOCOLS == expected
+        expected_protocols = frozenset({GOSSIPSUB_DEFAULT_PROTOCOL_ID, GOSSIPSUB_PROTOCOL_ID_V12})
+        expected_protocols |= REQRESP_PROTOCOL_IDS
+        assert SUPPORTED_PROTOCOLS == expected_protocols

--- a/tests/lean_spec/node/networking/client/test_reqresp_client.py
+++ b/tests/lean_spec/node/networking/client/test_reqresp_client.py
@@ -196,11 +196,11 @@ class TestReqRespClientStatusExchange:
         client.register_connection(peer_id, connection)  # type: ignore[arg-type]
 
         our_status = make_test_status()
-        result = await client.send_status(peer_id, our_status)
+        received_status = await client.send_status(peer_id, our_status)
 
-        assert result is not None
-        assert result.head.slot == Slot(150)
-        assert result.finalized.slot == Slot(50)
+        assert received_status is not None
+        assert received_status.head.slot == Slot(150)
+        assert received_status.finalized.slot == Slot(50)
 
     async def test_send_status_no_connection(self) -> None:
         """Request to unconnected peer returns None."""
@@ -209,9 +209,9 @@ class TestReqRespClientStatusExchange:
 
         # No connection registered
         our_status = make_test_status()
-        result = await client.send_status(peer_id, our_status)
+        received_status = await client.send_status(peer_id, our_status)
 
-        assert result is None
+        assert received_status is None
 
     async def test_send_status_server_error_response(self) -> None:
         """SERVER_ERROR response returns None."""
@@ -224,9 +224,9 @@ class TestReqRespClientStatusExchange:
 
         client.register_connection(peer_id, connection)  # type: ignore[arg-type]
 
-        result = await client.send_status(peer_id, make_test_status())
+        received_status = await client.send_status(peer_id, make_test_status())
 
-        assert result is None
+        assert received_status is None
 
     async def test_send_status_stream_closed(self) -> None:
         """Empty response (closed stream) returns None."""
@@ -239,9 +239,9 @@ class TestReqRespClientStatusExchange:
 
         client.register_connection(peer_id, connection)  # type: ignore[arg-type]
 
-        result = await client.send_status(peer_id, make_test_status())
+        received_status = await client.send_status(peer_id, make_test_status())
 
-        assert result is None
+        assert received_status is None
 
     async def test_send_status_writes_request(self) -> None:
         """Request is properly encoded and sent."""
@@ -324,7 +324,7 @@ class TestReqRespClientBlocksByRoot:
         blocks = await client.request_blocks_by_root(peer_id, roots)
 
         assert len(blocks) == 2
-        slots = {b.block.slot for b in blocks}
+        slots = {signed_block.block.slot for signed_block in blocks}
         assert Slot(10) in slots
         assert Slot(20) in slots
 
@@ -435,9 +435,9 @@ class TestReqRespClientTimeouts:
 
         client.register_connection(peer_id, connection)  # type: ignore[arg-type]
 
-        result = await client.send_status(peer_id, make_test_status())
+        received_status = await client.send_status(peer_id, make_test_status())
 
-        assert result is None
+        assert received_status is None
 
     async def test_blocks_by_root_timeout_returns_empty(self) -> None:
         """BlocksByRoot timeout returns empty list."""
@@ -481,9 +481,9 @@ class TestReqRespClientErrorHandling:
 
         client.register_connection(peer_id, connection)  # type: ignore[arg-type]
 
-        result = await client.send_status(peer_id, make_test_status())
+        received_status = await client.send_status(peer_id, make_test_status())
 
-        assert result is None
+        assert received_status is None
 
     async def test_read_failure_returns_gracefully(self) -> None:
         """Read failure during response handled gracefully."""
@@ -495,9 +495,9 @@ class TestReqRespClientErrorHandling:
 
         client.register_connection(peer_id, connection)  # type: ignore[arg-type]
 
-        result = await client.send_status(peer_id, make_test_status())
+        received_status = await client.send_status(peer_id, make_test_status())
 
-        assert result is None
+        assert received_status is None
 
     async def test_open_stream_failure_returns_gracefully(self) -> None:
         """Failure to open stream handled gracefully."""
@@ -507,9 +507,9 @@ class TestReqRespClientErrorHandling:
         connection = MockConnection(_fail_on_open=True)
         client.register_connection(peer_id, connection)  # type: ignore[arg-type]
 
-        result = await client.send_status(peer_id, make_test_status())
+        received_status = await client.send_status(peer_id, make_test_status())
 
-        assert result is None
+        assert received_status is None
 
     async def test_malformed_response_handled(self) -> None:
         """Malformed response data handled gracefully."""
@@ -523,9 +523,9 @@ class TestReqRespClientErrorHandling:
 
         client.register_connection(peer_id, connection)  # type: ignore[arg-type]
 
-        result = await client.send_status(peer_id, make_test_status())
+        received_status = await client.send_status(peer_id, make_test_status())
 
-        assert result is None
+        assert received_status is None
 
     async def test_blocks_codec_error_stops_reading(self) -> None:
         """CodecError during block response stops reading."""
@@ -581,19 +581,19 @@ class TestReqRespClientConcurrency:
         client.register_connection(peer2, conn2)  # type: ignore[arg-type]
 
         our_status = make_test_status()
-        results = list(
+        received_statuses = list(
             await asyncio.gather(
                 client.send_status(peer1, our_status),
                 client.send_status(peer2, our_status),
             )
         )
 
-        assert len(results) == 2
-        assert results[0] is not None
-        assert results[1] is not None
+        assert len(received_statuses) == 2
+        assert received_statuses[0] is not None
+        assert received_statuses[1] is not None
         # Verify we got different responses
-        assert results[0].head.slot == Slot(200)
-        assert results[1].head.slot == Slot(400)
+        assert received_statuses[0].head.slot == Slot(200)
+        assert received_statuses[1].head.slot == Slot(400)
 
     async def test_concurrent_mixed_requests(self) -> None:
         """Concurrent Status and BlocksByRoot work."""
@@ -886,7 +886,9 @@ class TestReqRespClientBlocksByRange:
         client = make_client()
         chain = build_chain(start_slot=10, count=4)
 
-        stream = MockRangeStream(response_chunks=[encode_success(b) for b in chain])
+        stream = MockRangeStream(
+            response_chunks=[encode_success(signed_block) for signed_block in chain]
+        )
         connection = MockRangeConnection(peer_id=peer_id, streams=[stream])
         client.register_connection(peer_id, connection)  # type: ignore[arg-type]
 
@@ -902,7 +904,9 @@ class TestReqRespClientBlocksByRange:
         client = make_client()
         chain = build_chain(start_slot=20, count=2)
 
-        stream = MockRangeStream(response_chunks=[encode_success(b) for b in chain])
+        stream = MockRangeStream(
+            response_chunks=[encode_success(signed_block) for signed_block in chain]
+        )
         connection = MockRangeConnection(peer_id=peer_id, streams=[stream])
         client.register_connection(peer_id, connection)  # type: ignore[arg-type]
 

--- a/tests/lean_spec/node/networking/enr/test_enr.py
+++ b/tests/lean_spec/node/networking/enr/test_enr.py
@@ -143,9 +143,9 @@ class TestOfficialEIP778Vector:
         assert uncompressed[0] == 0x04  # Uncompressed point prefix
 
         # Compute keccak256 of 64-byte x||y (excluding 0x04 prefix)
-        k = keccak.new(digest_bits=256)
-        k.update(uncompressed[1:])
-        computed_node_id = k.hexdigest()
+        keccak_hash = keccak.new(digest_bits=256)
+        keccak_hash.update(uncompressed[1:])
+        computed_node_id = keccak_hash.hexdigest()
 
         assert computed_node_id == OFFICIAL_NODE_ID
 
@@ -317,13 +317,13 @@ class TestPropertyAccessors:
             (b"\xc0\xa8\x01\x01", "192.168.1.1"),
             (b"\x0a\x00\x00\x01", "10.0.0.1"),
         ]
-        for ip_bytes, expected in test_cases:
+        for ip_bytes, expected_ip in test_cases:
             enr = ENR(
                 signature=Bytes64(b"\x00" * 64),
                 seq=SeqNumber(1),
                 pairs={keys.ID: b"v4", keys.IP: ip_bytes},
             )
-            assert enr.ip4 == expected
+            assert enr.ip4 == expected_ip
 
     def test_ip4_returns_none_when_missing(self) -> None:
         """ip4 returns None when 'ip' key is absent."""
@@ -360,13 +360,13 @@ class TestPropertyAccessors:
             (b"\x23\x28", Port(9000)),
             (b"\x76\x5f", Port(30303)),
         ]
-        for port_bytes, expected in test_cases:
+        for port_bytes, expected_port in test_cases:
             enr = ENR(
                 signature=Bytes64(b"\x00" * 64),
                 seq=SeqNumber(1),
                 pairs={keys.ID: b"v4", keys.UDP: port_bytes},
             )
-            assert enr.udp_port == expected
+            assert enr.udp_port == expected_port
 
     def test_udp_port_returns_none_when_missing(self) -> None:
         """udp_port returns None when 'udp' key is absent."""
@@ -494,8 +494,8 @@ class TestStringRepresentation:
             seq=SeqNumber(42),
             pairs={keys.ID: b"v4"},
         )
-        result = str(enr)
-        assert "seq=42" in result
+        enr_string = str(enr)
+        assert "seq=42" in enr_string
 
     def test_str_includes_ip(self) -> None:
         """__str__() includes IP address when present."""
@@ -504,8 +504,8 @@ class TestStringRepresentation:
             seq=SeqNumber(1),
             pairs={keys.ID: b"v4", keys.IP: b"\xc0\xa8\x01\x01"},
         )
-        result = str(enr)
-        assert "192.168.1.1" in result
+        enr_string = str(enr)
+        assert "192.168.1.1" in enr_string
 
     def test_str_includes_udp_port(self) -> None:
         """__str__() includes UDP port when present."""
@@ -514,8 +514,8 @@ class TestStringRepresentation:
             seq=SeqNumber(1),
             pairs={keys.ID: b"v4", keys.UDP: (30303).to_bytes(2, "big")},
         )
-        result = str(enr)
-        assert "udp=30303" in result
+        enr_string = str(enr)
+        assert "udp=30303" in enr_string
 
     def test_str_minimal_enr(self) -> None:
         """__str__() works for minimal ENR."""
@@ -524,10 +524,10 @@ class TestStringRepresentation:
             seq=SeqNumber(1),
             pairs={},
         )
-        result = str(enr)
-        assert result.startswith("ENR(")
-        assert result.endswith(")")
-        assert "seq=1" in result
+        enr_string = str(enr)
+        assert enr_string.startswith("ENR(")
+        assert enr_string.endswith(")")
+        assert "seq=1" in enr_string
 
 
 class TestKeyAccessMethods:
@@ -922,11 +922,11 @@ class TestRoundTripSerialization:
             seq=SeqNumber(1),
             pairs={keys.ID: b"v4", keys.SECP256K1: b"\x02" + b"\x00" * 32},
         )
-        result = enr.to_string()
+        enr_text = enr.to_string()
 
-        assert result.startswith("enr:")
+        assert enr_text.startswith("enr:")
         # Should not have padding
-        assert "=" not in result
+        assert "=" not in enr_text
 
 
 class TestSignatureVerification:
@@ -958,16 +958,16 @@ class TestSignatureVerification:
         content_rlp = encode_rlp(content_items)
 
         # Hash content.
-        k = keccak.new(digest_bits=256)
-        k.update(content_rlp)
-        digest = k.digest()
+        keccak_hash = keccak.new(digest_bits=256)
+        keccak_hash.update(content_rlp)
+        digest = keccak_hash.digest()
 
         # Sign with ECDSA using Prehashed mode.
         signature_der = private_key.sign(digest, ec.ECDSA(Prehashed(hashes.SHA256())))
 
         # Convert DER signature to r || s format.
-        r, s = decode_dss_signature(signature_der)
-        signature_64 = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+        signature_r, signature_s = decode_dss_signature(signature_der)
+        signature_64 = signature_r.to_bytes(32, "big") + signature_s.to_bytes(32, "big")
 
         # Create ENR.
         enr = ENR(

--- a/tests/lean_spec/node/networking/enr/test_eth2.py
+++ b/tests/lean_spec/node/networking/enr/test_eth2.py
@@ -18,23 +18,23 @@ class TestEth2Data:
 
     def test_create_eth2_data(self) -> None:
         """Eth2Data can be created with valid parameters."""
-        data = Eth2Data(
+        eth2_data = Eth2Data(
             fork_digest=ForkDigest(b"\x12\x34\x56\x78"),
             next_fork_version=Version(b"\x02\x00\x00\x00"),
             next_fork_epoch=Uint64(194048),
         )
-        assert data.fork_digest == ForkDigest(b"\x12\x34\x56\x78")
-        assert data.next_fork_epoch == Uint64(194048)
+        assert eth2_data.fork_digest == ForkDigest(b"\x12\x34\x56\x78")
+        assert eth2_data.next_fork_epoch == Uint64(194048)
 
     def test_eth2_data_immutable(self) -> None:
         """Eth2Data is immutable (frozen)."""
-        data = Eth2Data(
+        eth2_data = Eth2Data(
             fork_digest=ForkDigest(b"\x12\x34\x56\x78"),
             next_fork_version=Version(b"\x02\x00\x00\x00"),
             next_fork_epoch=Uint64(0),
         )
         with pytest.raises(ValidationError):
-            data.fork_digest = ForkDigest(b"\x00\x00\x00\x00")
+            eth2_data.fork_digest = ForkDigest(b"\x00\x00\x00\x00")
 
     def test_far_future_epoch_value(self) -> None:
         """FAR_FUTURE_EPOCH is max uint64."""
@@ -70,9 +70,9 @@ class TestAttestationSubnets:
     def test_subscribed_subnets_list(self) -> None:
         """subscribed_subnets() returns correct list."""
         subnets = AttestationSubnets.from_subnet_ids([10, 20, 30])
-        result = subnets.subscribed_subnets()
+        subscribed_subnet_ids = subnets.subscribed_subnets()
 
-        assert result == [SubnetId(10), SubnetId(20), SubnetId(30)]
+        assert subscribed_subnet_ids == [SubnetId(10), SubnetId(20), SubnetId(30)]
 
     def test_invalid_subnet_id_in_from_subnet_ids(self) -> None:
         """from_subnet_ids() raises for invalid subnet IDs."""

--- a/tests/lean_spec/node/networking/enr/test_rlp.py
+++ b/tests/lean_spec/node/networking/enr/test_rlp.py
@@ -63,8 +63,8 @@ class TestEncodeEmptyString:
 
     def test_encode_empty_string(self) -> None:
         """Empty string encodes to 0x80."""
-        result = encode_rlp(b"")
-        assert result == bytes.fromhex("80")
+        encoded = encode_rlp(b"")
+        assert encoded == bytes.fromhex("80")
 
 
 class TestEncodeSingleByte:
@@ -72,25 +72,25 @@ class TestEncodeSingleByte:
 
     def test_encode_byte_0x00(self) -> None:
         """Byte 0x00 encodes as itself."""
-        result = encode_rlp(b"\x00")
-        assert result == bytes.fromhex("00")
+        encoded = encode_rlp(b"\x00")
+        assert encoded == bytes.fromhex("00")
 
     def test_encode_byte_0x01(self) -> None:
         """Byte 0x01 encodes as itself."""
-        result = encode_rlp(b"\x01")
-        assert result == bytes.fromhex("01")
+        encoded = encode_rlp(b"\x01")
+        assert encoded == bytes.fromhex("01")
 
     def test_encode_byte_0x7f(self) -> None:
         """Maximum single-byte value (0x7f) encodes as itself."""
-        result = encode_rlp(b"\x7f")
-        assert result == bytes.fromhex("7f")
+        encoded = encode_rlp(b"\x7f")
+        assert encoded == bytes.fromhex("7f")
 
     @pytest.mark.parametrize("byte_value", range(0x00, SINGLE_BYTE_MAX + 1))
     def test_encode_all_single_byte_values(self, byte_value: int) -> None:
         """All single-byte values 0x00-0x7f encode as themselves."""
-        data = bytes([byte_value])
-        result = encode_rlp(data)
-        assert result == data
+        string_payload = bytes([byte_value])
+        encoded = encode_rlp(string_payload)
+        assert encoded == string_payload
 
 
 class TestEncodeShortString:
@@ -98,33 +98,33 @@ class TestEncodeShortString:
 
     def test_encode_short_string_dog(self) -> None:
         """'dog' encodes with prefix 0x83 (0x80 + 3) followed by ASCII bytes."""
-        result = encode_rlp(b"dog")
-        assert result == bytes.fromhex("83646f67")
+        encoded = encode_rlp(b"dog")
+        assert encoded == bytes.fromhex("83646f67")
 
     def test_encode_short_string_55_bytes(self) -> None:
         """55-byte string uses short string encoding (max for this category)."""
-        data = b"Lorem ipsum dolor sit amet, consectetur adipisicing eli"
-        assert len(data) == SHORT_STRING_MAX_LENGTH
-        result = encode_rlp(data)
-        expected = bytes.fromhex(
+        string_payload = b"Lorem ipsum dolor sit amet, consectetur adipisicing eli"
+        assert len(string_payload) == SHORT_STRING_MAX_LENGTH
+        encoded = encode_rlp(string_payload)
+        expected_encoding = bytes.fromhex(
             "b74c6f72656d20697073756d20646f6c6f722073697420616d65742c20"
             "636f6e7365637465747572206164697069736963696e6720656c69"
         )
-        assert result == expected
+        assert encoded == expected_encoding
 
     def test_encode_single_byte_above_0x7f(self) -> None:
         """Single byte 0x80 uses short string encoding, not single-byte encoding."""
-        result = encode_rlp(b"\x80")
-        assert result == bytes([SHORT_STRING_PREFIX + 1, 0x80])
+        encoded = encode_rlp(b"\x80")
+        assert encoded == bytes([SHORT_STRING_PREFIX + 1, 0x80])
 
     @pytest.mark.parametrize("length", [1, 10, 20, 30, 40, 50, SHORT_STRING_MAX_LENGTH])
     def test_encode_short_string_various_lengths(self, length: int) -> None:
         """Short strings of various lengths are prefixed with 0x80 + length."""
         # Use bytes above 0x7f to ensure short string encoding is used
-        data = bytes([0x80 + (i % 0x7F) for i in range(length)])
-        result = encode_rlp(data)
-        assert result[0] == SHORT_STRING_PREFIX + length
-        assert result[1:] == data
+        string_payload = bytes([0x80 + (i % 0x7F) for i in range(length)])
+        encoded = encode_rlp(string_payload)
+        assert encoded[0] == SHORT_STRING_PREFIX + length
+        assert encoded[1:] == string_payload
 
 
 class TestEncodeLongString:
@@ -132,35 +132,35 @@ class TestEncodeLongString:
 
     def test_encode_long_string_56_bytes(self) -> None:
         """56-byte string uses long string encoding."""
-        data = b"Lorem ipsum dolor sit amet, consectetur adipisicing elit"
-        assert len(data) == SHORT_STRING_MAX_LENGTH + 1
-        result = encode_rlp(data)
-        expected = bytes.fromhex(
+        string_payload = b"Lorem ipsum dolor sit amet, consectetur adipisicing elit"
+        assert len(string_payload) == SHORT_STRING_MAX_LENGTH + 1
+        encoded = encode_rlp(string_payload)
+        expected_encoding = bytes.fromhex(
             "b8384c6f72656d20697073756d20646f6c6f722073697420616d65742c20"
             "636f6e7365637465747572206164697069736963696e6720656c6974"
         )
-        assert result == expected
+        assert encoded == expected_encoding
 
     def test_encode_long_string_1024_bytes(self) -> None:
         """1024-byte string encodes with 2-byte length prefix."""
         # Use simple repeated bytes to avoid codespell false positives.
-        data = b"x" * 1024
-        assert len(data) == 1024
-        result = encode_rlp(data)
+        string_payload = b"x" * 1024
+        assert len(string_payload) == 1024
+        encoded = encode_rlp(string_payload)
         # Prefix 0xb9 = 0xb7 + 2 (2 bytes for length)
         # Length 0x0400 = 1024 in big-endian
-        assert result[0] == LONG_STRING_PREFIX + 1  # 0xb9
-        assert result[1:3] == b"\x04\x00"
-        assert result[3:] == data
+        assert encoded[0] == LONG_STRING_PREFIX + 1  # 0xb9
+        assert encoded[1:3] == b"\x04\x00"
+        assert encoded[3:] == string_payload
 
     def test_encode_long_string_boundary(self) -> None:
         """String at exact boundary (56 bytes) uses long encoding."""
-        data = b"a" * (SHORT_STRING_MAX_LENGTH + 1)
-        result = encode_rlp(data)
+        string_payload = b"a" * (SHORT_STRING_MAX_LENGTH + 1)
+        encoded = encode_rlp(string_payload)
         # Prefix 0xb8 = 0xb7 + 1 (1 byte for length)
-        assert result[0] == LONG_STRING_PREFIX
-        assert result[1] == len(data)
-        assert result[2:] == data
+        assert encoded[0] == LONG_STRING_PREFIX
+        assert encoded[1] == len(string_payload)
+        assert encoded[2:] == string_payload
 
 
 class TestEncodeEmptyList:
@@ -168,8 +168,8 @@ class TestEncodeEmptyList:
 
     def test_encode_empty_list(self) -> None:
         """Empty list encodes to 0xc0."""
-        result = encode_rlp([])
-        assert result == bytes.fromhex("c0")
+        encoded = encode_rlp([])
+        assert encoded == bytes.fromhex("c0")
 
 
 class TestEncodeShortList:
@@ -177,23 +177,23 @@ class TestEncodeShortList:
 
     def test_encode_string_list(self) -> None:
         """List of strings ['dog', 'god', 'cat'] encodes correctly."""
-        result = encode_rlp([b"dog", b"god", b"cat"])
-        assert result == bytes.fromhex("cc83646f6783676f6483636174")
+        encoded = encode_rlp([b"dog", b"god", b"cat"])
+        assert encoded == bytes.fromhex("cc83646f6783676f6483636174")
 
     def test_encode_multilist(self) -> None:
         """Mixed list ['zw', [4], 1] encodes correctly."""
         # 4 encodes as 0x04 (single byte)
         # 1 encodes as 0x01 (single byte)
-        result = encode_rlp([b"zw", [b"\x04"], b"\x01"])
-        assert result == bytes.fromhex("c6827a77c10401")
+        encoded = encode_rlp([b"zw", [b"\x04"], b"\x01"])
+        assert encoded == bytes.fromhex("c6827a77c10401")
 
     def test_encode_short_list_max_payload(self) -> None:
         """Short list with 55 bytes of payload uses short list encoding."""
         # Create a list that has exactly 55 bytes of payload
         # Each "a" encodes as 0x61 (single byte), so 55 "a"s = 55 bytes payload
-        items: list[RLPItem] = [b"a" for _ in range(SHORT_LIST_MAX_LENGTH)]
-        result = encode_rlp(items)
-        assert result[0] == SHORT_LIST_PREFIX + SHORT_LIST_MAX_LENGTH  # 0xf7
+        rlp_elements: list[RLPItem] = [b"a" for _ in range(SHORT_LIST_MAX_LENGTH)]
+        encoded = encode_rlp(rlp_elements)
+        assert encoded[0] == SHORT_LIST_PREFIX + SHORT_LIST_MAX_LENGTH  # 0xf7
 
 
 class TestEncodeLongList:
@@ -202,23 +202,23 @@ class TestEncodeLongList:
     def test_encode_long_list_four_nested(self) -> None:
         """Long list with 4 nested lists encodes correctly."""
         inner = [b"asdf", b"qwer", b"zxcv"]
-        result = encode_rlp([inner, inner, inner, inner])
-        expected = bytes.fromhex(
+        encoded = encode_rlp([inner, inner, inner, inner])
+        expected_encoding = bytes.fromhex(
             "f840cf84617364668471776572847a786376cf84617364668471776572847a786376"
             "cf84617364668471776572847a786376cf84617364668471776572847a786376"
         )
-        assert result == expected
+        assert encoded == expected_encoding
 
     def test_encode_long_list_32_nested(self) -> None:
         """Long list with 32 nested lists uses 2-byte length prefix."""
         inner = [b"asdf", b"qwer", b"zxcv"]
-        result = encode_rlp([inner] * 32)
+        encoded = encode_rlp([inner] * 32)
         expected_start = bytes.fromhex("f90200")  # 0xf9 = 0xf7 + 2, length = 0x0200 = 512
-        assert result[:3] == expected_start
+        assert encoded[:3] == expected_start
 
     def test_encode_short_list_11_elements(self) -> None:
         """List with 11 4-byte strings has >55 byte payload, uses long encoding."""
-        items: list[RLPItem] = [
+        rlp_elements: list[RLPItem] = [
             b"asdf",
             b"qwer",
             b"zxcv",
@@ -231,12 +231,12 @@ class TestEncodeLongList:
             b"asdf",
             b"qwer",
         ]
-        result = encode_rlp(items)
-        expected = bytes.fromhex(
+        encoded = encode_rlp(rlp_elements)
+        expected_encoding = bytes.fromhex(
             "f784617364668471776572847a78637684617364668471776572847a78637684617364"
             "668471776572847a78637684617364668471776572"
         )
-        assert result == expected
+        assert encoded == expected_encoding
 
 
 class TestEncodeNestedLists:
@@ -244,13 +244,13 @@ class TestEncodeNestedLists:
 
     def test_encode_lists_of_lists(self) -> None:
         """Nested empty lists [[[], []], []] encode correctly."""
-        result = encode_rlp([[[], []], []])
-        assert result == bytes.fromhex("c4c2c0c0c0")
+        encoded = encode_rlp([[[], []], []])
+        assert encoded == bytes.fromhex("c4c2c0c0c0")
 
     def test_encode_lists_of_lists_complex(self) -> None:
         """Complex nested structure [[], [[]], [[], [[]]]] encodes correctly."""
-        result = encode_rlp([[], [[]], [[], [[]]]])
-        assert result == bytes.fromhex("c7c0c1c0c3c0c1c0")
+        encoded = encode_rlp([[], [[]], [[], [[]]]])
+        assert encoded == bytes.fromhex("c7c0c1c0c3c0c1c0")
 
 
 class TestEncodeIntegers:
@@ -259,8 +259,8 @@ class TestEncodeIntegers:
     def test_encode_zero(self) -> None:
         """Integer 0 encodes as empty string (0x80)."""
         # In RLP, 0 is represented as empty byte string
-        result = encode_rlp(b"")
-        assert result == bytes.fromhex("80")
+        encoded = encode_rlp(b"")
+        assert encoded == bytes.fromhex("80")
 
     def test_encode_small_integers(self) -> None:
         """Small integers 1-127 encode as single bytes."""
@@ -284,11 +284,11 @@ class TestEncodeIntegers:
         """2^256 encodes as 33-byte string."""
         big_int = 2**256
         big_bytes = big_int.to_bytes(33, "big")
-        result = encode_rlp(big_bytes)
-        expected = bytes.fromhex(
+        encoded = encode_rlp(big_bytes)
+        expected_encoding = bytes.fromhex(
             "a1010000000000000000000000000000000000000000000000000000000000000000"
         )
-        assert result == expected
+        assert encoded == expected_encoding
 
 
 class TestEncodeTypeErrors:
@@ -320,8 +320,8 @@ class TestDecodeEmptyString:
 
     def test_decode_empty_string(self) -> None:
         """0x80 decodes to empty string."""
-        result = decode_rlp(bytes.fromhex("80"))
-        assert result == b""
+        decoded = decode_rlp(bytes.fromhex("80"))
+        assert decoded == b""
 
 
 class TestDecodeSingleByte:
@@ -329,25 +329,25 @@ class TestDecodeSingleByte:
 
     def test_decode_byte_0x00(self) -> None:
         """0x00 decodes to single byte 0x00."""
-        result = decode_rlp(bytes.fromhex("00"))
-        assert result == b"\x00"
+        decoded = decode_rlp(bytes.fromhex("00"))
+        assert decoded == b"\x00"
 
     def test_decode_byte_0x01(self) -> None:
         """0x01 decodes to single byte 0x01."""
-        result = decode_rlp(bytes.fromhex("01"))
-        assert result == b"\x01"
+        decoded = decode_rlp(bytes.fromhex("01"))
+        assert decoded == b"\x01"
 
     def test_decode_byte_0x7f(self) -> None:
         """0x7f decodes to single byte 0x7f."""
-        result = decode_rlp(bytes.fromhex("7f"))
-        assert result == b"\x7f"
+        decoded = decode_rlp(bytes.fromhex("7f"))
+        assert decoded == b"\x7f"
 
     @pytest.mark.parametrize("byte_value", range(0x00, SINGLE_BYTE_MAX + 1))
     def test_decode_all_single_byte_values(self, byte_value: int) -> None:
         """All single-byte values 0x00-0x7f decode correctly."""
-        data = bytes([byte_value])
-        result = decode_rlp(data)
-        assert result == data
+        single_byte = bytes([byte_value])
+        decoded = decode_rlp(single_byte)
+        assert decoded == single_byte
 
 
 class TestDecodeShortString:
@@ -355,8 +355,8 @@ class TestDecodeShortString:
 
     def test_decode_short_string_dog(self) -> None:
         """0x83646f67 decodes to 'dog'."""
-        result = decode_rlp(bytes.fromhex("83646f67"))
-        assert result == b"dog"
+        decoded = decode_rlp(bytes.fromhex("83646f67"))
+        assert decoded == b"dog"
 
     def test_decode_short_string_55_bytes(self) -> None:
         """55-byte short string decodes correctly."""
@@ -364,8 +364,8 @@ class TestDecodeShortString:
             "b74c6f72656d20697073756d20646f6c6f722073697420616d65742c20"
             "636f6e7365637465747572206164697069736963696e6720656c69"
         )
-        result = decode_rlp(encoded)
-        assert result == b"Lorem ipsum dolor sit amet, consectetur adipisicing eli"
+        decoded = decode_rlp(encoded)
+        assert decoded == b"Lorem ipsum dolor sit amet, consectetur adipisicing eli"
 
 
 class TestDecodeLongString:
@@ -377,16 +377,16 @@ class TestDecodeLongString:
             "b8384c6f72656d20697073756d20646f6c6f722073697420616d65742c20"
             "636f6e7365637465747572206164697069736963696e6720656c6974"
         )
-        result = decode_rlp(encoded)
-        assert result == b"Lorem ipsum dolor sit amet, consectetur adipisicing elit"
+        decoded = decode_rlp(encoded)
+        assert decoded == b"Lorem ipsum dolor sit amet, consectetur adipisicing elit"
 
     def test_decode_long_string_1024_bytes(self) -> None:
         """1024-byte string with 2-byte length prefix decodes correctly."""
         # Use simple repeated bytes to avoid codespell false positives.
         expected_data = b"y" * 1024
         encoded = encode_rlp(expected_data)
-        result = decode_rlp(encoded)
-        assert result == expected_data
+        decoded = decode_rlp(encoded)
+        assert decoded == expected_data
 
 
 class TestDecodeEmptyList:
@@ -394,8 +394,8 @@ class TestDecodeEmptyList:
 
     def test_decode_empty_list(self) -> None:
         """0xc0 decodes to empty list."""
-        result = decode_rlp(bytes.fromhex("c0"))
-        assert result == []
+        decoded = decode_rlp(bytes.fromhex("c0"))
+        assert decoded == []
 
 
 class TestDecodeShortList:
@@ -403,13 +403,13 @@ class TestDecodeShortList:
 
     def test_decode_string_list(self) -> None:
         """Encoded string list decodes correctly."""
-        result = decode_rlp(bytes.fromhex("cc83646f6783676f6483636174"))
-        assert result == [b"dog", b"god", b"cat"]
+        decoded = decode_rlp(bytes.fromhex("cc83646f6783676f6483636174"))
+        assert decoded == [b"dog", b"god", b"cat"]
 
     def test_decode_multilist(self) -> None:
         """Mixed list decodes correctly."""
-        result = decode_rlp(bytes.fromhex("c6827a77c10401"))
-        assert result == [b"zw", [b"\x04"], b"\x01"]
+        decoded = decode_rlp(bytes.fromhex("c6827a77c10401"))
+        assert decoded == [b"zw", [b"\x04"], b"\x01"]
 
 
 class TestDecodeLongList:
@@ -421,9 +421,9 @@ class TestDecodeLongList:
             "f840cf84617364668471776572847a786376cf84617364668471776572847a786376"
             "cf84617364668471776572847a786376cf84617364668471776572847a786376"
         )
-        result = decode_rlp(encoded)
+        decoded = decode_rlp(encoded)
         inner = [b"asdf", b"qwer", b"zxcv"]
-        assert result == [inner, inner, inner, inner]
+        assert decoded == [inner, inner, inner, inner]
 
 
 class TestDecodeNestedLists:
@@ -431,13 +431,13 @@ class TestDecodeNestedLists:
 
     def test_decode_lists_of_lists(self) -> None:
         """Nested empty lists decode correctly."""
-        result = decode_rlp(bytes.fromhex("c4c2c0c0c0"))
-        assert result == [[[], []], []]
+        decoded = decode_rlp(bytes.fromhex("c4c2c0c0c0"))
+        assert decoded == [[[], []], []]
 
     def test_decode_lists_of_lists_complex(self) -> None:
         """Complex nested structure decodes correctly."""
-        result = decode_rlp(bytes.fromhex("c7c0c1c0c3c0c1c0"))
-        assert result == [[], [[]], [[], [[]]]]
+        decoded = decode_rlp(bytes.fromhex("c7c0c1c0c3c0c1c0"))
+        assert decoded == [[], [[]], [[], [[]]]]
 
 
 class TestDecodeErrors:
@@ -488,16 +488,16 @@ class TestDecodeErrors:
         """Using long string encoding for short string is non-canonical."""
         # 0xb801 indicates long string with 1-byte length containing 0x38 (56)
         # but 0x38 <= 55, so this should be encoded as short string
-        expected = r"^Non-canonical: long string encoding for short string$"
-        with pytest.raises(RLPDecodingError, match=expected):
+        expected_error_pattern = r"^Non-canonical: long string encoding for short string$"
+        with pytest.raises(RLPDecodingError, match=expected_error_pattern):
             # 0xb8 followed by length 0x37 (55) - should have used short encoding
             decode_rlp(bytes.fromhex("b837") + b"a" * 55)
 
     def test_decode_non_canonical_long_list_for_short(self) -> None:
         """Using long list encoding for short list is non-canonical."""
         # 0xf8 followed by length 0x37 (55) - should have used short encoding
-        expected = r"^Non-canonical: long list encoding for short list$"
-        with pytest.raises(RLPDecodingError, match=expected):
+        expected_error_pattern = r"^Non-canonical: long list encoding for short list$"
+        with pytest.raises(RLPDecodingError, match=expected_error_pattern):
             decode_rlp(bytes.fromhex("f837") + bytes.fromhex("80") * 55)
 
     def test_decode_non_canonical_leading_zeros_long_string(self) -> None:
@@ -505,8 +505,8 @@ class TestDecodeErrors:
         # 0xb9 marks a long string with two length bytes.
         # The length bytes 00 38 decode to 56.
         # The leading zero is redundant since the canonical form is 0xb8 38 with one length byte.
-        expected = r"^Non-canonical: leading zeros in length encoding$"
-        with pytest.raises(RLPDecodingError, match=expected):
+        expected_error_pattern = r"^Non-canonical: leading zeros in length encoding$"
+        with pytest.raises(RLPDecodingError, match=expected_error_pattern):
             decode_rlp(bytes.fromhex("b90038") + b"a" * 56)
 
     def test_decode_non_canonical_leading_zeros_long_list(self) -> None:
@@ -514,8 +514,8 @@ class TestDecodeErrors:
         # 0xf9 marks a long list with two length bytes.
         # The length bytes 00 38 decode to 56.
         # The leading zero is redundant since the canonical form is 0xf8 38 with one length byte.
-        expected = r"^Non-canonical: leading zeros in length encoding$"
-        with pytest.raises(RLPDecodingError, match=expected):
+        expected_error_pattern = r"^Non-canonical: leading zeros in length encoding$"
+        with pytest.raises(RLPDecodingError, match=expected_error_pattern):
             decode_rlp(bytes.fromhex("f90038") + bytes.fromhex("80") * 56)
 
     def test_decode_list_payload_length_mismatch(self) -> None:
@@ -532,8 +532,8 @@ class TestDecodeListFunction:
 
     def test_decode_list_success(self) -> None:
         """decode_list returns list of bytes for flat list."""
-        result = decode_rlp_list(bytes.fromhex("cc83646f6783676f6483636174"))
-        assert result == [b"dog", b"god", b"cat"]
+        decoded = decode_rlp_list(bytes.fromhex("cc83646f6783676f6483636174"))
+        assert decoded == [b"dog", b"god", b"cat"]
 
     def test_decode_list_not_a_list(self) -> None:
         """decode_list raises error when data is not a list."""
@@ -551,7 +551,7 @@ class TestEncodeDecodeRoundtrip:
     """Tests for encode/decode roundtrip invariants."""
 
     @pytest.mark.parametrize(
-        "item",
+        "rlp_item",
         [
             b"",
             b"\x00",
@@ -569,11 +569,11 @@ class TestEncodeDecodeRoundtrip:
             [b"mixed", [b"nested", b"list"], b"end"],
         ],
     )
-    def test_roundtrip(self, item: RLPItem) -> None:
-        """Encoding then decoding returns the original item."""
-        encoded = encode_rlp(item)
+    def test_roundtrip(self, rlp_item: RLPItem) -> None:
+        """Encoding then decoding returns the original RLP item."""
+        encoded = encode_rlp(rlp_item)
         decoded = decode_rlp(encoded)
-        assert decoded == item
+        assert decoded == rlp_item
 
     def test_roundtrip_large_nested_structure(self) -> None:
         """Complex nested structure survives roundtrip."""
@@ -618,23 +618,23 @@ class TestOfficialEthereumVectors:
 
     def test_shortstring2(self) -> None:
         """Official test vector: shortstring2 (55 bytes - max short string)."""
-        data = b"Lorem ipsum dolor sit amet, consectetur adipisicing eli"
-        expected = bytes.fromhex(
+        rlp_item = b"Lorem ipsum dolor sit amet, consectetur adipisicing eli"
+        expected_encoding = bytes.fromhex(
             "b74c6f72656d20697073756d20646f6c6f722073697420616d65742c20"
             "636f6e7365637465747572206164697069736963696e6720656c69"
         )
-        assert encode_rlp(data) == expected
-        assert decode_rlp(expected) == data
+        assert encode_rlp(rlp_item) == expected_encoding
+        assert decode_rlp(expected_encoding) == rlp_item
 
     def test_longstring(self) -> None:
         """Official test vector: longstring (56 bytes - min long string)."""
-        data = b"Lorem ipsum dolor sit amet, consectetur adipisicing elit"
-        expected = bytes.fromhex(
+        rlp_item = b"Lorem ipsum dolor sit amet, consectetur adipisicing elit"
+        expected_encoding = bytes.fromhex(
             "b8384c6f72656d20697073756d20646f6c6f722073697420616d65742c20"
             "636f6e7365637465747572206164697069736963696e6720656c6974"
         )
-        assert encode_rlp(data) == expected
-        assert decode_rlp(expected) == data
+        assert encode_rlp(rlp_item) == expected_encoding
+        assert decode_rlp(expected_encoding) == rlp_item
 
     def test_emptylist(self) -> None:
         """Official test vector: emptylist."""
@@ -643,58 +643,58 @@ class TestOfficialEthereumVectors:
 
     def test_stringlist(self) -> None:
         """Official test vector: stringlist."""
-        data: RLPItem = [b"dog", b"god", b"cat"]
-        expected = bytes.fromhex("cc83646f6783676f6483636174")
-        assert encode_rlp(data) == expected
-        assert decode_rlp(expected) == data
+        rlp_item: RLPItem = [b"dog", b"god", b"cat"]
+        expected_encoding = bytes.fromhex("cc83646f6783676f6483636174")
+        assert encode_rlp(rlp_item) == expected_encoding
+        assert decode_rlp(expected_encoding) == rlp_item
 
     def test_multilist(self) -> None:
         """Official test vector: multilist."""
         # "zw" = 0x7a77, [4] = 0x04, 1 = 0x01
-        data: RLPItem = [b"zw", [b"\x04"], b"\x01"]
-        expected = bytes.fromhex("c6827a77c10401")
-        assert encode_rlp(data) == expected
-        assert decode_rlp(expected) == data
+        rlp_item: RLPItem = [b"zw", [b"\x04"], b"\x01"]
+        expected_encoding = bytes.fromhex("c6827a77c10401")
+        assert encode_rlp(rlp_item) == expected_encoding
+        assert decode_rlp(expected_encoding) == rlp_item
 
     def test_listsoflists(self) -> None:
         """Official test vector: listsoflists."""
-        data: RLPItem = [[[], []], []]
-        expected = bytes.fromhex("c4c2c0c0c0")
-        assert encode_rlp(data) == expected
-        assert decode_rlp(expected) == data
+        rlp_item: RLPItem = [[[], []], []]
+        expected_encoding = bytes.fromhex("c4c2c0c0c0")
+        assert encode_rlp(rlp_item) == expected_encoding
+        assert decode_rlp(expected_encoding) == rlp_item
 
     def test_listsoflists2(self) -> None:
         """Official test vector: listsoflists2."""
-        data: RLPItem = [[], [[]], [[], [[]]]]
-        expected = bytes.fromhex("c7c0c1c0c3c0c1c0")
-        assert encode_rlp(data) == expected
-        assert decode_rlp(expected) == data
+        rlp_item: RLPItem = [[], [[]], [[], [[]]]]
+        expected_encoding = bytes.fromhex("c7c0c1c0c3c0c1c0")
+        assert encode_rlp(rlp_item) == expected_encoding
+        assert decode_rlp(expected_encoding) == rlp_item
 
     def test_dicttest1(self) -> None:
         """Official test vector: dictTest1 (list of key-value pairs)."""
-        data: RLPItem = [
+        rlp_item: RLPItem = [
             [b"key1", b"val1"],
             [b"key2", b"val2"],
             [b"key3", b"val3"],
             [b"key4", b"val4"],
         ]
-        expected = bytes.fromhex(
+        expected_encoding = bytes.fromhex(
             "ecca846b6579318476616c31ca846b6579328476616c32"
             "ca846b6579338476616c33ca846b6579348476616c34"
         )
-        assert encode_rlp(data) == expected
-        assert decode_rlp(expected) == data
+        assert encode_rlp(rlp_item) == expected_encoding
+        assert decode_rlp(expected_encoding) == rlp_item
 
     def test_longlist1(self) -> None:
         """Official test vector: longList1."""
         inner: RLPItem = [b"asdf", b"qwer", b"zxcv"]
-        data: RLPItem = [inner, inner, inner, inner]
-        expected = bytes.fromhex(
+        rlp_item: RLPItem = [inner, inner, inner, inner]
+        expected_encoding = bytes.fromhex(
             "f840cf84617364668471776572847a786376cf84617364668471776572847a786376"
             "cf84617364668471776572847a786376cf84617364668471776572847a786376"
         )
-        assert encode_rlp(data) == expected
-        assert decode_rlp(expected) == data
+        assert encode_rlp(rlp_item) == expected_encoding
+        assert decode_rlp(expected_encoding) == rlp_item
 
 
 class TestBoundaryConditions:

--- a/tests/lean_spec/node/networking/gossipsub/test_behavior.py
+++ b/tests/lean_spec/node/networking/gossipsub/test_behavior.py
@@ -601,7 +601,7 @@ class TestMaintainMesh:
 
         expected_peers = {make_peer(name) for name in names}
         graft_rpc = RPC(control=ControlMessage(graft=[ControlGraft(topic_id=topic)]))
-        assert {p for p, _ in capture.sent} == expected_peers
+        assert {peer_id for peer_id, _ in capture.sent} == expected_peers
         assert all(rpc == graft_rpc for _, rpc in capture.sent)
         assert behavior.mesh.get_mesh_peers(topic) == expected_peers
 
@@ -629,7 +629,7 @@ class TestMaintainMesh:
         prune_rpc = RPC(
             control=ControlMessage(prune=[ControlPrune(topic_id=topic, backoff=PRUNE_BACKOFF)])
         )
-        pruned_peers = {p for p, _ in capture.sent}
+        pruned_peers = {peer_id for peer_id, _ in capture.sent}
         assert len(capture.sent) == 3
         assert all(rpc == prune_rpc for _, rpc in capture.sent)
         assert pruned_peers | mesh == all_peers
@@ -896,9 +896,9 @@ class TestHeartbeatIntegration:
         # Heartbeat emits gossip for fanout topics.
         # Filter to IHAVE RPCs for the fanout topic.
         fanout_ihaves = [
-            (p, r)
-            for p, r in capture.sent
-            if r.control and any(ih.topic_id == fan_topic for ih in r.control.ihave)
+            (peer_id, rpc)
+            for peer_id, rpc in capture.sent
+            if rpc.control and any(ihave.topic_id == fan_topic for ihave in rpc.control.ihave)
         ]
         assert fanout_ihaves == [
             (
@@ -930,7 +930,7 @@ class TestPublish:
         await behavior.publish(topic, b"hello")
 
         publish_rpc = RPC(publish=[Message(topic=topic, data=b"hello")])
-        assert {p for p, _ in capture.sent} == {p1, p2}
+        assert {peer_id for peer_id, _ in capture.sent} == {p1, p2}
         assert all(rpc == publish_rpc for _, rpc in capture.sent)
 
     @pytest.mark.asyncio
@@ -1090,8 +1090,10 @@ class TestBroadcastSubscription:
         prune_rpc = RPC(
             control=ControlMessage(prune=[ControlPrune(topic_id=topic, backoff=PRUNE_BACKOFF)])
         )
-        sub_sends = [(p, r) for p, r in capture.sent if r.subscriptions]
-        prune_sends = [(p, r) for p, r in capture.sent if r.control and r.control.prune]
+        sub_sends = [(peer_id, rpc) for peer_id, rpc in capture.sent if rpc.subscriptions]
+        prune_sends = [
+            (peer_id, rpc) for peer_id, rpc in capture.sent if rpc.control and rpc.control.prune
+        ]
         assert sub_sends == [(p1, sub_rpc), (p2, sub_rpc)]
-        assert {p for p, _ in prune_sends} == {p1, p2}
+        assert {peer_id for peer_id, _ in prune_sends} == {p1, p2}
         assert all(rpc == prune_rpc for _, rpc in prune_sends)

--- a/tests/lean_spec/node/networking/gossipsub/test_mcache.py
+++ b/tests/lean_spec/node/networking/gossipsub/test_mcache.py
@@ -45,18 +45,18 @@ class TestMessageCacheShift:
 
         # Put 3 messages in the first window.
         messages = [GossipsubMessage(topic=b"t", raw_data=f"d{i}".encode()) for i in range(3)]
-        for m in messages:
-            cache.put(TopicId("t"), m)
+        for message in messages:
+            cache.put(TopicId("t"), message)
 
         # One shift: still within capacity (2 windows).
         evicted = cache.shift()
         assert evicted == 0
-        assert all(cache.has(m.id) for m in messages)
+        assert all(cache.has(message.id) for message in messages)
 
         # Second shift: oldest window (with 3 messages) is evicted.
         evicted = cache.shift()
         assert evicted == 3
-        assert not any(cache.has(m.id) for m in messages)
+        assert not any(cache.has(message.id) for message in messages)
 
 
 class TestMessageCacheGetGossipIds:

--- a/tests/lean_spec/node/networking/gossipsub/test_mesh.py
+++ b/tests/lean_spec/node/networking/gossipsub/test_mesh.py
@@ -92,11 +92,11 @@ class TestFanoutEntry:
 
     def test_fanout_entry_staleness(self) -> None:
         """Test fanout entry staleness detection."""
-        entry = FanoutEntry()
-        entry.last_published = 1000.0
+        fanout_entry = FanoutEntry()
+        fanout_entry.last_published = 1000.0
 
-        assert not entry.is_stale(current_time=1050.0, ttl=60.0)
-        assert entry.is_stale(current_time=1070.0, ttl=60.0)
+        assert not fanout_entry.is_stale(current_time=1050.0, ttl=60.0)
+        assert fanout_entry.is_stale(current_time=1070.0, ttl=60.0)
 
 
 class TestFanoutOperations:
@@ -108,10 +108,10 @@ class TestFanoutOperations:
         topic = TopicId("fanout_topic")
 
         available = {peer("p1"), peer("p2"), peer("p3"), peer("p4")}
-        result = mesh.update_fanout(topic, available)
+        fanout_peers = mesh.update_fanout(topic, available)
 
-        assert len(result) <= 3  # Up to D peers
-        assert len(result) > 0
+        assert len(fanout_peers) <= 3  # Up to D peers
+        assert len(fanout_peers) > 0
 
     def test_update_fanout_returns_mesh_if_subscribed(self) -> None:
         """update_fanout returns mesh peers for subscribed topics."""
@@ -122,8 +122,8 @@ class TestFanoutOperations:
         p1 = peer("p1")
         mesh.add_to_mesh(topic, p1)
 
-        result = mesh.update_fanout(topic, {p1, peer("p2")})
-        assert result == {p1}
+        fanout_peers = mesh.update_fanout(topic, {p1, peer("p2")})
+        assert fanout_peers == {p1}
 
     def test_update_fanout_fills_to_d(self) -> None:
         """update_fanout fills fanout up to D peers."""
@@ -131,10 +131,10 @@ class TestFanoutOperations:
         topic = TopicId("fanout_topic")
 
         names = ["pA", "pB", "pC", "pD", "pE", "pF", "pG", "pH", "pJ", "pK"]
-        available = {peer(n) for n in names}
-        result = mesh.update_fanout(topic, available)
+        available = {peer(name) for name in names}
+        fanout_peers = mesh.update_fanout(topic, available)
 
-        assert len(result) == 4
+        assert len(fanout_peers) == 4
 
     def test_cleanup_fanouts_removes_stale(self) -> None:
         """cleanup_fanouts removes stale entries."""
@@ -187,8 +187,8 @@ class TestFanoutOperations:
         mesh.add_to_mesh(topic, p1)
         mesh.add_to_mesh(topic, p2)
 
-        result = mesh.unsubscribe(topic)
-        assert result == {p1, p2}
+        pruned_mesh_peers = mesh.unsubscribe(topic)
+        assert pruned_mesh_peers == {p1, p2}
 
     def test_select_peers_for_gossip_respects_d_lazy(self) -> None:
         """Gossip peer selection returns at most d_lazy peers."""
@@ -197,10 +197,10 @@ class TestFanoutOperations:
         mesh.subscribe(TopicId("topic"))
 
         names = ["gA", "gB", "gC", "gD", "gE", "gF", "gG", "gH", "gJ", "gK"]
-        all_peers = {peer(n) for n in names}
-        result = mesh.select_peers_for_gossip(TopicId("topic"), all_peers)
+        all_peers = {peer(name) for name in names}
+        gossip_peers = mesh.select_peers_for_gossip(TopicId("topic"), all_peers)
 
-        assert len(result) <= 2
+        assert len(gossip_peers) <= 2
 
     def test_select_peers_for_gossip_excludes_mesh(self) -> None:
         """Gossip peer selection excludes mesh peers."""
@@ -212,6 +212,6 @@ class TestFanoutOperations:
         mesh.add_to_mesh(TopicId("topic"), mesh_peer)
 
         all_peers = {mesh_peer, peer("p1"), peer("p2")}
-        result = mesh.select_peers_for_gossip(TopicId("topic"), all_peers)
+        gossip_peers = mesh.select_peers_for_gossip(TopicId("topic"), all_peers)
 
-        assert mesh_peer not in result
+        assert mesh_peer not in gossip_peers

--- a/tests/lean_spec/node/networking/gossipsub/test_rpc.py
+++ b/tests/lean_spec/node/networking/gossipsub/test_rpc.py
@@ -185,27 +185,27 @@ class TestSkipField:
     def test_skip_varint(self) -> None:
         """Skip a varint field."""
         # Encode a varint value (300 = 0xAC 0x02)
-        data = b"\xac\x02"
-        new_pos = _skip_field(data, 0, WIRE_TYPE_VARINT)
+        encoded_field = b"\xac\x02"
+        new_pos = _skip_field(encoded_field, 0, WIRE_TYPE_VARINT)
         assert new_pos == 2
 
     def test_skip_length_delimited(self) -> None:
         """Skip a length-delimited field."""
         # Length 3, then 3 bytes of data
-        data = b"\x03abc"
-        new_pos = _skip_field(data, 0, WIRE_TYPE_LENGTH_DELIMITED)
+        encoded_field = b"\x03abc"
+        new_pos = _skip_field(encoded_field, 0, WIRE_TYPE_LENGTH_DELIMITED)
         assert new_pos == 4
 
     def test_skip_32bit(self) -> None:
         """Skip a 32-bit fixed field."""
-        data = b"\x00\x00\x00\x00"
-        new_pos = _skip_field(data, 0, WIRE_TYPE_32BIT)
+        encoded_field = b"\x00\x00\x00\x00"
+        new_pos = _skip_field(encoded_field, 0, WIRE_TYPE_32BIT)
         assert new_pos == 4
 
     def test_skip_64bit(self) -> None:
         """Skip a 64-bit fixed field."""
-        data = b"\x00" * 8
-        new_pos = _skip_field(data, 0, WIRE_TYPE_64BIT)
+        encoded_field = b"\x00" * 8
+        new_pos = _skip_field(encoded_field, 0, WIRE_TYPE_64BIT)
         assert new_pos == 8
 
     def test_skip_unknown_wire_type_raises(self) -> None:
@@ -247,23 +247,23 @@ class TestForwardCompatibility:
     def test_rpc_with_unknown_varint_field(self) -> None:
         """RPC ignores unknown varint fields."""
         rpc = RPC(subscriptions=[SubOpts(subscribe=True, topic_id=TopicId("topic"))])
-        data = bytearray(rpc.encode())
+        encoded_rpc = bytearray(rpc.encode())
 
         # Append unknown field 99, wire type varint, value 42.
-        data.extend(encode_tag(99, WIRE_TYPE_VARINT))
-        data.extend(b"\x2a")  # varint 42
+        encoded_rpc.extend(encode_tag(99, WIRE_TYPE_VARINT))
+        encoded_rpc.extend(b"\x2a")  # varint 42
 
-        assert RPC.decode(bytes(data)) == rpc
+        assert RPC.decode(bytes(encoded_rpc)) == rpc
 
     def test_message_with_unknown_field(self) -> None:
         """Message ignores unknown length-delimited fields."""
         message = Message(topic=TopicId("t"), data=b"d")
-        data = bytearray(message.encode())
+        encoded_message = bytearray(message.encode())
 
         # Append unknown field 99.
-        data.extend(encode_bytes(99, b"unknown_data"))
+        encoded_message.extend(encode_bytes(99, b"unknown_data"))
 
-        assert Message.decode(bytes(data)) == message
+        assert Message.decode(bytes(encoded_message)) == message
 
 
 class TestLengthValidation:
@@ -272,17 +272,17 @@ class TestLengthValidation:
     def test_truncated_length_delimited_field(self) -> None:
         """Truncated length-delimited data raises ProtobufDecodeError."""
         # Field 1, wire type 2 (length-delimited), length=100 but only 3 bytes.
-        data = encode_tag(1, WIRE_TYPE_LENGTH_DELIMITED) + b"\x64abc"
+        encoded_field = encode_tag(1, WIRE_TYPE_LENGTH_DELIMITED) + b"\x64abc"
 
         with pytest.raises(ProtobufDecodeError, match="exceeds data size"):
-            SubOpts.decode(data)
+            SubOpts.decode(encoded_field)
 
     def test_truncated_rpc_field(self) -> None:
         """RPC with truncated field raises ProtobufDecodeError."""
-        data = encode_tag(1, WIRE_TYPE_LENGTH_DELIMITED) + b"\xff\x01"
+        encoded_rpc = encode_tag(1, WIRE_TYPE_LENGTH_DELIMITED) + b"\xff\x01"
 
         with pytest.raises(ProtobufDecodeError, match="exceeds data size"):
-            RPC.decode(data)
+            RPC.decode(encoded_rpc)
 
 
 class TestMultiTopicControl:

--- a/tests/lean_spec/node/networking/reqresp/test_codec.py
+++ b/tests/lean_spec/node/networking/reqresp/test_codec.py
@@ -191,12 +191,12 @@ class TestBoundaryConditions:
         """A valid 10-byte varint is accepted."""
         # Construct a 10-byte varint representing 2^63
         # This is the smallest value that requires 10 bytes
-        value = 2**63
-        encoded = encode_varint(value)
+        integer_value = 2**63
+        encoded = encode_varint(integer_value)
         assert len(encoded) == 10
 
         decoded, consumed = decode_varint(encoded)
-        assert decoded == value
+        assert decoded == integer_value
         assert consumed == 10
 
     def test_varint_11_bytes_rejected(self) -> None:

--- a/tests/lean_spec/node/networking/reqresp/test_handler.py
+++ b/tests/lean_spec/node/networking/reqresp/test_handler.py
@@ -626,7 +626,7 @@ class TestIntegration:
                 blocks.append(SignedBlock.decode_bytes(ssz_bytes))
 
         assert len(blocks) == 2
-        slots = {b.block.slot for b in blocks}
+        slots = {signed_block.block.slot for signed_block in blocks}
         assert Slot(10) in slots
         assert Slot(20) in slots
 
@@ -680,11 +680,11 @@ class TestStreamResponseAdapterMultipleResponses:
         assert len(written) == 3
 
         # Each response should be independently decodable
-        for i, data in enumerate(written):
-            code, decoded = ResponseCode.decode(data)
+        for i, response_bytes in enumerate(written):
+            code, decoded = ResponseCode.decode(response_bytes)
             assert code == ResponseCode.SUCCESS
-            expected = bytes([i * 2 + 1, i * 2 + 2])
-            assert decoded == expected
+            expected_payload = bytes([i * 2 + 1, i * 2 + 2])
+            assert decoded == expected_payload
 
     async def test_send_success_then_error(self) -> None:
         """Success response followed by error response."""
@@ -803,7 +803,7 @@ class TestReqRespServerChunkedRead:
         request_bytes = encode_request(peer_status.encode_bytes())
 
         # Split into single-byte chunks
-        chunks = [bytes([b]) for b in request_bytes]
+        chunks = [bytes([byte_value]) for byte_value in request_bytes]
 
         stream = MockChunkedStream(chunks=chunks)
 
@@ -990,19 +990,21 @@ class TestConcurrentRequestHandling:
             streams.append(MockStream(request_data=request_bytes))
 
         # Handle all requests concurrently
-        await asyncio.gather(*[server.handle_stream(s, STATUS_PROTOCOL_V1) for s in streams])
+        await asyncio.gather(
+            *[server.handle_stream(stream, STATUS_PROTOCOL_V1) for stream in streams]
+        )
 
         # Decode all responses
-        results = []
+        decoded_statuses = []
         for stream in streams:
             assert stream.closed
             assert len(stream.written) >= 1
             code, ssz_data = ResponseCode.decode(stream.written[0])
             assert code == ResponseCode.SUCCESS
-            results.append(Status.decode_bytes(ssz_data))
+            decoded_statuses.append(Status.decode_bytes(ssz_data))
 
         # All responses should be our status
-        for status in results:
+        for status in decoded_statuses:
             assert status.head.slot == Slot(200)
             assert status.finalized.slot == Slot(100)
 
@@ -1404,7 +1406,10 @@ class TestRequestHandlerBlocksByRange:
         request = BlocksByRangeRequest(start_slot=Slot(4000), count=Uint64(5))
         await handler.handle_blocks_by_range(request, response)  # type: ignore[arg-type]
 
-        decoded_slots = [SignedBlock.decode_bytes(s).block.slot for s in response.successes]
+        decoded_slots = [
+            SignedBlock.decode_bytes(success_bytes).block.slot
+            for success_bytes in response.successes
+        ]
         assert response.errors == []
         assert decoded_slots == [Slot(4000 + i) for i in range(5)]
 
@@ -1418,7 +1423,10 @@ class TestRequestHandlerBlocksByRange:
         request = BlocksByRangeRequest(start_slot=Slot(4000), count=Uint64(10))
         await handler.handle_blocks_by_range(request, response)  # type: ignore[arg-type]
 
-        decoded_slots = [SignedBlock.decode_bytes(s).block.slot for s in response.successes]
+        decoded_slots = [
+            SignedBlock.decode_bytes(success_bytes).block.slot
+            for success_bytes in response.successes
+        ]
         assert response.errors == []
         assert decoded_slots == [Slot(4000), Slot(4001), Slot(4002)]
 
@@ -1436,7 +1444,10 @@ class TestRequestHandlerBlocksByRange:
         request = BlocksByRangeRequest(start_slot=Slot(4000), count=Uint64(5))
         await handler.handle_blocks_by_range(request, response)  # type: ignore[arg-type]
 
-        decoded_slots = [SignedBlock.decode_bytes(s).block.slot for s in response.successes]
+        decoded_slots = [
+            SignedBlock.decode_bytes(success_bytes).block.slot
+            for success_bytes in response.successes
+        ]
         assert response.errors == []
         assert decoded_slots == [Slot(4000), Slot(4002), Slot(4004)]
 
@@ -1466,7 +1477,10 @@ class TestRequestHandlerBlocksByRange:
         request = BlocksByRangeRequest(start_slot=Slot(0), count=Uint64(1))
         await handler.handle_blocks_by_range(request, response)  # type: ignore[arg-type]
 
-        decoded_slots = [SignedBlock.decode_bytes(s).block.slot for s in response.successes]
+        decoded_slots = [
+            SignedBlock.decode_bytes(success_bytes).block.slot
+            for success_bytes in response.successes
+        ]
         assert response.errors == []
         assert decoded_slots == [Slot(0)]
 
@@ -1554,7 +1568,10 @@ class TestRequestHandlerBlocksByRange:
         request = BlocksByRangeRequest(start_slot=Slot(4000), count=Uint64(3))
         await handler.handle_blocks_by_range(request, response)  # type: ignore[arg-type]
 
-        decoded_slots = [SignedBlock.decode_bytes(s).block.slot for s in response.successes]
+        decoded_slots = [
+            SignedBlock.decode_bytes(success_bytes).block.slot
+            for success_bytes in response.successes
+        ]
         assert response.errors == []
         assert decoded_slots == [Slot(4001)]
 
@@ -1591,7 +1608,7 @@ class TestReqRespServerBlocksByRange:
             code, ssz_bytes = ResponseCode.decode(chunk)
             if code == ResponseCode.SUCCESS:
                 success_blocks.append(SignedBlock.decode_bytes(ssz_bytes))
-        assert [b.block.slot for b in success_blocks] == [Slot(4000)]
+        assert [signed_block.block.slot for signed_block in success_blocks] == [Slot(4000)]
 
     async def test_invalid_ssz_returns_invalid_request(self) -> None:
         """Invalid SSZ for BlocksByRange returns INVALID_REQUEST."""
@@ -1629,4 +1646,6 @@ class TestReqRespServerBlocksByRange:
             code, ssz_bytes = ResponseCode.decode(response_wire)
             if code == ResponseCode.SUCCESS:
                 success_blocks.append(SignedBlock.decode_bytes(ssz_bytes))
-        assert [b.block.slot for b in success_blocks] == [Slot(4000 + i) for i in range(3)]
+        assert [signed_block.block.slot for signed_block in success_blocks] == [
+            Slot(4000 + i) for i in range(3)
+        ]

--- a/tests/lean_spec/node/networking/test_peer.py
+++ b/tests/lean_spec/node/networking/test_peer.py
@@ -39,49 +39,49 @@ class TestPeerInfo:
     def test_create_peer_info(self) -> None:
         """PeerInfo can be created with peer ID."""
         test_peer = peer("16Uiu2HAk")
-        info = PeerInfo(peer_id=test_peer)
-        assert info.peer_id == test_peer
-        assert info.state == ConnectionState.DISCONNECTED
-        assert info.direction == Direction.OUTBOUND
-        assert info.address is None
+        peer_info = PeerInfo(peer_id=test_peer)
+        assert peer_info.peer_id == test_peer
+        assert peer_info.state == ConnectionState.DISCONNECTED
+        assert peer_info.direction == Direction.OUTBOUND
+        assert peer_info.address is None
 
     def test_create_with_all_fields(self) -> None:
         """PeerInfo can be created with all fields."""
-        info = PeerInfo(
+        peer_info = PeerInfo(
             peer_id=peer("16Uiu2HAk"),
             state=ConnectionState.CONNECTED,
             direction=Direction.INBOUND,
             address=Multiaddr("/ip4/192.168.1.1/udp/9000/quic-v1"),
         )
-        assert info.state == ConnectionState.CONNECTED
-        assert info.direction == Direction.INBOUND
-        assert info.address == "/ip4/192.168.1.1/udp/9000/quic-v1"
+        assert peer_info.state == ConnectionState.CONNECTED
+        assert peer_info.direction == Direction.INBOUND
+        assert peer_info.address == "/ip4/192.168.1.1/udp/9000/quic-v1"
 
     def test_is_connected(self) -> None:
         """is_connected() returns True only when connected."""
-        info = PeerInfo(peer_id=peer("test"))
+        peer_info = PeerInfo(peer_id=peer("test"))
 
-        info.state = ConnectionState.DISCONNECTED
-        assert not info.is_connected()
+        peer_info.state = ConnectionState.DISCONNECTED
+        assert not peer_info.is_connected()
 
-        info.state = ConnectionState.CONNECTING
-        assert not info.is_connected()
+        peer_info.state = ConnectionState.CONNECTING
+        assert not peer_info.is_connected()
 
-        info.state = ConnectionState.CONNECTED
-        assert info.is_connected()
+        peer_info.state = ConnectionState.CONNECTED
+        assert peer_info.is_connected()
 
-        info.state = ConnectionState.DISCONNECTING
-        assert not info.is_connected()
+        peer_info.state = ConnectionState.DISCONNECTING
+        assert not peer_info.is_connected()
 
     def test_enr_and_status_fields(self) -> None:
         """Test that enr and status fields exist and default to None."""
-        info = PeerInfo(peer_id=peer("test"))
-        assert info.enr is None
-        assert info.status is None
+        peer_info = PeerInfo(peer_id=peer("test"))
+        assert peer_info.enr is None
+        assert peer_info.status is None
 
     def test_status_can_be_set(self) -> None:
         """Test that status can be set and read back."""
-        info = PeerInfo(peer_id=peer("test"))
+        peer_info = PeerInfo(peer_id=peer("test"))
 
         # Create a test status
         test_checkpoint = Checkpoint(root=Bytes32(b"\x00" * 32), slot=Slot(100))
@@ -91,7 +91,7 @@ class TestPeerInfo:
         )
 
         # Set status
-        info.status = test_status
-        assert info.status is not None
-        assert info.status.finalized.slot == Slot(100)
-        assert info.status.head.slot == Slot(200)
+        peer_info.status = test_status
+        assert peer_info.status is not None
+        assert peer_info.status.finalized.slot == Slot(100)
+        assert peer_info.status.head.slot == Slot(200)

--- a/tests/lean_spec/node/networking/test_varint.py
+++ b/tests/lean_spec/node/networking/test_varint.py
@@ -39,10 +39,10 @@ PROTOBUF_VECTORS: list[tuple[int, bytes]] = [
 class TestEncodeVarint:
     """Tests for varint encoding against reference vectors."""
 
-    @pytest.mark.parametrize(("value", "expected"), PROTOBUF_VECTORS)
-    def test_encode(self, value: int, expected: bytes) -> None:
+    @pytest.mark.parametrize(("integer_value", "expected_encoding"), PROTOBUF_VECTORS)
+    def test_encode(self, integer_value: int, expected_encoding: bytes) -> None:
         """encode_varint produces the expected wire bytes."""
-        assert encode_varint(value) == expected
+        assert encode_varint(integer_value) == expected_encoding
 
     def test_negative_raises(self) -> None:
         """Negative values are rejected."""
@@ -53,15 +53,15 @@ class TestEncodeVarint:
 class TestDecodeVarint:
     """Tests for varint decoding against reference vectors."""
 
-    @pytest.mark.parametrize(("expected", "data"), PROTOBUF_VECTORS)
-    def test_decode(self, expected: int, data: bytes) -> None:
+    @pytest.mark.parametrize(("expected_value", "encoded_bytes"), PROTOBUF_VECTORS)
+    def test_decode(self, expected_value: int, encoded_bytes: bytes) -> None:
         """decode_varint reconstructs the original value."""
-        assert decode_varint(data, 0) == (expected, len(data))
+        assert decode_varint(encoded_bytes, 0) == (expected_value, len(encoded_bytes))
 
     def test_decode_at_offset(self) -> None:
         """Decoding respects the offset parameter."""
-        data = b"prefix\xac\x02suffix"
-        assert decode_varint(data, 6) == (300, 2)
+        encoded_bytes = b"prefix\xac\x02suffix"
+        assert decode_varint(encoded_bytes, 6) == (300, 2)
 
     def test_truncated_raises(self) -> None:
         """Continuation bit set on last byte with no follow-up raises."""
@@ -82,11 +82,11 @@ class TestDecodeVarint:
 class TestVarintRoundtrip:
     """Roundtrip: decode(encode(v)) == v for all valid values."""
 
-    @pytest.mark.parametrize(("value", "_expected"), PROTOBUF_VECTORS)
-    def test_roundtrip_vectors(self, value: int, _expected: bytes) -> None:
+    @pytest.mark.parametrize(("integer_value", "_expected_encoding"), PROTOBUF_VECTORS)
+    def test_roundtrip_vectors(self, integer_value: int, _expected_encoding: bytes) -> None:
         """Reference vectors survive an encode/decode cycle."""
-        encoded = encode_varint(value)
-        assert decode_varint(encoded, 0) == (value, len(encoded))
+        encoded = encode_varint(integer_value)
+        assert decode_varint(encoded, 0) == (integer_value, len(encoded))
 
     def test_64bit_max(self) -> None:
         """Maximum 64-bit value roundtrips in exactly 10 bytes."""
@@ -98,7 +98,7 @@ class TestVarintRoundtrip:
     @pytest.mark.parametrize(
         "power",
         [7, 14, 21, 28, 35, 42, 49, 56, 63],
-        ids=[f"2^{p}" for p in [7, 14, 21, 28, 35, 42, 49, 56, 63]],
+        ids=[f"2^{power}" for power in [7, 14, 21, 28, 35, 42, 49, 56, 63]],
     )
     def test_power_of_two_boundaries(self, power: int) -> None:
         """
@@ -107,28 +107,28 @@ class TestVarintRoundtrip:
         Each power of 7 is a byte-size boundary: values below 2^7
         fit in 1 byte, values below 2^14 fit in 2 bytes, etc.
         """
-        for value in [2**power - 1, 2**power]:
-            encoded = encode_varint(value)
-            assert decode_varint(encoded, 0) == (value, len(encoded))
+        for integer_value in [2**power - 1, 2**power]:
+            encoded = encode_varint(integer_value)
+            assert decode_varint(encoded, 0) == (integer_value, len(encoded))
 
         # The boundary value requires one more byte than its predecessor.
         assert len(encode_varint(2**power)) == len(encode_varint(2**power - 1)) + 1
 
     @pytest.mark.parametrize(
-        "value",
+        "integer_value",
         [65536, 2**20, 2**24, 2**32 - 1, 2**63],
     )
-    def test_large_values(self, value: int) -> None:
+    def test_large_values(self, integer_value: int) -> None:
         """Large multi-byte values roundtrip correctly."""
-        encoded = encode_varint(value)
-        assert decode_varint(encoded, 0) == (value, len(encoded))
+        encoded = encode_varint(integer_value)
+        assert decode_varint(encoded, 0) == (integer_value, len(encoded))
 
 
 class TestMaxBytesParameter:
     """Tests for the max_bytes cap shared by both encode and decode."""
 
     @pytest.mark.parametrize(
-        ("value", "byte_count"),
+        ("integer_value", "byte_count"),
         [
             (0, 1),
             (127, 1),
@@ -141,12 +141,12 @@ class TestMaxBytesParameter:
         ],
     )
     def test_five_byte_cap_accepts_values_up_to_five_bytes(
-        self, value: int, byte_count: int
+        self, integer_value: int, byte_count: int
     ) -> None:
         """A five-byte cap fits values that encode in five or fewer bytes."""
-        encoded = encode_varint(value, max_bytes=5)
+        encoded = encode_varint(integer_value, max_bytes=5)
         assert len(encoded) == byte_count
-        assert decode_varint(encoded, 0, max_bytes=5) == (value, byte_count)
+        assert decode_varint(encoded, 0, max_bytes=5) == (integer_value, byte_count)
 
     def test_five_byte_cap_rejects_value_needing_six_bytes(self) -> None:
         """A value past the five-byte ceiling is rejected on encode."""
@@ -161,5 +161,5 @@ class TestMaxBytesParameter:
     def test_five_byte_cap_accepts_five_bytes_at_boundary(self) -> None:
         """Five continuation bytes followed by a terminator decode successfully."""
         encoded = bytes([0x80, 0x80, 0x80, 0x80, 0x01])
-        value, consumed = decode_varint(encoded, 0, max_bytes=5)
-        assert (value, consumed) == (1 << 28, 5)
+        decoded_value, consumed = decode_varint(encoded, 0, max_bytes=5)
+        assert (decoded_value, consumed) == (1 << 28, 5)

--- a/tests/lean_spec/node/networking/transport/quic/test_connection.py
+++ b/tests/lean_spec/node/networking/transport/quic/test_connection.py
@@ -76,7 +76,7 @@ class TestIsQuicMultiaddr:
     """Tests for QUIC multiaddr detection per the multiaddr spec."""
 
     @pytest.mark.parametrize(
-        ("multiaddr", "expected"),
+        ("multiaddr", "expected_classification"),
         [
             # Valid QUIC multiaddrs (lowercase per spec)
             ("/ip4/127.0.0.1/udp/9000/quic-v1", True),
@@ -104,9 +104,9 @@ class TestIsQuicMultiaddr:
             "mixed-case-rejected",
         ],
     )
-    def test_detection(self, multiaddr: str, expected: bool) -> None:
+    def test_detection(self, multiaddr: str, expected_classification: bool) -> None:
         """Multiaddr is correctly classified as QUIC or non-QUIC."""
-        assert is_quic_multiaddr(multiaddr) == expected
+        assert is_quic_multiaddr(multiaddr) == expected_classification
 
 
 # Multiaddr parsing

--- a/tests/lean_spec/node/networking/transport/quic/test_stream_adapter.py
+++ b/tests/lean_spec/node/networking/transport/quic/test_stream_adapter.py
@@ -67,9 +67,9 @@ class TestNegotiateServer:
             await _read_message(client)
 
         task = asyncio.create_task(client_task())
-        result = await server.negotiate_server({GOSSIPSUB_ID, STATUS_ID})
+        negotiated_protocol = await server.negotiate_server({GOSSIPSUB_ID, STATUS_ID})
         await task
-        assert result == GOSSIPSUB_ID
+        assert negotiated_protocol == GOSSIPSUB_ID
 
     async def test_server_rejects_unsupported_then_accepts(self) -> None:
         """Server rejects unsupported protocols."""
@@ -79,16 +79,16 @@ class TestNegotiateServer:
             await _write_message(client, MULTISTREAM_PROTOCOL_ID)
             await _read_message(client)
             await _write_message(client, GOSSIPSUB_V12_ID)
-            response1 = await _read_message(client)
-            assert response1 == NA
+            first_rejection_response = await _read_message(client)
+            assert first_rejection_response == NA
             await _write_message(client, GOSSIPSUB_ID)
-            response2 = await _read_message(client)
-            assert response2 == GOSSIPSUB_ID
+            accepted_protocol = await _read_message(client)
+            assert accepted_protocol == GOSSIPSUB_ID
 
         task = asyncio.create_task(client_task())
-        result = await server.negotiate_server({GOSSIPSUB_ID})
+        negotiated_protocol = await server.negotiate_server({GOSSIPSUB_ID})
         await task
-        assert result == GOSSIPSUB_ID
+        assert negotiated_protocol == GOSSIPSUB_ID
 
     async def test_server_empty_supported(self) -> None:
         """Server raises error when no supported protocols."""
@@ -115,8 +115,8 @@ class TestNegotiateServer:
 
             for i in range(MAX_NEGOTIATION_ATTEMPTS):
                 await _write_message(client, ProtocolId(f"/proto{i}"))
-                resp = await _read_message(client)
-                assert resp == NA
+                rejection_response = await _read_message(client)
+                assert rejection_response == NA
 
         task = asyncio.create_task(client_task())
 
@@ -155,9 +155,9 @@ class TestLazyClient:
             await _write_message(server, protocol)
 
         task = asyncio.create_task(server_task())
-        result = await client.negotiate_lazy_client(GOSSIPSUB_ID)
+        negotiated_protocol = await client.negotiate_lazy_client(GOSSIPSUB_ID)
         await task
-        assert result == GOSSIPSUB_ID
+        assert negotiated_protocol == GOSSIPSUB_ID
 
     async def test_lazy_client_rejected(self) -> None:
         """Lazy client raises error when protocol rejected."""
@@ -207,11 +207,11 @@ class TestMessageFormat:
         stream, peer = _create_stream_pair()
         await _write_message(peer, STATUS_ID)
 
-        raw = await stream.read(100)
+        raw_frame = await stream.read(100)
         expected_payload = STATUS_ID.encode("utf-8") + b"\n"
         expected_length = len(expected_payload)
-        assert raw[0] == expected_length
-        assert raw[1:] == expected_payload
+        assert raw_frame[0] == expected_length
+        assert raw_frame[1:] == expected_payload
 
     async def test_message_roundtrip(self) -> None:
         """Write then read returns original message."""
@@ -282,8 +282,8 @@ class TestMessageFormat:
         peer.write(b"CDE")
         peer.write(b"FG")
         await peer.drain()
-        result = await stream.readexactly(6)
-        assert result == b"ABCDEF"
+        received_bytes = await stream.readexactly(6)
+        assert received_bytes == b"ABCDEF"
         assert await stream.read() == b"G"
 
     async def test_readexactly_eof_error(self) -> None:
@@ -334,15 +334,15 @@ class TestMessageFormat:
         """Valid message is Varint length + payload + newline"""
         stream, peer = _create_stream_pair()
 
-        payload = b"/my/proto/1.0.0\n"
-        length_prefix = encode_varint(len(payload))
-        framed = length_prefix + payload
+        message_payload = b"/my/proto/1.0.0\n"
+        length_prefix = encode_varint(len(message_payload))
+        framed = length_prefix + message_payload
 
         peer.write(framed)
         await peer.drain()
 
-        result = await stream._read_negotiation_message()
-        assert result == "/my/proto/1.0.0"
+        negotiation_message = await stream._read_negotiation_message()
+        assert negotiation_message == "/my/proto/1.0.0"
 
     async def test_read_negotiation_message_connection_closed(self) -> None:
         """Connection closed"""
@@ -364,8 +364,8 @@ class TestMessageFormat:
         """Message too long"""
         stream, peer = _create_stream_pair()
         too_big_length = MAX_MESSAGE_SIZE + 1
-        payload = b"A" * too_big_length
-        length_prefix = encode_varint(len(payload))
+        message_payload = b"A" * too_big_length
+        length_prefix = encode_varint(len(message_payload))
         peer.write(length_prefix)
         await peer.drain()
 
@@ -383,9 +383,9 @@ class TestMessageFormat:
     async def test_read_negotiation_message_no_trailing_newline(self) -> None:
         """No trailing newline"""
         stream, peer = _create_stream_pair()
-        payload = b"/my/proto/1.0.0"
-        length_prefix = encode_varint(len(payload))
-        peer.write(length_prefix + payload)
+        message_payload = b"/my/proto/1.0.0"
+        length_prefix = encode_varint(len(message_payload))
+        peer.write(length_prefix + message_payload)
         await peer.drain()
 
         with pytest.raises(NegotiationError, match="Message must end with newline"):
@@ -410,11 +410,11 @@ class TestMessageFormat:
         """Write negotiation message with correct varint"""
         stream, peer = _create_stream_pair()
         await stream._write_negotiation_message("/my/proto/1.0.0")
-        raw = await peer.read()
+        raw_frame = await peer.read()
         expected_payload = b"/my/proto/1.0.0\n"
-        expected = encode_varint(len(expected_payload)) + expected_payload
+        expected_frame = encode_varint(len(expected_payload)) + expected_payload
 
-        assert raw == expected
+        assert raw_frame == expected_frame
 
 
 class TestBufferedIO:
@@ -424,31 +424,31 @@ class TestBufferedIO:
         """read(n=None) returns buffered data."""
         stream, _ = _create_stream_pair()
         stream._buffer = b"already buffered"
-        result = await stream.read()
-        assert result == b"already buffered"
+        read_bytes = await stream.read()
+        assert read_bytes == b"already buffered"
         assert stream._buffer == b""
 
     async def test_read_n_none_empty_buffer(self) -> None:
         """read(n=None) with empty buffer reads from stream."""
         stream, peer = _create_stream_pair()
         stream._stream._read_queue.put_nowait(b"from stream")  # type: ignore[attribute-defined]
-        result = await stream.read()
-        assert result == b"from stream"
+        read_bytes = await stream.read()
+        assert read_bytes == b"from stream"
 
     async def test_read_partial_buffer(self) -> None:
         """read(n) returns from buffer when buffer has less than n."""
         stream, _ = _create_stream_pair()
         stream._buffer = b"abc"
-        result = await stream.read(5)
-        assert result == b"abc"
+        read_bytes = await stream.read(5)
+        assert read_bytes == b"abc"
         assert stream._buffer == b""
 
     async def test_read_buffer_overflow(self) -> None:
         """read(n) keeps leftover when buffer exceeds n."""
         stream, _ = _create_stream_pair()
         stream._buffer = b"abcdef"
-        result = await stream.read(3)
-        assert result == b"abc"
+        read_bytes = await stream.read(3)
+        assert read_bytes == b"abc"
         assert stream._buffer == b"def"
 
     async def test_read_empty_stream(self) -> None:
@@ -456,16 +456,16 @@ class TestBufferedIO:
         stream, _ = _create_stream_pair()
         stream._buffer = b""
         stream._stream._read_queue.put_nowait(b"")  # type: ignore[attribute-defined]
-        result = await stream.read(10)
-        assert result == b""
+        read_bytes = await stream.read(10)
+        assert read_bytes == b""
 
     async def test_readexactly_accumulates_chunks(self) -> None:
         """readexactly accumulates chunks until n bytes."""
         stream, peer = _create_stream_pair()
         stream._stream._read_queue.put_nowait(b"ab")  # type: ignore[attribute-defined]
         stream._stream._read_queue.put_nowait(b"cd")  # type: ignore[attribute-defined]
-        result = await stream.readexactly(4)
-        assert result == b"abcd"
+        read_bytes = await stream.readexactly(4)
+        assert read_bytes == b"abcd"
         assert stream._buffer == b""
 
     async def test_readexactly_eof_error(self) -> None:
@@ -567,9 +567,9 @@ class TestReadNegotiationMessage:
     async def test_message_no_trailing_newline(self) -> None:
         """Raises error when message doesn't end with newline."""
         stream, peer = _create_stream_pair()
-        payload = b"no newline"
-        length_prefix = encode_varint(len(payload))
-        stream._buffer = length_prefix + payload
+        message_payload = b"no newline"
+        length_prefix = encode_varint(len(message_payload))
+        stream._buffer = length_prefix + message_payload
         with pytest.raises(NegotiationError, match="Message must end with newline"):
             await stream._read_negotiation_message()
 
@@ -613,9 +613,9 @@ class TestClose:
 
     async def test_close_delegates_to_underlying(self) -> None:
         """Close delegates to stream"""
-        mock = _MockStream(_read_queue=asyncio.Queue(), _write_queue=None)
-        await QuicStreamAdapter(cast(QuicStream, mock)).close()
-        assert mock.close_called is True
+        mock_stream = _MockStream(_read_queue=asyncio.Queue(), _write_queue=None)
+        await QuicStreamAdapter(cast(QuicStream, mock_stream)).close()
+        assert mock_stream.close_called is True
 
 
 def _create_stream_pair() -> tuple[QuicStreamAdapter, QuicStreamAdapter]:
@@ -635,9 +635,9 @@ def _create_stream_pair() -> tuple[QuicStreamAdapter, QuicStreamAdapter]:
 
 async def _write_message(stream: QuicStreamAdapter, message: str) -> None:
     """Write a multistream message to a stream."""
-    payload = message.encode("utf-8") + b"\n"
-    length_prefix = encode_varint(len(payload))
-    stream.write(length_prefix + payload)
+    message_payload = message.encode("utf-8") + b"\n"
+    length_prefix = encode_varint(len(message_payload))
+    stream.write(length_prefix + message_payload)
     await stream.drain()
 
 
@@ -653,9 +653,9 @@ async def _read_message(stream: QuicStreamAdapter) -> str:
             break
 
     length, _ = decode_varint(bytes(length_bytes))
-    payload = await stream.readexactly(length)
+    message_payload = await stream.readexactly(length)
 
-    if not payload.endswith(b"\n"):
+    if not message_payload.endswith(b"\n"):
         raise NegotiationError("Message must end with newline")
 
-    return payload[:-1].decode("utf-8")
+    return message_payload[:-1].decode("utf-8")

--- a/tests/lean_spec/node/networking/transport/quic/test_tls.py
+++ b/tests/lean_spec/node/networking/transport/quic/test_tls.py
@@ -71,7 +71,7 @@ class TestEncodeAsn1Length:
     """Tests for DER length encoding covering all three code paths."""
 
     @pytest.mark.parametrize(
-        ("length", "expected"),
+        ("length", "expected_encoding"),
         [
             (0, bytes([0])),
             (1, bytes([1])),
@@ -79,12 +79,12 @@ class TestEncodeAsn1Length:
         ],
         ids=["zero", "one", "max-short-form"],
     )
-    def test_short_form(self, length: int, expected: bytes) -> None:
+    def test_short_form(self, length: int, expected_encoding: bytes) -> None:
         """Lengths below 128 use a single byte (short form)."""
-        assert _encode_asn1_length(length) == expected
+        assert _encode_asn1_length(length) == expected_encoding
 
     @pytest.mark.parametrize(
-        ("length", "expected"),
+        ("length", "expected_encoding"),
         [
             (128, bytes([0x81, 128])),
             (200, bytes([0x81, 200])),
@@ -92,12 +92,12 @@ class TestEncodeAsn1Length:
         ],
         ids=["min-long-1", "mid-long-1", "max-long-1"],
     )
-    def test_one_byte_long_form(self, length: int, expected: bytes) -> None:
+    def test_one_byte_long_form(self, length: int, expected_encoding: bytes) -> None:
         """Lengths 128..255 use 0x81 prefix + 1 length byte."""
-        assert _encode_asn1_length(length) == expected
+        assert _encode_asn1_length(length) == expected_encoding
 
     @pytest.mark.parametrize(
-        ("length", "expected"),
+        ("length", "expected_encoding"),
         [
             (256, bytes([0x82, 0x01, 0x00])),
             (1000, bytes([0x82, 0x03, 0xE8])),
@@ -105,9 +105,9 @@ class TestEncodeAsn1Length:
         ],
         ids=["min-long-2", "mid-long-2", "max-u16"],
     )
-    def test_two_byte_long_form(self, length: int, expected: bytes) -> None:
+    def test_two_byte_long_form(self, length: int, expected_encoding: bytes) -> None:
         """Lengths >= 256 use 0x82 prefix + 2 big-endian length bytes."""
-        assert _encode_asn1_length(length) == expected
+        assert _encode_asn1_length(length) == expected_encoding
 
 
 # ASN.1 OCTET STRING encoding
@@ -118,21 +118,21 @@ class TestEncodeAsn1OctetString:
 
     def test_encodes_data_with_tag_and_length(self) -> None:
         """OCTET STRING has tag 0x04, correct length, and verbatim data."""
-        result = _encode_asn1_octet_string(b"\xaa\xbb\xcc")
-        assert result == bytes([0x04, 3, 0xAA, 0xBB, 0xCC])
+        encoded = _encode_asn1_octet_string(b"\xaa\xbb\xcc")
+        assert encoded == bytes([0x04, 3, 0xAA, 0xBB, 0xCC])
 
     def test_empty_data(self) -> None:
         """Empty OCTET STRING is valid: tag 0x04, length 0, no content."""
-        result = _encode_asn1_octet_string(b"")
-        assert result == bytes([0x04, 0])
+        encoded = _encode_asn1_octet_string(b"")
+        assert encoded == bytes([0x04, 0])
 
     def test_long_form_length(self) -> None:
         """Data >= 128 bytes triggers long-form length encoding."""
-        data = bytes(range(256)) * 2  # 512 bytes
-        result = _encode_asn1_octet_string(data)
-        assert result[0] == 0x04
-        assert result[1:4] == bytes([0x82, 0x02, 0x00])
-        assert result[4:] == data
+        octet_payload = bytes(range(256)) * 2  # 512 bytes
+        encoded = _encode_asn1_octet_string(octet_payload)
+        assert encoded[0] == 0x04
+        assert encoded[1:4] == bytes([0x82, 0x02, 0x00])
+        assert encoded[4:] == octet_payload
 
 
 # ASN.1 SEQUENCE encoding
@@ -144,13 +144,13 @@ class TestEncodeAsn1Sequence:
     def test_wraps_content_with_tag_and_length(self) -> None:
         """SEQUENCE has tag 0x30, correct length, and verbatim content."""
         content = bytes([0x04, 2, 0xAA, 0xBB])
-        result = _encode_asn1_sequence(content)
-        assert result == bytes([0x30, 4, 0x04, 2, 0xAA, 0xBB])
+        encoded = _encode_asn1_sequence(content)
+        assert encoded == bytes([0x30, 4, 0x04, 2, 0xAA, 0xBB])
 
     def test_empty_sequence(self) -> None:
         """Empty SEQUENCE is valid: tag 0x30, length 0."""
-        result = _encode_asn1_sequence(b"")
-        assert result == bytes([0x30, 0])
+        encoded = _encode_asn1_sequence(b"")
+        assert encoded == bytes([0x30, 0])
 
 
 # ASN.1 SignedKey — SEQUENCE { OCTET STRING, OCTET STRING }
@@ -163,20 +163,20 @@ class TestEncodeAsn1SignedKey:
         """Output is a SEQUENCE containing two OCTET STRINGs."""
         protobuf = b"\x08\x02\x12\x21" + bytes(33)
         signature = bytes(64)
-        result = _encode_asn1_signed_key(protobuf, signature)
+        encoded = _encode_asn1_signed_key(protobuf, signature)
 
-        assert result[0] == 0x30  # SEQUENCE tag
+        assert encoded[0] == 0x30  # SEQUENCE tag
 
         # Parse inner content
-        _, inner = _parse_der_tlv(result)
+        _, inner = _parse_der_tlv(encoded)
         # First OCTET STRING
-        tag1, val1, rest = _parse_der_tlv_with_rest(inner)
+        tag1, first_octet_string_value, rest = _parse_der_tlv_with_rest(inner)
         assert tag1 == 0x04
-        assert val1 == protobuf
+        assert first_octet_string_value == protobuf
         # Second OCTET STRING
-        tag2, val2, rest2 = _parse_der_tlv_with_rest(rest)
+        tag2, second_octet_string_value, rest2 = _parse_der_tlv_with_rest(rest)
         assert tag2 == 0x04
-        assert val2 == signature
+        assert second_octet_string_value == signature
         assert rest2 == b""
 
 
@@ -193,12 +193,12 @@ class TestCreateExtensionPayload:
             encoding=serialization.Encoding.DER,
             format=serialization.PublicFormat.SubjectPublicKeyInfo,
         )
-        payload = _create_extension_payload(identity_key, tls_public_bytes)
+        extension_payload = _create_extension_payload(identity_key, tls_public_bytes)
 
-        assert payload[0] == 0x30
-        _, inner = _parse_der_tlv(payload)
-        tag1, val1, rest = _parse_der_tlv_with_rest(inner)
-        tag2, val2, _ = _parse_der_tlv_with_rest(rest)
+        assert extension_payload[0] == 0x30
+        _, inner = _parse_der_tlv(extension_payload)
+        tag1, first_octet_string_value, rest = _parse_der_tlv_with_rest(inner)
+        tag2, second_octet_string_value, _ = _parse_der_tlv_with_rest(rest)
         assert tag1 == 0x04
         assert tag2 == 0x04
 
@@ -209,9 +209,9 @@ class TestCreateExtensionPayload:
             encoding=serialization.Encoding.DER,
             format=serialization.PublicFormat.SubjectPublicKeyInfo,
         )
-        payload = _create_extension_payload(identity_key, tls_public_bytes)
+        extension_payload = _create_extension_payload(identity_key, tls_public_bytes)
 
-        _, inner = _parse_der_tlv(payload)
+        _, inner = _parse_der_tlv(extension_payload)
         _, public_key_protobuf, _ = _parse_der_tlv_with_rest(inner)
 
         # Protobuf field 1 (Type): varint tag=0x08, value=2 (secp256k1)
@@ -231,9 +231,9 @@ class TestCreateExtensionPayload:
             encoding=serialization.Encoding.DER,
             format=serialization.PublicFormat.SubjectPublicKeyInfo,
         )
-        payload = _create_extension_payload(identity_key, tls_public_bytes)
+        extension_payload = _create_extension_payload(identity_key, tls_public_bytes)
 
-        _, inner = _parse_der_tlv(payload)
+        _, inner = _parse_der_tlv(extension_payload)
         _, _, rest = _parse_der_tlv_with_rest(inner)
         _, signature, _ = _parse_der_tlv_with_rest(rest)
 
@@ -318,10 +318,10 @@ class TestGenerateLibp2pCertificate:
 
         ext = certificate.extensions.get_extension_for_oid(LIBP2P_EXTENSION_OID)
         assert isinstance(ext.value, x509.UnrecognizedExtension)
-        payload = ext.value.value
+        extension_payload = ext.value.value
 
         # Parse ASN.1 SEQUENCE → two OCTET STRINGs
-        _, inner = _parse_der_tlv(payload)
+        _, inner = _parse_der_tlv(extension_payload)
         _, _, rest = _parse_der_tlv_with_rest(inner)
         _, signature, _ = _parse_der_tlv_with_rest(rest)
 
@@ -357,28 +357,28 @@ class TestGenerateLibp2pCertificate:
 # Minimal DER TLV parser for verifying hand-encoded ASN.1 output.
 
 
-def _parse_der_length(data: bytes, offset: int) -> tuple[int, int]:
+def _parse_der_length(der_bytes: bytes, offset: int) -> tuple[int, int]:
     """Parse a DER length field, return (length, bytes_consumed)."""
-    first = data[offset]
+    first = der_bytes[offset]
     if first < 128:
         return first, 1
     num_bytes = first & 0x7F
-    length = int.from_bytes(data[offset + 1 : offset + 1 + num_bytes], "big")
+    length = int.from_bytes(der_bytes[offset + 1 : offset + 1 + num_bytes], "big")
     return length, 1 + num_bytes
 
 
-def _parse_der_tlv(data: bytes) -> tuple[int, bytes]:
+def _parse_der_tlv(der_bytes: bytes) -> tuple[int, bytes]:
     """Parse a single DER TLV, return (tag, value)."""
-    tag = data[0]
-    length, length_size = _parse_der_length(data, 1)
+    tag = der_bytes[0]
+    length, length_size = _parse_der_length(der_bytes, 1)
     value_start = 1 + length_size
-    return tag, data[value_start : value_start + length]
+    return tag, der_bytes[value_start : value_start + length]
 
 
-def _parse_der_tlv_with_rest(data: bytes) -> tuple[int, bytes, bytes]:
+def _parse_der_tlv_with_rest(der_bytes: bytes) -> tuple[int, bytes, bytes]:
     """Parse a single DER TLV, return (tag, value, remaining_bytes)."""
-    tag = data[0]
-    length, length_size = _parse_der_length(data, 1)
+    tag = der_bytes[0]
+    length, length_size = _parse_der_length(der_bytes, 1)
     value_start = 1 + length_size
     value_end = value_start + length
-    return tag, data[value_start:value_end], data[value_end:]
+    return tag, der_bytes[value_start:value_end], der_bytes[value_end:]

--- a/tests/lean_spec/node/networking/transport/test_peer_id.py
+++ b/tests/lean_spec/node/networking/transport/test_peer_id.py
@@ -56,9 +56,9 @@ class TestBase58:
         """Test known Base58 encodings."""
         # "Hello World" in Base58
         # (not standard test vector, but useful for sanity check)
-        result = Base58.encode(b"Hello World")
-        assert len(result) > 0
-        assert all(c in Base58.ALPHABET for c in result)
+        encoded = Base58.encode(b"Hello World")
+        assert len(encoded) > 0
+        assert all(character in Base58.ALPHABET for character in encoded)
 
     def test_base58_roundtrip(self) -> None:
         """Encode then decode returns original."""
@@ -73,10 +73,10 @@ class TestBase58:
             bytes(range(256)),  # All bytes
         ]
 
-        for data in test_cases:
-            encoded = Base58.encode(data)
+        for original_bytes in test_cases:
+            encoded = Base58.encode(original_bytes)
             decoded = Base58.decode(encoded)
-            assert decoded == data, f"Roundtrip failed for {data.hex()}"
+            assert decoded == original_bytes, f"Roundtrip failed for {original_bytes.hex()}"
 
     def test_base58_decode_invalid_character(self) -> None:
         """Decoding invalid characters raises ValueError."""
@@ -98,31 +98,31 @@ class TestMultihash:
 
     def test_identity_multihash_format(self) -> None:
         """Small data uses identity multihash: [0x00][length][data]."""
-        data = b"test"
-        mh = Multihash.from_data(data)
-        result = mh.encode()
+        input_bytes = b"test"
+        multihash = Multihash.from_data(input_bytes)
+        encoded = multihash.encode()
 
-        assert result[0] == MultihashCode.IDENTITY  # 0x00
-        assert result[1] == len(data)  # 4
-        assert result[2:] == data
+        assert encoded[0] == MultihashCode.IDENTITY  # 0x00
+        assert encoded[1] == len(input_bytes)  # 4
+        assert encoded[2:] == input_bytes
 
     def test_sha256_multihash_format(self) -> None:
         """Large data uses SHA256 multihash: [0x12][0x20][32-byte hash]."""
         # 50 bytes > 42-byte identity threshold → SHA256 path
-        data = bytes(50)
-        mh = Multihash.from_data(data)
-        result = mh.encode()
+        input_bytes = bytes(50)
+        multihash = Multihash.from_data(input_bytes)
+        encoded = multihash.encode()
 
-        assert result[0] == MultihashCode.SHA256  # 0x12
-        assert result[1] == 32  # SHA256 output length
-        assert len(result) == 2 + 32
+        assert encoded[0] == MultihashCode.SHA256  # 0x12
+        assert encoded[1] == 32  # SHA256 output length
+        assert len(encoded) == 2 + 32
 
     def test_sha256_multihash_deterministic(self) -> None:
         """Same large input produces same multihash."""
-        data = bytes(50)
-        result1 = Multihash.from_data(data).encode()
-        result2 = Multihash.from_data(data).encode()
-        assert result1 == result2
+        input_bytes = bytes(50)
+        first_multihash = Multihash.from_data(input_bytes).encode()
+        second_multihash = Multihash.from_data(input_bytes).encode()
+        assert first_multihash == second_multihash
 
 
 class TestEncodePublicKey:
@@ -242,7 +242,7 @@ class TestDerivePeerId:
         # Result should be a valid Base58 string
         peer_id_str = str(peer_id)
         assert len(peer_id_str) > 0
-        assert all(c in Base58.ALPHABET for c in peer_id_str)
+        assert all(character in Base58.ALPHABET for character in peer_id_str)
         # secp256k1 PeerIds start with "16Uiu2"
         assert peer_id_str.startswith("16Uiu2")
 
@@ -480,8 +480,8 @@ class TestKnownVectors:
         peer_id = PeerId.from_public_key(protobuf)
 
         # Expected PeerId from spec test vector
-        expected = "16Uiu2HAmLhLvBoYaoZfaMUKuibM6ac163GwKY74c5kiSLg5KvLpY"
-        assert str(peer_id) == expected
+        expected_peer_id = "16Uiu2HAmLhLvBoYaoZfaMUKuibM6ac163GwKY74c5kiSLg5KvLpY"
+        assert str(peer_id) == expected_peer_id
 
         # Verify roundtrip
         decoded = Base58.decode(str(peer_id))

--- a/tests/lean_spec/node/snappy/test_compress.py
+++ b/tests/lean_spec/node/snappy/test_compress.py
@@ -20,10 +20,10 @@ TESTDATA_DIRECTORY = Path(__file__).parent / "testdata"
 def load_test_file(filename: str, size_limit: int = 0) -> bytes:
     """Load a test data file, optionally truncated to size_limit."""
     path = TESTDATA_DIRECTORY / filename
-    data = path.read_bytes()
+    file_bytes = path.read_bytes()
     if size_limit > 0:
-        data = data[:size_limit]
-    return data
+        file_bytes = file_bytes[:size_limit]
+    return file_bytes
 
 
 # Test data files as defined in the C++ test suite
@@ -100,22 +100,22 @@ class TestSelfPatternExtension:
             for length in range(1, 65):
                 for extra_bytes in [0, 1, 15, 16, 128]:
                     size = pattern_size + length + extra_bytes
-                    data = bytearray(size)
+                    uncompressed = bytearray(size)
 
                     # Build pattern
                     for i in range(pattern_size):
-                        data[i] = ord("a") + i
+                        uncompressed[i] = ord("a") + i
 
                     # Repeat pattern
                     for i in range(length):
-                        data[pattern_size + i] = data[i % pattern_size]
+                        uncompressed[pattern_size + i] = uncompressed[i % pattern_size]
 
                     # Random suffix
                     for i in range(extra_bytes):
-                        data[pattern_size + length + i] = random.randint(0, 255)
+                        uncompressed[pattern_size + length + i] = random.randint(0, 255)
 
-                    compressed = compress(bytes(data))
-                    assert decompress(compressed) == bytes(data)
+                    compressed = compress(bytes(uncompressed))
+                    assert decompress(compressed) == bytes(uncompressed)
 
 
 class TestMaxBlowup:
@@ -126,18 +126,18 @@ class TestMaxBlowup:
         random.seed(42)
 
         # Build input with random bytes
-        data = bytearray(random.randint(0, 255) for _ in range(80000))
+        uncompressed = bytearray(random.randint(0, 255) for _ in range(80000))
 
         # Append four-byte sequences from the end
         for i in range(0, 80000, 4):
-            four_bytes = data[-(i + 4) : -i] if i > 0 else data[-4:]
-            data.extend(four_bytes)
+            four_bytes = uncompressed[-(i + 4) : -i] if i > 0 else uncompressed[-4:]
+            uncompressed.extend(four_bytes)
 
-        compressed = compress(bytes(data))
-        assert decompress(compressed) == bytes(data)
+        compressed = compress(bytes(uncompressed))
+        assert decompress(compressed) == bytes(uncompressed)
 
         # Verify max_compressed_length bound
-        assert len(compressed) <= max_compressed_length(len(data))
+        assert len(compressed) <= max_compressed_length(len(uncompressed))
 
 
 class TestRealDataFiles:
@@ -146,34 +146,34 @@ class TestRealDataFiles:
     @pytest.mark.parametrize("label,filename,size_limit", TEST_DATA_FILES)
     def test_roundtrip(self, label: str, filename: str, size_limit: int) -> None:
         """Test compression/decompression roundtrip for each test file."""
-        data = load_test_file(filename, size_limit)
-        compressed = compress(data)
+        uncompressed = load_test_file(filename, size_limit)
+        compressed = compress(uncompressed)
         decompressed = decompress(compressed)
-        assert decompressed == data, f"Roundtrip failed for {label}"
+        assert decompressed == uncompressed, f"Roundtrip failed for {label}"
 
     @pytest.mark.parametrize("label,filename,size_limit", TEST_DATA_FILES)
     def test_compression_bound(self, label: str, filename: str, size_limit: int) -> None:
         """Test that compressed size is within bounds."""
-        data = load_test_file(filename, size_limit)
-        compressed = compress(data)
-        assert len(compressed) <= max_compressed_length(len(data))
+        uncompressed = load_test_file(filename, size_limit)
+        compressed = compress(uncompressed)
+        assert len(compressed) <= max_compressed_length(len(uncompressed))
 
     def test_text_compression_ratio(self) -> None:
         """Text files should achieve good compression."""
         for label, filename, _ in TEST_DATA_FILES:
             if filename.endswith(".txt"):
-                data = load_test_file(filename)
-                compressed = compress(data)
-                ratio = len(compressed) / len(data)
+                uncompressed = load_test_file(filename)
+                compressed = compress(uncompressed)
+                ratio = len(compressed) / len(uncompressed)
                 # Text should compress to less than 70% of original
                 # (Snappy prioritizes speed over compression ratio)
                 assert ratio < 0.7, f"{label} compression ratio too high: {ratio:.2%}"
 
     def test_jpeg_low_compression(self) -> None:
         """JPEG files (already compressed) should have low compression ratio."""
-        data = load_test_file("fireworks.jpeg")
-        compressed = compress(data)
-        ratio = len(compressed) / len(data)
+        uncompressed = load_test_file("fireworks.jpeg")
+        compressed = compress(uncompressed)
+        ratio = len(compressed) / len(uncompressed)
         # JPEG shouldn't compress much (already compressed)
         # Allow up to 5% expansion or minimal compression
         assert ratio > 0.95, f"JPEG compressed too much: {ratio:.2%}"
@@ -186,9 +186,9 @@ class TestUtilities:
         """max_compressed_length returns a valid upper bound."""
         for size in [0, 100, 1000, 65536, 100000]:
             max_length = max_compressed_length(size)
-            data = bytes(range(256)) * (size // 256 + 1)
-            data = data[:size]
-            compressed = compress(data)
+            uncompressed = bytes(range(256)) * (size // 256 + 1)
+            uncompressed = uncompressed[:size]
+            compressed = compress(uncompressed)
             assert len(compressed) <= max_length
 
 
@@ -197,36 +197,36 @@ class TestSpecificPatterns:
 
     def test_overlapping_copy(self) -> None:
         """Overlapping copies (run-length encoding) work correctly."""
-        data = b"AAAAAAAAAAAA"
-        compressed = compress(data)
-        assert decompress(compressed) == data
+        uncompressed = b"AAAAAAAAAAAA"
+        compressed = compress(uncompressed)
+        assert decompress(compressed) == uncompressed
 
     def test_alternating_pattern(self) -> None:
         """Alternating patterns compress correctly."""
-        data = b"ABABABABABABABAB" * 100
-        compressed = compress(data)
-        assert decompress(compressed) == data
+        uncompressed = b"ABABABABABABABAB" * 100
+        compressed = compress(uncompressed)
+        assert decompress(compressed) == uncompressed
 
     def test_long_match(self) -> None:
         """Long matches (up to 64 bytes) are handled correctly."""
         pattern = bytes(range(64))
-        data = pattern * 100
-        compressed = compress(data)
-        assert decompress(compressed) == data
+        uncompressed = pattern * 100
+        compressed = compress(uncompressed)
+        assert decompress(compressed) == uncompressed
 
     def test_near_block_boundary(self) -> None:
         """Data near block boundaries compresses correctly."""
         for size in [65534, 65535, 65536, 65537, 65538]:
-            data = b"X" * size
-            compressed = compress(data)
-            assert decompress(compressed) == data
+            uncompressed = b"X" * size
+            compressed = compress(uncompressed)
+            assert decompress(compressed) == uncompressed
 
     def test_repeated_data_compresses(self) -> None:
         """Repeated data achieves significant compression."""
-        data = b"A" * 1000
-        compressed = compress(data)
-        assert len(compressed) < len(data) // 2
-        assert decompress(compressed) == data
+        uncompressed = b"A" * 1000
+        compressed = compress(uncompressed)
+        assert len(compressed) < len(uncompressed) // 2
+        assert decompress(compressed) == uncompressed
 
     def test_run_length_encoding(self) -> None:
         """Run-length patterns compress efficiently."""
@@ -237,15 +237,15 @@ class TestSpecificPatterns:
 
     def test_random_looking_data(self) -> None:
         """Data without patterns may not compress but still roundtrips."""
-        data = bytes([(i * 17 + 31) % 256 for i in range(500)])
-        compressed = compress(data)
-        assert decompress(compressed) == data
+        uncompressed = bytes([(i * 17 + 31) % 256 for i in range(500)])
+        compressed = compress(uncompressed)
+        assert decompress(compressed) == uncompressed
 
     def test_binary_data(self) -> None:
         """Binary data roundtrips correctly."""
-        data = bytes(range(256)) * 4
-        compressed = compress(data)
-        assert decompress(compressed) == data
+        uncompressed = bytes(range(256)) * 4
+        compressed = compress(uncompressed)
+        assert decompress(compressed) == uncompressed
 
 
 class TestMultiBlock:
@@ -253,21 +253,21 @@ class TestMultiBlock:
 
     def test_large_input(self) -> None:
         """Large inputs (multi-block) roundtrip correctly."""
-        data = b"Test pattern for large data compression. " * 5000
-        compressed = compress(data)
-        assert decompress(compressed) == data
+        uncompressed = b"Test pattern for large data compression. " * 5000
+        compressed = compress(uncompressed)
+        assert decompress(compressed) == uncompressed
 
     def test_exact_block_size(self) -> None:
         """Data exactly at block boundary."""
-        data = b"X" * 65536  # Exactly one block
-        compressed = compress(data)
-        assert decompress(compressed) == data
+        uncompressed = b"X" * 65536  # Exactly one block
+        compressed = compress(uncompressed)
+        assert decompress(compressed) == uncompressed
 
     def test_multiple_blocks(self) -> None:
         """Data spanning multiple blocks."""
-        data = b"Y" * (65536 * 3 + 1000)  # 3+ blocks
-        compressed = compress(data)
-        assert decompress(compressed) == data
+        uncompressed = b"Y" * (65536 * 3 + 1000)  # 3+ blocks
+        compressed = compress(uncompressed)
+        assert decompress(compressed) == uncompressed
 
 
 class TestExpandedData:
@@ -276,12 +276,12 @@ class TestExpandedData:
     @pytest.mark.parametrize("label,filename,size_limit", TEST_DATA_FILES)
     def test_expanded_roundtrip(self, label: str, filename: str, size_limit: int) -> None:
         """Test roundtrip with data expanded to span multiple blocks."""
-        data = load_test_file(filename, size_limit)
+        uncompressed = load_test_file(filename, size_limit)
 
         # Expand data to at least 3x block size (196KB)
-        expanded = data
+        expanded = uncompressed
         while len(expanded) < 3 * 65536:
-            expanded = expanded + data
+            expanded = expanded + uncompressed
 
         compressed = compress(expanded)
         assert decompress(compressed) == expanded

--- a/tests/lean_spec/node/snappy/test_decompress.py
+++ b/tests/lean_spec/node/snappy/test_decompress.py
@@ -21,10 +21,10 @@ TESTDATA_DIRECTORY = Path(__file__).parent / "testdata"
 def load_test_file(filename: str, size_limit: int = 0) -> bytes:
     """Load a test data file, optionally truncated to size_limit."""
     path = TESTDATA_DIRECTORY / filename
-    data = path.read_bytes()
+    file_bytes = path.read_bytes()
     if size_limit > 0:
-        data = data[:size_limit]
-    return data
+        file_bytes = file_bytes[:size_limit]
+    return file_bytes
 
 
 class TestSnappyLengthPrefix:
@@ -46,18 +46,18 @@ class TestSnappyLengthPrefix:
 
     def test_encode_large_values(self) -> None:
         """Large values encode correctly."""
-        for value in [65536, 2**20, 2**24, 2**32 - 1]:
-            encoded = encode_varint(value, max_bytes=SNAPPY_VARINT_MAX_BYTES)
+        for varint_value in [65536, 2**20, 2**24, 2**32 - 1]:
+            encoded = encode_varint(varint_value, max_bytes=SNAPPY_VARINT_MAX_BYTES)
             decoded, _ = decode_varint(encoded, max_bytes=SNAPPY_VARINT_MAX_BYTES)
-            assert decoded == value
+            assert decoded == varint_value
 
     def test_decode_roundtrip(self) -> None:
         """Encoding then decoding returns the original value."""
         test_values = [0, 1, 127, 128, 255, 256, 16383, 16384, 65535, 65536, 2**20, 2**32 - 1]
-        for value in test_values:
-            encoded = encode_varint(value, max_bytes=SNAPPY_VARINT_MAX_BYTES)
+        for varint_value in test_values:
+            encoded = encode_varint(varint_value, max_bytes=SNAPPY_VARINT_MAX_BYTES)
             decoded, bytes_consumed = decode_varint(encoded, max_bytes=SNAPPY_VARINT_MAX_BYTES)
-            assert decoded == value
+            assert decoded == varint_value
             assert bytes_consumed == len(encoded)
 
     def test_encode_negative_raises(self) -> None:
@@ -82,10 +82,12 @@ class TestSnappyLengthPrefix:
 
     def test_decode_with_offset(self) -> None:
         """Decoding at an offset works correctly."""
-        data = b"prefix\xac\x02suffix"
-        value, consumed = decode_varint(data, offset=6, max_bytes=SNAPPY_VARINT_MAX_BYTES)
-        assert value == 300
-        assert consumed == 2
+        prefixed_bytes = b"prefix\xac\x02suffix"
+        decoded_value, bytes_consumed = decode_varint(
+            prefixed_bytes, offset=6, max_bytes=SNAPPY_VARINT_MAX_BYTES
+        )
+        assert decoded_value == 300
+        assert bytes_consumed == 2
 
     def test_decompress_wraps_oversize_prefix(self) -> None:
         """A length prefix that overruns the cap surfaces as a decompression error."""
@@ -142,18 +144,18 @@ class TestCorruptedData:
     @pytest.mark.parametrize("bad_file", ["baddata1.snappy", "baddata2.snappy", "baddata3.snappy"])
     def test_bad_data_files(self, bad_file: str) -> None:
         """Test that bad data files from C++ test suite are rejected."""
-        data = load_test_file(bad_file)
+        bad_snappy_bytes = load_test_file(bad_file)
 
         # Bad data must either decompress safely or raise.
         try:
-            decompress(data)
+            decompress(bad_snappy_bytes)
         except SnappyDecompressionError:
             pass
 
     def test_truncated_literal(self) -> None:
         """Test handling of truncated literal data."""
-        data = b"Hello, World!"
-        compressed = compress(data)
+        uncompressed = b"Hello, World!"
+        compressed = compress(uncompressed)
 
         # Truncate to remove some literal data
         truncated = compressed[:-3]

--- a/tests/lean_spec/node/snappy/test_framing.py
+++ b/tests/lean_spec/node/snappy/test_framing.py
@@ -28,14 +28,14 @@ class TestStreamIdentifier:
 
     def test_stream_identifier_format(self) -> None:
         """Stream identifier matches spec: 0xff 0x06 0x00 0x00 sNaPpY."""
-        expected = b"\xff\x06\x00\x00sNaPpY"
-        assert STREAM_IDENTIFIER == expected
+        expected_stream_identifier = b"\xff\x06\x00\x00sNaPpY"
+        assert STREAM_IDENTIFIER == expected_stream_identifier
         assert len(STREAM_IDENTIFIER) == 10
 
     def test_compressed_starts_with_identifier(self) -> None:
         """All compressed output starts with stream identifier."""
-        data = b"test data"
-        compressed = frame_compress(data)
+        uncompressed = b"test data"
+        compressed = frame_compress(uncompressed)
         assert compressed.startswith(STREAM_IDENTIFIER)
 
     def test_empty_data_has_identifier(self) -> None:
@@ -45,14 +45,14 @@ class TestStreamIdentifier:
 
     def test_repeated_identifier_accepted(self) -> None:
         """Repeated stream identifiers in concatenated streams are accepted."""
-        data = b"test"
-        stream1 = frame_compress(data)
-        stream2 = frame_compress(data)
+        uncompressed = b"test"
+        stream1 = frame_compress(uncompressed)
+        stream2 = frame_compress(uncompressed)
         # Concatenate two valid streams
         combined = stream1 + stream2
         # Should decompress to concatenated data
-        result = frame_decompress(combined)
-        assert result == data + data
+        decompressed = frame_decompress(combined)
+        assert decompressed == uncompressed + uncompressed
 
     def test_invalid_identifier_rejected(self) -> None:
         """Invalid stream identifier content is rejected."""
@@ -77,8 +77,8 @@ class TestChunkFormat:
 
     def test_chunk_header_format(self) -> None:
         """Chunk header is [type: 1][length: 3 LE]."""
-        data = b"Hello"
-        compressed = frame_compress(data)
+        uncompressed = b"Hello"
+        compressed = frame_compress(uncompressed)
 
         # Skip stream identifier, read first chunk header
         pos = len(STREAM_IDENTIFIER)
@@ -93,8 +93,8 @@ class TestChunkFormat:
     def test_chunk_length_little_endian(self) -> None:
         """Chunk length is stored in little-endian format."""
         # Compress data that will create a known-size chunk
-        data = b"A" * 100
-        compressed = frame_compress(data)
+        uncompressed = b"A" * 100
+        compressed = frame_compress(uncompressed)
 
         pos = len(STREAM_IDENTIFIER)
         # Read 3-byte little-endian length
@@ -127,28 +127,28 @@ class TestCRC32C:
     def test_mask_formula(self) -> None:
         """Masking follows spec: ((x >> 15) | (x << 17)) + 0xa282ead8."""
         crc = 0x12345678
-        expected = (((crc >> 15) | (crc << 17)) + CRC32C_MASK_DELTA) & 0xFFFFFFFF
-        assert _mask_crc(crc) == expected
+        expected_masked_crc = (((crc >> 15) | (crc << 17)) + CRC32C_MASK_DELTA) & 0xFFFFFFFF
+        assert _mask_crc(crc) == expected_masked_crc
 
     def test_crc_stored_little_endian(self) -> None:
         """CRC is stored as 4 bytes little-endian in chunks."""
-        data = b"test"
-        compressed = frame_compress(data)
+        uncompressed = b"test"
+        compressed = frame_compress(uncompressed)
 
         # Find chunk after stream identifier
         pos = len(STREAM_IDENTIFIER) + 4  # Skip header
         stored_crc = int.from_bytes(compressed[pos : pos + 4], "little")
 
         # Compute expected CRC
-        expected_crc = _mask_crc(_crc32c(data))
+        expected_crc = _mask_crc(_crc32c(uncompressed))
         # Note: if compressed, CRC is of uncompressed data
         # For small data like "test", it may be uncompressed
         assert stored_crc == expected_crc or stored_crc != 0
 
     def test_crc_corruption_detected(self) -> None:
         """Corrupted CRC causes decompression to fail."""
-        data = b"test data for CRC validation"
-        compressed = bytearray(frame_compress(data))
+        uncompressed = b"test data for CRC validation"
+        compressed = bytearray(frame_compress(uncompressed))
 
         # Corrupt the CRC (byte 14-17 after stream identifier + chunk header)
         crc_pos = len(STREAM_IDENTIFIER) + 4
@@ -167,8 +167,8 @@ class TestCompressedChunk:
 
     def test_compressible_data_uses_compressed_chunk(self) -> None:
         """Highly compressible data uses compressed chunks."""
-        data = b"A" * 1000  # Very compressible
-        compressed = frame_compress(data)
+        uncompressed = b"A" * 1000  # Very compressible
+        compressed = frame_compress(uncompressed)
 
         # Check chunk type after stream identifier
         chunk_type = compressed[len(STREAM_IDENTIFIER)]
@@ -176,8 +176,8 @@ class TestCompressedChunk:
 
     def test_compressed_chunk_format(self) -> None:
         """Compressed chunk is [crc: 4][compressed_data]."""
-        data = b"A" * 1000
-        compressed = frame_compress(data)
+        uncompressed = b"A" * 1000
+        compressed = frame_compress(uncompressed)
 
         pos = len(STREAM_IDENTIFIER)
         chunk_type = compressed[pos]
@@ -198,8 +198,8 @@ class TestUncompressedChunk:
     def test_incompressible_data_uses_uncompressed_chunk(self) -> None:
         """Incompressible data uses uncompressed chunks."""
         # Random-looking data that doesn't compress
-        data = bytes([(i * 17 + 31) % 256 for i in range(100)])
-        compressed = frame_compress(data)
+        uncompressed = bytes([(i * 17 + 31) % 256 for i in range(100)])
+        compressed = frame_compress(uncompressed)
 
         # Check chunk type
         chunk_type = compressed[len(STREAM_IDENTIFIER)]
@@ -209,10 +209,10 @@ class TestUncompressedChunk:
     def test_uncompressed_roundtrip(self) -> None:
         """Data stored uncompressed roundtrips correctly."""
         # Small incompressible data
-        data = bytes(range(256))
-        compressed = frame_compress(data)
+        uncompressed = bytes(range(256))
+        compressed = frame_compress(uncompressed)
         decompressed = frame_decompress(compressed)
-        assert decompressed == data
+        assert decompressed == uncompressed
 
 
 class TestChunkSizeLimits:
@@ -224,8 +224,8 @@ class TestChunkSizeLimits:
 
     def test_large_data_split_into_chunks(self) -> None:
         """Data larger than 64KB is split into multiple chunks."""
-        data = b"X" * 100_000  # ~100KB
-        compressed = frame_compress(data)
+        uncompressed = b"X" * 100_000  # ~100KB
+        compressed = frame_compress(uncompressed)
 
         # Count chunks
         chunk_count = 0
@@ -240,10 +240,10 @@ class TestChunkSizeLimits:
 
     def test_exact_chunk_boundary(self) -> None:
         """Data exactly at chunk boundary handled correctly."""
-        data = b"Y" * MAX_UNCOMPRESSED_CHUNK_SIZE
-        compressed = frame_compress(data)
+        uncompressed = b"Y" * MAX_UNCOMPRESSED_CHUNK_SIZE
+        compressed = frame_compress(uncompressed)
         decompressed = frame_decompress(compressed)
-        assert decompressed == data
+        assert decompressed == uncompressed
 
     def test_oversized_uncompressed_chunk_rejected(self) -> None:
         """Chunks larger than 65536 bytes are rejected."""
@@ -277,8 +277,8 @@ class TestReservedChunks:
 
     def test_skippable_chunk_ignored(self) -> None:
         """Reserved skippable chunks (0x80-0xFD) are silently skipped."""
-        data = b"test"
-        compressed = bytearray(frame_compress(data))
+        uncompressed = b"test"
+        compressed = bytearray(frame_compress(uncompressed))
 
         # Insert a skippable chunk (type 0x80) with some padding
         padding_data = b"PADDING"
@@ -289,13 +289,13 @@ class TestReservedChunks:
         modified = compressed[:insert_pos] + skippable_chunk + compressed[insert_pos:]
 
         # Should still decompress correctly
-        result = frame_decompress(bytes(modified))
-        assert result == data
+        decompressed = frame_decompress(bytes(modified))
+        assert decompressed == uncompressed
 
     def test_padding_chunk_ignored(self) -> None:
         """Padding chunks (0xFE) are silently skipped."""
-        data = b"test"
-        compressed = bytearray(frame_compress(data))
+        uncompressed = b"test"
+        compressed = bytearray(frame_compress(uncompressed))
 
         # Insert padding chunk
         padding_chunk = b"\xfe\x10\x00\x00" + (b"\x00" * 16)
@@ -303,8 +303,8 @@ class TestReservedChunks:
         insert_pos = len(STREAM_IDENTIFIER)
         modified = compressed[:insert_pos] + padding_chunk + compressed[insert_pos:]
 
-        result = frame_decompress(bytes(modified))
-        assert result == data
+        decompressed = frame_decompress(bytes(modified))
+        assert decompressed == uncompressed
 
 
 class TestEdgeCases:
@@ -328,8 +328,8 @@ class TestEdgeCases:
 
     def test_truncated_chunk_data(self) -> None:
         """Truncated chunk data raises error."""
-        data = b"test"
-        compressed = frame_compress(data)
+        uncompressed = b"test"
+        compressed = frame_compress(uncompressed)
         # Truncate some bytes from the end
         truncated = compressed[:-5]
         with pytest.raises(SnappyDecompressionError, match="extends past end"):
@@ -338,10 +338,10 @@ class TestEdgeCases:
     def test_roundtrip_various_sizes(self) -> None:
         """Roundtrip works for various data sizes."""
         for size in [0, 1, 100, 1000, 65535, 65536, 65537, 100_000]:
-            data = bytes([i % 256 for i in range(size)])
-            compressed = frame_compress(data)
+            uncompressed = bytes([i % 256 for i in range(size)])
+            compressed = frame_compress(uncompressed)
             decompressed = frame_decompress(compressed)
-            assert decompressed == data, f"Roundtrip failed for size {size}"
+            assert decompressed == uncompressed, f"Roundtrip failed for size {size}"
 
 
 class TestInteroperability:
@@ -349,8 +349,8 @@ class TestInteroperability:
 
     def test_wire_format_structure(self) -> None:
         """Wire format matches expected structure for interop."""
-        data = b"Hello, Ethereum!"
-        compressed = frame_compress(data)
+        uncompressed = b"Hello, Ethereum!"
+        compressed = frame_compress(uncompressed)
 
         # Verify structure
         assert compressed[:10] == STREAM_IDENTIFIER
@@ -375,6 +375,6 @@ class TestInteroperability:
         stream3 = frame_compress(b"third")
 
         combined = stream1 + stream2 + stream3
-        result = frame_decompress(combined)
+        decompressed = frame_decompress(combined)
 
-        assert result == b"firstsecondthird"
+        assert decompressed == b"firstsecondthird"

--- a/tests/lean_spec/node/sync/test_backfill_sync.py
+++ b/tests/lean_spec/node/sync/test_backfill_sync.py
@@ -280,8 +280,8 @@ class TestRequestTracking:
     ) -> None:
         """Empty response completes the request, keeping the peer available."""
         manager = PeerManager()
-        info = PeerInfo(peer_id=peer_id, state=ConnectionState.CONNECTED)
-        manager.add_peer(info)
+        peer_info = PeerInfo(peer_id=peer_id, state=ConnectionState.CONNECTED)
+        manager.add_peer(peer_info)
         backfill = BackfillSync(
             peer_manager=manager,
             block_cache=BlockCache(),
@@ -294,7 +294,7 @@ class TestRequestTracking:
 
         peer = manager.peers.get(peer_id)
         assert peer == SyncPeer(
-            info=info,
+            info=peer_info,
             requests_in_flight=0,
             score=INITIAL_PEER_SCORE + SCORE_SUCCESS_BONUS,
         )

--- a/tests/lean_spec/node/sync/test_block_cache.py
+++ b/tests/lean_spec/node/sync/test_block_cache.py
@@ -140,9 +140,9 @@ class TestBlockCacheBasicOperations:
         """Getting a nonexistent block returns None."""
         cache = BlockCache()
 
-        result = cache.get(Bytes32.zero())
+        cached_block = cache.get(Bytes32.zero())
 
-        assert result is None
+        assert cached_block is None
 
     def test_remove_block(self, peer_id: PeerId) -> None:
         """Removing a block returns it and removes from cache."""
@@ -165,9 +165,9 @@ class TestBlockCacheBasicOperations:
         """Removing a nonexistent block returns None."""
         cache = BlockCache()
 
-        result = cache.remove(Bytes32.zero())
+        removed_block = cache.remove(Bytes32.zero())
 
-        assert result is None
+        assert removed_block is None
 
     def test_clear_cache(self, peer_id: PeerId) -> None:
         """Clear removes all blocks from the cache."""

--- a/tests/lean_spec/node/sync/test_checkpoint_sync.py
+++ b/tests/lean_spec/node/sync/test_checkpoint_sync.py
@@ -49,8 +49,8 @@ class TestStateVerification:
 
     async def test_valid_state_passes_verification(self, genesis_state: State) -> None:
         """Valid state with validators passes verification checks."""
-        result = verify_checkpoint_state(genesis_state)
-        assert result is True
+        is_valid_checkpoint = verify_checkpoint_state(genesis_state)
+        assert is_valid_checkpoint is True
 
     async def test_state_without_validators_fails_verification(self, genesis_state: State) -> None:
         """State with no validators fails verification."""
@@ -67,8 +67,8 @@ class TestStateVerification:
             justifications_validators=genesis_state.justifications_validators,
         )
 
-        result = verify_checkpoint_state(empty_state)
-        assert result is False
+        is_valid_checkpoint = verify_checkpoint_state(empty_state)
+        assert is_valid_checkpoint is False
 
     async def test_state_exceeding_validator_limit_fails(self) -> None:
         """State with more validators than VALIDATOR_REGISTRY_LIMIT fails."""
@@ -80,8 +80,8 @@ class TestStateVerification:
         mock_validators.__len__ = MagicMock(return_value=int(VALIDATOR_REGISTRY_LIMIT) + 1)
         mock_state.validators = mock_validators
 
-        result = verify_checkpoint_state(mock_state)
-        assert result is False
+        is_valid_checkpoint = verify_checkpoint_state(mock_state)
+        assert is_valid_checkpoint is False
 
     async def test_exception_during_hash_tree_root_returns_false(
         self, genesis_state: State
@@ -96,9 +96,9 @@ class TestStateVerification:
             "lean_spec.node.sync.checkpoint_sync.hash_tree_root",
             side_effect=RuntimeError("hash error"),
         ):
-            result = verify_checkpoint_state(genesis_state)
+            is_valid_checkpoint = verify_checkpoint_state(genesis_state)
 
-        assert result is False
+        assert is_valid_checkpoint is False
 
 
 class TestFetchFinalizedState:

--- a/tests/lean_spec/node/sync/test_head_sync.py
+++ b/tests/lean_spec/node/sync/test_head_sync.py
@@ -77,9 +77,9 @@ class TestGossipBlockProcessing:
         )
         block_root = hash_tree_root(block.block)
 
-        result, new_store = await head_sync.on_gossip_block(block, peer_id, store)
+        head_sync_result, new_store = await head_sync.on_gossip_block(block, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=True,
         )
         assert block_root in processed_blocks
@@ -107,9 +107,9 @@ class TestGossipBlockProcessing:
         )
         block_root = hash_tree_root(block.block)
 
-        result, _ = await head_sync.on_gossip_block(block, peer_id, store)
+        head_sync_result, _ = await head_sync.on_gossip_block(block, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=False,
         )
         assert block_root in head_sync.block_cache
@@ -147,9 +147,9 @@ class TestGossipBlockProcessing:
             process_block=should_not_be_called,
         )
 
-        result, _ = await head_sync.on_gossip_block(block, peer_id, store)
+        head_sync_result, _ = await head_sync.on_gossip_block(block, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=False,
         )
         assert call_count == 0
@@ -206,9 +206,9 @@ class TestDescendantProcessing:
         )
 
         # Process parent - should trigger child processing
-        result, _ = await head_sync.on_gossip_block(parent, peer_id, store)
+        head_sync_result, _ = await head_sync.on_gossip_block(parent, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=True,
         )
         assert processing_order == [parent_root, child_root]
@@ -259,9 +259,9 @@ class TestDescendantProcessing:
         )
 
         # Process first block - should cascade to all descendants
-        result, _ = await head_sync.on_gossip_block(blocks[0], peer_id, store)
+        head_sync_result, _ = await head_sync.on_gossip_block(blocks[0], peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=True,
         )
         assert processing_order == [1, 2, 3, 4]
@@ -296,9 +296,9 @@ class TestErrorHandling:
             state_root=Bytes32.zero(),
         )
 
-        result, returned_store = await head_sync.on_gossip_block(block, peer_id, store)
+        head_sync_result, returned_store = await head_sync.on_gossip_block(block, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=False,
             error="State transition failed",
         )
@@ -361,9 +361,9 @@ class TestStorePropagation:
             process_block=track_processing,
         )
 
-        result, new_store = await head_sync.on_gossip_block(parent, peer_id, store)
+        head_sync_result, new_store = await head_sync.on_gossip_block(parent, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=True,
         )
         assert {parent_root, child1_root, child2_root} <= set(new_store.blocks.keys())
@@ -406,9 +406,9 @@ class TestReentrantGuard:
         # Simulate reentrant call by pre-adding to _processing.
         head_sync._processing.add(block_root)
 
-        result, returned_store = await head_sync.on_gossip_block(block, peer_id, store)
+        head_sync_result, returned_store = await head_sync.on_gossip_block(block, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=False,
         )
         assert returned_store is store
@@ -519,9 +519,9 @@ class TestRejectionBelowFinalized:
         block = _gossip_block(slot=10, parent_root=unknown_parent, state_seed=1)
         block_root = hash_tree_root(block.block)
 
-        result, returned_store = await head_sync.on_gossip_block(block, peer_id, store)
+        head_sync_result, returned_store = await head_sync.on_gossip_block(block, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=False,
         )
         assert returned_store is store
@@ -539,9 +539,9 @@ class TestRejectionBelowFinalized:
         block = _gossip_block(slot=5, parent_root=unknown_parent, state_seed=1)
         block_root = hash_tree_root(block.block)
 
-        result, returned_store = await head_sync.on_gossip_block(block, peer_id, store)
+        head_sync_result, returned_store = await head_sync.on_gossip_block(block, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=False,
         )
         assert returned_store is store
@@ -563,9 +563,9 @@ class TestBackfillRoutingAboveHead:
         block = _gossip_block(slot=11, parent_root=unknown_parent, state_seed=1)
         block_root = hash_tree_root(block.block)
 
-        result, _ = await head_sync.on_gossip_block(block, peer_id, store)
+        head_sync_result, _ = await head_sync.on_gossip_block(block, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=False,
         )
         assert recorder.range_calls == []
@@ -582,9 +582,9 @@ class TestBackfillRoutingAboveHead:
         block = _gossip_block(slot=100, parent_root=unknown_parent, state_seed=1)
         block_root = hash_tree_root(block.block)
 
-        result, _ = await head_sync.on_gossip_block(block, peer_id, store)
+        head_sync_result, _ = await head_sync.on_gossip_block(block, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=False,
         )
         # gap_floor = head+1 = 21, gap_size = 100 - 21 = 79.
@@ -608,9 +608,9 @@ class TestAltForkRoutingAtOrBelowHead:
         block = _gossip_block(slot=15, parent_root=unknown_parent, state_seed=1)
         block_root = hash_tree_root(block.block)
 
-        result, _ = await head_sync.on_gossip_block(block, peer_id, store)
+        head_sync_result, _ = await head_sync.on_gossip_block(block, peer_id, store)
 
-        assert result == HeadSyncResult(
+        assert head_sync_result == HeadSyncResult(
             processed=False,
         )
         assert recorder.range_calls == []

--- a/tests/lean_spec/node/sync/test_peer_manager.py
+++ b/tests/lean_spec/node/sync/test_peer_manager.py
@@ -186,8 +186,8 @@ class TestPeerManagerPeerSelection:
         manager = PeerManager()
         manager.add_peer(connected_peer_info)
 
-        selected = manager.select_peer_for_request()
-        assert selected == SyncPeer(info=connected_peer_info)
+        selected_peer = manager.select_peer_for_request()
+        assert selected_peer == SyncPeer(info=connected_peer_info)
 
     def test_select_peer_for_request_none_when_empty(self) -> None:
         """select_peer_for_request returns None when no peers."""
@@ -224,8 +224,8 @@ class TestPeerManagerPeerSelection:
         )
 
         # Request slot 150 - only peer2 has it
-        selected = manager.select_peer_for_request(min_slot=Slot(150))
-        assert selected == sync_peer2
+        selected_peer = manager.select_peer_for_request(min_slot=Slot(150))
+        assert selected_peer == sync_peer2
 
 
 class TestPeerManagerNetworkConsensus:
@@ -238,8 +238,8 @@ class TestPeerManagerNetworkConsensus:
         manager = PeerManager()
 
         for pid, fin_slot in [(peer_id, 100), (peer_id_2, 100), (peer_id_3, 150)]:
-            info = PeerInfo(peer_id=pid, state=ConnectionState.CONNECTED)
-            sync_peer = manager.add_peer(info)
+            peer_info = PeerInfo(peer_id=pid, state=ConnectionState.CONNECTED)
+            sync_peer = manager.add_peer(peer_info)
             sync_peer.status = Status(
                 finalized=Checkpoint(root=Bytes32.zero(), slot=Slot(fin_slot)),
                 head=Checkpoint(root=Bytes32.zero(), slot=Slot(fin_slot + 50)),
@@ -380,5 +380,5 @@ class TestPeerScoring:
         peer1.requests_in_flight = MAX_CONCURRENT_REQUESTS
 
         peer2 = manager.peers.get(peer_id_2)
-        selected = manager.select_peer_for_request()
-        assert selected == peer2
+        selected_peer = manager.select_peer_for_request()
+        assert selected_peer == peer2

--- a/tests/lean_spec/node/sync/test_states.py
+++ b/tests/lean_spec/node/sync/test_states.py
@@ -20,8 +20,8 @@ class TestSyncStateValues:
 
     def test_states_are_unique(self) -> None:
         """Each state has a unique value."""
-        values = [state.value for state in SyncState]
-        assert len(values) == len(set(values))
+        state_values = [state.value for state in SyncState]
+        assert len(state_values) == len(set(state_values))
 
 
 class TestSyncStateAcceptsGossip:

--- a/tests/lean_spec/node/validator/test_registry.py
+++ b/tests/lean_spec/node/validator/test_registry.py
@@ -23,12 +23,17 @@ from lean_spec.spec.ssz.exceptions import SSZValueError
 
 def registry_state(registry: ValidatorRegistry) -> dict[ValidatorIndex, tuple[object, object]]:
     """Map each registry index to its (attestation_secret_key, proposal_secret_key) pair."""
-    result: dict[ValidatorIndex, tuple[object, object]] = {}
+    index_to_secret_keys: dict[ValidatorIndex, tuple[object, object]] = {}
     for index in registry.indices():
-        entry = registry.get(index)
-        assert entry is not None, f"Registry contains index {index} but get() returned None"
-        result[index] = (entry.attestation_secret_key, entry.proposal_secret_key)
-    return result
+        validator_entry = registry.get(index)
+        assert validator_entry is not None, (
+            f"Registry contains index {index} but get() returned None"
+        )
+        index_to_secret_keys[index] = (
+            validator_entry.attestation_secret_key,
+            validator_entry.proposal_secret_key,
+        )
+    return index_to_secret_keys
 
 
 @pytest.fixture
@@ -72,13 +77,13 @@ class TestValidatorEntry:
     def test_construction_stores_all_fields(self, km: XmssKeyManager) -> None:
         """All three fields are accessible after construction."""
         kp = km[ValidatorIndex(7)]
-        entry = ValidatorEntry(
+        validator_entry = ValidatorEntry(
             index=ValidatorIndex(7),
             attestation_secret_key=kp.attestation_keypair.secret_key,
             proposal_secret_key=kp.proposal_keypair.secret_key,
         )
 
-        assert entry == ValidatorEntry(
+        assert validator_entry == ValidatorEntry(
             index=ValidatorIndex(7),
             attestation_secret_key=kp.attestation_keypair.secret_key,
             proposal_secret_key=kp.proposal_keypair.secret_key,
@@ -90,7 +95,7 @@ class TestValidatorManifestEntry:
 
     def test_construction_stores_all_fields(self) -> None:
         """All fields are stored and accessible after construction."""
-        entry = ValidatorManifestEntry(
+        manifest_entry = ValidatorManifestEntry(
             index=ValidatorIndex(3),
             attestation_public_key_hex=Bytes52("0x" + "aa" * 52),
             proposal_public_key_hex=Bytes52("0x" + "bb" * 52),
@@ -98,7 +103,7 @@ class TestValidatorManifestEntry:
             proposal_private_key_file="prop.ssz",
         )
 
-        assert entry == ValidatorManifestEntry(
+        assert manifest_entry == ValidatorManifestEntry(
             index=ValidatorIndex(3),
             attestation_public_key_hex=Bytes52("0x" + "aa" * 52),
             proposal_public_key_hex=Bytes52("0x" + "bb" * 52),
@@ -152,10 +157,10 @@ class TestValidatorManifest:
 
     def test_from_yaml_file_parses_validators_list(self, tmp_path: Path) -> None:
         """Nested validators list is parsed into ValidatorManifestEntry objects."""
-        entries = [_manifest_entry_dict(0), _manifest_entry_dict(1)]
+        manifest_entry_dicts = [_manifest_entry_dict(0), _manifest_entry_dict(1)]
         manifest_file = tmp_path / "manifest.yaml"
         manifest_file.write_text(
-            yaml.dump(_minimal_manifest_dict(num_validators=2, validators=entries))
+            yaml.dump(_minimal_manifest_dict(num_validators=2, validators=manifest_entry_dicts))
         )
 
         manifest = ValidatorManifest.from_yaml_file(manifest_file)
@@ -223,10 +228,10 @@ class TestValidatorRegistry:
     def test_add_single_entry_and_retrieve(self, km: XmssKeyManager) -> None:
         """A single entry is stored and retrievable by index."""
         registry = ValidatorRegistry()
-        entry = self._entry(km, 0)
-        registry.add(entry)
+        validator_entry = self._entry(km, 0)
+        registry.add(validator_entry)
 
-        assert registry.get(ValidatorIndex(0)) == entry
+        assert registry.get(ValidatorIndex(0)) == validator_entry
 
     def test_get_miss_returns_none(self, km: XmssKeyManager) -> None:
         """get() returns None for an index that was never added."""
@@ -238,22 +243,22 @@ class TestValidatorRegistry:
     def test_add_multiple_entries(self, km: XmssKeyManager) -> None:
         """Multiple entries are stored with correct index-to-key mapping."""
         registry = ValidatorRegistry()
-        entries = {index: self._entry(km, index) for index in [3, 1, 4]}
-        for entry in entries.values():
-            registry.add(entry)
+        validator_entries = {index: self._entry(km, index) for index in [3, 1, 4]}
+        for validator_entry in validator_entries.values():
+            registry.add(validator_entry)
 
         assert registry_state(registry) == {
             ValidatorIndex(1): (
-                entries[1].attestation_secret_key,
-                entries[1].proposal_secret_key,
+                validator_entries[1].attestation_secret_key,
+                validator_entries[1].proposal_secret_key,
             ),
             ValidatorIndex(3): (
-                entries[3].attestation_secret_key,
-                entries[3].proposal_secret_key,
+                validator_entries[3].attestation_secret_key,
+                validator_entries[3].proposal_secret_key,
             ),
             ValidatorIndex(4): (
-                entries[4].attestation_secret_key,
-                entries[4].proposal_secret_key,
+                validator_entries[4].attestation_secret_key,
+                validator_entries[4].proposal_secret_key,
             ),
         }
 
@@ -286,9 +291,9 @@ class TestValidatorRegistry:
         for i in [2, 5, 7]:
             registry.add(self._entry(km, i))
 
-        result = registry.indices()
+        registered_indices = registry.indices()
 
-        assert set(result) == {ValidatorIndex(2), ValidatorIndex(5), ValidatorIndex(7)}
+        assert set(registered_indices) == {ValidatorIndex(2), ValidatorIndex(5), ValidatorIndex(7)}
 
     def test_primary_index_empty_registry(self) -> None:
         """Primary index is None for an empty registry."""
@@ -389,12 +394,12 @@ class TestValidatorRegistryFromYaml:
         # Loaded keys should match the originals from the key manager.
         for i in [0, 1]:
             validator_index = ValidatorIndex(i)
-            entry = registry.get(validator_index)
-            assert entry is not None
+            validator_entry = registry.get(validator_index)
+            assert validator_entry is not None
             expected_attestation = km[validator_index].attestation_keypair.secret_key.encode_bytes()
             expected_proposal = km[validator_index].proposal_keypair.secret_key.encode_bytes()
-            assert entry.attestation_secret_key.encode_bytes() == expected_attestation
-            assert entry.proposal_secret_key.encode_bytes() == expected_proposal
+            assert validator_entry.attestation_secret_key.encode_bytes() == expected_attestation
+            assert validator_entry.proposal_secret_key.encode_bytes() == expected_proposal
 
     def test_unknown_node_returns_empty_registry(self, tmp_path: Path) -> None:
         """An unrecognised node ID produces an empty registry without error."""

--- a/tests/lean_spec/node/validator/test_service.py
+++ b/tests/lean_spec/node/validator/test_service.py
@@ -124,9 +124,9 @@ class TestSignBlock:
         """The returned signed block contains the exact block object that was passed in."""
         service, block = self._setup(sync_service, key_manager)
 
-        result = service._sign_block(block, ValidatorIndex(0), [])
+        signed_block = service._sign_block(block, ValidatorIndex(0), [])
 
-        assert result.block is block
+        assert signed_block.block is block
 
     def test_attestation_proofs_merge_into_envelope(
         self, sync_service: SyncService, key_manager: XmssKeyManager, spec: LstarSpec
@@ -136,9 +136,9 @@ class TestSignBlock:
         attestation_data = spec.produce_attestation_data(sync_service.store, Slot(1))
         aggregate_proof = make_aggregated_proof(key_manager, [ValidatorIndex(0)], attestation_data)
 
-        result = service._sign_block(block, ValidatorIndex(0), [aggregate_proof])
+        signed_block = service._sign_block(block, ValidatorIndex(0), [aggregate_proof])
 
-        assert result.block.proposer_index == ValidatorIndex(0)
+        assert signed_block.block.proposer_index == ValidatorIndex(0)
 
     def test_missing_validator_raises_value_error(
         self, sync_service: SyncService, key_manager: XmssKeyManager
@@ -186,17 +186,17 @@ class TestSignAttestation:
         """The signed attestation contains the correct validator ID, data, and a valid signature."""
         service, attestation_data = self._setup(sync_service, key_manager, spec, index=3)
 
-        result = service._sign_attestation(attestation_data, ValidatorIndex(3))
+        signed_attestation = service._sign_attestation(attestation_data, ValidatorIndex(3))
 
-        assert result.validator_index == ValidatorIndex(3)
-        assert result.data is attestation_data
+        assert signed_attestation.validator_index == ValidatorIndex(3)
+        assert signed_attestation.data is attestation_data
 
         public_key = key_manager[ValidatorIndex(3)].attestation_keypair.public_key
         assert TARGET_SIGNATURE_SCHEME.verify(
             public_key=public_key,
             slot=attestation_data.slot,
             message=hash_tree_root(attestation_data),
-            signature=result.signature,
+            signature=signed_attestation.signature,
         )
 
     def test_uses_attestation_key_not_proposal_key(
@@ -205,14 +205,14 @@ class TestSignAttestation:
         """Attestation signature verifies with the attestation public key, not the proposal key."""
         service, attestation_data = self._setup(sync_service, key_manager, spec)
 
-        result = service._sign_attestation(attestation_data, ValidatorIndex(0))
+        signed_attestation = service._sign_attestation(attestation_data, ValidatorIndex(0))
 
         attestation_public_key = key_manager[ValidatorIndex(0)].attestation_keypair.public_key
         assert TARGET_SIGNATURE_SCHEME.verify(
             public_key=attestation_public_key,
             slot=attestation_data.slot,
             message=hash_tree_root(attestation_data),
-            signature=result.signature,
+            signature=signed_attestation.signature,
         )
 
     def test_missing_validator_raises_value_error(
@@ -244,30 +244,30 @@ class TestSignWithKey:
         key_manager: XmssKeyManager,
         index: int = 0,
     ) -> tuple[ValidatorService, ValidatorRegistry, ValidatorEntry, object, object]:
-        entry = _make_entry(key_manager, index)
-        attestation_key = entry.attestation_secret_key
-        proposal_key = entry.proposal_secret_key
+        validator_entry = _make_entry(key_manager, index)
+        attestation_key = validator_entry.attestation_secret_key
+        proposal_key = validator_entry.proposal_secret_key
         registry = ValidatorRegistry()
-        registry.add(entry)
+        registry.add(validator_entry)
         service = ValidatorService(
             sync_service=sync_service,
             clock=SlotClock(genesis_time=Uint64(0)),
             registry=registry,
         )
-        return service, registry, entry, attestation_key, proposal_key
+        return service, registry, validator_entry, attestation_key, proposal_key
 
     def test_no_advancement_when_slot_already_prepared(
         self, sync_service: SyncService, key_manager: XmssKeyManager
     ) -> None:
         """No key advancement when the slot is already within the prepared interval."""
-        service, _, entry, attestation_key, _ = self._setup(sync_service, key_manager)
+        service, _, validator_entry, attestation_key, _ = self._setup(sync_service, key_manager)
         mock_signature = MagicMock(name="sig")
 
         with patch(_SCHEME) as scheme:
             scheme.get_prepared_interval.return_value = [3]
             scheme.sign.return_value = mock_signature
 
-            service._sign_with_key(entry, Slot(3), MagicMock(), "attestation_secret_key")
+            service._sign_with_key(validator_entry, Slot(3), MagicMock(), "attestation_secret_key")
 
         scheme.advance_preparation.assert_not_called()
         scheme.sign.assert_called_once_with(attestation_key, Slot(3), scheme.sign.call_args[0][2])
@@ -276,7 +276,7 @@ class TestSignWithKey:
         self, sync_service: SyncService, key_manager: XmssKeyManager
     ) -> None:
         """Key advances exactly once when one step covers the target slot."""
-        service, _, entry, attestation_key, _ = self._setup(sync_service, key_manager)
+        service, _, validator_entry, attestation_key, _ = self._setup(sync_service, key_manager)
         advanced = MagicMock(name="advanced_key")
         mock_signature = MagicMock(name="sig")
 
@@ -287,7 +287,7 @@ class TestSignWithKey:
             scheme.advance_preparation.return_value = advanced
             scheme.sign.return_value = mock_signature
 
-            service._sign_with_key(entry, Slot(5), MagicMock(), "attestation_secret_key")
+            service._sign_with_key(validator_entry, Slot(5), MagicMock(), "attestation_secret_key")
 
         scheme.advance_preparation.assert_called_once_with(attestation_key)
         scheme.sign.assert_called_once_with(advanced, Slot(5), scheme.sign.call_args[0][2])
@@ -296,7 +296,7 @@ class TestSignWithKey:
         self, sync_service: SyncService, key_manager: XmssKeyManager
     ) -> None:
         """Key advancement loops until the target slot falls within the interval."""
-        service, _, entry, attestation_key, _ = self._setup(sync_service, key_manager)
+        service, _, validator_entry, attestation_key, _ = self._setup(sync_service, key_manager)
         key_v1 = MagicMock(name="key_v1")
         key_v2 = MagicMock(name="key_v2")
         key_v3 = MagicMock(name="key_v3")
@@ -307,7 +307,7 @@ class TestSignWithKey:
             scheme.advance_preparation.side_effect = [key_v1, key_v2, key_v3]
             scheme.sign.return_value = mock_signature
 
-            service._sign_with_key(entry, Slot(7), MagicMock(), "attestation_secret_key")
+            service._sign_with_key(validator_entry, Slot(7), MagicMock(), "attestation_secret_key")
 
         assert scheme.advance_preparation.call_count == 3
         scheme.sign.assert_called_once_with(key_v3, Slot(7), scheme.sign.call_args[0][2])
@@ -316,7 +316,9 @@ class TestSignWithKey:
         self, sync_service: SyncService, key_manager: XmssKeyManager
     ) -> None:
         """After signing, the registry holds an entry with the advanced key."""
-        service, registry, entry, attestation_key, _ = self._setup(sync_service, key_manager)
+        service, registry, validator_entry, attestation_key, _ = self._setup(
+            sync_service, key_manager
+        )
         advanced = MagicMock(name="advanced_att")
 
         with patch(_SCHEME) as scheme:
@@ -326,7 +328,7 @@ class TestSignWithKey:
             scheme.advance_preparation.return_value = advanced
             scheme.sign.return_value = MagicMock()
 
-            service._sign_with_key(entry, Slot(4), MagicMock(), "attestation_secret_key")
+            service._sign_with_key(validator_entry, Slot(4), MagicMock(), "attestation_secret_key")
 
         stored = registry.get(ValidatorIndex(0))
         assert stored is not None
@@ -336,7 +338,7 @@ class TestSignWithKey:
         self, sync_service: SyncService, key_manager: XmssKeyManager
     ) -> None:
         """Signing with the attestation key updates only that key; proposal key is untouched."""
-        service, registry, entry, attestation_key, proposal_key = self._setup(
+        service, registry, validator_entry, attestation_key, proposal_key = self._setup(
             sync_service, key_manager
         )
         advanced_attestation = MagicMock(name="new_att")
@@ -348,7 +350,7 @@ class TestSignWithKey:
             scheme.advance_preparation.return_value = advanced_attestation
             scheme.sign.return_value = MagicMock()
 
-            service._sign_with_key(entry, Slot(1), MagicMock(), "attestation_secret_key")
+            service._sign_with_key(validator_entry, Slot(1), MagicMock(), "attestation_secret_key")
 
         stored = registry.get(ValidatorIndex(0))
         assert stored is not None
@@ -359,7 +361,7 @@ class TestSignWithKey:
         self, sync_service: SyncService, key_manager: XmssKeyManager
     ) -> None:
         """Signing with the proposal key updates only that key; attestation key is untouched."""
-        service, registry, entry, attestation_key, proposal_key = self._setup(
+        service, registry, validator_entry, attestation_key, proposal_key = self._setup(
             sync_service, key_manager
         )
         advanced_proposal = MagicMock(name="new_prop")
@@ -371,7 +373,7 @@ class TestSignWithKey:
             scheme.advance_preparation.return_value = advanced_proposal
             scheme.sign.return_value = MagicMock()
 
-            service._sign_with_key(entry, Slot(1), MagicMock(), "proposal_secret_key")
+            service._sign_with_key(validator_entry, Slot(1), MagicMock(), "proposal_secret_key")
 
         stored = registry.get(ValidatorIndex(0))
         assert stored is not None
@@ -382,7 +384,7 @@ class TestSignWithKey:
         self, sync_service: SyncService, key_manager: XmssKeyManager
     ) -> None:
         """Return value is (updated ValidatorEntry, Signature) — both fields correct."""
-        service, _, entry, attestation_key, _ = self._setup(sync_service, key_manager)
+        service, _, validator_entry, attestation_key, _ = self._setup(sync_service, key_manager)
         advanced = MagicMock(name="adv")
         mock_signature = MagicMock(name="ret_sig")
 
@@ -394,7 +396,7 @@ class TestSignWithKey:
             scheme.sign.return_value = mock_signature
 
             returned_entry, returned_signature = service._sign_with_key(
-                entry, Slot(2), MagicMock(), "attestation_secret_key"
+                validator_entry, Slot(2), MagicMock(), "attestation_secret_key"
             )
 
         assert returned_signature is mock_signature
@@ -869,8 +871,8 @@ class TestProposerGossipAttestation:
 
         await service._produce_attestations(slot)
 
-        expected = {ValidatorIndex(i) for i in range(num_validators)}
-        assert set(attestation_validator_indices) == expected
+        expected_validator_indices = {ValidatorIndex(i) for i in range(num_validators)}
+        assert set(attestation_validator_indices) == expected_validator_indices
         assert service.attestations_produced == num_validators
 
 
@@ -1025,10 +1027,10 @@ class TestValidatorServiceIntegration:
         expected_source = store.latest_justified
 
         for signed_attestation in attestations_produced:
-            data = signed_attestation.data
-            assert data.head.root == expected_head_root
-            assert data.source == expected_source
-            assert data.slot == Slot(1)
+            attestation_data = signed_attestation.data
+            assert attestation_data.head.root == expected_head_root
+            assert attestation_data.source == expected_source
+            assert attestation_data.slot == Slot(1)
 
     async def test_proposer_signature_in_block(
         self,

--- a/tests/lean_spec/spec/crypto/test_koalabear.py
+++ b/tests/lean_spec/spec/crypto/test_koalabear.py
@@ -29,21 +29,21 @@ def test_base_field_arithmetic() -> None:
     Test basic arithmetic, equality, and error handling
     in the base field Fp.
     """
-    a = Fp(value=5)
-    b = Fp(value=10)
+    left = Fp(value=5)
+    right = Fp(value=10)
 
     # Test operations
-    assert a + b == Fp(value=15)
-    assert b - a == Fp(value=5)
-    assert -a == Fp(value=P - 5)
-    assert a * b == Fp(value=50)
-    assert a / b == Fp(value=5) * Fp(value=10).inverse()
+    assert left + right == Fp(value=15)
+    assert right - left == Fp(value=5)
+    assert -left == Fp(value=P - 5)
+    assert left * right == Fp(value=50)
+    assert left / right == Fp(value=5) * Fp(value=10).inverse()
 
     # Test equality against the same and different types
-    assert a == Fp(value=5)
-    assert a != b
-    assert a != 5
-    assert a != "5"
+    assert left == Fp(value=5)
+    assert left != right
+    assert left != 5
+    assert left != "5"
 
     # Test error on inverting the zero element
     with pytest.raises(ZeroDivisionError, match=r"^Cannot invert the zero element\.$"):
@@ -73,16 +73,16 @@ def test_ssz_serialize() -> None:
 def test_ssz_deserialize() -> None:
     """Test SSZ deserialization using the deserialize method."""
     # Test successful deserialization
-    data = b"\x2a\x00\x00\x00"  # 42 in LE
-    stream = io.BytesIO(data)
+    encoded_bytes = b"\x2a\x00\x00\x00"  # 42 in LE
+    stream = io.BytesIO(encoded_bytes)
     fp = Fp.deserialize(stream, 4)
     assert fp == Fp(value=42)
 
 
 def test_ssz_deserialize_wrong_scope() -> None:
     """Test deserialize error when scope doesn't match P_BYTES."""
-    data = b"\x2a\x00\x00\x00"
-    stream = io.BytesIO(data)
+    encoded_bytes = b"\x2a\x00\x00\x00"
+    stream = io.BytesIO(encoded_bytes)
     with pytest.raises(SSZSerializationError, match=r"^Expected 4 bytes for Fp, got 3$"):
         Fp.deserialize(stream, 3)
 
@@ -108,21 +108,21 @@ def test_ssz_encode_decode_bytes() -> None:
     """Test SSZ encode_bytes and decode_bytes methods."""
     # Test encode_bytes
     fp = Fp(value=100)
-    data = fp.encode_bytes()
-    assert len(data) == 4
-    assert data == b"\x64\x00\x00\x00"  # 100 in LE
+    encoded_bytes = fp.encode_bytes()
+    assert len(encoded_bytes) == 4
+    assert encoded_bytes == b"\x64\x00\x00\x00"  # 100 in LE
 
     # Test decode_bytes
-    fp2 = Fp.decode_bytes(data)
+    fp2 = Fp.decode_bytes(encoded_bytes)
     assert fp2 == fp
 
     # Test roundtrip for various values
     test_values = [0, 1, 42, 255, 256, 1000, 65535, 65536, 1000000, P - 1]
-    for value in test_values:
-        fp = Fp(value=value)
-        data = fp.encode_bytes()
-        recovered = Fp.decode_bytes(data)
-        assert recovered == fp, f"Failed for value={value}"
+    for field_value in test_values:
+        fp = Fp(value=field_value)
+        encoded = fp.encode_bytes()
+        recovered = Fp.decode_bytes(encoded)
+        assert recovered == fp, f"Failed for value={field_value}"
 
 
 def test_ssz_roundtrip() -> None:
@@ -131,12 +131,12 @@ def test_ssz_roundtrip() -> None:
 
     for _ in range(100):
         # Test with random values
-        value = random.randint(0, P - 1)
-        fp = Fp(value=value)
+        field_value = random.randint(0, P - 1)
+        fp = Fp(value=field_value)
 
         # Test deserialization works
-        data = fp.encode_bytes()
-        recovered = Fp.decode_bytes(data)
+        encoded = fp.encode_bytes()
+        recovered = Fp.decode_bytes(encoded)
         assert recovered == fp
 
 
@@ -169,7 +169,7 @@ def test_new_rejects_non_int_inputs(bad_value: Any, type_name: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("raw", "expected"),
+    ("raw", "expected_residue"),
     [
         (P, 0),
         (P + 7, 7),
@@ -178,52 +178,52 @@ def test_new_rejects_non_int_inputs(bad_value: Any, type_name: str) -> None:
         (2 * P + 42, 42),
     ],
 )
-def test_new_normalizes_into_canonical_range(raw: int, expected: int) -> None:
+def test_new_normalizes_into_canonical_range(raw: int, expected_residue: int) -> None:
     """Constructor reduces the input modulo P into the canonical range."""
     fp = Fp(raw)
-    assert int(fp) == expected
-    assert fp == Fp(expected)
+    assert int(fp) == expected_residue
+    assert fp == Fp(expected_residue)
 
 
 @pytest.mark.parametrize("op", ["+", "-", "*", "/"])
 def test_reverse_arithmetic_rejects_int_left_operand(op: str) -> None:
     """Reverse operators reject a raw int on the left to block silent int fallback."""
-    a = Fp(2)
-    table = {
-        "+": lambda: 1 + a,
-        "-": lambda: 1 - a,
-        "*": lambda: 1 * a,
-        "/": lambda: 1 / a,
+    field_element = Fp(2)
+    operations = {
+        "+": lambda: 1 + field_element,
+        "-": lambda: 1 - field_element,
+        "*": lambda: 1 * field_element,
+        "/": lambda: 1 / field_element,
     }
     with pytest.raises(
         TypeError,
         match=rf"^Unsupported operand type\(s\) for {re.escape(op)}: 'Fp' and 'int'$",
     ):
-        table[op]()
+        operations[op]()
 
 
 @pytest.mark.parametrize("op", ["+", "-", "*", "/"])
 def test_forward_arithmetic_rejects_raw_int_right_operand(op: str) -> None:
     """Forward operators reject a raw int on the right to enforce Fp-only arithmetic."""
-    a = Fp(2)
-    table = {
-        "+": lambda: a + 3,
-        "-": lambda: a - 3,
-        "*": lambda: a * 3,
-        "/": lambda: a / 3,
+    field_element = Fp(2)
+    operations = {
+        "+": lambda: field_element + 3,
+        "-": lambda: field_element - 3,
+        "*": lambda: field_element * 3,
+        "/": lambda: field_element / 3,
     }
     with pytest.raises(
         TypeError,
         match=rf"^Unsupported operand type\(s\) for {re.escape(op)}: 'Fp' and 'int'$",
     ):
-        table[op]()
+        operations[op]()
 
 
 def test_forward_arithmetic_rejects_bool_right_operand() -> None:
     """Forward arithmetic against a bool right operand is rejected as a non-Fp type."""
-    a = Fp(2)
+    field_element = Fp(2)
     with pytest.raises(TypeError, match=r"^Unsupported operand type\(s\) for \+: 'Fp' and 'bool'$"):
-        a + True  # noqa: B015
+        field_element + True  # noqa: B015
 
 
 def test_negation_of_zero_stays_zero() -> None:
@@ -232,7 +232,7 @@ def test_negation_of_zero_stays_zero() -> None:
 
 
 @pytest.mark.parametrize(
-    ("base", "exponent", "expected"),
+    ("base", "exponent", "expected_power"),
     [
         (Fp(7), 0, Fp(1)),
         (Fp(0), 0, Fp(1)),
@@ -240,23 +240,25 @@ def test_negation_of_zero_stays_zero() -> None:
         (Fp(3), 1, Fp(3)),
     ],
 )
-def test_pow_covers_zero_and_modular_exponents(base: Fp, exponent: int, expected: Fp) -> None:
+def test_pow_covers_zero_and_modular_exponents(base: Fp, exponent: int, expected_power: Fp) -> None:
     """Exponentiation handles zero exponent, modular exponent, and identity exponent."""
-    assert base**exponent == expected
+    assert base**exponent == expected_power
 
 
-@pytest.mark.parametrize("a", [Fp(1), Fp(2), Fp(P - 1)])
-def test_inverse_multiplicative_property(a: Fp) -> None:
+@pytest.mark.parametrize("field_element", [Fp(1), Fp(2), Fp(P - 1)])
+def test_inverse_multiplicative_property(field_element: Fp) -> None:
     """The inverse satisfies a times a-inverse equals one and matches Fermat's little theorem."""
-    inv = a.inverse()
-    assert a * inv == Fp(1)
-    assert inv == a ** (P - 2)
+    inverse = field_element.inverse()
+    assert field_element * inverse == Fp(1)
+    assert inverse == field_element ** (P - 2)
 
 
-@pytest.mark.parametrize(("a", "b"), [(Fp(7), Fp(3)), (Fp(P - 1), Fp(2)), (Fp(1), Fp(P - 5))])
-def test_truediv_inverts_multiplication(a: Fp, b: Fp) -> None:
+@pytest.mark.parametrize(
+    ("dividend", "divisor"), [(Fp(7), Fp(3)), (Fp(P - 1), Fp(2)), (Fp(1), Fp(P - 5))]
+)
+def test_truediv_inverts_multiplication(dividend: Fp, divisor: Fp) -> None:
     """Division is the inverse of multiplication for any non-zero divisor."""
-    assert (a / b) * b == a
+    assert (dividend / divisor) * divisor == dividend
 
 
 def test_truediv_by_zero_raises_zero_division() -> None:
@@ -267,16 +269,16 @@ def test_truediv_by_zero_raises_zero_division() -> None:
 
 def test_equality_matrix_covers_same_other_and_foreign_types() -> None:
     """Equality returns True only between matching Fp residues, never raises on foreign types."""
-    a = Fp(5)
-    assert a == Fp(5)
-    assert (a == Fp(6)) is False
-    assert (a == 5) is False
-    assert (a == "5") is False
-    assert (a == None) is False  # noqa: E711
-    assert a != Fp(6)
-    assert a != 5
-    assert a != "5"
-    assert a != None  # noqa: E711
+    field_element = Fp(5)
+    assert field_element == Fp(5)
+    assert (field_element == Fp(6)) is False
+    assert (field_element == 5) is False
+    assert (field_element == "5") is False
+    assert (field_element == None) is False  # noqa: E711
+    assert field_element != Fp(6)
+    assert field_element != 5
+    assert field_element != "5"
+    assert field_element != None  # noqa: E711
 
 
 def test_hash_mixes_in_type_and_keeps_residue_distinct_from_int() -> None:
@@ -350,6 +352,6 @@ def test_pydantic_schema_rejects_out_of_range_ints(bad: int) -> None:
 def test_pydantic_json_serialization_drops_subtype_to_plain_int() -> None:
     """JSON serialization emits a plain integer, hiding the Fp subtype."""
     model = _PydanticModelWithFp(x=Fp(99))
-    payload = model.model_dump(mode="json")
-    assert payload == {"x": 99}
+    serialized = model.model_dump(mode="json")
+    assert serialized == {"x": 99}
     assert json.loads(model.model_dump_json()) == {"x": 99}

--- a/tests/lean_spec/spec/crypto/test_merkleization.py
+++ b/tests/lean_spec/spec/crypto/test_merkleization.py
@@ -43,14 +43,14 @@ def pad(payload: bytes) -> Bytes32:
 
 def merge(leaf: Bytes32, branch: Iterable[Bytes32]) -> Bytes32:
     """Walk a single leaf up a chain of right siblings, hashing left at each step."""
-    out = leaf
+    running_node = leaf
     for sibling in branch:
-        out = h(out, sibling)
-    return out
+        running_node = h(running_node, sibling)
+    return running_node
 
 
-# Sample chunks for testing, c[i] = bytes32(i)
-c = [Bytes32(i.to_bytes(32, "little")) for i in range(16)]
+# Sample chunks for testing, sample_chunks[i] = bytes32(i)
+sample_chunks = [Bytes32(i.to_bytes(32, "little")) for i in range(16)]
 
 # Pre-calculate zero-tree roots for assertions
 # Z[0] = ZERO_HASH, Z[1] = h(Z[0], Z[0]), Z[2] = h(Z[1], Z[1]), etc.
@@ -105,73 +105,73 @@ def test_merkleize_empty_with_limit(
 
 def test_merkleize_single_chunk() -> None:
     """The root of a single chunk is the chunk itself."""
-    assert merkleize([c[1]]) == c[1]
+    assert merkleize([sample_chunks[1]]) == sample_chunks[1]
 
 
 def test_merkleize_power_of_two_chunks() -> None:
     """A power-of-two leaf count needs no padding."""
     # Test with 2 chunks
-    assert merkleize([c[0], c[1]]) == h(c[0], c[1])
+    assert merkleize([sample_chunks[0], sample_chunks[1]]) == h(sample_chunks[0], sample_chunks[1])
     # Test with 4 chunks
-    root_4 = h(h(c[0], c[1]), h(c[2], c[3]))
-    assert merkleize(c[0:4]) == root_4
+    root_4 = h(h(sample_chunks[0], sample_chunks[1]), h(sample_chunks[2], sample_chunks[3]))
+    assert merkleize(sample_chunks[0:4]) == root_4
 
 
 def test_merkleize_non_power_of_two_chunks() -> None:
     """A non-power-of-two leaf count pads to the next power of two."""
     # Test with 3 chunks (pads to 4)
-    expected = h(h(c[0], c[1]), h(c[2], Z[0]))
-    assert merkleize(c[0:3]) == expected
+    expected_root_3_chunks = h(h(sample_chunks[0], sample_chunks[1]), h(sample_chunks[2], Z[0]))
+    assert merkleize(sample_chunks[0:3]) == expected_root_3_chunks
     # Test with 5 chunks (pads to 8)
-    h01 = h(c[0], c[1])
-    h23 = h(c[2], c[3])
-    h4z = h(c[4], Z[0])
+    h01 = h(sample_chunks[0], sample_chunks[1])
+    h23 = h(sample_chunks[2], sample_chunks[3])
+    h4z = h(sample_chunks[4], Z[0])
     # The remaining leaves are zero, so their parent is h(Z[0], Z[0]) = Z[1]
-    expected = h(h(h01, h23), h(h4z, Z[1]))
-    assert merkleize(c[0:5]) == expected
+    expected_root_5_chunks = h(h(h01, h23), h(h4z, Z[1]))
+    assert merkleize(sample_chunks[0:5]) == expected_root_5_chunks
 
 
 def test_merkleize_with_limit_padding() -> None:
     """A limit larger than the leaf count widens the tree to the next power of two of the limit."""
     # 3 chunks, but limit is 8 (pads to width 8)
-    h01 = h(c[0], c[1])
-    h2z = h(c[2], Z[0])
+    h01 = h(sample_chunks[0], sample_chunks[1])
+    h2z = h(sample_chunks[2], Z[0])
     # The parent of h01 and h2z
     left_branch = h(h01, h2z)
     # The right branch is a zero-tree of width 4, so its root is Z[2].
     right_branch = Z[2]
-    expected = h(left_branch, right_branch)
-    assert merkleize(c[0:3], limit=8) == expected
+    expected_root = h(left_branch, right_branch)
+    assert merkleize(sample_chunks[0:3], limit=8) == expected_root
 
 
 def test_merkleize_error_on_exceeding_limit() -> None:
     """Raises when the chunk count exceeds the limit."""
     with pytest.raises(ValueError, match="input exceeds limit"):
-        merkleize(c[0:5], limit=4)
+        merkleize(sample_chunks[0:5], limit=4)
 
 
 def test_mix_in_length() -> None:
     """Mixes the length encoded as little-endian uint256 into the root."""
-    root = c[0]
+    root = sample_chunks[0]
     length = 12345
     length_bytes = Bytes32(length.to_bytes(32, "little"))
-    expected = h(root, length_bytes)
-    assert mix_in_length(root, length) == expected
+    expected_root = h(root, length_bytes)
+    assert mix_in_length(root, length) == expected_root
 
 
 def test_mix_in_length_zero() -> None:
     """Zero is a valid length."""
-    root = c[0]
+    root = sample_chunks[0]
     length = 0
     length_bytes = Bytes32(length.to_bytes(32, "little"))
-    expected = h(root, length_bytes)
-    assert mix_in_length(root, length) == expected
+    expected_root = h(root, length_bytes)
+    assert mix_in_length(root, length) == expected_root
 
 
 def test_mix_in_length_error_on_negative() -> None:
     """Rejects negative lengths."""
     with pytest.raises(ValueError):
-        mix_in_length(c[0], -1)
+        mix_in_length(sample_chunks[0], -1)
 
 
 def test_zero_tree_root_internal() -> None:
@@ -384,13 +384,13 @@ class EmptyContainer(Container):
     """Container with zero fields."""
 
 
-def le_padded(value: int, byte_length: int) -> Bytes32:
+def le_padded(integer_value: int, byte_length: int) -> Bytes32:
     """Encode an integer little-endian and right-pad to one chunk."""
-    return pad(value.to_bytes(byte_length, "little"))
+    return pad(integer_value.to_bytes(byte_length, "little"))
 
 
 @pytest.mark.parametrize(
-    "uint_type, byte_length, value",
+    "uint_type, byte_length, integer_value",
     [
         (Uint8, 1, 0x00),
         (Uint8, 1, 0x01),
@@ -407,25 +407,25 @@ def le_padded(value: int, byte_length: int) -> Bytes32:
         (Uint64, 8, 0xFFFFFFFFFFFFFFFF),
     ],
 )
-def test_hash_tree_root_uints(uint_type: type, byte_length: int, value: int) -> None:
+def test_hash_tree_root_uints(uint_type: type, byte_length: int, integer_value: int) -> None:
     """Unsigned integers hash as their little-endian bytes padded to one chunk."""
-    assert hash_tree_root(uint_type(value)) == le_padded(value, byte_length)
+    assert hash_tree_root(uint_type(integer_value)) == le_padded(integer_value, byte_length)
 
 
 @pytest.mark.parametrize(
-    "value, byte",
+    "boolean, expected_byte",
     [
         (Boolean(False), b"\x00"),
         (Boolean(True), b"\x01"),
     ],
 )
-def test_hash_tree_root_boolean(value: Boolean, byte: bytes) -> None:
+def test_hash_tree_root_boolean(boolean: Boolean, expected_byte: bytes) -> None:
     """Boolean hashes to a single byte padded to one chunk."""
-    assert hash_tree_root(value) == pad(byte)
+    assert hash_tree_root(boolean) == pad(expected_byte)
 
 
 @pytest.mark.parametrize(
-    "value",
+    "integer_value",
     [
         0,
         1,
@@ -433,9 +433,9 @@ def test_hash_tree_root_boolean(value: Boolean, byte: bytes) -> None:
         (1 << 31) - 2**24,  # Largest residue under the KoalaBear modulus.
     ],
 )
-def test_hash_tree_root_fp(value: int) -> None:
+def test_hash_tree_root_fp(integer_value: int) -> None:
     """KoalaBear field elements hash as their four-byte little-endian encoding."""
-    assert hash_tree_root(Fp(value)) == le_padded(value, 4)
+    assert hash_tree_root(Fp(integer_value)) == le_padded(integer_value, 4)
 
 
 @pytest.mark.parametrize(
@@ -460,7 +460,7 @@ def test_hash_tree_root_raw_bytes_like(payload: bytes) -> None:
 
 
 @pytest.mark.parametrize(
-    "payload, expected",
+    "payload, expected_root",
     [
         # Empty: zero chunks merkleizes to the all-zero leaf.
         (b"", Z[0]),
@@ -476,46 +476,46 @@ def test_hash_tree_root_raw_bytes_like(payload: bytes) -> None:
         (b"\xaa" * 32 + b"\xbb" * 32, h(b"\xaa" * 32, b"\xbb" * 32)),
     ],
 )
-def test_hash_tree_root_bytes_known_vectors(payload: bytes, expected: Bytes32) -> None:
+def test_hash_tree_root_bytes_known_vectors(payload: bytes, expected_root: Bytes32) -> None:
     """Raw byte payloads hash to the merkle root of their packed chunks."""
-    assert hash_tree_root(payload) == expected
+    assert hash_tree_root(payload) == expected_root
 
 
 def test_hash_tree_root_bytevector_single_chunk() -> None:
     """A 32-byte vector is exactly one chunk and is its own root."""
-    payload = bytes(range(32))
-    assert hash_tree_root(Bytes32(payload)) == Bytes32(payload)
+    raw_bytes = bytes(range(32))
+    assert hash_tree_root(Bytes32(raw_bytes)) == Bytes32(raw_bytes)
 
 
 def test_hash_tree_root_bytevector_two_chunks() -> None:
     """A 48-byte vector hashes its two chunks together; the trailing chunk is padded."""
-    payload = bytes(range(48))
-    expected = h(payload[:32], pad(payload[32:]))
-    assert hash_tree_root(Bytes48(payload)) == expected
+    raw_bytes = bytes(range(48))
+    expected_root = h(raw_bytes[:32], pad(raw_bytes[32:]))
+    assert hash_tree_root(Bytes48(raw_bytes)) == expected_root
 
 
 def test_hash_tree_root_bytevector_three_chunks() -> None:
     """A 96-byte vector merkleizes its three chunks with a zero pad to width four."""
-    payload = bytes(range(96))
-    left = h(payload[0:32], payload[32:64])
-    right = h(payload[64:96], Z[0])
-    assert hash_tree_root(Bytes96(payload)) == h(left, right)
+    raw_bytes = bytes(range(96))
+    left = h(raw_bytes[0:32], raw_bytes[32:64])
+    right = h(raw_bytes[64:96], Z[0])
+    assert hash_tree_root(Bytes96(raw_bytes)) == h(left, right)
 
 
 def test_hash_tree_root_bytelist_empty_single_chunk_capacity() -> None:
     """An empty list with single-chunk capacity mixes a zero chunk with length zero."""
-    expected = h(Z[0], pad(b"\x00"))
-    assert hash_tree_root(ByteList10(data=b"")) == expected
+    expected_root = h(Z[0], pad(b"\x00"))
+    assert hash_tree_root(ByteList10(data=b"")) == expected_root
 
 
 def test_hash_tree_root_bytelist_empty_large_capacity() -> None:
     """An empty list with 64-chunk capacity uses the depth-6 zero root before mix-in."""
-    expected = h(Z[6], pad(b"\x00"))
-    assert hash_tree_root(ByteList2048(data=b"")) == expected
+    expected_root = h(Z[6], pad(b"\x00"))
+    assert hash_tree_root(ByteList2048(data=b"")) == expected_root
 
 
 @pytest.mark.parametrize(
-    "list_cls, payload, expected",
+    "list_cls, payload, expected_root",
     [
         # Small list fits in one chunk; data root is the padded payload.
         (
@@ -550,15 +550,15 @@ def test_hash_tree_root_bytelist_empty_large_capacity() -> None:
     ],
 )
 def test_hash_tree_root_bytelist_various(
-    list_cls: type[BaseByteList], payload: bytes, expected: Bytes32
+    list_cls: type[BaseByteList], payload: bytes, expected_root: Bytes32
 ) -> None:
     """Variable-length byte lists merkleize their packed data then mix in the length."""
-    assert hash_tree_root(list_cls(data=payload)) == expected
+    assert hash_tree_root(list_cls(data=payload)) == expected_root
 
 
 def _bools(*values: int) -> list[Boolean]:
     """Build a typed boolean sequence from 0/1 integers."""
-    return [Boolean(bool(v)) for v in values]
+    return [Boolean(bool(bit)) for bit in values]
 
 
 @pytest.mark.parametrize(
@@ -616,86 +616,86 @@ def test_hash_tree_root_bitlist_small(
 ) -> None:
     """Short bitlists hash the data chunk and mix in the bit count."""
     bl = bl_cls(data=bits)
-    expected = h(expected_data_root, pad(expected_length.to_bytes(32, "little")))
-    assert hash_tree_root(bl) == expected
+    expected_root = h(expected_data_root, pad(expected_length.to_bytes(32, "little")))
+    assert hash_tree_root(bl) == expected_root
 
 
 def test_hash_tree_root_bitlist_chunk_boundary() -> None:
     """A bitlist whose data fills exactly one chunk mixes its 256-bit length in."""
     bl = Bitlist256(data=_bools(*([1] * 256)))
-    expected = h(b"\xff" * 32, pad((256).to_bytes(32, "little")))
-    assert hash_tree_root(bl) == expected
+    expected_root = h(b"\xff" * 32, pad((256).to_bytes(32, "little")))
+    assert hash_tree_root(bl) == expected_root
 
 
 def test_hash_tree_root_bitlist_two_chunks() -> None:
     """A bitlist whose data spans two chunks merkleizes them and mixes in 512."""
     bl = Bitlist512(data=_bools(*([1] * 512)))
     base = h(b"\xff" * 32, b"\xff" * 32)
-    expected = h(base, pad((512).to_bytes(32, "little")))
-    assert hash_tree_root(bl) == expected
+    expected_root = h(base, pad((512).to_bytes(32, "little")))
+    assert hash_tree_root(bl) == expected_root
 
 
 def test_hash_tree_root_vector_basic_single_chunk() -> None:
     """A vector of two Uint16 fits in one chunk; the root is the padded payload."""
-    v = Uint16Vector2(data=[Uint16(0x4567), Uint16(0x0123)])
-    assert hash_tree_root(v) == pad(b"\x67\x45\x23\x01")
+    vector = Uint16Vector2(data=[Uint16(0x4567), Uint16(0x0123)])
+    assert hash_tree_root(vector) == pad(b"\x67\x45\x23\x01")
 
 
 def test_hash_tree_root_vector_basic_chunk_boundary() -> None:
     """A vector of sixteen Uint16 fills exactly one 32-byte chunk."""
-    v = Uint16Vector16(data=[Uint16(i) for i in range(16)])
-    payload = b"".join(i.to_bytes(2, "little") for i in range(16))
-    assert hash_tree_root(v) == Bytes32(payload)
+    vector = Uint16Vector16(data=[Uint16(i) for i in range(16)])
+    packed_bytes = b"".join(i.to_bytes(2, "little") for i in range(16))
+    assert hash_tree_root(vector) == Bytes32(packed_bytes)
 
 
 def test_hash_tree_root_vector_single_element() -> None:
     """A one-element vector of Uint16 yields the padded little-endian element."""
-    v = Uint16Vector1(data=[Uint16(0xABCD)])
-    assert hash_tree_root(v) == pad(b"\xcd\xab")
+    vector = Uint16Vector1(data=[Uint16(0xABCD)])
+    assert hash_tree_root(vector) == pad(b"\xcd\xab")
 
 
 def test_hash_tree_root_vector_composite_elements() -> None:
     """A vector of three Bytes32 leaves merkleizes its element roots padded to width four."""
-    a = Bytes32(b"\xbb\xaa" + b"\x00" * 30)
-    b = Bytes32(b"\xad\xc0" + b"\x00" * 30)
-    c = Bytes32(b"\xff\xee" + b"\x00" * 30)
-    v = Bytes32Vector3(data=[a, b, c])
-    assert hash_tree_root(v) == h(h(a, b), h(c, Z[0]))
+    leaf_a = Bytes32(b"\xbb\xaa" + b"\x00" * 30)
+    leaf_b = Bytes32(b"\xad\xc0" + b"\x00" * 30)
+    leaf_c = Bytes32(b"\xff\xee" + b"\x00" * 30)
+    vector = Bytes32Vector3(data=[leaf_a, leaf_b, leaf_c])
+    assert hash_tree_root(vector) == h(h(leaf_a, leaf_b), h(leaf_c, Z[0]))
 
 
 def test_hash_tree_root_list_basic_small_limit() -> None:
     """A list of three Uint16 with capacity for 32 elements packs into a two-chunk tree."""
     test_list = Uint16List32(data=[Uint16(0xAABB), Uint16(0xC0AD), Uint16(0xEEFF)])
     base = h(pad(b"\xbb\xaa\xad\xc0\xff\xee"), Z[0])
-    expected = h(base, pad(b"\x03"))
-    assert hash_tree_root(test_list) == expected
+    expected_root = h(base, pad(b"\x03"))
+    assert hash_tree_root(test_list) == expected_root
 
 
 def test_hash_tree_root_list_basic_large_limit() -> None:
     """A list of three Uint32 with capacity 128 pads up four levels then mixes in the length."""
     test_list = Uint32List128(data=[Uint32(0xAABB), Uint32(0xC0AD), Uint32(0xEEFF)])
     base = merge(pad(b"\xbb\xaa\x00\x00\xad\xc0\x00\x00\xff\xee\x00\x00"), Z[0:4])
-    expected = h(base, pad(b"\x03"))
-    assert hash_tree_root(test_list) == expected
+    expected_root = h(base, pad(b"\x03"))
+    assert hash_tree_root(test_list) == expected_root
 
 
 def test_hash_tree_root_list_basic_empty() -> None:
     """An empty list with a large capacity uses the all-zero subtree at the capacity depth."""
     test_list = Uint32List128(data=[])
-    expected = h(Z[4], pad(b"\x00"))
-    assert hash_tree_root(test_list) == expected
+    expected_root = h(Z[4], pad(b"\x00"))
+    assert hash_tree_root(test_list) == expected_root
 
 
 def test_hash_tree_root_list_composite_elements() -> None:
     """A list of three Bytes32 elements merkleizes leaves to capacity depth then mixes length."""
-    a = Bytes32(b"\xbb\xaa" + b"\x00" * 30)
-    b = Bytes32(b"\xad\xc0" + b"\x00" * 30)
-    c = Bytes32(b"\xff\xee" + b"\x00" * 30)
-    test_list = Bytes32List32(data=[a, b, c])
-    base = h(h(a, b), h(c, Z[0]))
+    leaf_a = Bytes32(b"\xbb\xaa" + b"\x00" * 30)
+    leaf_b = Bytes32(b"\xad\xc0" + b"\x00" * 30)
+    leaf_c = Bytes32(b"\xff\xee" + b"\x00" * 30)
+    test_list = Bytes32List32(data=[leaf_a, leaf_b, leaf_c])
+    base = h(h(leaf_a, leaf_b), h(leaf_c, Z[0]))
     merkle = merge(base, Z[2:5])
-    expected = h(merkle, pad(b"\x03"))
-    assert hash_tree_root(test_list) == expected
+    expected_root = h(merkle, pad(b"\x03"))
+    assert hash_tree_root(test_list) == expected_root
 
 
 def test_hash_tree_root_container_empty() -> None:
@@ -705,36 +705,36 @@ def test_hash_tree_root_container_empty() -> None:
 
 def test_hash_tree_root_container_single_field() -> None:
     """A container with one basic field hashes that field as its only leaf."""
-    v = SingleField(A=Uint8(0xAB))
-    assert hash_tree_root(v) == pad(b"\xab")
+    container = SingleField(A=Uint8(0xAB))
+    assert hash_tree_root(container) == pad(b"\xab")
 
 
 def test_hash_tree_root_container_two_fields() -> None:
     """A container with two basic fields hashes each as its own leaf."""
-    v = Small(A=Uint16(0x4567), B=Uint16(0x0123))
-    assert hash_tree_root(v) == h(pad(b"\x67\x45"), pad(b"\x23\x01"))
+    container = Small(A=Uint16(0x4567), B=Uint16(0x0123))
+    assert hash_tree_root(container) == h(pad(b"\x67\x45"), pad(b"\x23\x01"))
 
 
 def test_hash_tree_root_container_three_fields_pads_to_four() -> None:
     """A three-field container pads its leaves with one zero chunk to width four."""
-    v = Fixed(A=Uint8(0xAB), B=Uint64(0xAABBCCDDEEFF0011), C=Uint32(0x12345678))
+    container = Fixed(A=Uint8(0xAB), B=Uint64(0xAABBCCDDEEFF0011), C=Uint32(0x12345678))
     left = h(pad(b"\xab"), pad(b"\x11\x00\xff\xee\xdd\xcc\xbb\xaa"))
     right = h(pad(b"\x78\x56\x34\x12"), Z[0])
-    assert hash_tree_root(v) == h(left, right)
+    assert hash_tree_root(container) == h(left, right)
 
 
 def test_hash_tree_root_container_with_empty_list_field() -> None:
     """An empty variable-size field contributes its own zero-tree root with length zero."""
-    v = Var(A=Uint16(0xABCD), B=Uint16List1024(data=()), C=Uint8(0xFF))
+    container = Var(A=Uint16(0xABCD), B=Uint16List1024(data=()), C=Uint8(0xFF))
     expected_b = h(Z[6], pad(b"\x00"))
     left = h(pad(b"\xcd\xab"), expected_b)
     right = h(pad(b"\xff"), Z[0])
-    assert hash_tree_root(v) == h(left, right)
+    assert hash_tree_root(container) == h(left, right)
 
 
 def test_hash_tree_root_container_with_populated_list_field() -> None:
     """A populated variable-size field contributes its data root with the element count."""
-    v = Var(
+    container = Var(
         A=Uint16(0xABCD),
         B=Uint16List1024(data=(Uint16(1), Uint16(2), Uint16(3))),
         C=Uint8(0xFF),
@@ -743,7 +743,7 @@ def test_hash_tree_root_container_with_populated_list_field() -> None:
     expected_b = h(base, pad(b"\x03"))
     left = h(pad(b"\xcd\xab"), expected_b)
     right = h(pad(b"\xff"), Z[0])
-    assert hash_tree_root(v) == h(left, right)
+    assert hash_tree_root(container) == h(left, right)
 
 
 def test_hash_tree_root_vector_of_composite_containers() -> None:
@@ -752,7 +752,7 @@ def test_hash_tree_root_vector_of_composite_containers() -> None:
     def fixed_root(a: bytes, b: bytes, c: bytes) -> Bytes32:
         return h(h(pad(a), pad(b)), h(pad(c), Z[0]))
 
-    fv = FixedVector4(
+    fixed_vector = FixedVector4(
         data=[
             Fixed(A=Uint8(0xCC), B=Uint64(0x4242424242424242), C=Uint32(0x13371337)),
             Fixed(A=Uint8(0xDD), B=Uint64(0x3333333333333333), C=Uint32(0xABCDABCD)),
@@ -760,11 +760,13 @@ def test_hash_tree_root_vector_of_composite_containers() -> None:
             Fixed(A=Uint8(0xFF), B=Uint64(0x5555555555555555), C=Uint32(0x44556677)),
         ]
     )
-    r0 = fixed_root(b"\xcc", b"\x42" * 8, b"\x37\x13\x37\x13")
-    r1 = fixed_root(b"\xdd", b"\x33" * 8, b"\xcd\xab\xcd\xab")
-    r2 = fixed_root(b"\xee", b"\x44" * 8, b"\x33\x22\x11\x00")
-    r3 = fixed_root(b"\xff", b"\x55" * 8, b"\x77\x66\x55\x44")
-    assert hash_tree_root(fv) == h(h(r0, r1), h(r2, r3))
+    element_root_0 = fixed_root(b"\xcc", b"\x42" * 8, b"\x37\x13\x37\x13")
+    element_root_1 = fixed_root(b"\xdd", b"\x33" * 8, b"\xcd\xab\xcd\xab")
+    element_root_2 = fixed_root(b"\xee", b"\x44" * 8, b"\x33\x22\x11\x00")
+    element_root_3 = fixed_root(b"\xff", b"\x55" * 8, b"\x77\x66\x55\x44")
+    assert hash_tree_root(fixed_vector) == h(
+        h(element_root_0, element_root_1), h(element_root_2, element_root_3)
+    )
 
 
 def test_hash_tree_root_vector_of_variable_containers() -> None:
@@ -775,7 +777,7 @@ def test_hash_tree_root_vector_of_variable_containers() -> None:
         b_root = h(base, pad(count.to_bytes(32, "little")))
         return h(h(pad(a), b_root), h(pad(c), Z[0]))
 
-    vv = VarVector2(
+    variable_vector = VarVector2(
         data=[
             Var(
                 A=Uint16(0xDEAD),
@@ -789,13 +791,13 @@ def test_hash_tree_root_vector_of_variable_containers() -> None:
             ),
         ]
     )
-    g0 = var_root(b"\xad\xde", b"\x01\x00\x02\x00\x03\x00", 3, b"\x11")
-    g1 = var_root(b"\xef\xbe", b"\x04\x00\x05\x00\x06\x00", 3, b"\x22")
-    assert hash_tree_root(vv) == h(g0, g1)
+    element_root_0 = var_root(b"\xad\xde", b"\x01\x00\x02\x00\x03\x00", 3, b"\x11")
+    element_root_1 = var_root(b"\xef\xbe", b"\x04\x00\x05\x00\x06\x00", 3, b"\x22")
+    assert hash_tree_root(variable_vector) == h(element_root_0, element_root_1)
 
 
 @pytest.mark.parametrize(
-    "value",
+    "unsupported_value",
     [
         42,
         "hello",
@@ -807,17 +809,17 @@ def test_hash_tree_root_vector_of_variable_containers() -> None:
     ],
     ids=["int", "str", "list", "dict", "tuple", "float", "none"],
 )
-def test_hash_tree_root_unsupported_type_raises(value: object) -> None:
+def test_hash_tree_root_unsupported_type_raises(unsupported_value: object) -> None:
     """The dispatch fallback rejects values without a registered handler."""
     with pytest.raises(TypeError, match=r"hash_tree_root: unsupported value type"):
-        hash_tree_root(value)
+        hash_tree_root(unsupported_value)
 
 
 def test_hash_tree_root_is_deterministic() -> None:
     """Repeated calls on equal inputs return byte-identical roots."""
-    a = Uint16List1024(data=(Uint16(1), Uint16(2), Uint16(3)))
-    b = Uint16List1024(data=(Uint16(1), Uint16(2), Uint16(3)))
-    assert hash_tree_root(a) == hash_tree_root(b)
+    first_list = Uint16List1024(data=(Uint16(1), Uint16(2), Uint16(3)))
+    second_list = Uint16List1024(data=(Uint16(1), Uint16(2), Uint16(3)))
+    assert hash_tree_root(first_list) == hash_tree_root(second_list)
 
 
 def test_hash_tree_root_distinguishes_by_length() -> None:

--- a/tests/lean_spec/spec/crypto/test_poseidon.py
+++ b/tests/lean_spec/spec/crypto/test_poseidon.py
@@ -219,21 +219,21 @@ class TestPoseidonEngine:
     def test_permute_determinism(self) -> None:
         """Same input produces same output."""
         engine = Poseidon(PARAMS_16)
-        state = [Fp(value=i) for i in range(16)]
+        input_state = [Fp(value=i) for i in range(16)]
 
-        output1 = engine.permute(state)
-        output2 = engine.permute(state)
+        output1 = engine.permute(input_state)
+        output2 = engine.permute(input_state)
 
         assert output1 == output2
 
     def test_permute_output_differs_from_input(self) -> None:
         """Permutation changes the state."""
         engine = Poseidon(PARAMS_16)
-        state = [Fp(value=i) for i in range(16)]
+        input_state = [Fp(value=i) for i in range(16)]
 
-        output = engine.permute(state)
+        permuted_output = engine.permute(input_state)
 
-        assert output != state
+        assert permuted_output != input_state
 
     @pytest.mark.parametrize(
         "params, input_state",
@@ -247,24 +247,24 @@ class TestPoseidonEngine:
         """Every output element lies strictly below the field modulus."""
         engine = Poseidon(params)
 
-        output = engine.permute(input_state)
+        permuted_output = engine.permute(input_state)
 
-        assert all(int(x) < P for x in output)
+        assert all(int(output_element) < P for output_element in permuted_output)
 
     def test_permute_all_zero_input(self) -> None:
         """All-zero input produces an in-field output of the expected width."""
         engine = Poseidon(PARAMS_16)
 
-        output = engine.permute([Fp(0)] * 16)
+        permuted_output = engine.permute([Fp(0)] * 16)
 
-        assert len(output) == 16
-        assert all(int(x) < P for x in output)
+        assert len(permuted_output) == 16
+        assert all(int(output_element) < P for output_element in permuted_output)
 
     def test_permute_field_boundary_input(self) -> None:
         """Maximum-value input stays in-field and exposes int64 regressions."""
         engine = Poseidon(PARAMS_16)
 
-        output = engine.permute([Fp(value=P - 1)] * 16)
+        permuted_output = engine.permute([Fp(value=P - 1)] * 16)
 
-        assert len(output) == 16
-        assert all(int(x) < P for x in output)
+        assert len(permuted_output) == 16
+        assert all(int(output_element) < P for output_element in permuted_output)

--- a/tests/lean_spec/spec/crypto/xmss/test_constants.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_constants.py
@@ -85,8 +85,8 @@ def test_signature_length_bytes_matches_layout() -> None:
     path = config.LOG_LIFETIME * config.HASH_LENGTH_FIELD_ELEMENTS * P_BYTES
     rho = config.RAND_LENGTH_FIELD_ELEMENTS * P_BYTES
     hashes = config.DIMENSION * config.HASH_LENGTH_FIELD_ELEMENTS * P_BYTES
-    expected = path + rho + hashes + 3 * BYTES_PER_LENGTH_OFFSET
-    assert config.SIGNATURE_LENGTH_BYTES == expected
+    expected_signature_length = path + rho + hashes + 3 * BYTES_PER_LENGTH_OFFSET
+    assert config.SIGNATURE_LENGTH_BYTES == expected_signature_length
 
 
 @pytest.mark.parametrize(

--- a/tests/lean_spec/spec/crypto/xmss/test_containers.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_containers.py
@@ -50,9 +50,9 @@ def hex_dict(keypair_a: KeyPair, keypair_b: KeyPair) -> dict[str, dict[str, str]
 def test_construct_from_keypair_instances(keypair_a: KeyPair, keypair_b: KeyPair) -> None:
     """Direct construction stores both pairs by value."""
     # Passing KeyPair instances skips the hex-decode branch.
-    vkp = ValidatorKeyPair(attestation_keypair=keypair_a, proposal_keypair=keypair_b)
-    assert vkp.attestation_keypair == keypair_a
-    assert vkp.proposal_keypair == keypair_b
+    validator_keypair = ValidatorKeyPair(attestation_keypair=keypair_a, proposal_keypair=keypair_b)
+    assert validator_keypair.attestation_keypair == keypair_a
+    assert validator_keypair.proposal_keypair == keypair_b
 
 
 def test_validate_from_nested_hex_dict(
@@ -83,22 +83,22 @@ def test_validator_accepts_0x_prefix(
 
 def test_validator_accepts_mixed_inputs(keypair_a: KeyPair, keypair_b: KeyPair) -> None:
     """One role as a KeyPair instance, the other as a hex mapping, both decode."""
-    data = {
+    keypair_mapping = {
         "attestation_keypair": keypair_a,
         "proposal_keypair": {
             "public_key": keypair_b.public_key.encode_bytes().hex(),
             "secret_key": keypair_b.secret_key.encode_bytes().hex(),
         },
     }
-    vkp = ValidatorKeyPair.model_validate(data)
-    assert vkp.attestation_keypair == keypair_a
-    assert vkp.proposal_keypair == keypair_b
+    validator_keypair = ValidatorKeyPair.model_validate(keypair_mapping)
+    assert validator_keypair.attestation_keypair == keypair_a
+    assert validator_keypair.proposal_keypair == keypair_b
 
 
 def test_json_dump_emits_nested_hex_shape(keypair_a: KeyPair, keypair_b: KeyPair) -> None:
     """JSON dump emits each key half as a 0x-prefixed hex string."""
-    vkp = ValidatorKeyPair(attestation_keypair=keypair_a, proposal_keypair=keypair_b)
-    assert json.loads(vkp.model_dump_json()) == {
+    validator_keypair = ValidatorKeyPair(attestation_keypair=keypair_a, proposal_keypair=keypair_b)
+    assert json.loads(validator_keypair.model_dump_json()) == {
         "attestation_keypair": {
             "public_key": "0x" + keypair_a.public_key.encode_bytes().hex(),
             "secret_key": "0x" + keypair_a.secret_key.encode_bytes().hex(),
@@ -113,15 +113,18 @@ def test_json_dump_emits_nested_hex_shape(keypair_a: KeyPair, keypair_b: KeyPair
 def test_json_roundtrip_preserves_equality(keypair_a: KeyPair, keypair_b: KeyPair) -> None:
     """Dump-then-validate yields a model equal to the original."""
     # Invariant: encode then decode is identity on every ValidatorKeyPair.
-    vkp = ValidatorKeyPair(attestation_keypair=keypair_a, proposal_keypair=keypair_b)
-    assert ValidatorKeyPair.model_validate_json(vkp.model_dump_json()) == vkp
+    validator_keypair = ValidatorKeyPair(attestation_keypair=keypair_a, proposal_keypair=keypair_b)
+    assert (
+        ValidatorKeyPair.model_validate_json(validator_keypair.model_dump_json())
+        == validator_keypair
+    )
 
 
 def test_frozen_blocks_field_assignment(keypair_a: KeyPair, keypair_b: KeyPair) -> None:
     """Reassigning a field after construction raises (frozen model)."""
-    vkp = ValidatorKeyPair(attestation_keypair=keypair_a, proposal_keypair=keypair_b)
+    validator_keypair = ValidatorKeyPair(attestation_keypair=keypair_a, proposal_keypair=keypair_b)
     with pytest.raises(ValidationError):
-        vkp.attestation_keypair = keypair_b
+        validator_keypair.attestation_keypair = keypair_b
 
 
 def test_extra_fields_rejected(
@@ -143,9 +146,12 @@ def test_rejects_non_keypair_non_mapping(
     bad_value: object,
 ) -> None:
     """Anything that is not a KeyPair or a Mapping fails validation."""
-    data = {"attestation_keypair": bad_value, "proposal_keypair": hex_dict["proposal_keypair"]}
+    keypair_mapping = {
+        "attestation_keypair": bad_value,
+        "proposal_keypair": hex_dict["proposal_keypair"],
+    }
     with pytest.raises(ValidationError):
-        ValidatorKeyPair.model_validate(data)
+        ValidatorKeyPair.model_validate(keypair_mapping)
 
 
 def test_rejects_missing_public_key(
@@ -153,12 +159,12 @@ def test_rejects_missing_public_key(
 ) -> None:
     """A role mapping without the public half fails to decode."""
     # KeyError on value["public_key"] surfaces as ValidationError.
-    data = {
+    keypair_mapping = {
         "attestation_keypair": {"secret_key": keypair_a.secret_key.encode_bytes().hex()},
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
     with pytest.raises(ValidationError):
-        ValidatorKeyPair.model_validate(data)
+        ValidatorKeyPair.model_validate(keypair_mapping)
 
 
 def test_rejects_missing_secret_key(
@@ -166,12 +172,12 @@ def test_rejects_missing_secret_key(
 ) -> None:
     """A role mapping without the secret half fails to decode."""
     # KeyError on value["secret_key"] surfaces as ValidationError.
-    data = {
+    keypair_mapping = {
         "attestation_keypair": {"public_key": keypair_a.public_key.encode_bytes().hex()},
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
     with pytest.raises(ValidationError):
-        ValidatorKeyPair.model_validate(data)
+        ValidatorKeyPair.model_validate(keypair_mapping)
 
 
 def test_rejects_non_string_hex_value(
@@ -179,7 +185,7 @@ def test_rejects_non_string_hex_value(
 ) -> None:
     """Hex fields must be strings; an integer is rejected before SSZ decoding."""
     # AttributeError on int.removeprefix surfaces as ValidationError.
-    data = {
+    keypair_mapping = {
         "attestation_keypair": {
             "public_key": 12345,
             "secret_key": keypair_a.secret_key.encode_bytes().hex(),
@@ -187,7 +193,7 @@ def test_rejects_non_string_hex_value(
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
     with pytest.raises(ValidationError):
-        ValidatorKeyPair.model_validate(data)
+        ValidatorKeyPair.model_validate(keypair_mapping)
 
 
 def test_rejects_invalid_hex_characters(
@@ -195,7 +201,7 @@ def test_rejects_invalid_hex_characters(
 ) -> None:
     """Non-hex characters surface as a validation error from the SSZ codec."""
     # ValueError from bytes.fromhex is wrapped natively by Pydantic.
-    data = {
+    keypair_mapping = {
         "attestation_keypair": {
             "public_key": "zz" * 26,
             "secret_key": keypair_a.secret_key.encode_bytes().hex(),
@@ -203,13 +209,13 @@ def test_rejects_invalid_hex_characters(
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
     with pytest.raises(ValidationError):
-        ValidatorKeyPair.model_validate(data)
+        ValidatorKeyPair.model_validate(keypair_mapping)
 
 
 def test_rejects_wrong_length_hex(keypair_a: KeyPair, hex_dict: dict[str, dict[str, str]]) -> None:
     """A hex string of the wrong byte length fails SSZ deserialization."""
     # SSZError from decode_bytes is rerouted to ValueError by the validator.
-    data = {
+    keypair_mapping = {
         "attestation_keypair": {
             "public_key": "deadbeef",
             "secret_key": keypair_a.secret_key.encode_bytes().hex(),
@@ -217,7 +223,7 @@ def test_rejects_wrong_length_hex(keypair_a: KeyPair, hex_dict: dict[str, dict[s
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
     with pytest.raises(ValidationError):
-        ValidatorKeyPair.model_validate(data)
+        ValidatorKeyPair.model_validate(keypair_mapping)
 
 
 def test_rejects_missing_role(hex_dict: dict[str, dict[str, str]]) -> None:
@@ -288,8 +294,10 @@ def test_public_key_ssz_roundtrip(signed_key_pair: KeyPair) -> None:
 def test_public_key_encoded_size_matches_layout(signed_key_pair: KeyPair) -> None:
     """The encoded public key is the digest plus parameter packed into field bytes."""
     encoded = signed_key_pair.public_key.encode_bytes()
-    expected = (TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS + TEST_CONFIG.PARAMETER_LENGTH) * P_BYTES
-    assert len(encoded) == expected
+    expected_encoded_length = (
+        TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS + TEST_CONFIG.PARAMETER_LENGTH
+    ) * P_BYTES
+    assert len(encoded) == expected_encoded_length
 
 
 def test_secret_key_ssz_roundtrip(signed_key_pair: KeyPair) -> None:

--- a/tests/lean_spec/spec/crypto/xmss/test_encoding.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_encoding.py
@@ -42,8 +42,8 @@ def test_encode_message_reads_little_endian() -> None:
 def test_encode_epoch_matches_prefixed_decomposition(epoch: int) -> None:
     """An epoch encodes to its value shifted above the message prefix."""
     acc = (epoch << 8) | TWEAK_PREFIX_MESSAGE
-    expected = int_to_base_p(acc, TEST_CONFIG.TWEAK_LENGTH_FIELD_ELEMENTS)
-    assert encode_epoch(TEST_CONFIG, Uint64(epoch)) == expected
+    expected_encoding = int_to_base_p(acc, TEST_CONFIG.TWEAK_LENGTH_FIELD_ELEMENTS)
+    assert encode_epoch(TEST_CONFIG, Uint64(epoch)) == expected_encoding
 
 
 def test_encode_epoch_is_injective_over_a_range() -> None:
@@ -63,20 +63,22 @@ def test_aborting_decode_known_decomposition() -> None:
     for _ in range(config.Z):
         expected_per_field_element.append(remaining % config.BASE)
         remaining //= config.BASE
-    expected = (expected_per_field_element * config.MH_HASH_LENGTH_FIELD_ELEMENTS)[
+    expected_digits = (expected_per_field_element * config.MH_HASH_LENGTH_FIELD_ELEMENTS)[
         : config.DIMENSION
     ]
 
-    assert aborting_decode(config, field_element_list) == expected
+    assert aborting_decode(config, field_element_list) == expected_digits
 
 
 def test_aborting_decode_accepts_largest_valid_element() -> None:
     """The element just below the abort threshold decodes successfully."""
     config = TEST_CONFIG
-    result = aborting_decode(config, [Fp(value=P - 2)] * config.MH_HASH_LENGTH_FIELD_ELEMENTS)
-    assert result is not None
-    assert len(result) == config.DIMENSION
-    assert all(0 <= d < config.BASE for d in result)
+    decoded_digits = aborting_decode(
+        config, [Fp(value=P - 2)] * config.MH_HASH_LENGTH_FIELD_ELEMENTS
+    )
+    assert decoded_digits is not None
+    assert len(decoded_digits) == config.DIMENSION
+    assert all(0 <= digit < config.BASE for digit in decoded_digits)
 
 
 def test_aborting_decode_rejects_threshold_element() -> None:
@@ -90,13 +92,13 @@ def test_message_hash_yields_valid_codeword() -> None:
     parameter = Parameter(data=random_field_elements(config.PARAMETER_LENGTH))
     randomness = Randomness(data=random_field_elements(config.RAND_LENGTH_FIELD_ELEMENTS))
 
-    result = message_hash(
+    codeword = message_hash(
         POSEIDON, config, parameter, Uint64(313), randomness, Bytes32(b"\xaa" * 32)
     )
 
-    assert result is not None
-    assert len(result) == config.DIMENSION
-    assert all(0 <= digit < config.BASE for digit in result)
+    assert codeword is not None
+    assert len(codeword) == config.DIMENSION
+    assert all(0 <= digit < config.BASE for digit in codeword)
 
 
 def test_target_sum_encode_accepts_codeword_on_target_layer() -> None:

--- a/tests/lean_spec/spec/crypto/xmss/test_field.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_field.py
@@ -16,7 +16,7 @@ from lean_spec.spec.crypto.xmss.types import HashDigestVector, Parameter
 
 
 @pytest.mark.parametrize(
-    "value, num_limbs, expected_values",
+    "integer_value, num_limbs, expected_limbs",
     [
         pytest.param(0, 4, [0, 0, 0, 0], id="zero spreads to all-zero limbs"),
         pytest.param(123, 4, [123, 0, 0, 0], id="small value in the lowest limb"),
@@ -27,10 +27,10 @@ from lean_spec.spec.crypto.xmss.types import HashDigestVector, Parameter
     ],
 )
 def test_int_to_base_p_known_decomposition(
-    value: int, num_limbs: int, expected_values: list[int]
+    integer_value: int, num_limbs: int, expected_limbs: list[int]
 ) -> None:
     """Decomposition matches hand-computed base-P limbs."""
-    assert int_to_base_p(value, num_limbs) == [Fp(value=v) for v in expected_values]
+    assert int_to_base_p(integer_value, num_limbs) == [Fp(value=limb) for limb in expected_limbs]
 
 
 def test_int_to_base_p_zero_limbs_returns_empty() -> None:
@@ -47,7 +47,7 @@ def test_int_to_base_p_roundtrip_is_reversible() -> None:
     """Decomposing then recomposing recovers the original integer."""
     num_limbs = 5
     original_limbs = [secrets.randbelow(P) for _ in range(num_limbs)]
-    original_value = sum(value * (P**i) for i, value in enumerate(original_limbs))
+    original_value = sum(limb * (P**i) for i, limb in enumerate(original_limbs))
 
     decomposed = [int(fp) for fp in int_to_base_p(original_value, num_limbs)]
 

--- a/tests/lean_spec/spec/crypto/xmss/test_interface.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_interface.py
@@ -28,8 +28,8 @@ def _test_correctness_roundtrip(
     # KEY GENERATION
     #
     # Generate a new key pair for the specified active range.
-    kp = scheme.key_gen(Slot(activation_slot), Uint64(num_active_slots))
-    public_key, secret_key = kp.public_key, kp.secret_key
+    key_pair = scheme.key_gen(Slot(activation_slot), Uint64(num_active_slots))
+    public_key, secret_key = key_pair.public_key, key_pair.secret_key
 
     # SIGN & VERIFY
     #
@@ -299,8 +299,8 @@ class TestVerifySecurityBounds:
         scheme = TEST_SIGNATURE_SCHEME
 
         # Generate valid keys.
-        kp = scheme.key_gen(Slot(0), Uint64(int(scheme.config.LIFETIME)))
-        public_key, secret_key = kp.public_key, kp.secret_key
+        key_pair = scheme.key_gen(Slot(0), Uint64(int(scheme.config.LIFETIME)))
+        public_key, secret_key = key_pair.public_key, key_pair.secret_key
 
         # Sign a valid message at a valid epoch.
         valid_epoch = Slot(4)
@@ -311,14 +311,14 @@ class TestVerifySecurityBounds:
         invalid_epoch = Slot(int(scheme.config.LIFETIME) + 1)
 
         # Must return False, not raise.
-        result = scheme.verify(public_key, invalid_epoch, message, signature)
-        assert result is False
+        verification_passed = scheme.verify(public_key, invalid_epoch, message, signature)
+        assert verification_passed is False
 
     def test_rejects_very_large_slot(self) -> None:
         """verify returns False for absurdly large slot values."""
         scheme = TEST_SIGNATURE_SCHEME
-        kp = scheme.key_gen(Slot(0), Uint64(int(scheme.config.LIFETIME)))
-        public_key, secret_key = kp.public_key, kp.secret_key
+        key_pair = scheme.key_gen(Slot(0), Uint64(int(scheme.config.LIFETIME)))
+        public_key, secret_key = key_pair.public_key, key_pair.secret_key
 
         valid_epoch = Slot(4)
         message = Bytes32(b"\x42" * 32)
@@ -328,5 +328,5 @@ class TestVerifySecurityBounds:
         huge_epoch = Slot(2**32)
 
         # Must return False, not raise.
-        result = scheme.verify(public_key, huge_epoch, message, signature)
-        assert result is False
+        is_valid = scheme.verify(public_key, huge_epoch, message, signature)
+        assert is_valid is False

--- a/tests/lean_spec/spec/crypto/xmss/test_merkle.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_merkle.py
@@ -379,7 +379,7 @@ def test_verify_path_accepts_boundary_position_without_raising() -> None:
     """The maximum valid position for the depth does not trip the bounds guard."""
     siblings = [random_domain(PROD_CONFIG) for _ in range(4)]
     opening = HashTreeOpening(siblings=HashDigestList(data=siblings))
-    result = verify_path(
+    verification_result = verify_path(
         poseidon=POSEIDON,
         config=PROD_CONFIG,
         parameter=random_parameter(PROD_CONFIG),
@@ -388,4 +388,4 @@ def test_verify_path_accepts_boundary_position_without_raising() -> None:
         leaf_parts=[random_domain(PROD_CONFIG)],
         opening=opening,
     )
-    assert isinstance(result, bool)
+    assert isinstance(verification_result, bool)

--- a/tests/lean_spec/spec/crypto/xmss/test_poseidon.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_poseidon.py
@@ -36,21 +36,21 @@ def test_get_engine_rejects_unsupported_width(width: int) -> None:
 @pytest.mark.parametrize("width", [16, 24])
 def test_compress_returns_requested_output_length(width: int) -> None:
     """Compression returns exactly the requested number of output elements."""
-    result = POSEIDON.compress([Fp(value=i) for i in range(8)], width, 8)
-    assert len(result) == 8
+    compressed = POSEIDON.compress([Fp(value=i) for i in range(8)], width, 8)
+    assert len(compressed) == 8
 
 
 def test_compress_truncates_to_short_output() -> None:
     """A short output length yields a truncated digest."""
-    result = POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 1)
-    assert len(result) == 1
+    compressed = POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 1)
+    assert len(compressed) == 1
 
 
 def test_compress_is_deterministic() -> None:
     """The same input compresses to the same output."""
-    a = POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 8)
-    b = POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 8)
-    assert a == b
+    first_compression = POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 8)
+    second_compression = POSEIDON.compress([Fp(value=i) for i in range(8)], 16, 8)
+    assert first_compression == second_compression
 
 
 def test_compress_rejects_output_longer_than_input() -> None:
@@ -90,34 +90,34 @@ def test_sponge_rejects_capacity_not_smaller_than_width() -> None:
 
 def test_tweak_hash_chain_uses_width_sixteen_compression() -> None:
     """A single digest input hashes through width-sixteen compression."""
-    result = POSEIDON.tweak_hash(
+    hashed_digest = POSEIDON.tweak_hash(
         TEST_CONFIG,
         _parameter(),
         ChainTweak(epoch=Uint64(0), chain_index=1, step=1),
         [random_domain(TEST_CONFIG)],
     )
-    assert isinstance(result, HashDigestVector)
-    assert len(result.data) == TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS
+    assert isinstance(hashed_digest, HashDigestVector)
+    assert len(hashed_digest.data) == TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS
 
 
 def test_tweak_hash_node_uses_width_twenty_four_compression() -> None:
     """Two digest inputs hash through width-twenty-four compression."""
-    result = POSEIDON.tweak_hash(
+    hashed_digest = POSEIDON.tweak_hash(
         TEST_CONFIG,
         _parameter(),
         TreeTweak(level=1, index=Uint64(0)),
         [random_domain(TEST_CONFIG), random_domain(TEST_CONFIG)],
     )
-    assert len(result.data) == TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS
+    assert len(hashed_digest.data) == TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS
 
 
 def test_tweak_hash_leaf_uses_sponge_mode() -> None:
     """More than two digest inputs hash through sponge mode."""
-    parts = [random_domain(TEST_CONFIG) for _ in range(TEST_CONFIG.DIMENSION)]
-    result = POSEIDON.tweak_hash(
-        TEST_CONFIG, _parameter(), TreeTweak(level=0, index=Uint64(0)), parts
+    leaf_digests = [random_domain(TEST_CONFIG) for _ in range(TEST_CONFIG.DIMENSION)]
+    hashed_digest = POSEIDON.tweak_hash(
+        TEST_CONFIG, _parameter(), TreeTweak(level=0, index=Uint64(0)), leaf_digests
     )
-    assert len(result.data) == TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS
+    assert len(hashed_digest.data) == TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS
 
 
 def test_tweak_hash_chain_and_tree_tweaks_are_domain_separated() -> None:
@@ -135,48 +135,48 @@ def test_tweak_hash_chain_and_tree_tweaks_are_domain_separated() -> None:
 
 def test_hash_chain_zero_steps_returns_start_digest() -> None:
     """Walking zero steps returns the starting digest unchanged."""
-    start = random_domain(TEST_CONFIG)
-    result = POSEIDON.hash_chain(
+    start_digest = random_domain(TEST_CONFIG)
+    walked_digest = POSEIDON.hash_chain(
         config=TEST_CONFIG,
         parameter=_parameter(),
         epoch=Uint64(0),
         chain_index=0,
         start_step=0,
         num_steps=0,
-        start_digest=start,
+        start_digest=start_digest,
     )
-    assert result == start
+    assert walked_digest == start_digest
 
 
 def test_hash_chain_is_composable() -> None:
     """Walking two steps equals walking one step then one more."""
     parameter = _parameter()
-    start = random_domain(TEST_CONFIG)
-    two = POSEIDON.hash_chain(
+    start_digest = random_domain(TEST_CONFIG)
+    walked_two_steps = POSEIDON.hash_chain(
         config=TEST_CONFIG,
         parameter=parameter,
         epoch=Uint64(0),
         chain_index=0,
         start_step=0,
         num_steps=2,
-        start_digest=start,
+        start_digest=start_digest,
     )
-    one = POSEIDON.hash_chain(
+    walked_one_step = POSEIDON.hash_chain(
         config=TEST_CONFIG,
         parameter=parameter,
         epoch=Uint64(0),
         chain_index=0,
         start_step=0,
         num_steps=1,
-        start_digest=start,
+        start_digest=start_digest,
     )
-    one_more = POSEIDON.hash_chain(
+    walked_one_more_step = POSEIDON.hash_chain(
         config=TEST_CONFIG,
         parameter=parameter,
         epoch=Uint64(0),
         chain_index=0,
         start_step=1,
         num_steps=1,
-        start_digest=one,
+        start_digest=walked_one_step,
     )
-    assert two == one_more
+    assert walked_two_steps == walked_one_more_step

--- a/tests/lean_spec/spec/crypto/xmss/test_types.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_types.py
@@ -41,8 +41,8 @@ def test_hash_digest_vector_length_is_digest_length() -> None:
 
 def test_hash_digest_vector_accepts_exact_length() -> None:
     """A digest vector of the configured length validates."""
-    data = [Fp(value=i) for i in range(TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS)]
-    assert HashDigestVector(data=data).data == tuple(data)
+    digest_elements = [Fp(value=i) for i in range(TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS)]
+    assert HashDigestVector(data=digest_elements).data == tuple(digest_elements)
 
 
 def test_hash_digest_vector_rejects_wrong_length() -> None:

--- a/tests/lean_spec/spec/forks/lstar/containers/test_aggregation.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_aggregation.py
@@ -317,28 +317,30 @@ def test_multi_message_aggregate_split_by_message_rejected_under_test_prover(
         attestation_args_a[3],
     )
 
-    vids_a = [ValidatorIndex(0), ValidatorIndex(1)]
-    vids_b = [ValidatorIndex(2), ValidatorIndex(3)]
-    part_a = _sign_and_aggregate(key_manager, vids_a, attestation_args_a)
-    part_b = _sign_and_aggregate(key_manager, vids_b, attestation_args_b)
+    validator_indices_a = [ValidatorIndex(0), ValidatorIndex(1)]
+    validator_indices_b = [ValidatorIndex(2), ValidatorIndex(3)]
+    aggregate_a = _sign_and_aggregate(key_manager, validator_indices_a, attestation_args_a)
+    aggregate_b = _sign_and_aggregate(key_manager, validator_indices_b, attestation_args_b)
 
     public_keys_a = [
-        key_manager[validator_index].attestation_keypair.public_key for validator_index in vids_a
+        key_manager[validator_index].attestation_keypair.public_key
+        for validator_index in validator_indices_a
     ]
     public_keys_b = [
-        key_manager[validator_index].attestation_keypair.public_key for validator_index in vids_b
+        key_manager[validator_index].attestation_keypair.public_key
+        for validator_index in validator_indices_b
     ]
 
     merged = MultiMessageAggregate.aggregate(
-        parts=[part_a, part_b],
-        public_keys_per_part=[public_keys_a, public_keys_b],
+        single_message_aggregates=[aggregate_a, aggregate_b],
+        public_keys_per_aggregate=[public_keys_a, public_keys_b],
     )
 
     with pytest.raises(AggregationError, match="multi-message aggregate split failed"):
         merged.split_by_message(
             message=hash_tree_root(attestation_data_a),
             public_keys_per_message=[public_keys_a, public_keys_b],
-            participants=part_a.participants,
+            participants=aggregate_a.participants,
         )
 
 
@@ -441,7 +443,7 @@ def test_aggregate_child_signed_different_message_fails(key_manager: XmssKeyMana
 def test_multi_message_aggregate_rejects_empty_parts() -> None:
     """multi-message aggregate aggregation requires at least one single-message aggregate input."""
     with pytest.raises(AggregationError, match="at least one single-message aggregate input"):
-        MultiMessageAggregate.aggregate(parts=[], public_keys_per_part=[])
+        MultiMessageAggregate.aggregate(single_message_aggregates=[], public_keys_per_aggregate=[])
 
 
 def test_multi_message_aggregate_rejects_mismatched_public_key_layout(
@@ -451,7 +453,7 @@ def test_multi_message_aggregate_rejects_mismatched_public_key_layout(
     source = Checkpoint(root=make_bytes32(200), slot=Slot(0))
     attestation_args = (Slot(7), 201, 202, source)
 
-    part = _sign_and_aggregate(
+    single_message_aggregate = _sign_and_aggregate(
         key_manager,
         [ValidatorIndex(0), ValidatorIndex(1)],
         attestation_args,
@@ -461,8 +463,8 @@ def test_multi_message_aggregate_rejects_mismatched_public_key_layout(
 
     with pytest.raises(AggregationError, match="expected 2 pubkeys, got 1"):
         MultiMessageAggregate.aggregate(
-            parts=[part],
-            public_keys_per_part=wrong_layout,
+            single_message_aggregates=[single_message_aggregate],
+            public_keys_per_aggregate=wrong_layout,
         )
 
 
@@ -472,22 +474,24 @@ def test_multi_message_aggregate_propagates_prover_error(key_manager: XmssKeyMan
     attestation_args = (Slot(8), 211, 212, source)
     validator_indices = [ValidatorIndex(0), ValidatorIndex(1)]
 
-    part = _sign_and_aggregate(key_manager, validator_indices, attestation_args)
+    single_message_aggregate = _sign_and_aggregate(key_manager, validator_indices, attestation_args)
     public_keys = [
         key_manager[validator_index].attestation_keypair.public_key
         for validator_index in validator_indices
     ]
 
-    corrupted_bytes = bytearray(part.proof.data)
+    corrupted_bytes = bytearray(single_message_aggregate.proof.data)
     corrupted_bytes[10] ^= 0xFF
     corrupted_bytes[20] ^= 0xFF
-    part = SingleMessageAggregate(
-        participants=part.participants,
+    corrupted_aggregate = SingleMessageAggregate(
+        participants=single_message_aggregate.participants,
         proof=ByteList512KiB(data=bytes(corrupted_bytes)),
     )
 
     with pytest.raises(AggregationError, match="merge_many_type_1 failed"):
-        MultiMessageAggregate.aggregate(parts=[part], public_keys_per_part=[public_keys])
+        MultiMessageAggregate.aggregate(
+            single_message_aggregates=[corrupted_aggregate], public_keys_per_aggregate=[public_keys]
+        )
 
 
 def test_multi_message_aggregate_verify_round_trip(key_manager: XmssKeyManager) -> None:
@@ -510,21 +514,23 @@ def test_multi_message_aggregate_verify_round_trip(key_manager: XmssKeyManager) 
         attestation_args_b[3],
     )
 
-    vids_a = [ValidatorIndex(0), ValidatorIndex(1)]
-    vids_b = [ValidatorIndex(2), ValidatorIndex(3)]
-    part_a = _sign_and_aggregate(key_manager, vids_a, attestation_args_a)
-    part_b = _sign_and_aggregate(key_manager, vids_b, attestation_args_b)
+    validator_indices_a = [ValidatorIndex(0), ValidatorIndex(1)]
+    validator_indices_b = [ValidatorIndex(2), ValidatorIndex(3)]
+    aggregate_a = _sign_and_aggregate(key_manager, validator_indices_a, attestation_args_a)
+    aggregate_b = _sign_and_aggregate(key_manager, validator_indices_b, attestation_args_b)
 
     public_keys_a = [
-        key_manager[validator_index].attestation_keypair.public_key for validator_index in vids_a
+        key_manager[validator_index].attestation_keypair.public_key
+        for validator_index in validator_indices_a
     ]
     public_keys_b = [
-        key_manager[validator_index].attestation_keypair.public_key for validator_index in vids_b
+        key_manager[validator_index].attestation_keypair.public_key
+        for validator_index in validator_indices_b
     ]
 
     merged = MultiMessageAggregate.aggregate(
-        parts=[part_a, part_b],
-        public_keys_per_part=[public_keys_a, public_keys_b],
+        single_message_aggregates=[aggregate_a, aggregate_b],
+        public_keys_per_aggregate=[public_keys_a, public_keys_b],
     )
 
     merged.verify(
@@ -560,24 +566,26 @@ def test_multi_message_aggregate_verify_rejects_message_swap(key_manager: XmssKe
         attestation_args_b[3],
     )
 
-    vids_a = [ValidatorIndex(0), ValidatorIndex(1)]
-    vids_b = [ValidatorIndex(2), ValidatorIndex(3)]
-    part_a = _sign_and_aggregate(key_manager, vids_a, attestation_args_a)
-    part_b = _sign_and_aggregate(key_manager, vids_b, attestation_args_b)
+    validator_indices_a = [ValidatorIndex(0), ValidatorIndex(1)]
+    validator_indices_b = [ValidatorIndex(2), ValidatorIndex(3)]
+    aggregate_a = _sign_and_aggregate(key_manager, validator_indices_a, attestation_args_a)
+    aggregate_b = _sign_and_aggregate(key_manager, validator_indices_b, attestation_args_b)
 
     public_keys_a = [
-        key_manager[validator_index].attestation_keypair.public_key for validator_index in vids_a
+        key_manager[validator_index].attestation_keypair.public_key
+        for validator_index in validator_indices_a
     ]
     public_keys_b = [
-        key_manager[validator_index].attestation_keypair.public_key for validator_index in vids_b
+        key_manager[validator_index].attestation_keypair.public_key
+        for validator_index in validator_indices_b
     ]
 
     merged = MultiMessageAggregate.aggregate(
-        parts=[part_a, part_b],
-        public_keys_per_part=[public_keys_a, public_keys_b],
+        single_message_aggregates=[aggregate_a, aggregate_b],
+        public_keys_per_aggregate=[public_keys_a, public_keys_b],
     )
 
-    # Swap the parallel messages: part_a's public_keys are now paired with part_b's
+    # Swap the parallel messages: aggregate_a's public_keys are now paired with aggregate_b's
     # message and vice versa.
     with pytest.raises(AggregationError, match="verification failed"):
         merged.verify(
@@ -597,15 +605,15 @@ def test_multi_message_aggregate_verify_rejects_mismatched_messages_length(
     attestation_args = (Slot(10), 501, 502, source)
 
     validator_indices = [ValidatorIndex(0), ValidatorIndex(1)]
-    part = _sign_and_aggregate(key_manager, validator_indices, attestation_args)
+    single_message_aggregate = _sign_and_aggregate(key_manager, validator_indices, attestation_args)
     public_keys = [
         key_manager[validator_index].attestation_keypair.public_key
         for validator_index in validator_indices
     ]
 
     merged = MultiMessageAggregate.aggregate(
-        parts=[part],
-        public_keys_per_part=[public_keys],
+        single_message_aggregates=[single_message_aggregate],
+        public_keys_per_aggregate=[public_keys],
     )
 
     with pytest.raises(AggregationError, match="expected 1 message bindings, got 0"):

--- a/tests/lean_spec/spec/forks/lstar/containers/test_checkpoint.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_checkpoint.py
@@ -183,31 +183,31 @@ class TestCheckpointAdvanceTo:
         self, current_slot: int, candidate_slot: int, winner: str
     ) -> None:
         """The candidate replaces the receiver only when its slot is strictly greater."""
-        current = Checkpoint(root=Bytes32(b"\xa0" * 32), slot=Slot(current_slot))
+        receiver_checkpoint = Checkpoint(root=Bytes32(b"\xa0" * 32), slot=Slot(current_slot))
         candidate = Checkpoint(root=Bytes32(b"\xb0" * 32), slot=Slot(candidate_slot))
-        expected = candidate if winner == "candidate" else current
-        assert current.advance_to(candidate) == expected
+        expected_winner = candidate if winner == "candidate" else receiver_checkpoint
+        assert receiver_checkpoint.advance_to(candidate) == expected_winner
 
     def test_tie_is_symmetric_to_the_caller(self) -> None:
         """On a slot tie the receiver of the call wins, swapping callers swaps the result."""
-        cp_a = Checkpoint(root=Bytes32(b"\xa0" * 32), slot=Slot(7))
-        cp_b = Checkpoint(root=Bytes32(b"\xb0" * 32), slot=Slot(7))
-        assert cp_a.advance_to(cp_b) == cp_a
-        assert cp_b.advance_to(cp_a) == cp_b
+        checkpoint_a = Checkpoint(root=Bytes32(b"\xa0" * 32), slot=Slot(7))
+        checkpoint_b = Checkpoint(root=Bytes32(b"\xb0" * 32), slot=Slot(7))
+        assert checkpoint_a.advance_to(checkpoint_b) == checkpoint_a
+        assert checkpoint_b.advance_to(checkpoint_a) == checkpoint_b
 
     def test_self_advance_returns_receiver(self) -> None:
         """Advancing a checkpoint against itself returns the receiver unchanged."""
-        cp = Checkpoint(root=Bytes32(b"\xa0" * 32), slot=Slot(2))
-        assert cp.advance_to(cp) == cp
+        checkpoint = Checkpoint(root=Bytes32(b"\xa0" * 32), slot=Slot(2))
+        assert checkpoint.advance_to(checkpoint) == checkpoint
 
     def test_zero_slot_receiver_yields_to_any_higher_candidate(self) -> None:
         """A genesis-slot checkpoint is replaced by any candidate at a higher slot."""
-        current = Checkpoint(root=Bytes32(b"\xa0" * 32), slot=Slot(0))
+        receiver_checkpoint = Checkpoint(root=Bytes32(b"\xa0" * 32), slot=Slot(0))
         candidate = Checkpoint(root=Bytes32(b"\xb0" * 32), slot=Slot(1))
-        assert current.advance_to(candidate) == candidate
+        assert receiver_checkpoint.advance_to(candidate) == candidate
 
     def test_max_slot_receiver_never_yields(self) -> None:
         """A checkpoint pinned at the uint64 maximum can never be advanced further."""
-        current = Checkpoint(root=Bytes32(b"\xa0" * 32), slot=Slot(2**64 - 1))
+        receiver_checkpoint = Checkpoint(root=Bytes32(b"\xa0" * 32), slot=Slot(2**64 - 1))
         candidate = Checkpoint(root=Bytes32(b"\xb0" * 32), slot=Slot(2**64 - 2))
-        assert current.advance_to(candidate) == current
+        assert receiver_checkpoint.advance_to(candidate) == receiver_checkpoint

--- a/tests/lean_spec/spec/forks/lstar/containers/test_identifiers.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_identifiers.py
@@ -40,7 +40,7 @@ class TestProposerForSlot:
     """Round-robin proposer selection by slot modulo the registry size."""
 
     @pytest.mark.parametrize(
-        ("slot", "num_validators", "expected"),
+        ("slot", "num_validators", "expected_proposer_index"),
         [
             # In-range slot, no wrap past the registry size.
             (0, 10, 0),
@@ -58,16 +58,18 @@ class TestProposerForSlot:
             (12_345, 1_000, 345),
         ],
     )
-    def test_round_robin_assignment(self, slot: int, num_validators: int, expected: int) -> None:
+    def test_round_robin_assignment(
+        self, slot: int, num_validators: int, expected_proposer_index: int
+    ) -> None:
         """The proposer for a given slot is the slot modulo the registry size."""
         assert ValidatorIndex.proposer_for_slot(
             Slot(slot), Uint64(num_validators)
-        ) == ValidatorIndex(expected)
+        ) == ValidatorIndex(expected_proposer_index)
 
     def test_return_type_is_validator_index(self) -> None:
         """The classmethod returns a strict ValidatorIndex, not a plain int."""
-        result = ValidatorIndex.proposer_for_slot(Slot(5), Uint64(7))
-        assert isinstance(result, ValidatorIndex)
+        proposer_index = ValidatorIndex.proposer_for_slot(Slot(5), Uint64(7))
+        assert isinstance(proposer_index, ValidatorIndex)
 
 
 class TestIsWithinRegistry:
@@ -100,7 +102,7 @@ class TestComputeSubnetId:
     """Subnet assignment by validator index modulo committee count."""
 
     @pytest.mark.parametrize(
-        ("validator_index", "num_committees", "expected"),
+        ("validator_index", "num_committees", "expected_subnet_id"),
         [
             # No wrap: validator index already inside the committee range.
             (0, 8, 0),
@@ -119,14 +121,14 @@ class TestComputeSubnetId:
         ],
     )
     def test_modulo_committee_count(
-        self, validator_index: int, num_committees: int, expected: int
+        self, validator_index: int, num_committees: int, expected_subnet_id: int
     ) -> None:
         """The subnet for a validator is its index modulo the committee count."""
         assert ValidatorIndex(validator_index).compute_subnet_id(
             Uint64(num_committees)
-        ) == SubnetId(expected)
+        ) == SubnetId(expected_subnet_id)
 
     def test_return_type_is_subnet_id(self) -> None:
         """The method returns a strict SubnetId, not a plain Uint64 or int."""
-        result = ValidatorIndex(5).compute_subnet_id(Uint64(64))
-        assert isinstance(result, SubnetId)
+        subnet_id = ValidatorIndex(5).compute_subnet_id(Uint64(64))
+        assert isinstance(subnet_id, SubnetId)

--- a/tests/lean_spec/spec/forks/lstar/containers/test_participation.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_participation.py
@@ -40,8 +40,8 @@ class TestAggregationBitsToValidatorIndices:
 
     def test_single_bit_set_at_last_valid_position(self) -> None:
         """Bitlist of length LIMIT with only the final bit set yields index LIMIT - 1."""
-        data = [Boolean(False)] * (int(VALIDATOR_REGISTRY_LIMIT) - 1) + [Boolean(True)]
-        bits = AggregationBits(data=data)
+        bit_flags = [Boolean(False)] * (int(VALIDATOR_REGISTRY_LIMIT) - 1) + [Boolean(True)]
+        bits = AggregationBits(data=bit_flags)
         assert bits.to_validator_indices() == ValidatorIndices(
             data=[ValidatorIndex(int(VALIDATOR_REGISTRY_LIMIT) - 1)]
         )
@@ -49,10 +49,10 @@ class TestAggregationBitsToValidatorIndices:
     def test_all_bits_set_at_full_limit(self) -> None:
         """All LIMIT bits set yields every validator index from 0 to LIMIT - 1 inclusive."""
         bits = AggregationBits(data=[Boolean(True)] * int(VALIDATOR_REGISTRY_LIMIT))
-        expected = ValidatorIndices(
+        expected_indices = ValidatorIndices(
             data=[ValidatorIndex(i) for i in range(int(VALIDATOR_REGISTRY_LIMIT))]
         )
-        assert bits.to_validator_indices() == expected
+        assert bits.to_validator_indices() == expected_indices
 
     def test_multiple_bits_set_ascending(self) -> None:
         """Multiple bits set yield indices in ascending order."""
@@ -65,29 +65,29 @@ class TestAggregationBitsToValidatorIndices:
 
     def test_two_bits_set_at_extremes(self) -> None:
         """Bits at positions 0 and LIMIT - 1 produce the two extreme indices in order."""
-        data = (
+        bit_values = (
             [Boolean(True)]
             + [Boolean(False)] * (int(VALIDATOR_REGISTRY_LIMIT) - 2)
             + [Boolean(True)]
         )
-        bits = AggregationBits(data=data)
+        bits = AggregationBits(data=bit_values)
         assert bits.to_validator_indices() == ValidatorIndices(
             data=[ValidatorIndex(0), ValidatorIndex(int(VALIDATOR_REGISTRY_LIMIT) - 1)]
         )
 
     def test_alternating_even_positions(self) -> None:
         """Bits true at every even position from 0 to 10 yield exactly those indices."""
-        data = [Boolean(i % 2 == 0) for i in range(11)]
-        bits = AggregationBits(data=data)
+        bit_values = [Boolean(i % 2 == 0) for i in range(11)]
+        bits = AggregationBits(data=bit_values)
         assert bits.to_validator_indices() == ValidatorIndices(
             data=[ValidatorIndex(i) for i in (0, 2, 4, 6, 8, 10)]
         )
 
     def test_trailing_false_bits_are_ignored(self) -> None:
         """Trailing false bits after the last set bit do not influence the index list."""
-        data = [Boolean(False)] * 10
-        data[2] = Boolean(True)
-        bits = AggregationBits(data=data)
+        bit_values = [Boolean(False)] * 10
+        bit_values[2] = Boolean(True)
+        bits = AggregationBits(data=bit_values)
         assert bits.to_validator_indices() == ValidatorIndices(data=[ValidatorIndex(2)])
 
 

--- a/tests/lean_spec/spec/forks/lstar/test_aggregation.py
+++ b/tests/lean_spec/spec/forks/lstar/test_aggregation.py
@@ -47,20 +47,20 @@ class TestSelectProofsForCoverage:
         wide = _proof([1, 2, 3], b"\xaa")
         narrow = _proof([4], b"\xbb")
 
-        selected, covered = select_proofs_for_coverage({wide, narrow})
+        selected_proofs, covered_validators = select_proofs_for_coverage({wide, narrow})
 
-        assert selected == [wide, narrow]
-        assert covered == {ValidatorIndex(i) for i in (1, 2, 3, 4)}
+        assert selected_proofs == [wide, narrow]
+        assert covered_validators == {ValidatorIndex(i) for i in (1, 2, 3, 4)}
 
     def test_stops_when_remaining_proof_adds_no_new_validator(self) -> None:
         """A proof whose validators are already covered is never selected."""
         full = _proof([1, 2, 3], b"\xaa")
         subset = _proof([1, 2], b"\xbb")
 
-        selected, covered = select_proofs_for_coverage({full, subset})
+        selected_proofs, covered_validators = select_proofs_for_coverage({full, subset})
 
-        assert selected == [full]
-        assert covered == {ValidatorIndex(i) for i in (1, 2, 3)}
+        assert selected_proofs == [full]
+        assert covered_validators == {ValidatorIndex(i) for i in (1, 2, 3)}
 
     def test_partial_overlap_picks_by_marginal_coverage(self) -> None:
         """Greedy scores by new coverage, then takes the next proof for its remainder."""
@@ -68,30 +68,32 @@ class TestSelectProofsForCoverage:
         first = _proof([1, 2, 3], b"\xaa")
         overlapping = _proof([3, 4], b"\xbb")
 
-        selected, covered = select_proofs_for_coverage({first, overlapping})
+        selected_proofs, covered_validators = select_proofs_for_coverage({first, overlapping})
 
-        assert selected == [first, overlapping]
-        assert covered == {ValidatorIndex(i) for i in (1, 2, 3, 4)}
+        assert selected_proofs == [first, overlapping]
+        assert covered_validators == {ValidatorIndex(i) for i in (1, 2, 3, 4)}
 
     def test_priority_pool_is_consumed_before_fallback(self) -> None:
         """A priority proof is chosen first even when a fallback proof covers more."""
         priority = _proof([1, 2], b"\xaa")
         fallback = _proof([1, 2, 3, 4, 5], b"\xbb")
 
-        selected, covered = select_proofs_for_coverage({priority}, {fallback})
+        selected_proofs, covered_validators = select_proofs_for_coverage({priority}, {fallback})
 
-        assert selected == [priority, fallback]
-        assert covered == {ValidatorIndex(i) for i in (1, 2, 3, 4, 5)}
+        assert selected_proofs == [priority, fallback]
+        assert covered_validators == {ValidatorIndex(i) for i in (1, 2, 3, 4, 5)}
 
     def test_fallback_proof_already_covered_by_priority_is_skipped(self) -> None:
         """A fallback proof adds nothing when priority already covers its validators."""
         priority = _proof([1, 2, 3], b"\xaa")
         redundant_fallback = _proof([1, 2], b"\xbb")
 
-        selected, covered = select_proofs_for_coverage({priority}, {redundant_fallback})
+        selected_proofs, covered_validators = select_proofs_for_coverage(
+            {priority}, {redundant_fallback}
+        )
 
-        assert selected == [priority]
-        assert covered == {ValidatorIndex(i) for i in (1, 2, 3)}
+        assert selected_proofs == [priority]
+        assert covered_validators == {ValidatorIndex(i) for i in (1, 2, 3)}
 
     def test_exhausting_priority_pool_early_still_processes_fallback(self) -> None:
         """Stopping one pool early still lets the next pool contribute."""
@@ -101,10 +103,10 @@ class TestSelectProofsForCoverage:
         subset = _proof([1, 2], b"\xbb")
         fallback = _proof([4], b"\xcc")
 
-        selected, covered = select_proofs_for_coverage({full, subset}, {fallback})
+        selected_proofs, covered_validators = select_proofs_for_coverage({full, subset}, {fallback})
 
-        assert selected == [full, fallback]
-        assert covered == {ValidatorIndex(i) for i in (1, 2, 3, 4)}
+        assert selected_proofs == [full, fallback]
+        assert covered_validators == {ValidatorIndex(i) for i in (1, 2, 3, 4)}
 
     def test_none_and_empty_pools_are_skipped(self) -> None:
         """None or empty pools contribute nothing and select nothing."""
@@ -123,10 +125,10 @@ class TestSelectProofsForCoverage:
         # If this ever flips, the assertion below is meaningless, so pin it.
         assert larger.encode_bytes() > smaller.encode_bytes()
 
-        selected, covered = select_proofs_for_coverage({smaller, larger})
+        selected_proofs, covered_validators = select_proofs_for_coverage({smaller, larger})
 
-        assert selected == [larger]
-        assert covered == {ValidatorIndex(1)}
+        assert selected_proofs == [larger]
+        assert covered_validators == {ValidatorIndex(1)}
 
 
 class TestAggregateCommitteeSignatures:
@@ -440,7 +442,7 @@ class TestEndToEndAggregationFlow:
 
         # Verify signatures were stored
         signatures = store.attestation_signatures.get(attestation_data, set())
-        stored_validators = {entry.validator_index for entry in signatures}
+        stored_validators = {stored_signature.validator_index for stored_signature in signatures}
         for validator_index in attesting_validators:
             assert validator_index in stored_validators, (
                 f"Signature for {validator_index} should be stored"
@@ -491,10 +493,10 @@ def test_aggregated_signatures_prefers_full_gossip_payload(
     }
 
     store.attestation_signatures = attestation_signatures
-    _, results = spec.aggregate(store)
+    _, aggregated_attestations = spec.aggregate(store)
 
-    assert len(results) == 1
-    assert set(results[0].proof.participants.to_validator_indices()) == {
+    assert len(aggregated_attestations) == 1
+    assert set(aggregated_attestations[0].proof.participants.to_validator_indices()) == {
         ValidatorIndex(0),
         ValidatorIndex(1),
     }
@@ -502,7 +504,7 @@ def test_aggregated_signatures_prefers_full_gossip_payload(
     public_keys = [
         head_state.validators[ValidatorIndex(i)].get_attestation_public_key() for i in range(2)
     ]
-    results[0].proof.verify(
+    aggregated_attestations[0].proof.verify(
         public_keys=public_keys,
         message=hash_tree_root(attestation_data),
         slot=attestation_data.slot,
@@ -515,9 +517,9 @@ def test_aggregate_with_empty_attestation_signatures(
 ) -> None:
     """Empty attestations list should return empty results."""
     store = make_store(num_validators=2, key_manager=container_key_manager)
-    _, results = spec.aggregate(store)
+    _, aggregated_attestations = spec.aggregate(store)
 
-    assert results == []
+    assert aggregated_attestations == []
 
 
 def test_aggregated_signatures_with_multiple_data_groups(
@@ -558,11 +560,11 @@ def test_aggregated_signatures_with_multiple_data_groups(
     }
 
     store.attestation_signatures = attestation_signatures
-    _, results = spec.aggregate(store)
+    _, aggregated_attestations = spec.aggregate(store)
 
-    assert len(results) == 2
+    assert len(aggregated_attestations) == 2
 
-    for signed_attestation in results:
+    for signed_attestation in aggregated_attestations:
         participants = signed_attestation.proof.participants.to_validator_indices()
         public_keys = [
             container_key_manager[validator_index].attestation_keypair.public_key
@@ -585,6 +587,6 @@ def test_aggregate_with_no_signatures(
     Returns empty results (no attestations can be aggregated without signatures).
     """
     store = make_store(num_validators=2, key_manager=container_key_manager)
-    _, results = spec.aggregate(store)
+    _, aggregated_attestations = spec.aggregate(store)
 
-    assert results == []
+    assert aggregated_attestations == []

--- a/tests/lean_spec/spec/forks/lstar/test_block_production.py
+++ b/tests/lean_spec/spec/forks/lstar/test_block_production.py
@@ -161,10 +161,10 @@ def test_build_block_keeps_genesis_self_vote(
     # A vote here therefore has source and target both at slot zero.
     # That shape is a genesis self-vote.
     anchor = Checkpoint(root=parent_root, slot=Slot(0))
-    data = AttestationData(slot=Slot(1), head=anchor, target=anchor, source=anchor)
+    attestation_data = AttestationData(slot=Slot(1), head=anchor, target=anchor, source=anchor)
 
     # Validator zero signs the vote, giving a single-validator proof.
-    proof = make_aggregated_proof(key_manager, [ValidatorIndex(0)], data)
+    proof = make_aggregated_proof(key_manager, [ValidatorIndex(0)], attestation_data)
 
     # Build the slot-one block with this lone self-vote in the pool.
     block, post_state, attestations, proofs = spec.build_block(
@@ -173,13 +173,15 @@ def test_build_block_keeps_genesis_self_vote(
         proposer_index=ValidatorIndex(1),
         parent_root=parent_root,
         known_block_roots={parent_root},
-        aggregated_payloads={data: {proof}},
+        aggregated_payloads={attestation_data: {proof}},
     )
 
     # The lone proof is kept verbatim, so the body is one attestation over it.
     # Slot zero is already justified, so this self-vote cannot advance justification.
     # It survives selection only through the genesis self-vote exemption.
-    expected_attestation = AggregatedAttestation(aggregation_bits=proof.participants, data=data)
+    expected_attestation = AggregatedAttestation(
+        aggregation_bits=proof.participants, data=attestation_data
+    )
     expected_block = Block(
         slot=Slot(1),
         proposer_index=ValidatorIndex(1),
@@ -199,8 +201,8 @@ def test_build_block_keeps_genesis_self_vote(
     # The kept proof still verifies against the signing validator's public key.
     proofs[0].verify(
         public_keys=[key_manager[ValidatorIndex(0)].attestation_keypair.public_key],
-        message=hash_tree_root(data),
-        slot=data.slot,
+        message=hash_tree_root(attestation_data),
+        slot=attestation_data.slot,
     )
 
 
@@ -209,7 +211,7 @@ def test_build_block_merges_split_proofs_into_one_attestation(
     spec: LstarSpec,
 ) -> None:
     """
-    Two proofs for the same data collapse into one attestation over their union.
+    Two proofs for the same vote collapse into one attestation over their union.
 
     - One subset arrives as a gossip-derived proof.
     - A second disjoint subset arrives as a separate proof.
@@ -227,12 +229,14 @@ def test_build_block_merges_split_proofs_into_one_attestation(
 
     # Every vote on a fresh chain anchors at genesis at slot zero.
     anchor = Checkpoint(root=parent_root, slot=Slot(0))
-    data = AttestationData(slot=Slot(1), head=anchor, target=anchor, source=anchor)
+    attestation_data = AttestationData(slot=Slot(1), head=anchor, target=anchor, source=anchor)
 
     # The same vote arrives as two proofs over disjoint validator sets.
     # One covers validator zero; the other covers validators one and two.
-    proof_one = make_aggregated_proof(key_manager, [ValidatorIndex(0)], data)
-    proof_two = make_aggregated_proof(key_manager, [ValidatorIndex(1), ValidatorIndex(2)], data)
+    proof_one = make_aggregated_proof(key_manager, [ValidatorIndex(0)], attestation_data)
+    proof_two = make_aggregated_proof(
+        key_manager, [ValidatorIndex(1), ValidatorIndex(2)], attestation_data
+    )
 
     # Build with both proofs for the one vote in the pool.
     block, post_state, attestations, _ = spec.build_block(
@@ -241,7 +245,7 @@ def test_build_block_merges_split_proofs_into_one_attestation(
         proposer_index=ValidatorIndex(1),
         parent_root=parent_root,
         known_block_roots={parent_root},
-        aggregated_payloads={data: {proof_one, proof_two}},
+        aggregated_payloads={attestation_data: {proof_one, proof_two}},
     )
 
     # Compaction folds the two proofs into one attestation.
@@ -381,13 +385,13 @@ def test_build_block_skips_vote_with_unjustified_source(
     block_two = Checkpoint(root=block_two_root, slot=Slot(2))
 
     # The vote builds from slot one, which no body has justified yet.
-    data = AttestationData(
+    attestation_data = AttestationData(
         slot=Slot(3),
         head=block_two,
         target=block_two,
         source=Checkpoint(root=block_one_root, slot=Slot(1)),
     )
-    proof = make_aggregated_proof(key_manager, voters, data)
+    proof = make_aggregated_proof(key_manager, voters, attestation_data)
 
     # Offer the vote while building at slot three.
     block, post_state, attestations, proofs = spec.build_block(
@@ -396,7 +400,7 @@ def test_build_block_skips_vote_with_unjustified_source(
         proposer_index=ValidatorIndex(3),
         parent_root=block_two_root,
         known_block_roots={block_one_root, block_two_root},
-        aggregated_payloads={data: {proof}},
+        aggregated_payloads={attestation_data: {proof}},
     )
 
     # A vote may only build from an already-justified source.
@@ -442,13 +446,13 @@ def test_build_block_skips_vote_for_already_justified_target(
 
     # The vote targets slot one, which is already justified.
     block_one = Checkpoint(root=block_one_root, slot=Slot(1))
-    data = AttestationData(
+    attestation_data = AttestationData(
         slot=Slot(3),
         head=block_one,
         target=block_one,
         source=Checkpoint(root=genesis_root, slot=Slot(0)),
     )
-    proof = make_aggregated_proof(key_manager, voters, data)
+    proof = make_aggregated_proof(key_manager, voters, attestation_data)
 
     # Offer the redundant vote while building at slot three.
     block, post_state, attestations, proofs = spec.build_block(
@@ -457,7 +461,7 @@ def test_build_block_skips_vote_for_already_justified_target(
         proposer_index=ValidatorIndex(3),
         parent_root=block_two_root,
         known_block_roots={genesis_root, block_one_root, block_two_root},
-        aggregated_payloads={data: {proof}},
+        aggregated_payloads={attestation_data: {proof}},
     )
 
     # An already-justified target gains nothing from more votes, so it is excluded.

--- a/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
+++ b/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
@@ -582,54 +582,54 @@ class TestValidateAttestationTimeCheck:
         block_2_root = hash_tree_root(block_2)
         genesis_root = store.latest_justified.root
 
-        data = AttestationData(
+        attestation_data = AttestationData(
             slot=ATTESTATION_SLOT,
             head=Checkpoint(root=block_2_root, slot=ATTESTATION_SLOT),
             target=Checkpoint(root=block_2_root, slot=ATTESTATION_SLOT),
             source=Checkpoint(root=genesis_root, slot=Slot(0)),
         )
-        return store, data
+        return store, attestation_data
 
     def test_attestation_at_current_slot_passes(
         self, spec: LstarSpec, observer_store: Store
     ) -> None:
         """A vote at the current slot is always accepted, every interval."""
-        store, data = self._build_two_block_chain(spec, observer_store)
+        store, attestation_data = self._build_two_block_chain(spec, observer_store)
 
         # Sweep every interval in the attestation's slot.
         for offset in range(int(INTERVALS_PER_SLOT)):
             store.time = ATTESTATION_START_INTERVAL + Interval(offset)
             local = store
-            spec.validate_attestation(local, data)
+            spec.validate_attestation(local, attestation_data)
 
     def test_attestation_in_past_passes(self, spec: LstarSpec, observer_store: Store) -> None:
         """A vote from a past slot is always accepted."""
-        store, data = self._build_two_block_chain(spec, observer_store)
+        store, attestation_data = self._build_two_block_chain(spec, observer_store)
 
         # Place the local clock several slots ahead.
         far_future = ATTESTATION_START_INTERVAL + Interval(int(INTERVALS_PER_SLOT) * 10)
         store.time = far_future
-        spec.validate_attestation(store, data)
+        spec.validate_attestation(store, attestation_data)
 
     def test_attestation_at_disparity_boundary_passes(
         self, spec: LstarSpec, observer_store: Store
     ) -> None:
         """At the disparity boundary the attestation is still accepted."""
-        store, data = self._build_two_block_chain(spec, observer_store)
+        store, attestation_data = self._build_two_block_chain(spec, observer_store)
 
         store.time = DISPARITY_BOUNDARY_INTERVAL
-        spec.validate_attestation(store, data)
+        spec.validate_attestation(store, attestation_data)
 
     def test_attestation_just_beyond_disparity_boundary_rejected(
         self, spec: LstarSpec, observer_store: Store
     ) -> None:
         """One interval past the disparity boundary the attestation is rejected."""
-        store, data = self._build_two_block_chain(spec, observer_store)
+        store, attestation_data = self._build_two_block_chain(spec, observer_store)
 
         store.time = JUST_BEYOND_DISPARITY_BOUNDARY_INTERVAL
 
         with pytest.raises(AssertionError, match="Attestation too far in future"):
-            spec.validate_attestation(store, data)
+            spec.validate_attestation(store, attestation_data)
 
     def test_attestation_one_full_slot_in_future_rejected(
         self, spec: LstarSpec, observer_store: Store
@@ -641,12 +641,12 @@ class TestValidateAttestationTimeCheck:
         That window let an adversary pre-publish next-slot aggregates
         before any honest validator could produce them.
         """
-        store, data = self._build_two_block_chain(spec, observer_store)
+        store, attestation_data = self._build_two_block_chain(spec, observer_store)
 
         store.time = ONE_FULL_SLOT_BEHIND_INTERVAL
 
         with pytest.raises(AssertionError, match="Attestation too far in future"):
-            spec.validate_attestation(store, data)
+            spec.validate_attestation(store, attestation_data)
 
 
 def test_prunes_entries_with_head_at_finalized(spec: LstarSpec, pruning_store: Store) -> None:
@@ -1372,18 +1372,18 @@ class TestIntegrationScenarios:
         )
 
         head_state = store.states[store.head]
-        public_keys_per_part: list[list] = [
+        public_keys_per_aggregate: list[list] = [
             [
                 head_state.validators[validator_index].get_attestation_public_key()
                 for validator_index in proof.participants.to_validator_indices()
             ]
             for proof in signatures
         ]
-        public_keys_per_part.append([proposer_public_key])
+        public_keys_per_aggregate.append([proposer_public_key])
 
         merged = MultiMessageAggregate.aggregate(
             [*signatures, proposer_single_message_aggregate],
-            public_keys_per_part=public_keys_per_part,
+            public_keys_per_aggregate=public_keys_per_aggregate,
         )
         signed_block = SignedBlock(
             block=block,
@@ -1493,8 +1493,10 @@ def test_on_block_preserves_immutability_of_aggregated_payloads(
     )
 
     # Capture the original list lengths for keys that already exist
+    new_payloads_before = store_before_block_2.latest_new_aggregated_payloads
     original_signature_lengths = {
-        k: len(v) for k, v in store_before_block_2.latest_new_aggregated_payloads.items()
+        attestation_data: len(signatures)
+        for attestation_data, signatures in new_payloads_before.items()
     }
 
     # Process the second block
@@ -1549,9 +1551,9 @@ class TestOnGossipAttestationImportGating:
         updated_store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=True)
 
         signatures = updated_store.attestation_signatures.get(attestation_data, set())
-        assert attester_validator in {entry.validator_index for entry in signatures}, (
-            "Aggregator should store any attestation it receives"
-        )
+        assert attester_validator in {
+            stored_signature.validator_index for stored_signature in signatures
+        }, "Aggregator should store any attestation it receives"
 
     def test_aggregator_stores_multiple_attestations(
         self, key_manager: XmssKeyManager, spec: LstarSpec
@@ -1564,22 +1566,26 @@ class TestOnGossipAttestationImportGating:
             key_manager, num_validators=8, validator_index=current_validator
         )
 
-        def make_signed(v: ValidatorIndex) -> SignedAttestation:
+        def make_signed(attester: ValidatorIndex) -> SignedAttestation:
             return SignedAttestation(
-                validator_index=v,
+                validator_index=attester,
                 data=attestation_data,
-                signature=key_manager.sign_attestation_data(v, attestation_data),
+                signature=key_manager.sign_attestation_data(attester, attestation_data),
             )
 
-        updated = store
-        for v in attesters:
-            updated = spec.on_gossip_attestation(updated, make_signed(v), is_aggregator=True)
+        updated_store = store
+        for attester in attesters:
+            updated_store = spec.on_gossip_attestation(
+                updated_store, make_signed(attester), is_aggregator=True
+            )
 
-        stored_ids = {
-            entry.validator_index
-            for entry in updated.attestation_signatures.get(attestation_data, set())
+        stored_validator_indices = {
+            stored_signature.validator_index
+            for stored_signature in updated_store.attestation_signatures.get(
+                attestation_data, set()
+            )
         }
-        assert stored_ids == set(attesters), (
+        assert stored_validator_indices == set(attesters), (
             "Aggregator should store attestations from all received validators"
         )
 
@@ -1603,9 +1609,9 @@ class TestOnGossipAttestationImportGating:
         updated_store = spec.on_gossip_attestation(store, signed_attestation, is_aggregator=False)
 
         signatures = updated_store.attestation_signatures.get(attestation_data, set())
-        assert attester_validator not in {entry.validator_index for entry in signatures}, (
-            "Non-aggregator should never store gossip signatures"
-        )
+        assert attester_validator not in {
+            stored_signature.validator_index for stored_signature in signatures
+        }, "Non-aggregator should never store gossip signatures"
 
     def test_non_aggregator_does_not_create_signatures_entry(
         self, key_manager: XmssKeyManager, spec: LstarSpec

--- a/tests/lean_spec/spec/forks/lstar/test_validator_duties.py
+++ b/tests/lean_spec/spec/forks/lstar/test_validator_duties.py
@@ -614,10 +614,10 @@ class TestValidatorErrorHandling:
         num_validators = len(state.validators)
 
         # Proposer comparison should work (though likely not match).
-        result = large_validator == ValidatorIndex.proposer_for_slot(
+        is_proposer = large_validator == ValidatorIndex.proposer_for_slot(
             large_slot, Uint64(num_validators)
         )
-        assert isinstance(result, bool)
+        assert isinstance(is_proposer, bool)
 
         # Attestation can be created for any validator
         attestation_data = spec.produce_attestation_data(sample_store, Slot(1))

--- a/tests/lean_spec/spec/forks/test_protocol.py
+++ b/tests/lean_spec/spec/forks/test_protocol.py
@@ -54,8 +54,8 @@ class TestForkProtocolGeneric:
 
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom):
-                mod = node.module or ""
-                assert "devnet" not in mod, f"Forbidden import from {mod}"
+                module_name = node.module or ""
+                assert "devnet" not in module_name, f"Forbidden import from {module_name}"
             elif isinstance(node, ast.Import):
                 for alias in node.names:
                     assert "devnet" not in alias.name, f"Forbidden import of {alias.name}"
@@ -69,13 +69,19 @@ class TestForkProtocolGeneric:
             for node in ast.walk(tree):
                 # `from X import Y` — `X` is the module being imported from.
                 if isinstance(node, ast.ImportFrom):
-                    mod = node.module or ""
-                    if any(mod.startswith(p) for p in _FORBIDDEN_FORK_PREFIXES):
-                        offenders.append(f"{location}:{node.lineno}: from {mod} import ...")
+                    module_name = node.module or ""
+                    if any(
+                        module_name.startswith(forbidden_prefix)
+                        for forbidden_prefix in _FORBIDDEN_FORK_PREFIXES
+                    ):
+                        offenders.append(f"{location}:{node.lineno}: from {module_name} import ...")
                 # `import X` — each `alias.name` is a fully-qualified module path.
                 elif isinstance(node, ast.Import):
                     for alias in node.names:
-                        if any(alias.name.startswith(p) for p in _FORBIDDEN_FORK_PREFIXES):
+                        if any(
+                            alias.name.startswith(forbidden_prefix)
+                            for forbidden_prefix in _FORBIDDEN_FORK_PREFIXES
+                        ):
                             offenders.append(f"{location}:{node.lineno}: import {alias.name}")
 
         assert not offenders, "Subspecs must not import concrete forks:\n" + "\n".join(offenders)

--- a/tests/lean_spec/spec/ssz/test_bitfields.py
+++ b/tests/lean_spec/spec/ssz/test_bitfields.py
@@ -70,12 +70,12 @@ class TestBitvector:
 
     def test_instantiation_from_generator(self) -> None:
         """Fixed-length type materializes a generator into a tuple before validation."""
-        bits_gen = (Boolean(b) for b in [True, False, True, False])
-        instance = Bitvector4(data=bits_gen)  # type: ignore[arg-type]
+        bit_generator = (Boolean(bit) for bit in [True, False, True, False])
+        instance = Bitvector4(data=bit_generator)  # type: ignore[arg-type]
         assert len(instance) == 4
 
     @pytest.mark.parametrize(
-        "values, count",
+        "bits, expected_element_count",
         [
             ([Boolean(True), Boolean(False), Boolean(True)], 3),
             (
@@ -85,14 +85,16 @@ class TestBitvector:
         ],
     )
     def test_instantiation_with_wrong_length_raises_error(
-        self, values: list[Boolean], count: int
+        self, bits: list[Boolean], expected_element_count: int
     ) -> None:
         """Wrong-length input raises with the exact element count in the message."""
         with pytest.raises(
             ValueOrValidationError,
-            match=re.escape(f"Bitvector4 requires exactly 4 elements, got {count}"),
+            match=re.escape(
+                f"Bitvector4 requires exactly 4 elements, got {expected_element_count}"
+            ),
         ):
-            Bitvector4(data=values)
+            Bitvector4(data=bits)
 
     def test_pydantic_validation_accepts_valid_list(self) -> None:
         """Pydantic validation accepts a valid list of booleans."""
@@ -105,7 +107,7 @@ class TestBitvector:
         "invalid_value",
         [
             {"data": [Boolean(True), Boolean(False), Boolean(True)]},
-            {"data": [Boolean(b) for b in [True, False, True, False, True]]},
+            {"data": [Boolean(bit) for bit in [True, False, True, False, True]]},
         ],
     )
     def test_pydantic_validation_rejects_wrong_length(self, invalid_value: Any) -> None:
@@ -149,13 +151,15 @@ class TestBitlist:
         """Instantiation succeeds with any number of items up to LIMIT."""
         instance = Bitlist8(data=[Boolean(True), Boolean(False), Boolean(1), Boolean(0)])
         assert len(instance) == 4
-        expected = Bitlist8(data=[Boolean(True), Boolean(False), Boolean(True), Boolean(False)])
-        assert instance == expected
+        expected_bitlist = Bitlist8(
+            data=[Boolean(True), Boolean(False), Boolean(True), Boolean(False)]
+        )
+        assert instance == expected_bitlist
 
     def test_instantiation_from_generator(self) -> None:
         """Variable-length type materializes a generator into a list before validation."""
-        bits_gen = (Boolean(b) for b in [True, False, True])
-        instance = Bitlist8(data=bits_gen)  # type: ignore[arg-type]
+        bit_generator = (Boolean(bit) for bit in [True, False, True])
+        instance = Bitlist8(data=bit_generator)  # type: ignore[arg-type]
         assert len(instance) == 3
 
     @pytest.mark.parametrize(
@@ -196,7 +200,7 @@ class TestBitlist:
             ValueOrValidationError,
             match=re.escape("Bitlist4 exceeds limit of 4, got 5"),
         ):
-            Bitlist4(data=[Boolean(b) for b in [True, False, True, False, True]])
+            Bitlist4(data=[Boolean(bit) for bit in [True, False, True, False, True]])
 
     def test_pydantic_validation_accepts_valid_list(self) -> None:
         """Pydantic validation accepts a valid list of booleans."""
@@ -221,37 +225,37 @@ class TestBitlist:
     def test_get_item_slice(self) -> None:
         """Indexing by slice returns a list of Booleans."""
         bitlist = Bitlist8(data=[Boolean(True), Boolean(False), Boolean(True), Boolean(False)])
-        result = bitlist[1:3]
-        assert result == [Boolean(False), Boolean(True)]
-        assert isinstance(result, list)
+        sliced_bits = bitlist[1:3]
+        assert sliced_bits == [Boolean(False), Boolean(True)]
+        assert isinstance(sliced_bits, list)
 
     def test_add_with_list(self) -> None:
         """Concatenating a Bitlist with a list returns a new instance."""
         bitlist = Bitlist8(data=[Boolean(True), Boolean(False), Boolean(True)])
-        result = bitlist + [Boolean(False), Boolean(True)]
-        assert len(result) == 5
-        assert list(result.data) == [
+        concatenated = bitlist + [Boolean(False), Boolean(True)]
+        assert len(concatenated) == 5
+        assert list(concatenated.data) == [
             Boolean(True),
             Boolean(False),
             Boolean(True),
             Boolean(False),
             Boolean(True),
         ]
-        assert isinstance(result, Bitlist8)
+        assert isinstance(concatenated, Bitlist8)
 
     def test_add_with_bitlist(self) -> None:
         """Concatenating two Bitlists of the same type returns a new instance."""
         bitlist1 = Bitlist8(data=[Boolean(True), Boolean(False)])
         bitlist2 = Bitlist8(data=[Boolean(True), Boolean(True)])
-        result = bitlist1 + bitlist2
-        assert len(result) == 4
-        assert list(result.data) == [
+        concatenated = bitlist1 + bitlist2
+        assert len(concatenated) == 4
+        assert list(concatenated.data) == [
             Boolean(True),
             Boolean(False),
             Boolean(True),
             Boolean(True),
         ]
-        assert isinstance(result, Bitlist8)
+        assert isinstance(concatenated, Bitlist8)
 
     def test_add_with_unsupported_type_raises(self) -> None:
         """Adding an unsupported type returns NotImplemented and Python raises TypeError."""
@@ -299,7 +303,7 @@ class TestBitfieldSSZ:
             Bitlist10.get_byte_length()
 
     @pytest.mark.parametrize(
-        "length, value, expected_hex",
+        "length, bits, expected_hex",
         [
             (8, (1, 1, 0, 1, 0, 1, 0, 0), "2b"),
             (4, (0, 1, 0, 1), "0a"),
@@ -311,15 +315,15 @@ class TestBitfieldSSZ:
         ],
     )
     def test_bitvector_round_trip(
-        self, length: int, value: tuple[int, ...], expected_hex: str
+        self, length: int, bits: tuple[int, ...], expected_hex: str
     ) -> None:
         """Bitvector round-trips through encode_bytes, decode_bytes, and stream serialization."""
 
         class TestBitvector(BaseBitvector):
             LENGTH = length
 
-        bool_value = tuple(Boolean(b) for b in value)
-        instance = TestBitvector(data=bool_value)
+        boolean_bits = tuple(Boolean(bit) for bit in bits)
+        instance = TestBitvector(data=boolean_bits)
 
         encoded = instance.encode_bytes()
         assert encoded.hex() == expected_hex
@@ -335,7 +339,7 @@ class TestBitfieldSSZ:
         assert decoded2 == instance
 
     @pytest.mark.parametrize(
-        "limit, value, expected_hex",
+        "limit, bits, expected_hex",
         [
             (8, (), "01"),
             (8, (1, 1, 0, 1, 0, 1, 0, 0), "2b01"),
@@ -347,16 +351,14 @@ class TestBitfieldSSZ:
             (513, tuple([1] * 513), ("ff" * 64) + "03"),
         ],
     )
-    def test_bitlist_round_trip(
-        self, limit: int, value: tuple[int, ...], expected_hex: str
-    ) -> None:
+    def test_bitlist_round_trip(self, limit: int, bits: tuple[int, ...], expected_hex: str) -> None:
         """Bitlist round-trips through encode_bytes, decode_bytes, and stream serialization."""
 
         class TestBitlist(BaseBitlist):
             LIMIT = limit
 
-        bool_value = tuple(Boolean(b) for b in value)
-        instance = TestBitlist(data=bool_value)
+        boolean_bits = tuple(Boolean(bit) for bit in bits)
+        instance = TestBitlist(data=boolean_bits)
 
         encoded = instance.encode_bytes()
         assert encoded.hex() == expected_hex

--- a/tests/lean_spec/spec/ssz/test_boolean.py
+++ b/tests/lean_spec/spec/ssz/test_boolean.py
@@ -80,9 +80,9 @@ def test_wrapping_existing_boolean_succeeds() -> None:
 
 def test_instantiation_and_type() -> None:
     """Tests that a Boolean is an instance of `int` and its own class."""
-    value = Boolean(True)
-    assert isinstance(value, int)
-    assert isinstance(value, Boolean)
+    boolean = Boolean(True)
+    assert isinstance(boolean, int)
+    assert isinstance(boolean, Boolean)
 
 
 @pytest.mark.parametrize(
@@ -253,15 +253,15 @@ class TestBooleanSSZ:
         assert Boolean.get_byte_length() == 1
 
     @pytest.mark.parametrize(
-        "value, expected_bytes",
+        "boolean_value, expected_bytes",
         [
             (True, b"\x01"),
             (False, b"\x00"),
         ],
     )
-    def test_encode_decode_roundtrip(self, value: bool, expected_bytes: bytes) -> None:
+    def test_encode_decode_roundtrip(self, boolean_value: bool, expected_bytes: bytes) -> None:
         """Tests the encode_bytes and decode_bytes round-trip."""
-        boolean_instance = Boolean(value)
+        boolean_instance = Boolean(boolean_value)
 
         # Test encoding
         encoded = boolean_instance.encode_bytes()

--- a/tests/lean_spec/spec/ssz/test_byte_arrays.py
+++ b/tests/lean_spec/spec/ssz/test_byte_arrays.py
@@ -51,13 +51,13 @@ class TestBaseBytesConstruction:
         """Concrete subclasses inherit from BaseBytes and stay bytes-compatible."""
         assert issubclass(Bytes32, BaseBytes)
         assert Bytes32.LENGTH == 32
-        v = Bytes32(b"\x00" * 32)
-        assert isinstance(v, Bytes32)
-        assert isinstance(v, bytes)
-        assert len(v) == 32
+        byte_array = Bytes32(b"\x00" * 32)
+        assert isinstance(byte_array, Bytes32)
+        assert isinstance(byte_array, bytes)
+        assert len(byte_array) == 32
 
     @pytest.mark.parametrize(
-        "input_value, expected",
+        "input_value, expected_bytes",
         [
             (b"\x00\x01\x02\x03", b"\x00\x01\x02\x03"),
             (bytearray(b"\x00\x01\x02\x03"), b"\x00\x01\x02\x03"),
@@ -67,10 +67,10 @@ class TestBaseBytesConstruction:
             ("0x00010203", b"\x00\x01\x02\x03"),
         ],
     )
-    def test_coercion_from_supported_inputs(self, input_value: Any, expected: bytes) -> None:
+    def test_coercion_from_supported_inputs(self, input_value: Any, expected_bytes: bytes) -> None:
         """Bytes, bytearray, iterables, generators, and hex strings all coerce to bytes."""
-        v = Bytes4(input_value)
-        assert bytes(v) == expected
+        coerced = Bytes4(input_value)
+        assert bytes(coerced) == expected_bytes
 
     @pytest.mark.parametrize(
         "wrong_input, count",
@@ -102,9 +102,9 @@ class TestBaseBytesConstruction:
 
     def test_zero_factory(self) -> None:
         """The zero classmethod returns an instance of LENGTH zero bytes."""
-        v = Bytes4.zero()
-        assert isinstance(v, Bytes4)
-        assert bytes(v) == b"\x00\x00\x00\x00"
+        zero_array = Bytes4.zero()
+        assert isinstance(zero_array, Bytes4)
+        assert bytes(zero_array) == b"\x00\x00\x00\x00"
 
 
 class TestBaseBytesEquality:
@@ -145,8 +145,8 @@ class TestBaseBytesEquality:
 
     def test_hash_distinct_from_raw_bytes(self) -> None:
         """The hash binds the value to its concrete type, so equal raw bytes hash differently."""
-        v = Bytes4(b"\x00\x01\x02\x03")
-        assert hash(v) != hash(b"\x00\x01\x02\x03")
+        byte_array = Bytes4(b"\x00\x01\x02\x03")
+        assert hash(byte_array) != hash(b"\x00\x01\x02\x03")
 
     def test_hash_same_for_equal_instances(self) -> None:
         """Equal instances of the same type produce the same hash."""
@@ -169,37 +169,37 @@ class TestBaseBytesOperations:
 
     def test_length_iter_getitem(self) -> None:
         """The instance supports len, iteration, and integer indexing."""
-        v = Bytes4(b"\x00\x01\x02\x03")
-        assert len(v) == 4
-        assert list(iter(v)) == [0, 1, 2, 3]
-        assert v[2] == 2
+        byte_array = Bytes4(b"\x00\x01\x02\x03")
+        assert len(byte_array) == 4
+        assert list(iter(byte_array)) == [0, 1, 2, 3]
+        assert byte_array[2] == 2
 
     def test_concatenation_returns_plain_bytes(self) -> None:
         """Concatenation of two instances returns plain bytes."""
-        a = Bytes4(b"\x00\x00\x00\x01")
-        b = Bytes4(b"\x00\x00\x00\x02")
-        conc = a + b
-        assert type(conc) is bytes
-        assert conc == b"\x00\x00\x00\x01\x00\x00\x00\x02"
+        left_array = Bytes4(b"\x00\x00\x00\x01")
+        right_array = Bytes4(b"\x00\x00\x00\x02")
+        concatenated = left_array + right_array
+        assert type(concatenated) is bytes
+        assert concatenated == b"\x00\x00\x00\x01\x00\x00\x00\x02"
 
     def test_reverse_concatenation_returns_plain_bytes(self) -> None:
         """Concatenation with raw bytes on the left returns plain bytes."""
-        a = Bytes4(b"\x00\x00\x00\x01")
-        conc = b"\xff" + a
-        assert type(conc) is bytes
-        assert conc == b"\xff\x00\x00\x00\x01"
+        byte_array = Bytes4(b"\x00\x00\x00\x01")
+        concatenated = b"\xff" + byte_array
+        assert type(concatenated) is bytes
+        assert concatenated == b"\xff\x00\x00\x00\x01"
 
     def test_sort_lexicographic(self) -> None:
         """Instances sort lexicographically by byte content."""
-        a = Bytes32(b"\x00" * 31 + b"\x01")
-        b = Bytes32(b"\x00" * 31 + b"\x02")
-        c = Bytes32(b"\xff" * 32)
-        assert sorted([c, b, a]) == [a, b, c]
+        smallest = Bytes32(b"\x00" * 31 + b"\x01")
+        middle = Bytes32(b"\x00" * 31 + b"\x02")
+        largest = Bytes32(b"\xff" * 32)
+        assert sorted([largest, middle, smallest]) == [smallest, middle, largest]
 
     def test_hashlib_compatibility(self) -> None:
         """An instance is usable wherever a bytes-like value is expected."""
-        r = Bytes32(b"\x01" + b"\x00" * 31)
-        digest = hashlib.sha256(r).digest()
+        byte_array = Bytes32(b"\x01" + b"\x00" * 31)
+        digest = hashlib.sha256(byte_array).digest()
         assert len(digest) == 32
 
 
@@ -224,17 +224,17 @@ class TestBaseBytesSSZ:
     )
     def test_encode_decode_roundtrip(self, cls: type[BaseBytes], payload: bytes) -> None:
         """BaseBytes round-trips through encode_bytes, decode_bytes, and stream serialization."""
-        v = cls(payload)
-        assert v.encode_bytes() == payload
-        assert cls.decode_bytes(payload) == v
+        byte_array = cls(payload)
+        assert byte_array.encode_bytes() == payload
+        assert cls.decode_bytes(payload) == byte_array
 
         buffer = io.BytesIO()
-        n = v.serialize(buffer)
-        assert n == len(payload)
+        bytes_written = byte_array.serialize(buffer)
+        assert bytes_written == len(payload)
 
         buffer.seek(0)
-        v2 = cls.deserialize(buffer, len(payload))
-        assert v == v2
+        deserialized = cls.deserialize(buffer, len(payload))
+        assert byte_array == deserialized
 
     def test_deserialize_scope_mismatch_raises(self) -> None:
         """deserialize rejects a scope that doesn't match LENGTH."""
@@ -260,22 +260,22 @@ class TestBaseBytesPydantic:
 
     def test_accepts_typed_instances_and_supported_inputs(self) -> None:
         """Pydantic accepts existing instances built from hex strings or iterables."""
-        m = ModelVectors(
+        model = ModelVectors(
             root=Bytes32("0x" + "11" * 32),
             key=Bytes4([0, 1, 2, 3]),
         )
-        assert isinstance(m.root, Bytes32)
-        assert isinstance(m.key, Bytes4)
-        assert bytes(m.root) == b"\x11" * 32
-        assert bytes(m.key) == b"\x00\x01\x02\x03"
+        assert isinstance(model.root, Bytes32)
+        assert isinstance(model.key, Bytes4)
+        assert bytes(model.root) == b"\x11" * 32
+        assert bytes(model.key) == b"\x00\x01\x02\x03"
 
     def test_json_serialization_to_hex(self) -> None:
         """Serialization uses 0x-prefixed lowercase hex for JSON output."""
-        m = ModelVectors(
+        model = ModelVectors(
             root=Bytes32("0x" + "11" * 32),
             key=Bytes4([0, 1, 2, 3]),
         )
-        dumped = m.model_dump()
+        dumped = model.model_dump()
         assert dumped["root"] == "0x" + "11" * 32
         assert dumped["key"] == "0x00010203"
 
@@ -285,13 +285,13 @@ class TestBaseByteListConstruction:
 
     def test_inheritance(self) -> None:
         """Concrete subclasses carry the declared limit."""
-        v = ByteList16(data=b"\x01\x02")
-        assert isinstance(v, ByteList16)
+        byte_list = ByteList16(data=b"\x01\x02")
+        assert isinstance(byte_list, ByteList16)
         assert ByteList16.LIMIT == 16
-        assert len(v.data) == 2
+        assert len(byte_list.data) == 2
 
     @pytest.mark.parametrize(
-        "input_value, expected",
+        "input_value, expected_bytes",
         [
             (b"\x00\x01\x02\x03\x04", b"\x00\x01\x02\x03\x04"),
             (bytearray(b"\x00\x01\x02\x03\x04"), b"\x00\x01\x02\x03\x04"),
@@ -300,11 +300,11 @@ class TestBaseByteListConstruction:
             ("0x0001020304", b"\x00\x01\x02\x03\x04"),
         ],
     )
-    def test_coercion_from_supported_inputs(self, input_value: Any, expected: bytes) -> None:
+    def test_coercion_from_supported_inputs(self, input_value: Any, expected_bytes: bytes) -> None:
         """Bytes, bytearray, iterables, and hex strings all coerce to bytes."""
-        v = ByteList5(data=input_value)
-        assert v.data == expected
-        assert len(v.data) == len(expected)
+        byte_list = ByteList5(data=input_value)
+        assert byte_list.data == expected_bytes
+        assert len(byte_list.data) == len(expected_bytes)
 
     def test_construction_over_limit_raises(self) -> None:
         """Input exceeding LIMIT raises with the exact size in the message."""
@@ -385,17 +385,17 @@ class TestBaseByteListOperations:
 
     def test_concatenation_returns_plain_bytes(self) -> None:
         """Concatenation with a bytes-like value returns plain bytes."""
-        v = ByteList16(data=b"\x00\x01\x02")
-        conc = v + b"\x03\x04"
-        assert type(conc) is bytes
-        assert conc == b"\x00\x01\x02\x03\x04"
+        byte_list = ByteList16(data=b"\x00\x01\x02")
+        concatenated = byte_list + b"\x03\x04"
+        assert type(concatenated) is bytes
+        assert concatenated == b"\x00\x01\x02\x03\x04"
 
     def test_reverse_concatenation_returns_plain_bytes(self) -> None:
         """Concatenation with raw bytes on the left returns plain bytes."""
-        v = ByteList16(data=b"\x00\x01")
-        conc = b"\xff" + v
-        assert type(conc) is bytes
-        assert conc == b"\xff\x00\x01"
+        byte_list = ByteList16(data=b"\x00\x01")
+        concatenated = b"\xff" + byte_list
+        assert type(concatenated) is bytes
+        assert concatenated == b"\xff\x00\x01"
 
 
 class TestBaseByteListSSZ:
@@ -428,17 +428,17 @@ class TestBaseByteListSSZ:
         class TestByteList(BaseByteList):
             LIMIT = limit
 
-        x = TestByteList(data=data)
-        assert x.encode_bytes() == data
-        assert TestByteList.decode_bytes(data) == x
+        byte_list = TestByteList(data=data)
+        assert byte_list.encode_bytes() == data
+        assert TestByteList.decode_bytes(data) == byte_list
 
         buffer = io.BytesIO()
-        n = x.serialize(buffer)
-        assert n == len(data)
+        bytes_written = byte_list.serialize(buffer)
+        assert bytes_written == len(data)
 
         buffer.seek(0)
-        y = TestByteList.deserialize(buffer, len(data))
-        assert y == x
+        deserialized = TestByteList.deserialize(buffer, len(data))
+        assert deserialized == byte_list
 
     def test_deserialize_negative_scope_raises(self) -> None:
         """deserialize rejects a negative scope."""
@@ -473,10 +473,10 @@ class TestBaseByteListPydantic:
 
     def test_accepts_valid_input(self) -> None:
         """Pydantic accepts construction with bytes within LIMIT."""
-        data = bytes.fromhex("000102030405060708090a0b0c0d0e0f")
-        m = ModelLists(payload=ByteList16(data=data))
-        assert isinstance(m.payload, ByteList16)
-        assert m.payload.encode_bytes() == data
+        raw_bytes = bytes.fromhex("000102030405060708090a0b0c0d0e0f")
+        model = ModelLists(payload=ByteList16(data=raw_bytes))
+        assert isinstance(model.payload, ByteList16)
+        assert model.payload.encode_bytes() == raw_bytes
 
     def test_rejects_oversized_input(self) -> None:
         """Pydantic rejects data exceeding LIMIT via SSZValueError."""
@@ -485,9 +485,9 @@ class TestBaseByteListPydantic:
 
     def test_json_serialization_to_hex(self) -> None:
         """JSON-mode serialization renders the data field as a 0x-prefixed hex string."""
-        data = bytes.fromhex("0001020304")
-        m = ModelLists(payload=ByteList16(data=data))
-        dumped = m.model_dump(mode="json")
+        raw_bytes = bytes.fromhex("0001020304")
+        model = ModelLists(payload=ByteList16(data=raw_bytes))
+        dumped = model.model_dump(mode="json")
         assert dumped["payload"]["data"] == "0x0001020304"
 
 
@@ -499,9 +499,9 @@ def test_zero_hash_constant() -> None:
 
 def test_json_dumpable_via_hex() -> None:
     """Byte instances are JSON-dumpable when pre-encoded to hex strings."""
-    obj = {
+    hex_encoded_fields = {
         "root": Bytes32(b"\x11" * 32).hex(),
         "key": Bytes4(b"\x00\x01\x02\x03").hex(),
         "payload": ByteList5(data=b"\x00\x01\x02").hex(),
     }
-    assert json.loads(json.dumps(obj)) == obj
+    assert json.loads(json.dumps(hex_encoded_fields)) == hex_encoded_fields

--- a/tests/lean_spec/spec/ssz/test_collections.py
+++ b/tests/lean_spec/spec/ssz/test_collections.py
@@ -240,7 +240,7 @@ class TestSSZVectorValidator:
 
     def test_generator_input_coerced(self) -> None:
         """A generator is materialized and each value is coerced to ELEMENT_TYPE."""
-        instance = Uint8Vector4(data=cast(Any, (value for value in range(1, 5))))
+        instance = Uint8Vector4(data=cast(Any, (number for number in range(1, 5))))
 
         assert tuple(instance) == (Uint8(1), Uint8(2), Uint8(3), Uint8(4))
 
@@ -463,7 +463,7 @@ class TestSSZListValidator:
 
     def test_generator_input_coerced(self) -> None:
         """A generator is materialized and each value is coerced to ELEMENT_TYPE."""
-        instance = Uint8List4(data=cast(Any, (value for value in range(3))))
+        instance = Uint8List4(data=cast(Any, (number for number in range(3))))
 
         assert list(instance) == [Uint8(0), Uint8(1), Uint8(2)]
 
@@ -599,42 +599,44 @@ class TestSSZListAccessors:
 
     def test_add_with_sszlist(self) -> None:
         """Concatenating two SSZLists yields a fresh list of the same type."""
-        result = Uint8List10(data=[Uint8(1), Uint8(2)]) + Uint8List10(data=[Uint8(3), Uint8(4)])
+        concatenated = Uint8List10(data=[Uint8(1), Uint8(2)]) + Uint8List10(
+            data=[Uint8(3), Uint8(4)]
+        )
 
-        assert result == Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
-        assert isinstance(result, Uint8List10)
+        assert concatenated == Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
+        assert isinstance(concatenated, Uint8List10)
 
     def test_add_with_plain_list(self) -> None:
         """Concatenating with a plain list coerces the right-hand values."""
-        result = Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3)]) + [4, 5]
+        concatenated = Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3)]) + [4, 5]
 
-        assert result == Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4), Uint8(5)])
+        assert concatenated == Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4), Uint8(5)])
 
     def test_add_with_tuple(self) -> None:
         """Concatenating with a tuple coerces the right-hand values."""
-        result = Uint8List10(data=[Uint8(1), Uint8(2)]) + (3, 4)
+        concatenated = Uint8List10(data=[Uint8(1), Uint8(2)]) + (3, 4)
 
-        assert result == Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
+        assert concatenated == Uint8List10(data=[Uint8(1), Uint8(2), Uint8(3), Uint8(4)])
 
     def test_add_empty_to_empty(self) -> None:
         """Concatenating two empty lists yields an empty list of the same type."""
-        result = Uint8List10(data=[]) + Uint8List10(data=[])
+        concatenated = Uint8List10(data=[]) + Uint8List10(data=[])
 
-        assert result == Uint8List10(data=[])
+        assert concatenated == Uint8List10(data=[])
 
     def test_add_empty_to_non_empty(self) -> None:
         """Concatenating an empty list to a populated one preserves the populated list."""
         populated = Uint8List10(data=[Uint8(1), Uint8(2)])
-        result = Uint8List10(data=[]) + populated
+        concatenated = Uint8List10(data=[]) + populated
 
-        assert result == populated
+        assert concatenated == populated
 
     def test_add_non_empty_to_empty(self) -> None:
         """Concatenating a populated list to an empty one preserves the populated list."""
         populated = Uint8List10(data=[Uint8(1), Uint8(2)])
-        result = populated + Uint8List10(data=[])
+        concatenated = populated + Uint8List10(data=[])
 
-        assert result == populated
+        assert concatenated == populated
 
     def test_add_unsupported_type_returns_not_implemented(self) -> None:
         """Unsupported operands return NotImplemented from the add hook."""
@@ -656,7 +658,7 @@ class TestSSZVectorSerialization:
     """Tests SSZ serialization and deserialization for SSZVector."""
 
     @pytest.mark.parametrize(
-        "vector_type, value, expected_hex",
+        "vector_type, elements, expected_hex",
         [
             (Uint16Vector2, (0x4567, 0x0123), "67452301"),
             (Uint8Vector4, (1, 2, 3, 4), "01020304"),
@@ -694,11 +696,11 @@ class TestSSZVectorSerialization:
     def test_fixed_size_element_vector_roundtrip(
         self,
         vector_type: type[SSZVector],
-        value: tuple[Any, ...],
+        elements: tuple[Any, ...],
         expected_hex: str,
     ) -> None:
         """Fixed-size vectors encode to a known hex layout and round-trip back."""
-        instance = vector_type(data=value)
+        instance = vector_type(data=elements)
         encoded = instance.encode_bytes()
 
         assert encoded.hex() == expected_hex
@@ -754,14 +756,14 @@ class TestSSZVectorSerialization:
         #
         #     offsets[0] = 8   (table-end, valid first offset)
         #     offsets[1] = 6   (decreasing, triggers the monotonic check)
-        payload = b"\x08\x00\x00\x00\x06\x00\x00\x00"
+        encoded_bytes = b"\x08\x00\x00\x00\x06\x00\x00\x00"
         with pytest.raises(
             SSZSerializationError,
             match=re.escape(
                 "VariableContainerVector2: offsets not monotonically increasing: 8 -> 6"
             ),
         ):
-            VariableContainerVector2.decode_bytes(payload)
+            VariableContainerVector2.decode_bytes(encoded_bytes)
 
     def test_variable_size_vector_rejects_final_offset_overflow(self) -> None:
         """A final offset that exceeds the scope triggers the monotonic check first."""
@@ -772,21 +774,21 @@ class TestSSZVectorSerialization:
         #
         # Pairwise iteration appends scope as the final boundary, so the 100 -> 20
         # transition trips the monotonic check before the final-offset-exceeds-scope check.
-        payload = b"\x08\x00\x00\x00\x64\x00\x00\x00" + b"\x00" * 12
+        encoded_bytes = b"\x08\x00\x00\x00\x64\x00\x00\x00" + b"\x00" * 12
         with pytest.raises(
             SSZSerializationError,
             match=re.escape(
                 "VariableContainerVector2: offsets not monotonically increasing: 100 -> 20"
             ),
         ):
-            VariableContainerVector2.decode_bytes(payload)
+            VariableContainerVector2.decode_bytes(encoded_bytes)
 
 
 class TestSSZListSerialization:
     """Tests SSZ serialization and deserialization for SSZList."""
 
     @pytest.mark.parametrize(
-        "list_type, value, expected_hex",
+        "list_type, elements, expected_hex",
         [
             (Uint16List32, (0xAABB, 0xC0AD, 0xEEFF), "bbaaadc0ffee"),
             (Uint8List10, (), ""),
@@ -820,11 +822,11 @@ class TestSSZListSerialization:
     def test_fixed_size_element_list_roundtrip(
         self,
         list_type: type[SSZList],
-        value: tuple[Any, ...],
+        elements: tuple[Any, ...],
         expected_hex: str,
     ) -> None:
         """Fixed-size lists pack bodies back-to-back without separators."""
-        instance = list_type(data=value)
+        instance = list_type(data=elements)
         encoded = instance.encode_bytes()
 
         assert encoded.hex() == expected_hex
@@ -891,12 +893,12 @@ class TestSSZListSerialization:
         # Layout:
         #
         #     first_offset = 12   (count = 12 / 4 = 3, above LIMIT=2)
-        payload = b"\x0c\x00\x00\x00" + b"\x00" * 8
+        encoded_bytes = b"\x0c\x00\x00\x00" + b"\x00" * 8
         with pytest.raises(
             SSZValueError,
             match=re.escape("VariableContainerList2 exceeds limit of 2, got 3"),
         ):
-            VariableContainerList2.decode_bytes(payload)
+            VariableContainerList2.decode_bytes(encoded_bytes)
 
     def test_variable_size_list_rejects_non_monotonic_offsets(self) -> None:
         """A later offset smaller than an earlier one means a body would have negative width."""
@@ -904,30 +906,32 @@ class TestSSZListSerialization:
         #
         #     first_offset = 8     (count = 2, table-end)
         #     offsets[1]   = 6     (decreasing, triggers the monotonic check)
-        payload = b"\x08\x00\x00\x00\x06\x00\x00\x00" + b"\x00" * 12
+        encoded_bytes = b"\x08\x00\x00\x00\x06\x00\x00\x00" + b"\x00" * 12
         with pytest.raises(
             SSZSerializationError,
             match=re.escape("VariableContainerList2: offsets not monotonically increasing: 8 -> 6"),
         ):
-            VariableContainerList2.decode_bytes(payload)
+            VariableContainerList2.decode_bytes(encoded_bytes)
 
     def test_variable_size_list_rejects_final_offset_overflow(self) -> None:
         """An interior offset past the payload's end triggers the monotonic check."""
-        payload = b"\x08\x00\x00\x00\x64\x00\x00\x00" + b"\x00" * 12
+        encoded_bytes = b"\x08\x00\x00\x00\x64\x00\x00\x00" + b"\x00" * 12
         with pytest.raises(
             SSZSerializationError,
             match=re.escape(
                 "VariableContainerList2: offsets not monotonically increasing: 100 -> 20"
             ),
         ):
-            VariableContainerList2.decode_bytes(payload)
+            VariableContainerList2.decode_bytes(encoded_bytes)
 
     def test_variable_size_list_single_element_decodes(self) -> None:
         """A single-element list reads no further offsets after the first."""
-        value = VariableContainer(a=Uint8(1), b=Uint16List4(data=[Uint16(10)]))
-        encoded = VariableContainerList2(data=[value]).encode_bytes()
+        element = VariableContainer(a=Uint8(1), b=Uint16List4(data=[Uint16(10)]))
+        encoded = VariableContainerList2(data=[element]).encode_bytes()
 
-        assert VariableContainerList2.decode_bytes(encoded) == VariableContainerList2(data=[value])
+        assert VariableContainerList2.decode_bytes(encoded) == VariableContainerList2(
+            data=[element]
+        )
 
 
 class TestJsonSerialization:

--- a/tests/lean_spec/spec/ssz/test_container.py
+++ b/tests/lean_spec/spec/ssz/test_container.py
@@ -155,9 +155,9 @@ class TestVariableContainer:
         )
         # Fixed-part width is 8 bytes for two Uint32 offsets.
         # First offset is 8, second offset is 12 because the first payload spans 4 bytes.
-        expected = bytes.fromhex("080000000c00000034127856bc9a")
-        assert original.encode_bytes() == expected
-        assert TwoVar.decode_bytes(expected) == original
+        expected_encoding = bytes.fromhex("080000000c00000034127856bc9a")
+        assert original.encode_bytes() == expected_encoding
+        assert TwoVar.decode_bytes(expected_encoding) == original
 
 
 class TestOneVariableField:
@@ -207,9 +207,9 @@ class TestMixedContainer:
             c=Uint32(0xEEFF),
             d=Uint16List4(data=[Uint16(3)]),
         )
-        expected = bytes.fromhex("ddccbbaa0000000014000000ffee000018000000010002000300")
-        assert original.encode_bytes() == expected
-        assert Mixed.decode_bytes(expected) == original
+        expected_encoding = bytes.fromhex("ddccbbaa0000000014000000ffee000018000000010002000300")
+        assert original.encode_bytes() == expected_encoding
+        assert Mixed.decode_bytes(expected_encoding) == original
 
 
 class TestNestedContainer:
@@ -245,9 +245,11 @@ class TestNestedContainer:
             head=Uint64(99),
             inner=InnerVar(a=Uint64(7), b=Uint16List4(data=[Uint16(1), Uint16(2)])),
         )
-        expected = bytes.fromhex("63000000000000000c00000007000000000000000c00000001000200")
-        assert original.encode_bytes() == expected
-        assert OuterVarNested.decode_bytes(expected) == original
+        expected_encoding = bytes.fromhex(
+            "63000000000000000c00000007000000000000000c00000001000200"
+        )
+        assert original.encode_bytes() == expected_encoding
+        assert OuterVarNested.decode_bytes(expected_encoding) == original
 
 
 class TestSubclassInheritance:
@@ -266,9 +268,9 @@ class TestSubclassInheritance:
         )
         # Fixed part is slot (8) plus data offset (4) plus signature (8) for 20 bytes.
         # Data offset value is therefore 20 and the payload is [1] as Uint16.
-        expected = bytes.fromhex("05000000000000001400000063000000000000000100")
-        assert original.encode_bytes() == expected
-        assert SignedAttestation.decode_bytes(expected) == original
+        expected_encoding = bytes.fromhex("05000000000000001400000063000000000000000100")
+        assert original.encode_bytes() == expected_encoding
+        assert SignedAttestation.decode_bytes(expected_encoding) == original
 
 
 class TestSerialize:
@@ -316,7 +318,7 @@ class TestErrors:
         """The first variable offset must equal the end of the fixed part."""
         # Fixed part of Mixed is 8 + 4 + 4 + 4 = 20 bytes.
         # The payload deviates by one byte in either direction from the canonical offset.
-        data = (
+        encoded_bytes = (
             (1).to_bytes(8, "little")
             + bad_offset.to_bytes(4, "little")
             + (2).to_bytes(4, "little")
@@ -325,16 +327,16 @@ class TestErrors:
             + bytes.fromhex("0300")
         )
         with pytest.raises(SSZSerializationError) as exc_info:
-            Mixed.decode_bytes(data)
+            Mixed.decode_bytes(encoded_bytes)
         assert exc_info.value.args[0] == expected_message
 
     def test_non_monotonic_offsets_raise(self) -> None:
         """A second offset below the first triggers a non-monotonic offsets error."""
         # Fixed part is 8 bytes for two Uint32 offsets.
         # First offset is 8 (valid), second offset is 5 (decreasing).
-        data = (8).to_bytes(4, "little") + (5).to_bytes(4, "little") + b"\x34\x12"
+        encoded_bytes = (8).to_bytes(4, "little") + (5).to_bytes(4, "little") + b"\x34\x12"
         with pytest.raises(SSZSerializationError) as exc_info:
-            TwoVar.decode_bytes(data)
+            TwoVar.decode_bytes(encoded_bytes)
         assert exc_info.value.args[0] == "TwoVar.a: non-monotonic offsets (8 > 5)"
 
     def test_short_input_on_fixed_field_raises(self) -> None:

--- a/tests/lean_spec/spec/ssz/test_uint.py
+++ b/tests/lean_spec/spec/ssz/test_uint.py
@@ -51,9 +51,9 @@ def test_pydantic_validation_accepts_valid_int(uint_class: Type[BaseUint]) -> No
     """Tests that Pydantic validation correctly accepts a valid integer."""
     model = UINT_MODELS[uint_class]
     instance = model(value=10)
-    value = instance.value  # type: ignore[attribute-defined]
-    assert isinstance(value, uint_class)
-    assert value == uint_class(10)
+    validated_value = instance.value  # type: ignore[attribute-defined]
+    assert isinstance(validated_value, uint_class)
+    assert validated_value == uint_class(10)
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -83,25 +83,25 @@ def test_instantiation_from_invalid_types_raises_error(
     uint_class: Type[BaseUint], invalid_value: Any, expected_type_name: str
 ) -> None:
     """Tests that instantiating with non-integer types raises SSZTypeError."""
-    expected = f"Expected int, got {expected_type_name}"
-    with pytest.raises(SSZTypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Expected int, got {expected_type_name}"
+    with pytest.raises(SSZTypeError, match=rf"^{re.escape(expected_message)}$"):
         uint_class(invalid_value)
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_instantiation_and_type(uint_class: Type[BaseUint]) -> None:
     """Tests that Uint types are instances of `int` and their own class."""
-    value = uint_class(5)
-    assert isinstance(value, int)
-    assert isinstance(value, BaseUint)
-    assert isinstance(value, uint_class)
+    uint_instance = uint_class(5)
+    assert isinstance(uint_instance, int)
+    assert isinstance(uint_instance, BaseUint)
+    assert isinstance(uint_instance, uint_class)
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_instantiation_negative(uint_class: Type[BaseUint]) -> None:
     """Tests that instantiating with a negative number raises SSZValueError."""
-    expected = f"-5 out of range for {uint_class.__name__} [0, {2**uint_class.BITS - 1}]"
-    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"-5 out of range for {uint_class.__name__} [0, {2**uint_class.BITS - 1}]"
+    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected_message)}$"):
         uint_class(-5)
 
 
@@ -109,8 +109,8 @@ def test_instantiation_negative(uint_class: Type[BaseUint]) -> None:
 def test_instantiation_too_large(uint_class: Type[BaseUint]) -> None:
     """Tests that instantiating with a value >= MAX raises SSZValueError."""
     max_value = 2**uint_class.BITS
-    expected = f"{max_value} out of range for {uint_class.__name__} [0, {max_value - 1}]"
-    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"{max_value} out of range for {uint_class.__name__} [0, {max_value - 1}]"
+    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected_message)}$"):
         uint_class(max_value)
 
 
@@ -126,42 +126,42 @@ def test_arithmetic_operators(uint_class: Type[BaseUint]) -> None:
     """Tests all standard arithmetic operators."""
     # Use smaller values for high-bit integers to avoid massive numbers
     a_value, b_value = (100, 3) if uint_class.BITS > 8 else (20, 3)
-    a = uint_class(a_value)
-    b = uint_class(b_value)
+    left = uint_class(a_value)
+    right = uint_class(b_value)
     max_int = (2**uint_class.BITS) - 1
     max_value = uint_class(max_int)
     name = uint_class.__name__
 
     # Addition
-    assert a + b == uint_class(a_value + b_value)
-    expected = f"{max_int + b_value} out of range for {name} [0, {max_int}]"
-    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
-        _ = max_value + b
+    assert left + right == uint_class(a_value + b_value)
+    expected_message = f"{max_int + b_value} out of range for {name} [0, {max_int}]"
+    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected_message)}$"):
+        _ = max_value + right
 
     # Subtraction
-    assert a - b == uint_class(a_value - b_value)
-    expected = f"{b_value - a_value} out of range for {name} [0, {max_int}]"
-    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
-        _ = b - a
+    assert left - right == uint_class(a_value - b_value)
+    expected_message = f"{b_value - a_value} out of range for {name} [0, {max_int}]"
+    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected_message)}$"):
+        _ = right - left
 
     # Multiplication
-    assert a * b == uint_class(a_value * b_value)
-    expected = f"{max_int * b_value} out of range for {name} [0, {max_int}]"
-    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
-        _ = max_value * b
+    assert left * right == uint_class(a_value * b_value)
+    expected_message = f"{max_int * b_value} out of range for {name} [0, {max_int}]"
+    with pytest.raises(SSZValueError, match=rf"^{re.escape(expected_message)}$"):
+        _ = max_value * right
 
     # Floor Division
-    assert a // b == uint_class(a_value // b_value)
+    assert left // right == uint_class(a_value // b_value)
 
     # Modulo
-    assert a % b == uint_class(a_value % b_value)
+    assert left % right == uint_class(a_value % b_value)
 
     # Exponentiation
     assert uint_class(b_value) ** uint_class(4) == uint_class(b_value**4)
     if uint_class.BITS <= 16:  # Pow gets too big quickly
-        expected = f"{a_value**b_value} out of range for {name} [0, {max_int}]"
-        with pytest.raises(SSZValueError, match=rf"^{re.escape(expected)}$"):
-            _ = a**b
+        expected_message = f"{a_value**b_value} out of range for {name} [0, {max_int}]"
+        with pytest.raises(SSZValueError, match=rf"^{re.escape(expected_message)}$"):
+            _ = left**right
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -169,38 +169,38 @@ def test_reverse_arithmetic_operators_raise_error(uint_class: Type[BaseUint]) ->
     """Tests that reverse arithmetic operators raise a TypeError."""
     name = uint_class.__name__
 
-    expected = f"Unsupported operand type(s) for +: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for +: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = 100 + uint_class(3)
 
-    expected = f"Unsupported operand type(s) for -: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for -: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = 100 - uint_class(3)
 
-    expected = f"Unsupported operand type(s) for *: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for *: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = 100 * uint_class(3)
 
-    expected = f"Unsupported operand type(s) for //: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for //: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = 100 // uint_class(3)
 
-    expected = f"Unsupported operand type(s) for %: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for %: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = 100 % uint_class(3)
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_divmod(uint_class: Type[BaseUint]) -> None:
     """Tests the divmod function."""
-    q, r = divmod(uint_class(100), uint_class(3))
-    assert q == uint_class(33)
-    assert r == uint_class(1)
-    assert isinstance(q, uint_class)
-    assert isinstance(r, uint_class)
+    quotient, remainder = divmod(uint_class(100), uint_class(3))
+    assert quotient == uint_class(33)
+    assert remainder == uint_class(1)
+    assert isinstance(quotient, uint_class)
+    assert isinstance(remainder, uint_class)
 
-    expected = f"Unsupported operand type(s) for divmod: '{uint_class.__name__}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for divmod: '{uint_class.__name__}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = divmod(100, uint_class(3))
 
 
@@ -220,35 +220,35 @@ def test_inplace_immutability(uint_class: Type[BaseUint]) -> None:
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_bitwise_operators(uint_class: Type[BaseUint]) -> None:
     """Tests all standard bitwise operators."""
-    a = uint_class(0b1100)  # 12
-    b = uint_class(0b1010)  # 10
+    left = uint_class(0b1100)  # 12
+    right = uint_class(0b1010)  # 10
     name = uint_class.__name__
 
-    assert a & b == uint_class(0b1000)
-    assert a | b == uint_class(0b1110)
-    assert a ^ b == uint_class(0b0110)
-    assert a << uint_class(2) == uint_class(0b110000)
-    assert a >> uint_class(2) == uint_class(0b11)
+    assert left & right == uint_class(0b1000)
+    assert left | right == uint_class(0b1110)
+    assert left ^ right == uint_class(0b0110)
+    assert left << uint_class(2) == uint_class(0b110000)
+    assert left >> uint_class(2) == uint_class(0b11)
 
-    expected = f"Unsupported operand type(s) for &: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
-        _ = a & 1
+    expected_message = f"Unsupported operand type(s) for &: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
+        _ = left & 1
 
-    expected = f"Unsupported operand type(s) for |: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
-        _ = a | 1
+    expected_message = f"Unsupported operand type(s) for |: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
+        _ = left | 1
 
-    expected = f"Unsupported operand type(s) for ^: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
-        _ = a ^ 1
+    expected_message = f"Unsupported operand type(s) for ^: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
+        _ = left ^ 1
 
-    expected = f"Unsupported operand type(s) for <<: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
-        _ = a << 1
+    expected_message = f"Unsupported operand type(s) for <<: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
+        _ = left << 1
 
-    expected = f"Unsupported operand type(s) for >>: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
-        _ = a >> 1
+    expected_message = f"Unsupported operand type(s) for >>: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
+        _ = left >> 1
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -269,39 +269,39 @@ def test_all_comparisons_with_other_types_raise_error(
     """Tests that all comparisons with incompatible types raise TypeError."""
     name = uint_class.__name__
 
-    expected = f"Unsupported operand type(s) for ==: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for ==: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = uint_class(10) == 10
 
-    expected = f"Unsupported operand type(s) for !=: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for !=: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = 10 != uint_class(10)
 
-    expected = f"Unsupported operand type(s) for >: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for >: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = uint_class(10) > 5
 
     # 5 < uint(10) routes to uint(10).__gt__(5) because uint is a strict int subclass.
-    expected = f"Unsupported operand type(s) for >: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for >: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = 5 < uint_class(10)
 
-    expected = f"Unsupported operand type(s) for >=: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for >=: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = uint_class(10) >= 10
 
     # 10 <= uint(10) routes to uint(10).__ge__(10) by subclass priority.
-    expected = f"Unsupported operand type(s) for >=: '{name}' and 'int'"
-    with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+    expected_message = f"Unsupported operand type(s) for >=: '{name}' and 'int'"
+    with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
         _ = 10 <= uint_class(10)
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_repr_and_str(uint_class: Type[BaseUint]) -> None:
     """Tests the string and official representations."""
-    value = uint_class(42)
-    assert str(value) == "42"
-    assert repr(value) == f"{uint_class.__name__}(42)"
+    uint_instance = uint_class(42)
+    assert str(uint_instance) == "42"
+    assert repr(uint_instance) == f"{uint_class.__name__}(42)"
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -315,56 +315,56 @@ def test_hash(uint_class: Type[BaseUint]) -> None:
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_index_list_access(uint_class: Type[BaseUint]) -> None:
     """Tests that Uint types can be used directly for list indexing."""
-    data = ["a", "b", "c", "d", "e"]
+    letters = ["a", "b", "c", "d", "e"]
     index = uint_class(2)
-    assert data[index] == "c"
-    assert data[uint_class(0)] == "a"
-    assert data[uint_class(4)] == "e"
+    assert letters[index] == "c"
+    assert letters[uint_class(0)] == "a"
+    assert letters[uint_class(4)] == "e"
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_index_slicing(uint_class: Type[BaseUint]) -> None:
     """Tests that Uint types can be used in slice operations."""
-    data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     start = uint_class(2)
     stop = uint_class(7)
     step = uint_class(2)
 
-    assert data[start:stop] == [2, 3, 4, 5, 6]
-    assert data[:stop] == [0, 1, 2, 3, 4, 5, 6]
-    assert data[start:] == [2, 3, 4, 5, 6, 7, 8, 9]
-    assert data[start:stop:step] == [2, 4, 6]
+    assert numbers[start:stop] == [2, 3, 4, 5, 6]
+    assert numbers[:stop] == [0, 1, 2, 3, 4, 5, 6]
+    assert numbers[start:] == [2, 3, 4, 5, 6, 7, 8, 9]
+    assert numbers[start:stop:step] == [2, 4, 6]
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_index_range(uint_class: Type[BaseUint]) -> None:
     """Tests that Uint types can be used in range()."""
-    n = uint_class(5)
-    result = list(range(n))
-    assert result == [0, 1, 2, 3, 4]
+    stop = uint_class(5)
+    single_argument_range = list(range(stop))
+    assert single_argument_range == [0, 1, 2, 3, 4]
 
     start = uint_class(2)
     stop = uint_class(8)
     step = uint_class(2)
-    result = list(range(start, stop, step))
-    assert result == [2, 4, 6]
+    strided_range = list(range(start, stop, step))
+    assert strided_range == [2, 4, 6]
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_index_hex_bin_oct(uint_class: Type[BaseUint]) -> None:
     """Tests that Uint types work with hex(), bin(), oct()."""
-    value = uint_class(42)
-    assert hex(value) == "0x2a"
-    assert bin(value) == "0b101010"
-    assert oct(value) == "0o52"
+    uint_instance = uint_class(42)
+    assert hex(uint_instance) == "0x2a"
+    assert bin(uint_instance) == "0b101010"
+    assert oct(uint_instance) == "0o52"
 
 
 @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
 def test_index_operator_index(uint_class: Type[BaseUint]) -> None:
     """Tests that operator.index() works with Uint types."""
-    value = uint_class(42)
-    assert operator.index(value) == 42
-    assert isinstance(operator.index(value), int)
+    uint_instance = uint_class(42)
+    assert operator.index(uint_instance) == 42
+    assert isinstance(operator.index(uint_instance), int)
 
 
 class TestUintSSZ:
@@ -416,10 +416,10 @@ class TestUintSSZ:
         # Create byte string that is one byte too short.
         expected_length = uint_class.get_byte_length()
         invalid_data = b"\x00" * (expected_length - 1)
-        expected = (
+        expected_message = (
             f"{uint_class.__name__}: expected {expected_length} bytes, got {expected_length - 1}"
         )
-        with pytest.raises(SSZSerializationError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(SSZSerializationError, match=rf"^{re.escape(expected_message)}$"):
             uint_class.decode_bytes(invalid_data)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -447,11 +447,11 @@ class TestUintSSZ:
         byte_length = uint_class.get_byte_length()
         stream = io.BytesIO(b"\x00" * byte_length)
         invalid_scope = byte_length - 1
-        expected = (
+        expected_message = (
             f"{uint_class.__name__}: invalid scope, "
             f"expected {byte_length} bytes, got {invalid_scope}"
         )
-        with pytest.raises(SSZSerializationError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(SSZSerializationError, match=rf"^{re.escape(expected_message)}$"):
             uint_class.deserialize(stream, scope=invalid_scope)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
@@ -460,8 +460,10 @@ class TestUintSSZ:
         byte_length = uint_class.get_byte_length()
         # Create a stream that is shorter than what the type requires.
         stream = io.BytesIO(b"\x00" * (byte_length - 1))
-        expected = f"{uint_class.__name__}: expected {byte_length} bytes, got {byte_length - 1}"
-        with pytest.raises(SSZSerializationError, match=rf"^{re.escape(expected)}$"):
+        expected_message = (
+            f"{uint_class.__name__}: expected {byte_length} bytes, got {byte_length - 1}"
+        )
+        with pytest.raises(SSZSerializationError, match=rf"^{re.escape(expected_message)}$"):
             uint_class.deserialize(stream, scope=byte_length)
 
 
@@ -484,8 +486,10 @@ class TestForwardArithmeticTypeErrors:
     ) -> None:
         """Forward arithmetic operator raises TypeError when given a plain int."""
         # Call the dunder method directly with a plain int operand.
-        expected = f"Unsupported operand type(s) for {op_symbol}: '{uint_class.__name__}' and 'int'"
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        expected_message = (
+            f"Unsupported operand type(s) for {op_symbol}: '{uint_class.__name__}' and 'int'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             getattr(uint_class(5), method)(3)
 
 
@@ -496,41 +500,41 @@ class TestReverseArithmeticSuccessPaths:
     def test_radd_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse add returns the correct sum when called directly."""
         # __radd__(other) computes other + self
-        result = uint_class(3).__radd__(uint_class(5))
-        assert result == uint_class(8)
-        assert isinstance(result, uint_class)
+        reverse_sum = uint_class(3).__radd__(uint_class(5))
+        assert reverse_sum == uint_class(8)
+        assert isinstance(reverse_sum, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rsub_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse sub returns the correct difference when called directly."""
         # __rsub__(other) computes other - self
-        result = uint_class(3).__rsub__(uint_class(10))
-        assert result == uint_class(7)
-        assert isinstance(result, uint_class)
+        reverse_difference = uint_class(3).__rsub__(uint_class(10))
+        assert reverse_difference == uint_class(7)
+        assert isinstance(reverse_difference, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rmul_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse mul returns the correct product when called directly."""
         # __rmul__(other) computes other * self
-        result = uint_class(3).__rmul__(uint_class(5))
-        assert result == uint_class(15)
-        assert isinstance(result, uint_class)
+        reverse_product = uint_class(3).__rmul__(uint_class(5))
+        assert reverse_product == uint_class(15)
+        assert isinstance(reverse_product, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rfloordiv_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse floordiv returns the correct quotient when called directly."""
         # __rfloordiv__(other) computes other // self
-        result = uint_class(3).__rfloordiv__(uint_class(10))
-        assert result == uint_class(3)
-        assert isinstance(result, uint_class)
+        reverse_quotient = uint_class(3).__rfloordiv__(uint_class(10))
+        assert reverse_quotient == uint_class(3)
+        assert isinstance(reverse_quotient, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rmod_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse mod returns the correct remainder when called directly."""
         # __rmod__(other) computes other % self
-        result = uint_class(3).__rmod__(uint_class(10))
-        assert result == uint_class(1)
-        assert isinstance(result, uint_class)
+        reverse_remainder = uint_class(3).__rmod__(uint_class(10))
+        assert reverse_remainder == uint_class(1)
+        assert isinstance(reverse_remainder, uint_class)
 
 
 class TestPowAndRpow:
@@ -540,25 +544,25 @@ class TestPowAndRpow:
     def test_pow_with_modulo(self, uint_class: Type[BaseUint]) -> None:
         """Three-argument pow(base, exp, mod) validates the modulo and returns correct result."""
         # pow(2, 10, 100) == 1024 % 100 == 24
-        result = pow(uint_class(2), uint_class(10), uint_class(100))
-        assert result == uint_class(24)
-        assert isinstance(result, uint_class)
+        modular_power = pow(uint_class(2), uint_class(10), uint_class(100))
+        assert modular_power == uint_class(24)
+        assert isinstance(modular_power, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rpow_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse pow computes base ** self when called directly."""
         # __rpow__(base) computes base ** self => 2 ** 3 == 8
-        result = uint_class(3).__rpow__(uint_class(2))
-        assert result == uint_class(8)
-        assert isinstance(result, uint_class)
+        reverse_power = uint_class(3).__rpow__(uint_class(2))
+        assert reverse_power == uint_class(8)
+        assert isinstance(reverse_power, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rpow_with_modulo(self, uint_class: Type[BaseUint]) -> None:
         """Three-argument reverse pow validates the modulo and returns the correct result."""
         # __rpow__(base, mod) computes pow(base, self, mod) => pow(2, 10, 100) == 24
-        result = uint_class(10).__rpow__(uint_class(2), uint_class(100))
-        assert result == uint_class(24)
-        assert isinstance(result, uint_class)
+        reverse_modular_power = uint_class(10).__rpow__(uint_class(2), uint_class(100))
+        assert reverse_modular_power == uint_class(24)
+        assert isinstance(reverse_modular_power, uint_class)
 
 
 class TestPowShiftStrictOperands:
@@ -568,66 +572,66 @@ class TestPowShiftStrictOperands:
     @pytest.mark.parametrize("bad", [3, True, "3", 1.5])
     def test_pow_rejects_non_uint_exponent(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Exponentiation rejects any exponent of a different type."""
-        expected = (
+        expected_message = (
             f"Unsupported operand type(s) for **: "
             f"'{uint_class.__name__}' and '{type(bad).__name__}'"
         )
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             uint_class(2) ** bad
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [100, True])
     def test_pow_rejects_non_uint_modulo(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Three-argument pow rejects any modulo of a different type."""
-        expected = (
+        expected_message = (
             f"Unsupported operand type(s) for **: "
             f"'{uint_class.__name__}' and '{type(bad).__name__}'"
         )
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             pow(uint_class(2), uint_class(10), bad)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [2, True])
     def test_rpow_rejects_non_uint_base(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Reverse pow rejects any base of a different type."""
-        expected = (
+        expected_message = (
             f"Unsupported operand type(s) for **: "
             f"'{uint_class.__name__}' and '{type(bad).__name__}'"
         )
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             uint_class(3).__rpow__(bad)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [100, True])
     def test_rpow_rejects_non_uint_modulo(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Three-argument reverse pow rejects any modulo of a different type."""
-        expected = (
+        expected_message = (
             f"Unsupported operand type(s) for **: "
             f"'{uint_class.__name__}' and '{type(bad).__name__}'"
         )
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             uint_class(10).__rpow__(uint_class(2), bad)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [3, True])
     def test_lshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Left shift rejects any shift amount of a different type."""
-        expected = (
+        expected_message = (
             f"Unsupported operand type(s) for <<: "
             f"'{uint_class.__name__}' and '{type(bad).__name__}'"
         )
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             uint_class(1) << bad
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [2, True])
     def test_rshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Right shift rejects any shift amount of a different type."""
-        expected = (
+        expected_message = (
             f"Unsupported operand type(s) for >>: "
             f"'{uint_class.__name__}' and '{type(bad).__name__}'"
         )
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             uint_class(8) >> bad
 
 
@@ -637,19 +641,21 @@ class TestDivmodEdgeCases:
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_divmod_rejects_plain_int(self, uint_class: Type[BaseUint]) -> None:
         """Forward divmod raises TypeError when the divisor is a plain int."""
-        expected = f"Unsupported operand type(s) for divmod: '{uint_class.__name__}' and 'int'"
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        expected_message = (
+            f"Unsupported operand type(s) for divmod: '{uint_class.__name__}' and 'int'"
+        )
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             divmod(uint_class(10), 3)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rdivmod_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse divmod returns correct (quotient, remainder) when called directly."""
         # __rdivmod__(other) computes divmod(other, self) => divmod(10, 3) == (3, 1)
-        q, r = uint_class(3).__rdivmod__(uint_class(10))
-        assert q == uint_class(3)
-        assert r == uint_class(1)
-        assert isinstance(q, uint_class)
-        assert isinstance(r, uint_class)
+        quotient, remainder = uint_class(3).__rdivmod__(uint_class(10))
+        assert quotient == uint_class(3)
+        assert remainder == uint_class(1)
+        assert isinstance(quotient, uint_class)
+        assert isinstance(remainder, uint_class)
 
 
 class TestReverseBitwiseOperators:
@@ -659,25 +665,25 @@ class TestReverseBitwiseOperators:
     def test_rand_delegates_to_and(self, uint_class: Type[BaseUint]) -> None:
         """Reverse AND delegates to forward AND and returns the correct result."""
         # __rand__ delegates to __and__
-        result = uint_class(0b1100).__rand__(uint_class(0b1010))
-        assert result == uint_class(0b1000)
-        assert isinstance(result, uint_class)
+        reverse_and_result = uint_class(0b1100).__rand__(uint_class(0b1010))
+        assert reverse_and_result == uint_class(0b1000)
+        assert isinstance(reverse_and_result, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_ror_delegates_to_or(self, uint_class: Type[BaseUint]) -> None:
         """Reverse OR delegates to forward OR and returns the correct result."""
         # __ror__ delegates to __or__
-        result = uint_class(0b1100).__ror__(uint_class(0b1010))
-        assert result == uint_class(0b1110)
-        assert isinstance(result, uint_class)
+        reverse_or_result = uint_class(0b1100).__ror__(uint_class(0b1010))
+        assert reverse_or_result == uint_class(0b1110)
+        assert isinstance(reverse_or_result, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rxor_delegates_to_xor(self, uint_class: Type[BaseUint]) -> None:
         """Reverse XOR delegates to forward XOR and returns the correct result."""
         # __rxor__ delegates to __xor__
-        result = uint_class(0b1100).__rxor__(uint_class(0b1010))
-        assert result == uint_class(0b0110)
-        assert isinstance(result, uint_class)
+        reverse_xor_result = uint_class(0b1100).__rxor__(uint_class(0b1010))
+        assert reverse_xor_result == uint_class(0b0110)
+        assert isinstance(reverse_xor_result, uint_class)
 
 
 class TestReverseShiftOperators:
@@ -687,38 +693,38 @@ class TestReverseShiftOperators:
     def test_rlshift_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse left shift computes other << self."""
         # __rlshift__(other) computes other << self => 1 << 2 == 4
-        result = uint_class(2).__rlshift__(uint_class(1))
-        assert result == uint_class(4)
-        assert isinstance(result, uint_class)
+        reverse_left_shift = uint_class(2).__rlshift__(uint_class(1))
+        assert reverse_left_shift == uint_class(4)
+        assert isinstance(reverse_left_shift, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [1, True])
     def test_rlshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Reverse left shift rejects any operand of a different type."""
-        expected = (
+        expected_message = (
             f"Unsupported operand type(s) for <<: "
             f"'{uint_class.__name__}' and '{type(bad).__name__}'"
         )
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             uint_class(2).__rlshift__(bad)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_rrshift_success(self, uint_class: Type[BaseUint]) -> None:
         """Reverse right shift computes other >> self."""
         # __rrshift__(other) computes other >> self => 8 >> 2 == 2
-        result = uint_class(2).__rrshift__(uint_class(8))
-        assert result == uint_class(2)
-        assert isinstance(result, uint_class)
+        reverse_right_shift = uint_class(2).__rrshift__(uint_class(8))
+        assert reverse_right_shift == uint_class(2)
+        assert isinstance(reverse_right_shift, uint_class)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     @pytest.mark.parametrize("bad", [8, True])
     def test_rrshift_rejects_non_uint(self, uint_class: Type[BaseUint], bad: Any) -> None:
         """Reverse right shift rejects any operand of a different type."""
-        expected = (
+        expected_message = (
             f"Unsupported operand type(s) for >>: "
             f"'{uint_class.__name__}' and '{type(bad).__name__}'"
         )
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             uint_class(2).__rrshift__(bad)
 
 
@@ -728,15 +734,15 @@ class TestComparisonTypeErrors:
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_lt_rejects_plain_int(self, uint_class: Type[BaseUint]) -> None:
         """Less-than raises TypeError when compared to a plain int directly."""
-        expected = f"Unsupported operand type(s) for <: '{uint_class.__name__}' and 'int'"
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        expected_message = f"Unsupported operand type(s) for <: '{uint_class.__name__}' and 'int'"
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             uint_class(5).__lt__(10)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_le_rejects_plain_int(self, uint_class: Type[BaseUint]) -> None:
         """Less-than-or-equal raises TypeError when compared to a plain int directly."""
-        expected = f"Unsupported operand type(s) for <=: '{uint_class.__name__}' and 'int'"
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        expected_message = f"Unsupported operand type(s) for <=: '{uint_class.__name__}' and 'int'"
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             uint_class(5).__le__(10)
 
 
@@ -746,11 +752,11 @@ class TestIndexReturnsPlainInt:
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
     def test_index_returns_plain_int(self, uint_class: Type[BaseUint]) -> None:
         """__index__ returns a plain int so that built-in operations receive a raw integer."""
-        result = uint_class(42).__index__()
+        index_value = uint_class(42).__index__()
         # The value must be correct.
-        assert result == 42
+        assert index_value == 42
         # The type must be plain int, not a BaseUint subclass.
-        assert type(result) is int
+        assert type(index_value) is int
 
 
 class TestCrossWidthEqualityIsStrict:
@@ -759,19 +765,19 @@ class TestCrossWidthEqualityIsStrict:
     @pytest.mark.parametrize("type_a, type_b", CROSS_UINT_TYPE_PAIRS)
     def test_eq_across_widths_raises(self, type_a: Type[BaseUint], type_b: Type[BaseUint]) -> None:
         """Equality across two distinct widths raises."""
-        expected = (
+        expected_message = (
             f"Unsupported operand type(s) for ==: '{type_a.__name__}' and '{type_b.__name__}'"
         )
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             _ = type_a(5) == type_b(5)
 
     @pytest.mark.parametrize("type_a, type_b", CROSS_UINT_TYPE_PAIRS)
     def test_ne_across_widths_raises(self, type_a: Type[BaseUint], type_b: Type[BaseUint]) -> None:
         """Inequality across two distinct widths raises."""
-        expected = (
+        expected_message = (
             f"Unsupported operand type(s) for !=: '{type_a.__name__}' and '{type_b.__name__}'"
         )
-        with pytest.raises(TypeError, match=rf"^{re.escape(expected)}$"):
+        with pytest.raises(TypeError, match=rf"^{re.escape(expected_message)}$"):
             _ = type_a(5) != type_b(5)
 
     @pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)

--- a/tests/lean_spec/test_base.py
+++ b/tests/lean_spec/test_base.py
@@ -38,9 +38,9 @@ class TestCamelModelToJson:
         """
         model = SampleCamelModel(first_name="Alice", current_slot=42)
 
-        result = model.to_json()
+        serialized = model.to_json()
 
-        assert result == {"firstName": "Alice", "currentSlot": 42}
+        assert serialized == {"firstName": "Alice", "currentSlot": 42}
 
     def test_to_json_rejects_mode_kwarg(self) -> None:
         """Overriding serialization mode raises an error instead of being silently accepted."""
@@ -65,10 +65,10 @@ class TestCamelModelToJson:
         model = SampleCamelModel(first_name="Dave", current_slot=0)
 
         # exclude_defaults=True should be forwarded to model_dump.
-        result = model.to_json(exclude_defaults=True)
+        serialized = model.to_json(exclude_defaults=True)
 
         # current_slot=0 is the default for int, so it gets excluded.
-        assert "firstName" in result
+        assert "firstName" in serialized
 
 
 class TestStrictBaseModel:
@@ -110,6 +110,6 @@ class TestStrictBaseModel:
         """
         model = SampleStrictModel(slot_number=42, block_root="0xdef")
 
-        result = model.to_json()
+        serialized = model.to_json()
 
-        assert result == {"slotNumber": 42, "blockRoot": "0xdef"}
+        assert serialized == {"slotNumber": 42, "blockRoot": "0xdef"}


### PR DESCRIPTION
## Motivation

A reference spec must read unambiguously line by line. Names like the ones below force the reader to scroll and reconstruct context:

```python
expected = len(part.participants.to_validator_indices())
for index, (part, public_keys) in enumerate(zip(parts, public_keys_per_part, strict=True)):
```

What is expected? A count? Of what? What is a part? This PR sweeps the whole tree (src, packages, tests — ~550 sites) so every local variable, loop target, comprehension variable, and parameter names the thing it holds.

## Changes

- **Aggregation API**: MultiMessageAggregate.aggregate now takes `single_message_aggregates` and `public_keys_per_aggregate` (was `parts` / `public_keys_per_part`); miscount guards use `expected_public_key_count`; all call sites updated.
- **Fork choice**: validation reads through `source_checkpoint` / `target_checkpoint` / `head_checkpoint` instead of a bare `data` alias; the aggregated-attestation path names `attestation_data` and `aggregated_proof` explicitly.
- **src/ sweep** (~70 sites): `result` → `decoded_value` / `digest` / `quotient`; `items` → `rlp_items`; `parts` → `multiaddr_components` / `topic_components`; `entry` → `validator_entry` / `cache_entry`; single letters expanded (`q, r` → `quotient, remainder`, …).
- **packages/ sweep** (~90 sites): `expected` / `actual` → typed `expected_*_root` / `actual_field_value`; serializer params and single-letter comprehension vars expanded; pytest hook signatures kept verbatim.
- **tests/ sweep** (~390 sites): every `expected` next to an assert names what is compared (`expected_state_root`, `expected_encoding`, `expected_mesh_size`); every `result` names what was produced (`decoded_block`, `negotiated_protocol`, `fanout_peers`).

## Deliberately kept verbatim

- Wire/serialized names: dict/JSON keys, protobuf fields, SSZ/pydantic field names (`data=`, `proof=`)
- API contracts: pytest hook parameters, stdlib idioms (`args`, `kwargs`, `tmp_path`, `exc_info`)
- Canonical protocol identifiers: `peer_id`, `node_id`, `protocol_id`, `subnet_id`, `stream_id`
- Single-letter math notation mirroring cited formulas (XMSS [HKKTW26] combinatorics, SSZ field correspondence)

## Verification

- `just check` passes (ruff lint + format, ty, codespell, mdformat)
- Full unit suite passes: 3139 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)