### PR TITLE
refactor(testing): stop mutating the block spec while building

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -369,12 +369,13 @@ class BlockSpec(CamelModel):
         ]
 
         # Build a valid-only copy for normal attestation construction.
-        self.attestations = [
+        # A copy keeps this spec unchanged, so building twice gives the same result.
+        valid_specs = [
             attestation_spec
             for attestation_spec in (self.attestations or [])
             if attestation_spec not in invalid_specs
         ]
-        valid_only = self
+        valid_only = self.model_copy(update={"attestations": valid_specs})
 
         # Build valid attestations and their signatures.
         valid_attestations, signature_lookup, _ = valid_only.build_attestations(


### PR DESCRIPTION
## Motivation

Audit finding (Tier 4): `BlockSpec.build_signed_block` reassigned `self.attestations` to a filtered valid-only list mid-build. A spec is the test's *input* — rewriting it during the build breaks idempotency: building twice from the same spec would see the already-filtered list the second time, silently dropping the invalid attestation specs the test declared.

## Change

The valid-only view is now `self.model_copy(update={"attestations": valid_specs})` — the original spec stays untouched, the build is repeatable, and the downstream code is unchanged (it already operated on the `valid_only` reference).

## Verification

- `just check` passes (ruff, format, ty, codespell, mdformat)
- Smoke fill of `test_invalid_signatures.py` (exercises exactly the invalid-spec filtering path): 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)