### PR TITLE
fix(testing): pin and verify the key archive, stamp the key-set digest

### DIFF
--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -18,6 +18,7 @@ File format:
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Iterator, Mapping
 from pathlib import Path
@@ -121,6 +122,29 @@ def get_keys_directory(scheme_name: str) -> Path:
     return Path(__file__).parent / "test_keys" / f"{scheme_name}_scheme"
 
 
+def compute_key_set_digest(keys_directory: Path) -> str:
+    """
+    Compute the SHA-256 digest identifying a directory's key set.
+
+    Hashes every validator's public keys in ascending index order.
+    Two fills agree on vectors only if they agree on this digest.
+
+    Args:
+        keys_directory: Directory holding per-validator key files.
+
+    Returns:
+        Hex digest prefixed with 0x.
+    """
+    digest = hashlib.sha256()
+    key_files = sorted(keys_directory.glob("*.json"), key=lambda key_file: int(key_file.stem))
+    for key_file in key_files:
+        key_data = json.loads(key_file.read_text())
+        digest.update(key_file.stem.encode())
+        digest.update(bytes.fromhex(key_data["attestation_keypair"]["public_key"]))
+        digest.update(bytes.fromhex(key_data["proposal_keypair"]["public_key"]))
+    return f"0x{digest.hexdigest()}"
+
+
 class XmssKeyManager:
     """
     Stateful manager for XMSS signing in tests.
@@ -146,6 +170,7 @@ class XmssKeyManager:
         "_public_cache",
         "_available_indices",
         "_secret_state",
+        "_key_set_digest",
     )
 
     _cache: ClassVar[dict[str, XmssKeyManager]] = {}
@@ -223,6 +248,9 @@ class XmssKeyManager:
 
         # Advanced secret-key state held as live Python objects.
         self._secret_state: dict[tuple[ValidatorIndex, KeyRole], SecretKey] = {}
+
+        # Computed lazily on first request.
+        self._key_set_digest: str | None = None
 
     def _scan_indices(self) -> set[ValidatorIndex]:
         """
@@ -327,6 +355,16 @@ class XmssKeyManager:
     def __iter__(self) -> Iterator[ValidatorIndex]:
         """Iterate over validator indices in ascending order."""
         return iter(sorted(self._scan_indices()))
+
+    def key_set_digest(self) -> str:
+        """
+        Return the digest identifying this manager's on-disk key set.
+
+        Computed once and cached for the manager's lifetime.
+        """
+        if self._key_set_digest is None:
+            self._key_set_digest = compute_key_set_digest(self._keys_directory)
+        return self._key_set_digest
 
     def get_public_keys(self, index: ValidatorIndex) -> tuple[PublicKey, PublicKey]:
         """

--- a/packages/testing/src/consensus_testing/keys_cli.py
+++ b/packages/testing/src/consensus_testing/keys_cli.py
@@ -16,6 +16,7 @@ Regenerating Keys:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import shutil
 import sys
@@ -27,7 +28,11 @@ from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 from pathlib import Path
 
-from consensus_testing.keys import LEAN_ENV_TO_SCHEMES, get_keys_directory
+from consensus_testing.keys import (
+    LEAN_ENV_TO_SCHEMES,
+    compute_key_set_digest,
+    get_keys_directory,
+)
 from lean_spec.spec.crypto.xmss.containers import ValidatorKeyPair
 from lean_spec.spec.crypto.xmss.interface import GeneralizedXmssScheme
 from lean_spec.spec.forks import Slot
@@ -42,6 +47,31 @@ GitHub release URLs for pre-generated key archives.
 
 Keyed by scheme name ("test" or "prod").
 Each URL points to a tar.gz containing per-validator JSON files.
+"""
+
+PINNED_KEY_ARCHIVE_SHA256 = {
+    "test": "2d616857f4936cde4e2720fa95a76f2644015390f4b8c188acbaa756f521dac8",
+    "prod": "a40aa60fc0c0d1b4c761f19fb1678039400ae318da85f782dd57bc8cc0eb617d",
+}
+"""
+SHA-256 of each scheme's key archive.
+
+The release tag is mutable, so these checksums are the real pin.
+A re-cut release fails the download instead of silently changing vectors.
+Update together with the key-set digests when adopting a new release.
+"""
+
+PINNED_KEY_SET_DIGESTS = {
+    "test": "0x49306dfdb6dddd72afe265ec3b20a1901834dde9b3dfe4fee6b4f7ca58c7aa43",
+    "prod": "0xc2b5fc4c1f1fbc181ddf07db3df985f79e1dcedcfb7df732ef20863d7cbcf491",
+}
+"""
+Expected key-set digest per scheme.
+
+Guards the on-disk keys, which the archive checksum cannot see.
+
+- test: the key set committed to this repository.
+- prod: the key set served by the current release.
 """
 
 NUM_VALIDATORS: int = 8
@@ -176,16 +206,46 @@ def download_keys(scheme: str) -> None:
         with urllib.request.urlopen(url) as response, tmp_path.open("wb") as out:
             shutil.copyfileobj(response, out)
 
-        # Remove any existing keys for this scheme before extracting.
-        target_directory = base_directory / f"{scheme}_scheme"
-        if target_directory.exists():
-            shutil.rmtree(target_directory)
-        base_directory.mkdir(parents=True, exist_ok=True)
+        # Verify the archive against the pinned checksum before extracting.
+        # The release tag is mutable, so the checksum is the real pin.
+        with tmp_path.open("rb") as archive_handle:
+            archive_sha256 = hashlib.file_digest(archive_handle, "sha256").hexdigest()
+        if archive_sha256 != PINNED_KEY_ARCHIVE_SHA256[scheme]:
+            raise RuntimeError(
+                f"downloaded {scheme} key archive does not match the pinned checksum\n"
+                f"  expected: {PINNED_KEY_ARCHIVE_SHA256[scheme]}\n"
+                f"  actual:   {archive_sha256}\n"
+                "The release was re-cut upstream. Adopting the new key set requires "
+                "updating the pinned checksum and key-set digest on purpose."
+            )
 
-        # Extract the archive into the base directory.
+        # Extract into a scratch directory and verify there first.
+        # A rejected archive must never destroy working keys.
         # The archive root is the scheme directory itself.
-        with tarfile.open(tmp_path, "r:gz") as tar:
-            tar.extractall(path=base_directory, filter="data")
+        with tempfile.TemporaryDirectory() as scratch_name:
+            scratch_directory = Path(scratch_name)
+            with tarfile.open(tmp_path, "r:gz") as tar:
+                tar.extractall(path=scratch_directory, filter="data")
+
+            # Verify the extracted key set against the pinned digest.
+            # Catches content drift the checksum pin alone would miss.
+            extracted_directory = scratch_directory / f"{scheme}_scheme"
+            extracted_digest = compute_key_set_digest(extracted_directory)
+            if extracted_digest != PINNED_KEY_SET_DIGESTS[scheme]:
+                raise RuntimeError(
+                    f"extracted {scheme} key set does not match the pinned digest\n"
+                    f"  expected: {PINNED_KEY_SET_DIGESTS[scheme]}\n"
+                    f"  actual:   {extracted_digest}\n"
+                    "The archive carries a different key set than the canonical one. "
+                    "For the test scheme, restore the committed keys from version control."
+                )
+
+            # Replace the live key set only after both verifications pass.
+            target_directory = base_directory / f"{scheme}_scheme"
+            if target_directory.exists():
+                shutil.rmtree(target_directory)
+            base_directory.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(extracted_directory), str(target_directory))
 
         print(f"Extracted {scheme} keys to {target_directory}/")
     finally:

--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -8,6 +8,7 @@ from typing import Any, ClassVar
 from framework.forks import BaseFork
 from pydantic import Field, field_serializer
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.base import CamelModel
 from lean_spec.config import LEAN_ENV
 
@@ -146,5 +147,9 @@ class BaseConsensusFixture(CamelModel):
         self.info["testId"] = test_id
         self.info["description"] = description
         self.info["fixtureFormat"] = self.format_name
+
+        # Why: consumers can detect vectors generated from a different key set.
+        self.info["keySetDigest"] = XmssKeyManager.shared().key_set_digest()
+
         # Set network field on the fixture itself
         self.network = fork.name()

--- a/packages/testing/src/framework/cli/fill.py
+++ b/packages/testing/src/framework/cli/fill.py
@@ -64,14 +64,18 @@ def fill(
 
     # Check and download keys if needed
     # Import here to avoid loading leanSpec modules before LEAN_ENV is set
-    from consensus_testing.keys import get_keys_directory
-    from consensus_testing.keys_cli import download_keys
+    from consensus_testing.keys import compute_key_set_digest, get_keys_directory
+    from consensus_testing.keys_cli import PINNED_KEY_SET_DIGESTS, download_keys
 
     keys_directory = get_keys_directory(scheme.lower())
 
     # Check if keys already exist, if not, download them
     if not (keys_directory.exists() and any(keys_directory.glob("*.json"))):
         click.echo(f"Test keys for '{scheme}' scheme not found. Downloading...")
+        download_keys(scheme.lower())
+    # Why: stale or modified local keys would silently change every vector.
+    elif compute_key_set_digest(keys_directory) != PINNED_KEY_SET_DIGESTS[scheme.lower()]:
+        click.echo(f"Local '{scheme}' keys do not match the pinned key set. Re-downloading...")
         download_keys(scheme.lower())
 
     config_path = Path(__file__).parent / "pytest_ini_files" / "pytest-fill.ini"


### PR DESCRIPTION
## Motivation

Item 8 of the `packages/testing/` audit — and the risk turned out to be **live**, not theoretical. While implementing, I found:

- `KEY_DOWNLOAD_URLS` points at the **mutable `latest` tag**, fetched with zero integrity checking
- the `latest` release was **re-cut on 2026-05-22 with entirely different test keys** than the ones committed to this repository (every public key differs, validator by validator)
- the newest immutable tag (`leanspec-d6844a0`) carries an **old incompatible file schema** (`attestation_public`/`attestation_secret` flat layout), so pinning a tag is not currently possible — the checksum must be the pin
- consequence today: anyone whose key download path triggers gets vectors with different signatures and **different state roots** (public keys are merkleized into state) than the committed keys produce

## Changes

**Two-stage verification in `download_keys`:**
1. **Archive checksum** — SHA-256 of the downloaded tar.gz against `PINNED_KEY_ARCHIVE_SHA256` before extraction; a re-cut release fails loudly with an expected/actual diff and instructions to bump the pin deliberately
2. **Key-set digest** — extraction lands in a scratch directory; the extracted keys are verified against `PINNED_KEY_SET_DIGESTS` (SHA-256 over every validator's public keys in index order) **before** replacing the live key set, so a rejected archive never destroys working keys

**Fill startup staleness check** (`fill.py`): if local keys disagree with the pinned digest, re-download (which re-verifies). Catches hand-edited or stale local key sets the download path can't see.

**Key-set digest stamped into every fixture's `_info`** (`keySetDigest`): consumers can now detect vectors generated from a different key set. The fixture content `hash` excludes `_info`, so vector hashes are unchanged.

**Pin values encode today's canonical reality**: `test` → the committed key set (authoritative, in-repo); `prod` → the current release's prod archive (what CI downloads; prod keys are not committed).

## Verified live

Ran `keys_cli --download --scheme test` against the drifted release: checksum **passed**, digest verification **rejected** the archive (`expected 0x4930… / actual 0x2926…`), and the committed keys were left untouched — exactly the failure mode this PR exists to catch.

## Follow-up for upstream

The `latest` release of `leansig-test-keys` is out of sync with this repo's committed test keys. Reconciling (re-publishing the committed set, ideally under an immutable tag) would let the pins point at a tag instead of a checksum.

## Verification

- `just check` passes (ruff, format, ty, codespell, mdformat)
- Smoke fill passes; `_info` now carries `keySetDigest` matching the committed-keys pin
- Live negative test of both verification stages (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)