### PR TITLE
fix(testing): reset XMSS signing state per test and probe determinism

### DIFF
--- a/packages/testing/src/framework/pytest_plugins/filler.py
+++ b/packages/testing/src/framework/pytest_plugins/filler.py
@@ -4,11 +4,13 @@ import json
 import shutil
 import sys
 from collections import defaultdict
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
 from consensus_testing.forks import FORKS_BY_NAME
+from consensus_testing.keys import DEFAULT_MAX_SLOT, XmssKeyManager
 from consensus_testing.test_fixtures import (
     ApiEndpointTest,
     ForkChoiceTest,
@@ -24,6 +26,9 @@ from consensus_testing.test_fixtures import (
     VerifySignaturesTest,
     VerifySingleMessageProofsTest,
 )
+
+from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.ssz import Bytes32
 
 
 class FixtureCollector:
@@ -292,6 +297,39 @@ def _check_markers_valid_for_fork(
     return any(fork_class <= until_fork for until_fork in valid_until_forks)
 
 
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """
+    Fail the session fast if re-signing the same message is not byte-identical.
+
+    A signature must depend only on the key, the slot, and the message.
+    Prior signing activity must never influence the bytes.
+
+    Why: a scheme change breaking this invariant must abort the fill.
+    Emitting order-dependent vectors would be worse than failing.
+
+    Under sharded runs every worker process probes its own key state.
+    """
+    probe_message = Bytes32(b"\x07" * 32)
+    fresh_signature = XmssKeyManager.shared().sign_block_root(
+        ValidatorIndex(0), Slot(1), probe_message
+    )
+
+    # Advance the key state to the manager's slot limit, reset, and sign again.
+    XmssKeyManager.shared().sign_block_root(ValidatorIndex(0), DEFAULT_MAX_SLOT, probe_message)
+    XmssKeyManager.reset_signing_state()
+    resigned_signature = XmssKeyManager.shared().sign_block_root(
+        ValidatorIndex(0), Slot(1), probe_message
+    )
+
+    assert fresh_signature.encode_bytes() == resigned_signature.encode_bytes(), (
+        "XMSS re-signing produced different bytes for the same validator, slot, and "
+        "message; emitted vectors would depend on test execution order"
+    )
+
+    # Restore the manager to a disk-fresh state.
+    XmssKeyManager.reset_signing_state()
+
+
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     """Write all collected fixtures at the end of the session."""
     if hasattr(session.config, "fixture_collector"):
@@ -343,6 +381,21 @@ def test_case_description(request: pytest.FixtureRequest) -> str:
 
     combined_docstring = f"{test_class_doc}\n\n{test_function_doc}".strip()
     return combined_docstring
+
+
+@pytest.fixture(autouse=True)
+def reset_xmss_signing_state() -> Iterator[None]:
+    """
+    Reset shared XMSS signing state before every test.
+
+    XMSS signing is stateful.
+    Each signature consumes a one-time leaf and advances the shared key state.
+
+    Every test must start from the same fresh key state.
+    Otherwise emitted vectors could depend on test order or worker sharding.
+    """
+    XmssKeyManager.reset_signing_state()
+    yield
 
 
 def base_spec_filler_parametrizer(fixture_class: Any) -> Any:

--- a/tests/consensus/lstar/fc/test_block_attestation_limits.py
+++ b/tests/consensus/lstar/fc/test_block_attestation_limits.py
@@ -9,26 +9,11 @@ from consensus_testing import (
     ForkChoiceTestFiller,
     StoreChecks,
 )
-from consensus_testing.keys import XmssKeyManager
 
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import MAX_ATTESTATIONS_DATA
 
 pytestmark = pytest.mark.valid_until("Lstar")
-
-
-@pytest.fixture(autouse=True)
-def _reset_xmss_signing_state():
-    """
-    Reset XMSS signing state around each test in this module.
-
-    Tests here sign at high slots (50+). Without resetting, the advanced
-    key state poisons the cache for any later test on the same
-    worker that need low-slot signatures.
-    """
-    XmssKeyManager.reset_signing_state()
-    yield
-    XmssKeyManager.reset_signing_state()
 
 
 def _justifiable_slots(n: int) -> list[Slot]:


### PR DESCRIPTION
## Motivation

Item 7 of the `packages/testing/` audit — the highest-trust-risk finding. `XmssKeyManager.shared()` is a process-global singleton whose `_secret_state` advances on every sign (XMSS is stateful). The filler **never reset it between tests**, so under `fill -n auto` (the documented default) worker sharding determined each key's advancement when a test signed. The safety net (`reset_signing_state`) existed but was dead code in the generation path — only `test_block_attestation_limits.py` defended itself with a hand-rolled autouse fixture.

## Changes

**1. Plugin-level autouse reset per test** (`filler.py`): every test starts from the same disk-fresh key state regardless of execution order or sharding. The hand-rolled module fixture is deleted — the plugin now covers every consumer.

**2. Determinism tripwire at session start** (`pytest_sessionstart`): sign `(validator 0, slot 1, probe message)`, advance the key to the manager's slot limit, reset, re-sign, assert **byte equality**. A future scheme change that makes signing path-dependent (e.g. randomized rho, interval-start advancement) aborts the fill loudly instead of silently emitting order-dependent vectors. Runs once per worker process under xdist — each worker probes its own key state.

## Empirical grounding

- Probed the invariant before building on it: re-signing the same `(validator, slot, message)` is byte-identical today, with and without reset, even after advancing past the slot — so **current vectors are unaffected**; this change locks the invariant in
- Signing-heavy 20-test subset: fill time unchanged (89.5s branch vs 91.6s main — per-test reset cost is noise) and emitted vector trees **byte-identical**

## Review panel (py-architect)

Verdict *ship with fixes*, all applied:
- the probe moved from a session-scoped autouse fixture into `pytest_sessionstart` — the once-before-any-signing guarantee is now explicit in the hook contract rather than implicit in fixture-scope ordering, and the per-worker xdist semantics are documented
- the probe now advances to the manager's slot limit (not slot 3), so it exercises meaningful advancement before reset and is honest about what it proves
- confirmed reset-before-only is correct (the next test's setup reset makes teardown resets redundant), and that no other module hand-rolls a reset

## Verification

- `just check` passes (ruff, format, ty, codespell, mdformat)
- Smoke fill of a signing test passes with the probe and per-test reset active

🤖 Generated with [Claude Code](https://claude.com/claude-code)