### PR TITLE
feat(testing): always emit the post-state root and per-step store snapshots

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -19,6 +19,7 @@ from consensus_testing.test_types import (
     BlockStep,
     ForkChoiceStep,
     GossipAggregatedAttestationStep,
+    StoreSnapshot,
     TickStep,
 )
 from lean_spec.node.chain.clock import SlotClock
@@ -360,6 +361,11 @@ class ForkChoiceTest(BaseConsensusFixture):
                         raise ValueError(
                             f"Step {step_index}: unknown step type {type(step).__name__}"
                         )
+
+                # Record the canonical store observables for this step.
+                # Clients replay the step and must reproduce every field.
+                # Authored checks below remain a human-readable overlay.
+                step.store_snapshot = StoreSnapshot.from_store(store)
 
                 # Validate Store state if checks are provided.
                 if step.checks is not None:

--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -89,6 +89,17 @@ class StateTransitionTest(BaseConsensusFixture):
     If None, no post-state validation is performed (e.g., for invalid tests).
     """
 
+    post_state_root: Bytes32 | None = None
+    """
+    Hash tree root of the full post-state.
+
+    Populated by the framework whenever processing succeeds.
+    Tests must not set this.
+    Clients must reproduce this root exactly, so two clients cannot
+    pass the same vector while holding divergent state.
+    Stays None for invalid tests, which produce no post-state.
+    """
+
     expect_exception_message: str | None = None
     """Expected exception message for invalid tests."""
 
@@ -183,6 +194,12 @@ class StateTransitionTest(BaseConsensusFixture):
                         f"Expected exception message '{self.expect_exception_message}' "
                         f"but got '{exception_raised}'"
                     )
+
+        # Pin the full post-state for clients.
+        # Selective expectations below only cover authored fields.
+        # The root covers every field, closing the divergence gap.
+        if actual_post_state is not None:
+            self.post_state_root = hash_tree_root(actual_post_state)
 
         # Validate post-state expectations if provided
         if self.post is not None and actual_post_state is not None:

--- a/packages/testing/src/consensus_testing/test_types/__init__.py
+++ b/packages/testing/src/consensus_testing/test_types/__init__.py
@@ -19,12 +19,14 @@ from consensus_testing.test_types.store_checks import (
     AttestationCheck,
     StoreChecks,
 )
+from consensus_testing.test_types.store_snapshot import StoreSnapshot
 
 __all__ = [
     "AggregatedAttestationSpec",
     "GossipAttestationSpec",
     "StateExpectation",
     "StoreChecks",
+    "StoreSnapshot",
     "AttestationCheck",
     "AggregatedAttestationCheck",
     "BaseForkChoiceStep",

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -10,6 +10,7 @@ from consensus_testing.test_types.attestation_specs import (
 )
 from consensus_testing.test_types.block_spec import BlockSpec
 from consensus_testing.test_types.store_checks import StoreChecks
+from consensus_testing.test_types.store_snapshot import StoreSnapshot
 from lean_spec.base import CamelModel
 from lean_spec.spec.forks.lstar.containers import (
     Block,
@@ -48,6 +49,16 @@ class BaseForkChoiceStep(CamelModel):
     If provided, the fixture will validate the Store state matches
     these checks after executing the step.
     Only fields that are explicitly set will be validated.
+    """
+
+    store_snapshot: StoreSnapshot | None = None
+    """
+    Canonical store observables after this step.
+
+    Populated by the framework for every successful step.
+    Tests must not set this.
+    Stays None for steps expected to fail, where the resulting
+    store state is implementation-defined.
     """
 
 

--- a/packages/testing/src/consensus_testing/test_types/store_snapshot.py
+++ b/packages/testing/src/consensus_testing/test_types/store_snapshot.py
@@ -1,0 +1,45 @@
+"""Canonical store snapshot emitted after every fork choice step."""
+
+from lean_spec.base import CamelModel
+from lean_spec.spec.forks import Interval
+from lean_spec.spec.forks.lstar.containers import Checkpoint, Store
+from lean_spec.spec.ssz import Bytes32
+
+
+class StoreSnapshot(CamelModel):
+    """
+    Canonical store observables captured after a fork choice step.
+
+    Recorded by the framework after every successful step.
+    Clients must reproduce every field, not just authored checks.
+
+    Why explicit fields instead of an opaque digest:
+    a digest needs a spec-defined canonical store encoding.
+    Explicit fields are self-describing and language-neutral.
+    """
+
+    time: Interval
+    """Store time in intervals since genesis."""
+
+    head_root: Bytes32
+    """Root of the canonical chain head block."""
+
+    safe_target_root: Bytes32
+    """Root of the current safe attestation target."""
+
+    latest_justified: Checkpoint
+    """Highest slot justified checkpoint known to the store."""
+
+    latest_finalized: Checkpoint
+    """Highest slot finalized checkpoint known to the store."""
+
+    @classmethod
+    def from_store(cls, store: Store) -> "StoreSnapshot":
+        """Capture the canonical observables of a store."""
+        return cls(
+            time=store.time,
+            head_root=store.head,
+            safe_target_root=store.safe_target,
+            latest_justified=store.latest_justified,
+            latest_finalized=store.latest_finalized,
+        )


### PR DESCRIPTION
## Motivation

`StateExpectation` and `StoreChecks` only validate fields the test author explicitly set. There was no always-on `hash_tree_root(post_state)` assertion anywhere, so two clients could pass identical vectors while holding divergent state, then fork in production. consensus-specs compares the entire post-state; the data here is already computed at fill time.

The gap is real despite the per-block state-root check in `state_transition`:

- skip-slot blocks are built with a zero placeholder state root and run through block processing only, so those vectors pinned nothing,
- explicit state-root override blocks likewise bypass the pin,
- fork choice vectors had no always-on assertion at all — only author-set selective checks.

## What changed

**State transition vectors** now always carry `postStateRoot`, the hash tree root of the full post-state, whenever processing succeeds. Absent for invalid tests, which produce no post-state.

**Fork choice vectors** now record a canonical store snapshot after every successful step (`storeSnapshot`): time, head root, safe target root, and the latest justified and finalized checkpoints. Steps expected to fail get none, since the post-failure store state (e.g. whether the implied tick applied) is implementation-defined. Per-block states are already pinned indirectly: block import runs the state transition, which checks each block's state root.

One deliberate deviation from the audit wording ("canonical store digest"): explicit snapshot fields are emitted instead of an opaque digest. A digest would require a spec-defined canonical Store encoding (including sorting the attestation-payload maps) before another client could reproduce it. Explicit fields are self-describing and language-neutral, matching what consensus-specs emits per step. The attestation pools remain pinned only indirectly — pinning those directly is possible follow-up work.

Authored `StateExpectation` / `StoreChecks` remain a human-readable overlay on top.

## Verification

- Filled genesis, fork-choice-head, and slot-monotonicity vectors:
  - `postStateRoot` present on valid vectors (matches the last block's state root on the normal path), absent on `expectException` vectors,
  - every successful fork-choice step carries a populated `storeSnapshot` with evolving head and time.
- No in-repo consumer parses the fixture JSON, so the change is purely additive.
- `just check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)