### PR TITLE
feat(testing): emit language-neutral rejection reasons in negative vectors

### DIFF
--- a/packages/testing/src/consensus_testing/rejection.py
+++ b/packages/testing/src/consensus_testing/rejection.py
@@ -1,0 +1,72 @@
+"""Classification of spec rejections into language-neutral reasons."""
+
+from lean_spec.spec.forks import RejectionReason
+from lean_spec.spec.forks.lstar.containers import AggregationError
+
+_REASON_BY_MESSAGE_FRAGMENT: list[tuple[str, RejectionReason]] = [
+    ("Target slot must be in the future", RejectionReason.BLOCK_SLOT_NOT_IN_FUTURE),
+    ("Block is older than latest header", RejectionReason.BLOCK_OLDER_THAN_LATEST_HEADER),
+    ("Block slot mismatch", RejectionReason.BLOCK_SLOT_MISMATCH),
+    ("Block parent root mismatch", RejectionReason.PARENT_ROOT_MISMATCH),
+    ("Invalid block state root", RejectionReason.STATE_ROOT_MISMATCH),
+    ("Parent state not found", RejectionReason.UNKNOWN_PARENT_BLOCK),
+    ("Sync parent chain", RejectionReason.UNKNOWN_PARENT_BLOCK),
+    ("Proposer index out of range", RejectionReason.PROPOSER_INDEX_OUT_OF_RANGE),
+    ("is not the proposer for slot", RejectionReason.WRONG_PROPOSER),
+    ("Incorrect block proposer", RejectionReason.WRONG_PROPOSER),
+    (
+        "Aggregated attestation must reference at least one validator",
+        RejectionReason.EMPTY_AGGREGATION_BITS,
+    ),
+    ("distinct AttestationData entries", RejectionReason.TOO_MANY_ATTESTATION_DATA),
+    ("duplicate AttestationData", RejectionReason.DUPLICATE_ATTESTATION_DATA),
+    ("Unknown source block", RejectionReason.UNKNOWN_SOURCE_BLOCK),
+    ("Unknown target block", RejectionReason.UNKNOWN_TARGET_BLOCK),
+    ("Unknown head block", RejectionReason.UNKNOWN_HEAD_BLOCK),
+    ("Source checkpoint slot must not exceed target", RejectionReason.SOURCE_AFTER_TARGET),
+    ("Head checkpoint must not be older than target", RejectionReason.HEAD_OLDER_THAN_TARGET),
+    ("Source checkpoint slot mismatch", RejectionReason.SOURCE_SLOT_MISMATCH),
+    ("Target checkpoint slot mismatch", RejectionReason.TARGET_SLOT_MISMATCH),
+    ("Head checkpoint slot mismatch", RejectionReason.HEAD_SLOT_MISMATCH),
+    ("Attestation too far in future", RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE),
+    ("not found in state", RejectionReason.VALIDATOR_NOT_IN_STATE),
+    ("Validator index out of range", RejectionReason.VALIDATOR_INDEX_OUT_OF_RANGE),
+    ("Signature verification failed", RejectionReason.INVALID_SIGNATURE),
+    ("Block proof verification failed", RejectionReason.INVALID_SIGNATURE),
+    ("Anchor block state root must match", RejectionReason.ANCHOR_STATE_ROOT_MISMATCH),
+]
+"""
+Ordered mapping from spec rejection messages to reasons.
+
+The first fragment contained in the exception message wins.
+Fragments mirror the spec's assertion messages one-to-one.
+"""
+
+
+def classify_rejection(exception: Exception) -> RejectionReason:
+    """
+    Resolve the language-neutral reason behind a spec rejection.
+
+    Args:
+        exception: The exception the spec raised for the invalid input.
+
+    Returns:
+        The reason emitted into the test vector.
+
+    Raises:
+        ValueError: If the rejection is not in the vocabulary yet.
+    """
+    # Aggregate proof failures carry library-specific messages.
+    # The type alone identifies them as signature verification failures.
+    if isinstance(exception, AggregationError):
+        return RejectionReason.INVALID_SIGNATURE
+
+    message = str(exception)
+    for message_fragment, reason in _REASON_BY_MESSAGE_FRAGMENT:
+        if message_fragment in message:
+            return reason
+
+    raise ValueError(
+        f"no rejection reason mapped for {type(exception).__name__}: {message}\n"
+        "Add the new rejection to the reason vocabulary and this mapping."
+    )

--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -6,10 +6,11 @@ from functools import cached_property
 from typing import Any, ClassVar
 
 from framework.forks import BaseFork
-from pydantic import Field, field_serializer
+from pydantic import Field
 
 from lean_spec.base import CamelModel
 from lean_spec.config import LEAN_ENV
+from lean_spec.spec.forks import RejectionReason
 
 
 class BaseConsensusFixture(CamelModel):
@@ -39,20 +40,24 @@ class BaseConsensusFixture(CamelModel):
     info: dict[str, Any] = Field(default_factory=dict, alias="_info")
     """Metadata about the test (description, fork, etc.)."""
 
-    expect_exception: type[Exception] | None = None
+    expect_exception: type[Exception] | None = Field(default=None, exclude=True)
     """
     Expected exception type for invalid tests.
 
     If set, the fixture expects this exception during processing.
     The test passes only if the exception is raised.
+
+    Excluded from JSON output: a Python class name means nothing to
+    other-language clients. It remains a fill-time self-check only.
     """
 
-    @field_serializer("expect_exception", when_used="json")
-    def serialize_exception(self, exception_type: type[Exception] | None) -> str | None:
-        """Serialize exception type to its class name for JSON output."""
-        if exception_type is None:
-            return None
-        return exception_type.__name__
+    rejection_reason: RejectionReason | None = None
+    """
+    Language-neutral reason the vector's input must be rejected.
+
+    Filled during generation for negative vectors.
+    This is the field clients assert against.
+    """
 
     def assert_expected_outcome(self, exception_raised: Exception | None) -> None:
         """

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -13,6 +13,7 @@ from pydantic import Field, model_validator
 
 from consensus_testing.genesis import generate_pre_state
 from consensus_testing.keys import XmssKeyManager
+from consensus_testing.rejection import classify_rejection
 from consensus_testing.test_fixtures.base import BaseConsensusFixture
 from consensus_testing.test_types import (
     AttestationStep,
@@ -210,6 +211,8 @@ class ForkChoiceTest(BaseConsensusFixture):
                         f"  Expected error containing: {self.expected_anchor_error!r}\n"
                         f"  Actual error: {exception!r}"
                     ) from exception
+                # Emit the language-neutral reason clients assert against.
+                self.rejection_reason = classify_rejection(exception)
                 return self
 
             raise AssertionError("Store.from_anchor was expected to fail but succeeded")
@@ -394,6 +397,9 @@ class ForkChoiceTest(BaseConsensusFixture):
                         f"  Expected error containing: {step.expected_error!r}\n"
                         f"  Actual error: {exception!r}"
                     ) from exception
+
+                # Emit the language-neutral reason clients assert against.
+                step.rejection_reason = classify_rejection(exception)
 
                 continue
 

--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -26,7 +26,7 @@ from lean_spec.node.networking.reqresp.codec import (
 from lean_spec.node.networking.transport.peer_id import KeyType, PeerId, PublicKeyProtobuf
 from lean_spec.node.networking.varint import decode_varint, encode_varint
 from lean_spec.node.snappy import compress, decompress, frame_compress, frame_decompress
-from lean_spec.spec.forks import SubnetId
+from lean_spec.spec.forks import RejectionReason, SubnetId
 
 
 def _to_hex(data: bytes) -> str:
@@ -115,8 +115,7 @@ class NetworkingCodecTest(BaseConsensusFixture):
         - `bytes`: hex-encoded malformed input.
 
         Returns:
-            A dict echoing the decoder name along with the error type and
-            message for reproducibility.
+            A dict echoing the decoder name.
 
         Raises:
             AssertionError: If the decoder succeeds or raises a mismatched
@@ -160,11 +159,9 @@ class NetworkingCodecTest(BaseConsensusFixture):
                 f"{type(exception_raised).__name__}: {exception_raised}"
             )
 
-        return {
-            "decoder": decoder_name,
-            "errorType": type(exception_raised).__name__,
-            "errorMessage": str(exception_raised),
-        }
+        # Emit the language-neutral reason clients assert against.
+        self.rejection_reason = RejectionReason.DECODE_ERROR
+        return {"decoder": decoder_name}
 
     def _make_varint(self) -> dict[str, Any]:
         """Encode a value as LEB128, decode it back, assert roundtrip."""

--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -8,6 +8,7 @@ from consensus_testing.test_fixtures.base import BaseConsensusFixture
 from lean_spec.base import CamelModel
 from lean_spec.spec.crypto.koalabear import Fp
 from lean_spec.spec.crypto.merkleization import hash_tree_root
+from lean_spec.spec.forks import RejectionReason
 from lean_spec.spec.ssz.boolean import Boolean
 from lean_spec.spec.ssz.ssz_base import SSZType
 
@@ -139,4 +140,5 @@ class SSZTest(BaseConsensusFixture):
 
         self.serialized = "0x" + raw.hex()
         self.root = ""
+        self.rejection_reason = RejectionReason.DECODE_ERROR
         return self

--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -6,6 +6,7 @@ from pydantic import ConfigDict, Field, PrivateAttr, field_serializer
 
 from consensus_testing.genesis import generate_pre_state
 from consensus_testing.keys import XmssKeyManager
+from consensus_testing.rejection import classify_rejection
 from consensus_testing.test_fixtures.base import BaseConsensusFixture
 from consensus_testing.test_types import AggregatedAttestationSpec, BlockSpec, StateExpectation
 from lean_spec.spec.crypto.merkleization import hash_tree_root
@@ -100,8 +101,13 @@ class StateTransitionTest(BaseConsensusFixture):
     Stays None for invalid tests, which produce no post-state.
     """
 
-    expect_exception_message: str | None = None
-    """Expected exception message for invalid tests."""
+    expect_exception_message: str | None = Field(default=None, exclude=True)
+    """
+    Expected exception message for invalid tests.
+
+    Excluded from JSON output: an English message means nothing to
+    other-language clients. It remains a fill-time self-check only.
+    """
 
     @field_serializer("blocks", when_used="json")
     def serialize_blocks(self, block_specs: list[BlockSpec]) -> list[dict[str, Any]]:
@@ -194,6 +200,8 @@ class StateTransitionTest(BaseConsensusFixture):
                         f"Expected exception message '{self.expect_exception_message}' "
                         f"but got '{exception_raised}'"
                     )
+            # Emit the language-neutral reason clients assert against.
+            self.rejection_reason = classify_rejection(exception_raised)
 
         # Pin the full post-state for clients.
         # Selective expectations below only cover authored fields.

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
@@ -13,6 +13,7 @@ from lean_spec.spec.crypto.xmss.containers import PublicKey
 from lean_spec.spec.forks import (
     AggregationBits,
     Checkpoint,
+    RejectionReason,
     Slot,
     ValidatorIndex,
 )
@@ -250,6 +251,9 @@ class VerifySingleMessageProofsTest(BaseConsensusFixture):
         except Exception as exception:
             exception_raised = exception
         self.assert_expected_outcome(exception_raised)
+        # Every tamper breaks the proof's cryptographic binding.
+        if self.expect_exception is not None:
+            self.rejection_reason = RejectionReason.INVALID_SIGNATURE
 
         # Phase 4: publish the client-visible outputs and return self.
         self.message = message
@@ -494,6 +498,9 @@ class VerifyMultiMessageProofsTest(BaseConsensusFixture):
         except Exception as exception:
             exception_raised = exception
         self.assert_expected_outcome(exception_raised)
+        # Every tamper breaks the proof's cryptographic binding.
+        if self.expect_exception is not None:
+            self.rejection_reason = RejectionReason.INVALID_SIGNATURE
 
         # Phase 5: publish the client-visible outputs and return self.
         self.messages = messages

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from consensus_testing.genesis import generate_pre_state
 from consensus_testing.keys import XmssKeyManager
+from consensus_testing.rejection import classify_rejection
 from consensus_testing.test_fixtures.base import BaseConsensusFixture
 from consensus_testing.test_types import BlockSpec
 from lean_spec.spec.crypto.merkleization import hash_tree_root
@@ -187,6 +188,8 @@ class VerifySignaturesTest(BaseConsensusFixture):
                     f"Expected {self.expect_exception.__name__} "
                     f"but got {type(exception_raised).__name__}: {exception_raised}"
                 )
+            # Emit the language-neutral reason clients assert against.
+            self.rejection_reason = classify_rejection(exception_raised)
 
         return self
 

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -12,6 +12,7 @@ from consensus_testing.test_types.block_spec import BlockSpec
 from consensus_testing.test_types.store_checks import StoreChecks
 from consensus_testing.test_types.store_snapshot import StoreSnapshot
 from lean_spec.base import CamelModel
+from lean_spec.spec.forks import RejectionReason
 from lean_spec.spec.forks.lstar.containers import (
     Block,
     SignedAggregatedAttestation,
@@ -33,13 +34,24 @@ class BaseForkChoiceStep(CamelModel):
     valid: bool = True
     """Whether this step is expected to succeed."""
 
-    expected_error: str | None = None
+    expected_error: str | None = Field(default=None, exclude=True)
     """
     Expected error message substring when valid=False.
 
     When set, the exception message must contain this string.
     When None and valid=False, any exception is accepted.
     Ignored when valid=True.
+
+    Excluded from JSON output: an English substring means nothing to
+    other-language clients. It remains a fill-time self-check only.
+    """
+
+    rejection_reason: RejectionReason | None = None
+    """
+    Language-neutral reason this step's input must be rejected.
+
+    Filled during generation for invalid steps.
+    This is the field clients assert against.
     """
 
     checks: StoreChecks | None = None

--- a/src/lean_spec/spec/forks/__init__.py
+++ b/src/lean_spec/spec/forks/__init__.py
@@ -26,6 +26,7 @@ from lean_spec.spec.forks.lstar.containers import (
     ValidatorIndices,
     Validators,
 )
+from lean_spec.spec.forks.lstar.rejection_reason import RejectionReason
 from lean_spec.spec.forks.lstar.spec import LstarSpec, LstarStore
 from lean_spec.spec.forks.protocol import ForkProtocol, SpecStateType, SpecStoreType
 from lean_spec.spec.forks.registry import ForkRegistry
@@ -59,6 +60,7 @@ __all__ = [
     "Interval",
     "LstarSpec",
     "LstarStore",
+    "RejectionReason",
     "SignedAggregatedAttestation",
     "SignedAttestation",
     "SignedBlock",

--- a/src/lean_spec/spec/forks/lstar/rejection_reason.py
+++ b/src/lean_spec/spec/forks/lstar/rejection_reason.py
@@ -1,0 +1,92 @@
+"""Language-neutral rejection reasons for invalid consensus inputs."""
+
+from enum import StrEnum
+
+
+class RejectionReason(StrEnum):
+    """
+    Why the spec rejects an invalid block, attestation, or wire message.
+
+    Test vectors emit these instead of Python exception details.
+    Clients in any language assert the reason, not an English message.
+    """
+
+    # Block validation
+    BLOCK_SLOT_NOT_IN_FUTURE = "BLOCK_SLOT_NOT_IN_FUTURE"
+    """The block slot is not strictly greater than the current state slot."""
+
+    BLOCK_OLDER_THAN_LATEST_HEADER = "BLOCK_OLDER_THAN_LATEST_HEADER"
+    """The block slot is not newer than the latest block header."""
+
+    BLOCK_SLOT_MISMATCH = "BLOCK_SLOT_MISMATCH"
+    """The block slot disagrees with the state slot after slot processing."""
+
+    PARENT_ROOT_MISMATCH = "PARENT_ROOT_MISMATCH"
+    """The block parent root disagrees with the latest block header root."""
+
+    STATE_ROOT_MISMATCH = "STATE_ROOT_MISMATCH"
+    """The block state root disagrees with the computed post-state root."""
+
+    UNKNOWN_PARENT_BLOCK = "UNKNOWN_PARENT_BLOCK"
+    """The block references a parent the store has never seen."""
+
+    PROPOSER_INDEX_OUT_OF_RANGE = "PROPOSER_INDEX_OUT_OF_RANGE"
+    """The proposer index does not address any registered validator."""
+
+    WRONG_PROPOSER = "WRONG_PROPOSER"
+    """The block proposer is not the scheduled proposer for its slot."""
+
+    TOO_MANY_ATTESTATION_DATA = "TOO_MANY_ATTESTATION_DATA"
+    """The block carries more distinct attestation data entries than allowed."""
+
+    DUPLICATE_ATTESTATION_DATA = "DUPLICATE_ATTESTATION_DATA"
+    """The block carries the same attestation data entry more than once."""
+
+    EMPTY_AGGREGATION_BITS = "EMPTY_AGGREGATION_BITS"
+    """An aggregated attestation references no validator at all."""
+
+    # Attestation validation
+    UNKNOWN_SOURCE_BLOCK = "UNKNOWN_SOURCE_BLOCK"
+    """The attestation source root is not a known block."""
+
+    UNKNOWN_TARGET_BLOCK = "UNKNOWN_TARGET_BLOCK"
+    """The attestation target root is not a known block."""
+
+    UNKNOWN_HEAD_BLOCK = "UNKNOWN_HEAD_BLOCK"
+    """The attestation head root is not a known block."""
+
+    SOURCE_AFTER_TARGET = "SOURCE_AFTER_TARGET"
+    """The attestation source checkpoint slot exceeds its target slot."""
+
+    HEAD_OLDER_THAN_TARGET = "HEAD_OLDER_THAN_TARGET"
+    """The attestation head checkpoint is older than its target."""
+
+    SOURCE_SLOT_MISMATCH = "SOURCE_SLOT_MISMATCH"
+    """The source checkpoint slot disagrees with the referenced block."""
+
+    TARGET_SLOT_MISMATCH = "TARGET_SLOT_MISMATCH"
+    """The target checkpoint slot disagrees with the referenced block."""
+
+    HEAD_SLOT_MISMATCH = "HEAD_SLOT_MISMATCH"
+    """The head checkpoint slot disagrees with the referenced block."""
+
+    ATTESTATION_TOO_FAR_IN_FUTURE = "ATTESTATION_TOO_FAR_IN_FUTURE"
+    """The attestation slot is beyond the store's acceptance horizon."""
+
+    VALIDATOR_NOT_IN_STATE = "VALIDATOR_NOT_IN_STATE"
+    """The referenced validator does not exist in the state registry."""
+
+    VALIDATOR_INDEX_OUT_OF_RANGE = "VALIDATOR_INDEX_OUT_OF_RANGE"
+    """The validator index does not address any registered validator."""
+
+    # Cryptographic verification
+    INVALID_SIGNATURE = "INVALID_SIGNATURE"
+    """A signature or aggregate proof fails cryptographic verification."""
+
+    # Anchor initialization
+    ANCHOR_STATE_ROOT_MISMATCH = "ANCHOR_STATE_ROOT_MISMATCH"
+    """The anchor block state root disagrees with the anchor state."""
+
+    # Wire decoding
+    DECODE_ERROR = "DECODE_ERROR"
+    """The input bytes cannot be decoded into the expected structure."""


### PR DESCRIPTION
## Motivation

Item 12 of the `packages/testing/` audit — rated highest-impact for cross-client conformance. Negative vectors emitted `"expectException": "AssertionError"` and English substrings like `"expectedError": "Unknown target block"`. No non-Python client can reproduce either, so today's negative vectors only prove *"rejected somehow"* — a client that rejects a vector **for the wrong reason** (e.g. an unrelated bounds bug masking a missing source-check) passes silently.

## Before / after — a real vector

Invalid attestation step from `test_attestation_unknown_target_block_rejected` (fork-choice format), trimmed:

**Before** — Python exception name + English substring as the contract:

```json
{
  "stepType": "attestation",
  "valid": false,
  "expectedError": "Unknown target block",
  "attestation": { "validatorIndex": 1, "data": { "...": "..." }, "signature": "0x..." },
  "isAggregator": false
}
```

**After** — a vocabulary member any language can assert:

```json
{
  "stepType": "attestation",
  "valid": false,
  "rejectionReason": "UNKNOWN_TARGET_BLOCK",
  "attestation": { "validatorIndex": 1, "data": { "...": "..." }, "signature": "0x..." },
  "isAggregator": false
}
```

Same flip everywhere else: state-transition fixtures replace `"expectException": "AssertionError"` + `"expectExceptionMessage": "Block slot mismatch"` with `"rejectionReason": "BLOCK_SLOT_MISMATCH"`, and codec decode failures replace `"errorType": "VarintError", "errorMessage": "..."` with `"rejectionReason": "DECODE_ERROR"`.

## Changes

**1. The spec defines the vocabulary** (`lstar/rejection_reason.py`): a `RejectionReason` string enum, one member per distinct rejection check (`UNKNOWN_TARGET_BLOCK`, `INVALID_SIGNATURE`, `WRONG_PROPOSER`, `DECODE_ERROR`, …), each documented for client teams. 26 members.

**2. The framework classifies rejections** (`consensus_testing/rejection.py`): one ordered message-fragment table mapping the spec's assertion messages to reasons, plus a type rule for aggregation errors. An unmapped rejection **fails the fill loudly** with instructions to extend the vocabulary — no rejection can slip through unclassified.

**3. Python details become fill-time self-checks**: `expect_exception`, `expect_exception_message`, and `expected_error` are now `exclude=True` — the author-facing test API is **unchanged**; they just no longer leak into the client contract.

## Validation

- Filled the negative-heavy suites (`verify_signatures`, `ssz`, `networking`, block-processing/slot-monotonicity state transitions, gossip attestation validation): **305/305 pass**, **21 distinct reasons** emitted, and a recursive audit of every emitted JSON confirms **zero** Python class names or English error fields remain
- The loud-failure guard proved itself during development: three spec rejections (`Invalid block state root`, `Incorrect block proposer`, `Aggregated attestation must reference at least one validator`) were not in the initial vocabulary, failed the fill with a clear message, and became enum entries
- `just check` passes (ruff, format, ty, codespell, mdformat)

## Consumer impact

This intentionally changes the negative-vector contract (per the audit's recommendation): clients should assert `rejectionReason` instead of parsing Python exception names. Fixture content hashes change for negative vectors since the emitted fields changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
