### PR TITLE
refactor(testing): fixture consistency pass

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -1,7 +1,5 @@
 """Test tools for generating and consuming leanSpec consensus test vectors."""
 
-from typing import Type
-
 from consensus_testing import forks
 from consensus_testing.genesis import build_anchor, generate_pre_state
 from consensus_testing.test_fixtures import (
@@ -47,19 +45,19 @@ from consensus_testing.test_types import (
     TickStep,
 )
 
-StateTransitionTestFiller = Type[StateTransitionTest]
-ForkChoiceTestFiller = Type[ForkChoiceTest]
-VerifySingleMessageProofsTestFiller = Type[VerifySingleMessageProofsTest]
-VerifyMultiMessageProofsTestFiller = Type[VerifyMultiMessageProofsTest]
-VerifySignaturesTestFiller = Type[VerifySignaturesTest]
-SSZTestFiller = Type[SSZTest]
-NetworkingCodecTestFiller = Type[NetworkingCodecTest]
-GossipsubHandlerTestFiller = Type[GossipsubHandlerTest]
-ApiEndpointTestFiller = Type[ApiEndpointTest]
-SlotClockTestFiller = Type[SlotClockTest]
-JustifiabilityTestFiller = Type[JustifiabilityTest]
-PoseidonPermutationTestFiller = Type[PoseidonPermutationTest]
-SyncTestFiller = Type[SyncTest]
+StateTransitionTestFiller = type[StateTransitionTest]
+ForkChoiceTestFiller = type[ForkChoiceTest]
+VerifySingleMessageProofsTestFiller = type[VerifySingleMessageProofsTest]
+VerifyMultiMessageProofsTestFiller = type[VerifyMultiMessageProofsTest]
+VerifySignaturesTestFiller = type[VerifySignaturesTest]
+SSZTestFiller = type[SSZTest]
+NetworkingCodecTestFiller = type[NetworkingCodecTest]
+GossipsubHandlerTestFiller = type[GossipsubHandlerTest]
+ApiEndpointTestFiller = type[ApiEndpointTest]
+SlotClockTestFiller = type[SlotClockTest]
+JustifiabilityTestFiller = type[JustifiabilityTest]
+PoseidonPermutationTestFiller = type[PoseidonPermutationTest]
+SyncTestFiller = type[SyncTest]
 
 __all__ = [
     # Public API

--- a/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
@@ -233,7 +233,7 @@ class ApiEndpointTest(BaseConsensusFixture):
     expectedContentType, expectedBody.
     """
 
-    format_name: ClassVar[str] = "api_endpoint"
+    format_name: ClassVar[str] = "api_endpoint_test"
     description: ClassVar[str] = "Tests API endpoint responses against known state"
 
     endpoint: str

--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -59,7 +59,11 @@ class BaseConsensusFixture(CamelModel):
     This is the field clients assert against.
     """
 
-    def assert_expected_outcome(self, exception_raised: Exception | None) -> None:
+    def assert_expected_outcome(
+        self,
+        exception_raised: Exception | None,
+        expected_message: str | None = None,
+    ) -> None:
         """
         Compare a self-verification outcome against the configured expectation.
 
@@ -68,6 +72,7 @@ class BaseConsensusFixture(CamelModel):
 
         Args:
             exception_raised: The exception the verifier raised, or None on success.
+            expected_message: Optional exact message the exception must carry.
 
         Raises:
             AssertionError: When the outcome disagrees with the expectation.
@@ -86,6 +91,11 @@ class BaseConsensusFixture(CamelModel):
             raise AssertionError(
                 f"Expected {self.expect_exception.__name__} but got "
                 f"{type(exception_raised).__name__}: {exception_raised}"
+            )
+        # A wrong message means the rejection fired for the wrong reason.
+        elif expected_message is not None and str(exception_raised) != expected_message:
+            raise AssertionError(
+                f"Expected exception message '{expected_message}' but got '{exception_raised}'"
             )
 
     @cached_property
@@ -116,20 +126,15 @@ class BaseConsensusFixture(CamelModel):
         h = hashlib.sha256(json_str.encode("utf-8")).hexdigest()
         return f"0x{h}"
 
-    def json_dict_with_info(self, hash_only: bool = False) -> dict[str, Any]:
+    def json_dict_with_info(self) -> dict[str, Any]:
         """
         Return JSON representation with the info field included.
-
-        Args:
-            hash_only: If True, only include the hash in _info.
 
         Returns:
             Dictionary ready for JSON serialization.
         """
         dict_with_info = self.json_dict.copy()
-        dict_with_info["_info"] = {"hash": self.hash}
-        if not hash_only:
-            dict_with_info["_info"].update(self.info)
+        dict_with_info["_info"] = {"hash": self.hash, **self.info}
         return dict_with_info
 
     def fill_info(

--- a/packages/testing/src/consensus_testing/test_fixtures/gossipsub_handler.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/gossipsub_handler.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass, field
 from typing import Any, ClassVar
 from unittest.mock import patch
 
+from pydantic import Field
+
 from consensus_testing.test_fixtures.base import BaseConsensusFixture
 from lean_spec.node.networking import PeerId
 from lean_spec.node.networking.gossipsub.behavior import GossipsubBehavior, PeerState
@@ -147,7 +149,7 @@ class GossipsubHandlerTest(BaseConsensusFixture):
     JSON output: params, initialState, event, now, expected.
     """
 
-    format_name: ClassVar[str] = "gossipsub_handler"
+    format_name: ClassVar[str] = "gossipsub_handler_test"
     description: ClassVar[str] = "Tests gossipsub handler protocol decisions"
 
     handler_name: str
@@ -165,7 +167,7 @@ class GossipsubHandlerTest(BaseConsensusFixture):
     now: float = 1000.0
     """Current timestamp for backoff checks."""
 
-    expected: dict[str, Any] = {}
+    expected: dict[str, Any] = Field(default_factory=dict)
     """Expected output. Filled by make_fixture."""
 
     def make_fixture(self) -> "GossipsubHandlerTest":

--- a/packages/testing/src/consensus_testing/test_fixtures/justifiability.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/justifiability.py
@@ -14,6 +14,8 @@ Every client must implement this identically for consensus.
 
 from typing import Any, ClassVar
 
+from pydantic import Field
+
 from consensus_testing.test_fixtures.base import BaseConsensusFixture
 from lean_spec.spec.forks import Slot
 
@@ -28,7 +30,7 @@ class JustifiabilityTest(BaseConsensusFixture):
     JSON output: slot, finalizedSlot, output.
     """
 
-    format_name: ClassVar[str] = "justifiability"
+    format_name: ClassVar[str] = "justifiability_test"
     description: ClassVar[str] = "Tests 3SF-mini slot justifiability rules"
 
     slot: int
@@ -37,7 +39,7 @@ class JustifiabilityTest(BaseConsensusFixture):
     finalized_slot: int
     """Last finalized slot."""
 
-    output: dict[str, Any] = {}
+    output: dict[str, Any] = Field(default_factory=dict)
     """Computed output. Filled by make_fixture."""
 
     def make_fixture(self) -> "JustifiabilityTest":

--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -2,6 +2,8 @@
 
 from typing import Any, ClassVar
 
+from pydantic import Field
+
 from consensus_testing.test_fixtures.base import BaseConsensusFixture
 from lean_spec.node.networking.enr.enr import ENR
 from lean_spec.node.networking.gossipsub.message import GossipsubMessage
@@ -48,7 +50,7 @@ class NetworkingCodecTest(BaseConsensusFixture):
     JSON output: codecName, input, output.
     """
 
-    format_name: ClassVar[str] = "networking_codec"
+    format_name: ClassVar[str] = "networking_codec_test"
     description: ClassVar[str] = "Tests networking codec encode/decode roundtrip"
 
     codec_name: str
@@ -57,7 +59,7 @@ class NetworkingCodecTest(BaseConsensusFixture):
     input: dict[str, Any]
     """Codec-specific input parameters."""
 
-    output: dict[str, Any] = {}
+    output: dict[str, Any] = Field(default_factory=dict)
     """Computed output. Filled by make_fixture."""
 
     def make_fixture(self) -> "NetworkingCodecTest":
@@ -65,7 +67,7 @@ class NetworkingCodecTest(BaseConsensusFixture):
         Dispatch to the codec handler and produce computed output.
 
         Returns:
-            A copy of this fixture with output populated.
+            This fixture with output populated.
 
         Raises:
             ValueError: If codec_name is unknown.

--- a/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
@@ -8,6 +8,8 @@ output states bit-for-bit for every input state.
 
 from typing import Any, ClassVar
 
+from pydantic import Field
+
 from consensus_testing.test_fixtures.base import BaseConsensusFixture
 from lean_spec.spec.crypto.koalabear import Fp
 from lean_spec.spec.crypto.poseidon import PARAMS_16, PARAMS_24, Poseidon
@@ -24,7 +26,7 @@ class PoseidonPermutationTest(BaseConsensusFixture):
     JSON output: width, input, output.
     """
 
-    format_name: ClassVar[str] = "poseidon_permutation"
+    format_name: ClassVar[str] = "poseidon_permutation_test"
     description: ClassVar[str] = "Tests Poseidon permutation at widths 16 and 24"
 
     width: int
@@ -33,7 +35,7 @@ class PoseidonPermutationTest(BaseConsensusFixture):
     input: dict[str, Any]
     """Input state. Key inputState holds a list of decimal element strings."""
 
-    output: dict[str, Any] = {}
+    output: dict[str, Any] = Field(default_factory=dict)
     """Computed output state. Filled by make_fixture."""
 
     def make_fixture(self) -> "PoseidonPermutationTest":
@@ -41,7 +43,7 @@ class PoseidonPermutationTest(BaseConsensusFixture):
         Run the Poseidon permutation and produce the output state.
 
         Returns:
-            A copy of this fixture with output populated.
+            This fixture with output populated.
 
         Raises:
             ValueError: If the width is unsupported.

--- a/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
@@ -8,6 +8,8 @@ to coordinate block proposals and attestations.
 
 from typing import Any, ClassVar
 
+from pydantic import Field
+
 from consensus_testing.test_fixtures.base import BaseConsensusFixture
 from lean_spec.node.chain.clock import SlotClock
 from lean_spec.spec.forks import Interval, Slot
@@ -29,7 +31,7 @@ class SlotClockTest(BaseConsensusFixture):
     JSON output: operation, input, config, output.
     """
 
-    format_name: ClassVar[str] = "slot_clock"
+    format_name: ClassVar[str] = "slot_clock_test"
     description: ClassVar[str] = "Tests slot clock time-to-slot/interval conversion"
 
     operation: str
@@ -39,7 +41,7 @@ class SlotClockTest(BaseConsensusFixture):
     input: dict[str, Any]
     """Operation-specific input parameters."""
 
-    output: dict[str, Any] = {}
+    output: dict[str, Any] = Field(default_factory=dict)
     """Computed output. Filled by make_fixture."""
 
     def make_fixture(self) -> "SlotClockTest":

--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -27,7 +27,7 @@ class SSZTest(BaseConsensusFixture):
       shape; `serialized` holds the malformed bytes and `root` is empty.
     """
 
-    format_name: ClassVar[str] = "ssz"
+    format_name: ClassVar[str] = "ssz_test"
     description: ClassVar[str] = "Tests SSZ serialization roundtrip and hash_tree_root"
 
     type_name: str
@@ -77,7 +77,7 @@ class SSZTest(BaseConsensusFixture):
         Verify SSZ roundtrip or decode-failure and produce the reference output.
 
         Returns:
-            A copy of this fixture with `serialized` and `root` populated.
+            This fixture with serialized bytes and root populated.
 
         Raises:
             AssertionError:

--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -172,34 +172,14 @@ class StateTransitionTest(BaseConsensusFixture):
             actual_post_state = state
         except (AssertionError, ValueError) as exception:
             exception_raised = exception
-            # If we expect an exception, this is fine
-            if self.expect_exception is None:
-                # Unexpected failure
-                raise AssertionError(
-                    f"Unexpected error processing blocks: {exception}"
-                ) from exception
         finally:
             # Always store filled blocks for serialization, even if an exception occurred
             # This ensures the test fixture includes all blocks that were attempted
             self._filled_blocks = filled_blocks
 
         # Validate exception expectations
-        if self.expect_exception is not None:
-            if exception_raised is None:
-                raise AssertionError(
-                    f"Expected exception {self.expect_exception.__name__} but processing succeeded"
-                )
-            if not isinstance(exception_raised, self.expect_exception):
-                raise AssertionError(
-                    f"Expected {self.expect_exception.__name__} "
-                    f"but got {type(exception_raised).__name__}: {exception_raised}"
-                )
-            if self.expect_exception_message is not None:
-                if str(exception_raised) != self.expect_exception_message:
-                    raise AssertionError(
-                        f"Expected exception message '{self.expect_exception_message}' "
-                        f"but got '{exception_raised}'"
-                    )
+        self.assert_expected_outcome(exception_raised, self.expect_exception_message)
+        if exception_raised is not None:
             # Emit the language-neutral reason clients assert against.
             self.rejection_reason = classify_rejection(exception_raised)
 

--- a/packages/testing/src/consensus_testing/test_fixtures/sync.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/sync.py
@@ -8,6 +8,8 @@ sync-layer decisions bit-for-bit.
 
 from typing import Any, ClassVar
 
+from pydantic import Field
+
 from consensus_testing.genesis import build_anchor, generate_pre_state
 from consensus_testing.test_fixtures.base import BaseConsensusFixture
 from lean_spec.node.sync.checkpoint_sync import verify_checkpoint_state
@@ -28,7 +30,7 @@ class SyncTest(BaseConsensusFixture):
     JSON output: operation, input, output.
     """
 
-    format_name: ClassVar[str] = "sync"
+    format_name: ClassVar[str] = "sync_test"
     description: ClassVar[str] = "Tests sync-layer helpers clients must reproduce"
 
     operation: str
@@ -37,7 +39,7 @@ class SyncTest(BaseConsensusFixture):
     input: dict[str, Any]
     """Operation-specific input. See per-handler docstrings."""
 
-    output: dict[str, Any] = {}
+    output: dict[str, Any] = Field(default_factory=dict)
     """Computed output. Filled by make_fixture."""
 
     def make_fixture(self) -> "SyncTest":
@@ -45,7 +47,7 @@ class SyncTest(BaseConsensusFixture):
         Dispatch to the operation handler.
 
         Returns:
-            A copy of this fixture with output populated.
+            This fixture with output populated.
 
         Raises:
             ValueError: If the operation name is unknown.

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -166,28 +166,14 @@ class VerifySignaturesTest(BaseConsensusFixture):
             LstarSpec().verify_signatures(signed_block, self.anchor_state.validators)
         except AssertionError as exception:
             exception_raised = exception
-            # If we expect an exception, this is fine
-            if self.expect_exception is None:
-                # Unexpected failure
-                raise AssertionError(
-                    f"Unexpected error verifying block signature(s): {exception}"
-                ) from exception
         finally:
             # Always store filled block for serialization, even if an exception occurred
             # This ensures the test fixture contains the signed block that consumer can test with
             self.signed_block = signed_block
 
         # Validate exception expectations
-        if self.expect_exception is not None:
-            if exception_raised is None:
-                raise AssertionError(
-                    f"Expected exception {self.expect_exception.__name__} but processing succeeded"
-                )
-            if not isinstance(exception_raised, self.expect_exception):
-                raise AssertionError(
-                    f"Expected {self.expect_exception.__name__} "
-                    f"but got {type(exception_raised).__name__}: {exception_raised}"
-                )
+        self.assert_expected_outcome(exception_raised)
+        if exception_raised is not None:
             # Emit the language-neutral reason clients assert against.
             self.rejection_reason = classify_rejection(exception_raised)
 

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -134,25 +134,19 @@ class BlockStep(BaseForkChoiceStep):
     @field_serializer("block", when_used="json")
     def serialize_block(self, block_spec: BlockSpec) -> dict[str, Any]:
         """
-        Serialize the filled Block instead of the BlockSpec.
+        Serialize the filled block instead of the input spec.
 
-        This ensures the fixture output contains the complete Block that was
-        filled from the spec, not the input BlockSpec.
+        This ensures the fixture output contains the complete block that was
+        filled from the spec, not the input specification.
 
-        Parameters:
-        ----------
-        block_spec : BlockSpec
-            The BlockSpec field value (ignored, we use _filled_block instead).
+        Args:
+            block_spec: The spec field value, ignored in favor of the filled block.
 
         Returns:
-        -------
-        dict[str, Any]
-            The serialized Block.
+            The serialized block.
 
         Raises:
-        ------
-        ValueError
-            If _filled_block is None (make_fixture not called yet).
+            ValueError: If the block has not been filled yet.
         """
         if self._filled_block is None:
             raise ValueError(
@@ -204,25 +198,19 @@ class AttestationStep(BaseForkChoiceStep):
         self, attestation_spec: GossipAttestationSpec
     ) -> dict[str, Any]:
         """
-        Serialize the filled SignedAttestation instead of the spec.
+        Serialize the filled attestation instead of the input spec.
 
         This ensures the fixture output contains the complete attestation that was
         filled from the spec, not the input specification.
 
-        Parameters:
-        ----------
-        attestation_spec : GossipAttestationSpec
-            The spec field value (ignored, we use _filled_attestation instead).
+        Args:
+            attestation_spec: The spec field value, ignored in favor of the filled attestation.
 
         Returns:
-        -------
-        dict[str, Any]
-            The serialized SignedAttestation.
+            The serialized attestation.
 
         Raises:
-        ------
-        ValueError
-            If _filled_attestation is None (make_fixture not called yet).
+            ValueError: If the attestation has not been filled yet.
         """
         if self._filled_attestation is None:
             raise ValueError(

--- a/tests/consensus/lstar/api/test_api_endpoints.py
+++ b/tests/consensus/lstar/api/test_api_endpoints.py
@@ -17,57 +17,57 @@ GENESIS_8V = {"numValidators": 8, "genesisTime": 0}
 """Larger genesis: 8 validators produce a different state root than 4."""
 
 
-def test_health(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_health(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """Health returns a fixed payload independent of consensus state."""
-    api_endpoint(endpoint="/lean/v0/health", genesis_params=GENESIS_4V)
+    api_endpoint_test(endpoint="/lean/v0/health", genesis_params=GENESIS_4V)
 
 
-def test_justified_checkpoint_4v(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_justified_checkpoint_4v(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """Justified checkpoint at genesis with 4 validators."""
-    api_endpoint(endpoint="/lean/v0/checkpoints/justified", genesis_params=GENESIS_4V)
+    api_endpoint_test(endpoint="/lean/v0/checkpoints/justified", genesis_params=GENESIS_4V)
 
 
-def test_justified_checkpoint_8v(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_justified_checkpoint_8v(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """Justified checkpoint at genesis with 8 validators. Root differs from 4v."""
-    api_endpoint(endpoint="/lean/v0/checkpoints/justified", genesis_params=GENESIS_8V)
+    api_endpoint_test(endpoint="/lean/v0/checkpoints/justified", genesis_params=GENESIS_8V)
 
 
-def test_finalized_state_4v(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_finalized_state_4v(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """Full SSZ-encoded finalized state for a 4-validator genesis."""
-    api_endpoint(endpoint="/lean/v0/states/finalized", genesis_params=GENESIS_4V)
+    api_endpoint_test(endpoint="/lean/v0/states/finalized", genesis_params=GENESIS_4V)
 
 
-def test_fork_choice_4v(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_fork_choice_4v(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """Fork choice tree at genesis: single node, zero attestation weights."""
-    api_endpoint(endpoint="/lean/v0/fork_choice", genesis_params=GENESIS_4V)
+    api_endpoint_test(endpoint="/lean/v0/fork_choice", genesis_params=GENESIS_4V)
 
 
-def test_fork_choice_8v(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_fork_choice_8v(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """Fork choice tree at genesis with 8 validators. Same shape, higher count."""
-    api_endpoint(endpoint="/lean/v0/fork_choice", genesis_params=GENESIS_8V)
+    api_endpoint_test(endpoint="/lean/v0/fork_choice", genesis_params=GENESIS_8V)
 
 
-def test_aggregator_status_disabled(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_aggregator_status_disabled(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """GET aggregator status on a node started with aggregator disabled."""
-    api_endpoint(
+    api_endpoint_test(
         endpoint="/lean/v0/admin/aggregator",
         genesis_params=GENESIS_4V,
         initial_is_aggregator=False,
     )
 
 
-def test_aggregator_status_enabled(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_aggregator_status_enabled(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """GET aggregator status on a node started with aggregator enabled."""
-    api_endpoint(
+    api_endpoint_test(
         endpoint="/lean/v0/admin/aggregator",
         genesis_params=GENESIS_4V,
         initial_is_aggregator=True,
     )
 
 
-def test_aggregator_toggle_activate(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_aggregator_toggle_activate(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """POST enable=true flips the role from off to on."""
-    api_endpoint(
+    api_endpoint_test(
         endpoint="/lean/v0/admin/aggregator",
         method="POST",
         genesis_params=GENESIS_4V,
@@ -76,9 +76,9 @@ def test_aggregator_toggle_activate(api_endpoint: ApiEndpointTestFiller) -> None
     )
 
 
-def test_aggregator_toggle_deactivate(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_aggregator_toggle_deactivate(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """POST enable=false flips the role from on to off."""
-    api_endpoint(
+    api_endpoint_test(
         endpoint="/lean/v0/admin/aggregator",
         method="POST",
         genesis_params=GENESIS_4V,
@@ -87,9 +87,9 @@ def test_aggregator_toggle_deactivate(api_endpoint: ApiEndpointTestFiller) -> No
     )
 
 
-def test_aggregator_toggle_idempotent_enable(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_aggregator_toggle_idempotent_enable(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """POST enable=true on an already-enabled node returns previous=true and is a no-op."""
-    api_endpoint(
+    api_endpoint_test(
         endpoint="/lean/v0/admin/aggregator",
         method="POST",
         genesis_params=GENESIS_4V,
@@ -98,9 +98,9 @@ def test_aggregator_toggle_idempotent_enable(api_endpoint: ApiEndpointTestFiller
     )
 
 
-def test_aggregator_toggle_idempotent_disable(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_aggregator_toggle_idempotent_disable(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """POST enable=false on an already-disabled node returns previous=false and is a no-op."""
-    api_endpoint(
+    api_endpoint_test(
         endpoint="/lean/v0/admin/aggregator",
         method="POST",
         genesis_params=GENESIS_4V,

--- a/tests/consensus/lstar/api/test_api_post_genesis.py
+++ b/tests/consensus/lstar/api/test_api_post_genesis.py
@@ -16,7 +16,7 @@ GENESIS_4V_AT_SLOT_3 = {"numValidators": 4, "genesisTime": 0, "anchorSlot": 3}
 """4-validator store advanced through three empty blocks past genesis."""
 
 
-def test_fork_choice_tree_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_fork_choice_tree_at_slot_3(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """
     Fork-choice response carries a multi-node tree once the chain advances.
 
@@ -25,10 +25,10 @@ def test_fork_choice_tree_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None
     parent-root linkage are pinned so clients diverge only when their
     tree traversal or SSZ root computation differs.
     """
-    api_endpoint(endpoint="/lean/v0/fork_choice", genesis_params=GENESIS_4V_AT_SLOT_3)
+    api_endpoint_test(endpoint="/lean/v0/fork_choice", genesis_params=GENESIS_4V_AT_SLOT_3)
 
 
-def test_finalized_state_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_finalized_state_at_slot_3(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """
     Finalized-state response returns the SSZ-encoded anchor state after chain advance.
 
@@ -37,10 +37,10 @@ def test_finalized_state_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
     historical_block_hashes because the chain has processed three empty
     blocks. Pins the exact SSZ bytes at that configuration.
     """
-    api_endpoint(endpoint="/lean/v0/states/finalized", genesis_params=GENESIS_4V_AT_SLOT_3)
+    api_endpoint_test(endpoint="/lean/v0/states/finalized", genesis_params=GENESIS_4V_AT_SLOT_3)
 
 
-def test_justified_checkpoint_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> None:
+def test_justified_checkpoint_at_slot_3(api_endpoint_test: ApiEndpointTestFiller) -> None:
     """
     Justified-checkpoint response at a non-genesis slot pins the slot=0 root.
 
@@ -48,7 +48,7 @@ def test_justified_checkpoint_at_slot_3(api_endpoint: ApiEndpointTestFiller) -> 
     the chain advances. This vector pins that the response still
     reports the genesis checkpoint, not a synthesised advance.
     """
-    api_endpoint(
+    api_endpoint_test(
         endpoint="/lean/v0/checkpoints/justified",
         genesis_params=GENESIS_4V_AT_SLOT_3,
     )

--- a/tests/consensus/lstar/api/test_metrics_endpoint.py
+++ b/tests/consensus/lstar/api/test_metrics_endpoint.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_metrics_endpoint_scrape_contract(
-    api_endpoint: ApiEndpointTestFiller,
+    api_endpoint_test: ApiEndpointTestFiller,
 ) -> None:
     """
     GET /metrics returns the Prometheus-format scrape with the required metric names.
@@ -18,7 +18,7 @@ def test_metrics_endpoint_scrape_contract(
     metric names a compliant node must expose. Clients replay the
     fixture and confirm every listed metric appears in their scrape.
     """
-    api_endpoint(
+    api_endpoint_test(
         endpoint="/metrics",
         method="GET",
         genesis_params={"numValidators": 4, "genesisTime": 0},

--- a/tests/consensus/lstar/chain/test_slot_clock.py
+++ b/tests/consensus/lstar/chain/test_slot_clock.py
@@ -18,65 +18,65 @@ GENESIS = 1700000000
 # --- Interval.from_unix_time ---
 
 
-def test_from_unix_time_at_genesis(slot_clock: SlotClockTestFiller) -> None:
+def test_from_unix_time_at_genesis(slot_clock_test: SlotClockTestFiller) -> None:
     """At genesis, zero seconds elapsed yields interval 0."""
-    slot_clock(
+    slot_clock_test(
         operation="from_unix_time",
         input={"unixSeconds": GENESIS, "genesisTime": GENESIS},
     )
 
 
-def test_from_unix_time_one_second(slot_clock: SlotClockTestFiller) -> None:
+def test_from_unix_time_one_second(slot_clock_test: SlotClockTestFiller) -> None:
     """One second = 1000 ms. floor(1000 / 800) = 1 interval."""
-    slot_clock(
+    slot_clock_test(
         operation="from_unix_time",
         input={"unixSeconds": GENESIS + 1, "genesisTime": GENESIS},
     )
 
 
-def test_from_unix_time_one_slot(slot_clock: SlotClockTestFiller) -> None:
+def test_from_unix_time_one_slot(slot_clock_test: SlotClockTestFiller) -> None:
     """One slot = 4 seconds = 4000 ms. 4000 / 800 = 5 intervals."""
-    slot_clock(
+    slot_clock_test(
         operation="from_unix_time",
         input={"unixSeconds": GENESIS + 4, "genesisTime": GENESIS},
     )
 
 
-def test_from_unix_time_two_seconds(slot_clock: SlotClockTestFiller) -> None:
+def test_from_unix_time_two_seconds(slot_clock_test: SlotClockTestFiller) -> None:
     """Two seconds = 2000 ms. floor(2000 / 800) = 2 intervals."""
-    slot_clock(
+    slot_clock_test(
         operation="from_unix_time",
         input={"unixSeconds": GENESIS + 2, "genesisTime": GENESIS},
     )
 
 
-def test_from_unix_time_three_seconds(slot_clock: SlotClockTestFiller) -> None:
+def test_from_unix_time_three_seconds(slot_clock_test: SlotClockTestFiller) -> None:
     """Three seconds = 3000 ms. floor(3000 / 800) = 3 intervals."""
-    slot_clock(
+    slot_clock_test(
         operation="from_unix_time",
         input={"unixSeconds": GENESIS + 3, "genesisTime": GENESIS},
     )
 
 
-def test_from_unix_time_ten_slots(slot_clock: SlotClockTestFiller) -> None:
+def test_from_unix_time_ten_slots(slot_clock_test: SlotClockTestFiller) -> None:
     """Ten slots = 40 seconds = 50 intervals."""
-    slot_clock(
+    slot_clock_test(
         operation="from_unix_time",
         input={"unixSeconds": GENESIS + 40, "genesisTime": GENESIS},
     )
 
 
-def test_from_unix_time_one_day(slot_clock: SlotClockTestFiller) -> None:
+def test_from_unix_time_one_day(slot_clock_test: SlotClockTestFiller) -> None:
     """One day = 86400 seconds = 108000 intervals."""
-    slot_clock(
+    slot_clock_test(
         operation="from_unix_time",
         input={"unixSeconds": GENESIS + 86400, "genesisTime": GENESIS},
     )
 
 
-def test_from_unix_time_genesis_zero(slot_clock: SlotClockTestFiller) -> None:
+def test_from_unix_time_genesis_zero(slot_clock_test: SlotClockTestFiller) -> None:
     """Genesis at Unix epoch 0. 100 seconds elapsed = 125 intervals."""
-    slot_clock(
+    slot_clock_test(
         operation="from_unix_time",
         input={"unixSeconds": 100, "genesisTime": 0},
     )
@@ -85,64 +85,64 @@ def test_from_unix_time_genesis_zero(slot_clock: SlotClockTestFiller) -> None:
 # --- Interval.from_slot ---
 
 
-def test_from_slot_zero(slot_clock: SlotClockTestFiller) -> None:
+def test_from_slot_zero(slot_clock_test: SlotClockTestFiller) -> None:
     """Slot 0 starts at interval 0."""
-    slot_clock(operation="from_slot", input={"slot": 0})
+    slot_clock_test(operation="from_slot", input={"slot": 0})
 
 
-def test_from_slot_one(slot_clock: SlotClockTestFiller) -> None:
+def test_from_slot_one(slot_clock_test: SlotClockTestFiller) -> None:
     """Slot 1 starts at interval 5."""
-    slot_clock(operation="from_slot", input={"slot": 1})
+    slot_clock_test(operation="from_slot", input={"slot": 1})
 
 
-def test_from_slot_ten(slot_clock: SlotClockTestFiller) -> None:
+def test_from_slot_ten(slot_clock_test: SlotClockTestFiller) -> None:
     """Slot 10 starts at interval 50."""
-    slot_clock(operation="from_slot", input={"slot": 10})
+    slot_clock_test(operation="from_slot", input={"slot": 10})
 
 
-def test_from_slot_hundred(slot_clock: SlotClockTestFiller) -> None:
+def test_from_slot_hundred(slot_clock_test: SlotClockTestFiller) -> None:
     """Slot 100 starts at interval 500."""
-    slot_clock(operation="from_slot", input={"slot": 100})
+    slot_clock_test(operation="from_slot", input={"slot": 100})
 
 
 # --- SlotClock.current_slot ---
 
 
-def test_current_slot_at_genesis(slot_clock: SlotClockTestFiller) -> None:
+def test_current_slot_at_genesis(slot_clock_test: SlotClockTestFiller) -> None:
     """Exactly at genesis: slot 0."""
-    slot_clock(
+    slot_clock_test(
         operation="current_slot",
         input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000},
     )
 
 
-def test_current_slot_before_genesis(slot_clock: SlotClockTestFiller) -> None:
+def test_current_slot_before_genesis(slot_clock_test: SlotClockTestFiller) -> None:
     """Before genesis: clamped to slot 0."""
-    slot_clock(
+    slot_clock_test(
         operation="current_slot",
         input={"genesisTime": GENESIS, "currentTimeMs": (GENESIS - 10) * 1000},
     )
 
 
-def test_current_slot_mid_slot(slot_clock: SlotClockTestFiller) -> None:
+def test_current_slot_mid_slot(slot_clock_test: SlotClockTestFiller) -> None:
     """2 seconds into slot 0: still slot 0."""
-    slot_clock(
+    slot_clock_test(
         operation="current_slot",
         input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 2000},
     )
 
 
-def test_current_slot_at_boundary(slot_clock: SlotClockTestFiller) -> None:
+def test_current_slot_at_boundary(slot_clock_test: SlotClockTestFiller) -> None:
     """Exactly at slot 1 boundary (4 seconds): slot 1."""
-    slot_clock(
+    slot_clock_test(
         operation="current_slot",
         input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 4000},
     )
 
 
-def test_current_slot_before_boundary(slot_clock: SlotClockTestFiller) -> None:
+def test_current_slot_before_boundary(slot_clock_test: SlotClockTestFiller) -> None:
     """One ms before slot 1 boundary: still slot 0 (integer division floors)."""
-    slot_clock(
+    slot_clock_test(
         operation="current_slot",
         input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 3999},
     )
@@ -151,49 +151,49 @@ def test_current_slot_before_boundary(slot_clock: SlotClockTestFiller) -> None:
 # --- SlotClock.current_interval ---
 
 
-def test_current_interval_at_slot_start(slot_clock: SlotClockTestFiller) -> None:
+def test_current_interval_at_slot_start(slot_clock_test: SlotClockTestFiller) -> None:
     """Exactly at slot start: interval 0."""
-    slot_clock(
+    slot_clock_test(
         operation="current_interval",
         input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000},
     )
 
 
-def test_current_interval_800ms(slot_clock: SlotClockTestFiller) -> None:
+def test_current_interval_800ms(slot_clock_test: SlotClockTestFiller) -> None:
     """800 ms into slot: interval 1."""
-    slot_clock(
+    slot_clock_test(
         operation="current_interval",
         input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 800},
     )
 
 
-def test_current_interval_1600ms(slot_clock: SlotClockTestFiller) -> None:
+def test_current_interval_1600ms(slot_clock_test: SlotClockTestFiller) -> None:
     """1600 ms into slot: interval 2."""
-    slot_clock(
+    slot_clock_test(
         operation="current_interval",
         input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 1600},
     )
 
 
-def test_current_interval_3200ms(slot_clock: SlotClockTestFiller) -> None:
+def test_current_interval_3200ms(slot_clock_test: SlotClockTestFiller) -> None:
     """3200 ms into slot: interval 4."""
-    slot_clock(
+    slot_clock_test(
         operation="current_interval",
         input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 3200},
     )
 
 
-def test_current_interval_wraps_at_next_slot(slot_clock: SlotClockTestFiller) -> None:
+def test_current_interval_wraps_at_next_slot(slot_clock_test: SlotClockTestFiller) -> None:
     """4000 ms = next slot start: interval wraps back to 0."""
-    slot_clock(
+    slot_clock_test(
         operation="current_interval",
         input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 4000},
     )
 
 
-def test_current_interval_before_genesis(slot_clock: SlotClockTestFiller) -> None:
+def test_current_interval_before_genesis(slot_clock_test: SlotClockTestFiller) -> None:
     """Before genesis: interval 0."""
-    slot_clock(
+    slot_clock_test(
         operation="current_interval",
         input={"genesisTime": GENESIS, "currentTimeMs": (GENESIS - 5) * 1000},
     )
@@ -202,17 +202,17 @@ def test_current_interval_before_genesis(slot_clock: SlotClockTestFiller) -> Non
 # --- SlotClock.total_intervals ---
 
 
-def test_total_intervals_multi_slot(slot_clock: SlotClockTestFiller) -> None:
+def test_total_intervals_multi_slot(slot_clock_test: SlotClockTestFiller) -> None:
     """14.4 seconds = 18 intervals (14400 ms / 800 ms)."""
-    slot_clock(
+    slot_clock_test(
         operation="total_intervals",
         input={"genesisTime": GENESIS, "currentTimeMs": GENESIS * 1000 + 14400},
     )
 
 
-def test_total_intervals_before_genesis(slot_clock: SlotClockTestFiller) -> None:
+def test_total_intervals_before_genesis(slot_clock_test: SlotClockTestFiller) -> None:
     """Before genesis: 0 intervals."""
-    slot_clock(
+    slot_clock_test(
         operation="total_intervals",
         input={"genesisTime": GENESIS, "currentTimeMs": (GENESIS - 1) * 1000},
     )

--- a/tests/consensus/lstar/networking/test_decode_failure_smoke.py
+++ b/tests/consensus/lstar/networking/test_decode_failure_smoke.py
@@ -11,14 +11,14 @@ from consensus_testing import NetworkingCodecTestFiller
 pytestmark = pytest.mark.valid_until("Lstar")
 
 
-def test_decode_failure_varint_truncated(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_decode_failure_varint_truncated(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """
     A truncated varint (continuation bit set on the final byte) must fail to decode.
 
     Pins the new `decode_failure` codec dispatch path on the
     networking_codec fixture.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "varint", "bytes": "0x80"},
         expect_exception=Exception,

--- a/tests/consensus/lstar/networking/test_enr_and_peer_id.py
+++ b/tests/consensus/lstar/networking/test_enr_and_peer_id.py
@@ -68,52 +68,52 @@ ENR_HIGH_SEQ = (
 # --- ENR ---
 
 
-def test_enr_official_eip778(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_enr_official_eip778(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Official EIP-778 vector. Exercises node_id, ip4, udp_port, multiaddr, signature."""
-    networking_codec(codec_name="enr", input={"enrString": OFFICIAL_ENR})
+    networking_codec_test(codec_name="enr", input={"enrString": OFFICIAL_ENR})
 
 
-def test_enr_with_extensions(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_enr_with_extensions(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """ENR with extension keys: eth2, attnets, QUIC, is_aggregator."""
-    networking_codec(codec_name="enr", input={"enrString": ENR_WITH_EXTENSIONS})
+    networking_codec_test(codec_name="enr", input={"enrString": ENR_WITH_EXTENSIONS})
 
 
-def test_enr_minimal_seq_zero(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_enr_minimal_seq_zero(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Minimal ENR with seq=0. Only required keys (id + secp256k1)."""
-    networking_codec(codec_name="enr", input={"enrString": ENR_MINIMAL})
+    networking_codec_test(codec_name="enr", input={"enrString": ENR_MINIMAL})
 
 
-def test_enr_no_eth2_field(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_enr_no_eth2_field(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """ENR with ip4 + udp but no eth2 or attnets. Verifies absent optional fields."""
-    networking_codec(codec_name="enr", input={"enrString": ENR_NO_ETH2})
+    networking_codec_test(codec_name="enr", input={"enrString": ENR_NO_ETH2})
 
 
-def test_enr_eth2_far_future_fork(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_enr_eth2_far_future_fork(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """ENR with eth2 where next_fork_epoch is max uint64 (far future). Verifies large epoch."""
-    networking_codec(codec_name="enr", input={"enrString": ENR_ETH2_FAR_FUTURE})
+    networking_codec_test(codec_name="enr", input={"enrString": ENR_ETH2_FAR_FUTURE})
 
 
-def test_enr_attnets_all_zeros(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_enr_attnets_all_zeros(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """ENR with attnets bitfield all zeros. Verifies empty subscribed subnet list."""
-    networking_codec(codec_name="enr", input={"enrString": ENR_ATTNETS_ALL_ZEROS})
+    networking_codec_test(codec_name="enr", input={"enrString": ENR_ATTNETS_ALL_ZEROS})
 
 
-def test_enr_attnets_all_ones(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_enr_attnets_all_ones(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """ENR with attnets bitfield all ones. Verifies all 64 subnets are subscribed."""
-    networking_codec(codec_name="enr", input={"enrString": ENR_ATTNETS_ALL_ONES})
+    networking_codec_test(codec_name="enr", input={"enrString": ENR_ATTNETS_ALL_ONES})
 
 
-def test_enr_high_seq(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_enr_high_seq(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """ENR with high sequence number (2^32 - 1). Verifies large seq parsing."""
-    networking_codec(codec_name="enr", input={"enrString": ENR_HIGH_SEQ})
+    networking_codec_test(codec_name="enr", input={"enrString": ENR_HIGH_SEQ})
 
 
 # --- PeerId ---
 
 
-def test_peer_id_ed25519(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_peer_id_ed25519(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """ED25519 PeerId from libp2p spec. 32-byte key, identity multihash."""
-    networking_codec(
+    networking_codec_test(
         codec_name="peer_id",
         input={
             "keyType": "ed25519",
@@ -122,9 +122,9 @@ def test_peer_id_ed25519(networking_codec: NetworkingCodecTestFiller) -> None:
     )
 
 
-def test_peer_id_secp256k1(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_peer_id_secp256k1(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """secp256k1 PeerId from libp2p spec. 33-byte key, identity multihash."""
-    networking_codec(
+    networking_codec_test(
         codec_name="peer_id",
         input={
             "keyType": "secp256k1",
@@ -133,9 +133,9 @@ def test_peer_id_secp256k1(networking_codec: NetworkingCodecTestFiller) -> None:
     )
 
 
-def test_peer_id_ecdsa(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_peer_id_ecdsa(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """ECDSA PeerId from libp2p spec. 91-byte key, SHA256 multihash (over 42 bytes)."""
-    networking_codec(
+    networking_codec_test(
         codec_name="peer_id",
         input={
             "keyType": "ecdsa",
@@ -149,9 +149,9 @@ def test_peer_id_ecdsa(networking_codec: NetworkingCodecTestFiller) -> None:
     )
 
 
-def test_peer_id_secp256k1_from_enr(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_peer_id_secp256k1_from_enr(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """secp256k1 PeerId using the public key from the official EIP-778 ENR."""
-    networking_codec(
+    networking_codec_test(
         codec_name="peer_id",
         input={
             "keyType": "secp256k1",

--- a/tests/consensus/lstar/networking/test_enr_non_canonical.py
+++ b/tests/consensus/lstar/networking/test_enr_non_canonical.py
@@ -40,7 +40,7 @@ UNSORTED_ENR_HEX: str = "0x" + _build_unsorted_enr_rlp().hex()
 
 
 def test_enr_decode_rejects_non_canonical_key_order(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     An ENR with keys outside lexicographic order must be rejected.
@@ -49,7 +49,7 @@ def test_enr_decode_rejects_non_canonical_key_order(
     such a record would verify a signature over bytes the signer never
     produced.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "enr", "bytes": UNSORTED_ENR_HEX},
         expect_exception=ValueError,

--- a/tests/consensus/lstar/networking/test_enr_rejections.py
+++ b/tests/consensus/lstar/networking/test_enr_rejections.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_enr_decode_rejects_oversize_payload(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     An ENR RLP payload above the 300-byte cap is rejected.
@@ -17,7 +17,7 @@ def test_enr_decode_rejects_oversize_payload(
     rejected before any RLP parsing runs.
     """
     oversize = "0x" + "ff" * 301
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "enr", "bytes": oversize},
         expect_exception=ValueError,
@@ -25,7 +25,7 @@ def test_enr_decode_rejects_oversize_payload(
 
 
 def test_enr_decode_rejects_malformed_rlp(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     An input that cannot be parsed as an RLP list is rejected.
@@ -34,7 +34,7 @@ def test_enr_decode_rejects_malformed_rlp(
     list structure. The ENR decoder requires a list header, so the parse
     fails and the error surfaces as a ValueError on the ENR API.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "enr", "bytes": "0x00"},
         expect_exception=ValueError,

--- a/tests/consensus/lstar/networking/test_gossip_message_id.py
+++ b/tests/consensus/lstar/networking/test_gossip_message_id.py
@@ -18,9 +18,9 @@ BLOCK_TOPIC = "0x" + b"/leanconsensus/12345678/block/ssz_snappy".hex()
 # --- Valid snappy domain ---
 
 
-def test_message_id_valid_snappy(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_id_valid_snappy(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Message ID with valid-snappy domain and typical block data."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_message_id",
         input={
             "topic": BLOCK_TOPIC,
@@ -30,9 +30,11 @@ def test_message_id_valid_snappy(networking_codec: NetworkingCodecTestFiller) ->
     )
 
 
-def test_message_id_valid_snappy_large_payload(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_id_valid_snappy_large_payload(
+    networking_codec_test: NetworkingCodecTestFiller,
+) -> None:
     """Message ID with valid-snappy domain and a larger payload."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_message_id",
         input={
             "topic": BLOCK_TOPIC,
@@ -45,9 +47,9 @@ def test_message_id_valid_snappy_large_payload(networking_codec: NetworkingCodec
 # --- Invalid snappy domain ---
 
 
-def test_message_id_invalid_snappy(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_id_invalid_snappy(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Message ID with invalid-snappy domain and same data as the valid test."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_message_id",
         input={
             "topic": BLOCK_TOPIC,
@@ -60,9 +62,9 @@ def test_message_id_invalid_snappy(networking_codec: NetworkingCodecTestFiller) 
 # --- Empty inputs ---
 
 
-def test_message_id_empty_data(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_id_empty_data(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Message ID with empty payload."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_message_id",
         input={
             "topic": BLOCK_TOPIC,
@@ -72,9 +74,9 @@ def test_message_id_empty_data(networking_codec: NetworkingCodecTestFiller) -> N
     )
 
 
-def test_message_id_empty_topic(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_id_empty_topic(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Message ID with empty topic string."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_message_id",
         input={
             "topic": "0x",
@@ -84,9 +86,9 @@ def test_message_id_empty_topic(networking_codec: NetworkingCodecTestFiller) -> 
     )
 
 
-def test_message_id_both_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_id_both_empty(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Message ID with both topic and data empty."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_message_id",
         input={
             "topic": "0x",
@@ -99,9 +101,9 @@ def test_message_id_both_empty(networking_codec: NetworkingCodecTestFiller) -> N
 # --- Domain differentiation ---
 
 
-def test_message_id_domain_changes_id(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_id_domain_changes_id(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Same topic and data with invalid-snappy domain produces a different ID."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_message_id",
         input={
             "topic": "0x" + b"test-topic".hex(),
@@ -111,9 +113,11 @@ def test_message_id_domain_changes_id(networking_codec: NetworkingCodecTestFille
     )
 
 
-def test_message_id_domain_valid_same_data(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_id_domain_valid_same_data(
+    networking_codec_test: NetworkingCodecTestFiller,
+) -> None:
     """Same topic and data with valid-snappy domain for cross-reference."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_message_id",
         input={
             "topic": "0x" + b"test-topic".hex(),

--- a/tests/consensus/lstar/networking/test_gossip_topic.py
+++ b/tests/consensus/lstar/networking/test_gossip_topic.py
@@ -12,17 +12,17 @@ FORK_DIGEST = "12345678"
 # --- Block topics ---
 
 
-def test_block_topic(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_block_topic(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Block topic with typical fork digest."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={"kind": "block", "forkDigest": FORK_DIGEST},
     )
 
 
-def test_block_topic_different_digest(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_block_topic_different_digest(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Block topic with a different fork digest to verify digest embedding."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={"kind": "block", "forkDigest": "aabbccdd"},
     )
@@ -31,9 +31,9 @@ def test_block_topic_different_digest(networking_codec: NetworkingCodecTestFille
 # --- Aggregation topics ---
 
 
-def test_aggregation_topic(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_aggregation_topic(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Committee aggregation topic."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={"kind": "aggregation", "forkDigest": FORK_DIGEST},
     )
@@ -42,25 +42,25 @@ def test_aggregation_topic(networking_codec: NetworkingCodecTestFiller) -> None:
 # --- Attestation subnet topics ---
 
 
-def test_attestation_subnet_zero(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_attestation_subnet_zero(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Attestation subnet 0. First subnet ID."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={"kind": "attestation", "forkDigest": FORK_DIGEST, "subnetId": 0},
     )
 
 
-def test_attestation_subnet_seven(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_attestation_subnet_seven(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Attestation subnet 7. Mid-range subnet ID."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={"kind": "attestation", "forkDigest": FORK_DIGEST, "subnetId": 7},
     )
 
 
-def test_attestation_subnet_63(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_attestation_subnet_63(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Attestation subnet 63. Last subnet in a 64-subnet network."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={"kind": "attestation", "forkDigest": FORK_DIGEST, "subnetId": 63},
     )
@@ -69,17 +69,17 @@ def test_attestation_subnet_63(networking_codec: NetworkingCodecTestFiller) -> N
 # --- Edge cases ---
 
 
-def test_block_topic_zero_digest(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_block_topic_zero_digest(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Block topic with all-zero fork digest."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={"kind": "block", "forkDigest": "00000000"},
     )
 
 
-def test_block_topic_max_digest(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_block_topic_max_digest(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Block topic with all-0xff fork digest."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={"kind": "block", "forkDigest": "ffffffff"},
     )

--- a/tests/consensus/lstar/networking/test_gossip_topic_fork.py
+++ b/tests/consensus/lstar/networking/test_gossip_topic_fork.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_gossip_topic_network_name_matches(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     Block topic whose network name matches the expected value validates cleanly.
@@ -22,7 +22,7 @@ def test_gossip_topic_network_name_matches(
     Pins the accept branch of validate_fork: a topic built with a network
     name equal to the expected one must pass the check.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={
             "kind": "block",
@@ -33,7 +33,7 @@ def test_gossip_topic_network_name_matches(
 
 
 def test_gossip_topic_network_name_mismatch(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     Block topic with a network name different from the expected one is rejected.
@@ -43,7 +43,7 @@ def test_gossip_topic_network_name_mismatch(
     output reports forkValid=false so clients align on the rejection
     verdict.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={
             "kind": "block",
@@ -54,7 +54,7 @@ def test_gossip_topic_network_name_mismatch(
 
 
 def test_gossip_topic_network_name_match_on_attestation_subnet(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     Attestation-subnet topic carries the subnet id and still validates its network name.
@@ -63,7 +63,7 @@ def test_gossip_topic_network_name_match_on_attestation_subnet(
     to confirm the validator reads network_name independent of other
     topic components.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="gossip_topic",
         input={
             "kind": "attestation",

--- a/tests/consensus/lstar/networking/test_gossipsub_handlers.py
+++ b/tests/consensus/lstar/networking/test_gossipsub_handlers.py
@@ -17,9 +17,9 @@ MESSAGE_ID_2 = "0xb51451075fcc3e8f0baa9041d8256c647ceaeaac"
 # --- GRAFT handler ---
 
 
-def test_graft_accept(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_graft_accept(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """Accept GRAFT when subscribed and mesh has capacity."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="graft",
         params=PARAMS,
         initial_state={
@@ -34,9 +34,9 @@ def test_graft_accept(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
     )
 
 
-def test_graft_reject_capacity(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_graft_reject_capacity(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """Reject GRAFT with PRUNE when mesh is at d_high."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="graft",
         params={"d": 4, "dLow": 3, "dHigh": 3, "dLazy": 3},
         initial_state={
@@ -53,9 +53,9 @@ def test_graft_reject_capacity(gossipsub_handler: GossipsubHandlerTestFiller) ->
     )
 
 
-def test_graft_reject_backoff(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_graft_reject_backoff(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """Reject GRAFT with PRUNE when peer is in backoff period."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="graft",
         params=PARAMS,
         initial_state={
@@ -71,9 +71,9 @@ def test_graft_reject_backoff(gossipsub_handler: GossipsubHandlerTestFiller) -> 
     )
 
 
-def test_graft_ignore_unsubscribed(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_graft_ignore_unsubscribed(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """Silently ignore GRAFT for a topic we are not subscribed to."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="graft",
         params=PARAMS,
         initial_state={
@@ -87,9 +87,9 @@ def test_graft_ignore_unsubscribed(gossipsub_handler: GossipsubHandlerTestFiller
     )
 
 
-def test_graft_idempotent(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_graft_idempotent(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """GRAFT for a peer already in mesh is harmless."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="graft",
         params=PARAMS,
         initial_state={
@@ -106,9 +106,9 @@ def test_graft_idempotent(gossipsub_handler: GossipsubHandlerTestFiller) -> None
 # --- PRUNE handler ---
 
 
-def test_prune_with_backoff(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_prune_with_backoff(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """PRUNE removes peer from mesh and sets backoff timer."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="prune",
         params=PARAMS,
         initial_state={
@@ -123,9 +123,9 @@ def test_prune_with_backoff(gossipsub_handler: GossipsubHandlerTestFiller) -> No
     )
 
 
-def test_prune_zero_backoff(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_prune_zero_backoff(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """PRUNE with backoff=0 removes from mesh but does not set backoff timer."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="prune",
         params=PARAMS,
         initial_state={
@@ -142,9 +142,9 @@ def test_prune_zero_backoff(gossipsub_handler: GossipsubHandlerTestFiller) -> No
 # --- IHAVE handler ---
 
 
-def test_ihave_unseen_triggers_iwant(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_ihave_unseen_triggers_iwant(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """IHAVE for an unseen message triggers an IWANT response."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="ihave",
         params=PARAMS,
         initial_state={
@@ -161,9 +161,9 @@ def test_ihave_unseen_triggers_iwant(gossipsub_handler: GossipsubHandlerTestFill
     )
 
 
-def test_ihave_seen_no_iwant(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_ihave_seen_no_iwant(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """IHAVE for an already-seen message produces no IWANT."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="ihave",
         params=PARAMS,
         initial_state={
@@ -180,9 +180,9 @@ def test_ihave_seen_no_iwant(gossipsub_handler: GossipsubHandlerTestFiller) -> N
     )
 
 
-def test_ihave_mixed(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_ihave_mixed(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """IHAVE with seen and unseen IDs. IWANT only for the unseen one."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="ihave",
         params=PARAMS,
         initial_state={
@@ -202,9 +202,9 @@ def test_ihave_mixed(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
 # --- IWANT handler ---
 
 
-def test_iwant_cached_responds(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_iwant_cached_responds(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """IWANT for a cached message responds with the full message."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="iwant",
         params=PARAMS,
         initial_state={
@@ -226,9 +226,9 @@ def test_iwant_cached_responds(gossipsub_handler: GossipsubHandlerTestFiller) ->
 # --- Message handler ---
 
 
-def test_message_forward_to_mesh(gossipsub_handler: GossipsubHandlerTestFiller) -> None:
+def test_message_forward_to_mesh(gossipsub_handler_test: GossipsubHandlerTestFiller) -> None:
     """New message forwarded to mesh peers except the sender."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="message",
         params=PARAMS,
         initial_state={
@@ -248,10 +248,10 @@ def test_message_forward_to_mesh(gossipsub_handler: GossipsubHandlerTestFiller) 
 
 
 def test_message_duplicate_not_forwarded(
-    gossipsub_handler: GossipsubHandlerTestFiller,
+    gossipsub_handler_test: GossipsubHandlerTestFiller,
 ) -> None:
     """Duplicate message (already in seen cache) is not forwarded."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="message",
         params=PARAMS,
         initial_state={
@@ -271,10 +271,10 @@ def test_message_duplicate_not_forwarded(
 
 
 def test_message_idontwant_skips_peer(
-    gossipsub_handler: GossipsubHandlerTestFiller,
+    gossipsub_handler_test: GossipsubHandlerTestFiller,
 ) -> None:
     """Peer that sent IDONTWANT for this message ID is skipped during forwarding."""
-    gossipsub_handler(
+    gossipsub_handler_test(
         handler_name="message",
         params=PARAMS,
         initial_state={

--- a/tests/consensus/lstar/networking/test_gossipsub_rpc.py
+++ b/tests/consensus/lstar/networking/test_gossipsub_rpc.py
@@ -16,9 +16,9 @@ PEER_ID = "0x" + "dd" * 32
 # --- SubOpts ---
 
 
-def test_sub_opts_subscribe(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_sub_opts_subscribe(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """SubOpts encoding for a topic subscription."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [{"subscribe": True, "topicId": TOPIC_A}],
@@ -27,9 +27,9 @@ def test_sub_opts_subscribe(networking_codec: NetworkingCodecTestFiller) -> None
     )
 
 
-def test_sub_opts_unsubscribe(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_sub_opts_unsubscribe(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """SubOpts encoding for a topic unsubscription."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [{"subscribe": False, "topicId": TOPIC_A}],
@@ -38,9 +38,9 @@ def test_sub_opts_unsubscribe(networking_codec: NetworkingCodecTestFiller) -> No
     )
 
 
-def test_sub_opts_empty_topic(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_sub_opts_empty_topic(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """SubOpts with an empty topic string."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [{"subscribe": True, "topicId": ""}],
@@ -52,9 +52,9 @@ def test_sub_opts_empty_topic(networking_codec: NetworkingCodecTestFiller) -> No
 # --- Message ---
 
 
-def test_message_topic_only(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_topic_only(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Published message with only the topic field set."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -63,9 +63,9 @@ def test_message_topic_only(networking_codec: NetworkingCodecTestFiller) -> None
     )
 
 
-def test_message_all_fields(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_all_fields(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Published message with every optional field populated."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -83,9 +83,9 @@ def test_message_all_fields(networking_codec: NetworkingCodecTestFiller) -> None
     )
 
 
-def test_message_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_message_empty(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Published message with no fields set. Encodes as zero bytes."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -97,9 +97,9 @@ def test_message_empty(networking_codec: NetworkingCodecTestFiller) -> None:
 # --- ControlGraft ---
 
 
-def test_graft_single_topic(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_graft_single_topic(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """GRAFT requesting mesh membership for one topic."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -109,9 +109,9 @@ def test_graft_single_topic(networking_codec: NetworkingCodecTestFiller) -> None
     )
 
 
-def test_graft_empty_topic(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_graft_empty_topic(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """GRAFT with an empty topic string."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -124,9 +124,9 @@ def test_graft_empty_topic(networking_codec: NetworkingCodecTestFiller) -> None:
 # --- ControlIHave ---
 
 
-def test_ihave_single_id(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_ihave_single_id(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """IHAVE advertising one cached message ID."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -138,9 +138,9 @@ def test_ihave_single_id(networking_codec: NetworkingCodecTestFiller) -> None:
     )
 
 
-def test_ihave_multiple_ids(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_ihave_multiple_ids(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """IHAVE advertising three cached message IDs."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -154,9 +154,9 @@ def test_ihave_multiple_ids(networking_codec: NetworkingCodecTestFiller) -> None
     )
 
 
-def test_ihave_empty_ids(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_ihave_empty_ids(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """IHAVE with a topic but no message IDs."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -171,9 +171,9 @@ def test_ihave_empty_ids(networking_codec: NetworkingCodecTestFiller) -> None:
 # --- ControlIWant ---
 
 
-def test_iwant_single_id(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_iwant_single_id(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """IWANT requesting one message by ID."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -185,9 +185,9 @@ def test_iwant_single_id(networking_codec: NetworkingCodecTestFiller) -> None:
     )
 
 
-def test_iwant_multiple_ids(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_iwant_multiple_ids(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """IWANT requesting two messages by ID."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -202,9 +202,9 @@ def test_iwant_multiple_ids(networking_codec: NetworkingCodecTestFiller) -> None
 # --- ControlPrune ---
 
 
-def test_prune_topic_only(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_prune_topic_only(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """PRUNE with topic but no peer exchange or backoff."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -216,9 +216,9 @@ def test_prune_topic_only(networking_codec: NetworkingCodecTestFiller) -> None:
     )
 
 
-def test_prune_with_backoff(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_prune_with_backoff(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """PRUNE with a 60-second backoff duration."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -230,9 +230,9 @@ def test_prune_with_backoff(networking_codec: NetworkingCodecTestFiller) -> None
     )
 
 
-def test_prune_with_peer_exchange(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_prune_with_peer_exchange(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """PRUNE with peer exchange information and backoff."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -255,9 +255,9 @@ def test_prune_with_peer_exchange(networking_codec: NetworkingCodecTestFiller) -
 # --- ControlIDontWant ---
 
 
-def test_idontwant_single_id(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_idontwant_single_id(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """IDONTWANT declining one message. Gossipsub v1.2 extension."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -269,9 +269,9 @@ def test_idontwant_single_id(networking_codec: NetworkingCodecTestFiller) -> Non
     )
 
 
-def test_idontwant_multiple_ids(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_idontwant_multiple_ids(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """IDONTWANT declining two messages."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -286,9 +286,9 @@ def test_idontwant_multiple_ids(networking_codec: NetworkingCodecTestFiller) -> 
 # --- ControlMessage ---
 
 
-def test_control_single_graft(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_control_single_graft(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Control message containing only a single GRAFT."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -298,9 +298,9 @@ def test_control_single_graft(networking_codec: NetworkingCodecTestFiller) -> No
     )
 
 
-def test_control_all_types(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_control_all_types(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Control message with one of each control type."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -316,9 +316,9 @@ def test_control_all_types(networking_codec: NetworkingCodecTestFiller) -> None:
     )
 
 
-def test_control_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_control_empty(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Empty control message. All repeated fields empty, encodes to zero bytes."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -331,9 +331,9 @@ def test_control_empty(networking_codec: NetworkingCodecTestFiller) -> None:
 # --- Full RPC ---
 
 
-def test_rpc_subscriptions_only(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_rpc_subscriptions_only(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """RPC with only subscription changes."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [
@@ -345,9 +345,9 @@ def test_rpc_subscriptions_only(networking_codec: NetworkingCodecTestFiller) -> 
     )
 
 
-def test_rpc_publish_only(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_rpc_publish_only(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """RPC with only published messages."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -359,9 +359,9 @@ def test_rpc_publish_only(networking_codec: NetworkingCodecTestFiller) -> None:
     )
 
 
-def test_rpc_control_only(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_rpc_control_only(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """RPC with only control messages."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],
@@ -374,9 +374,9 @@ def test_rpc_control_only(networking_codec: NetworkingCodecTestFiller) -> None:
     )
 
 
-def test_rpc_full(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_rpc_full(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """RPC with subscriptions, published messages, and control all present."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [{"subscribe": True, "topicId": TOPIC_A}],
@@ -389,9 +389,9 @@ def test_rpc_full(networking_codec: NetworkingCodecTestFiller) -> None:
     )
 
 
-def test_rpc_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_rpc_empty(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Empty RPC. No subscriptions, messages, or control."""
-    networking_codec(
+    networking_codec_test(
         codec_name="gossipsub_rpc",
         input={
             "subscriptions": [],

--- a/tests/consensus/lstar/networking/test_gossipsub_rpc_rejections.py
+++ b/tests/consensus/lstar/networking/test_gossipsub_rpc_rejections.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_gossipsub_rpc_decode_rejects_unknown_wire_type(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     A protobuf tag with an unrecognised wire type must be rejected.
@@ -18,7 +18,7 @@ def test_gossipsub_rpc_decode_rejects_unknown_wire_type(
     beyond the set 0, 1, 2, 5 are unassigned; any occurrence in RPC traffic
     must be rejected rather than silently skipped.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "gossipsub_rpc", "bytes": "0x0e"},
         expect_exception=ProtobufDecodeError,
@@ -26,7 +26,7 @@ def test_gossipsub_rpc_decode_rejects_unknown_wire_type(
 
 
 def test_gossipsub_rpc_decode_rejects_length_exceeding_data(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     A length-delimited field whose length runs past the payload is rejected.
@@ -36,7 +36,7 @@ def test_gossipsub_rpc_decode_rejects_length_exceeding_data(
     zero bytes, so the declared length cannot possibly be covered. The
     decoder must raise before reading past the buffer end.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "gossipsub_rpc", "bytes": "0x0a64"},
         expect_exception=ProtobufDecodeError,

--- a/tests/consensus/lstar/networking/test_reqresp_codec.py
+++ b/tests/consensus/lstar/networking/test_reqresp_codec.py
@@ -9,51 +9,51 @@ pytestmark = pytest.mark.valid_until("Lstar")
 # --- Request encoding ---
 
 
-def test_request_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_empty(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Request with empty SSZ payload. Varint prefix is 0x00."""
-    networking_codec(codec_name="reqresp_request", input={"sszData": "0x"})
+    networking_codec_test(codec_name="reqresp_request", input={"sszData": "0x"})
 
 
-def test_request_small(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_small(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Request with 4-byte SSZ payload."""
-    networking_codec(codec_name="reqresp_request", input={"sszData": "0x01020304"})
+    networking_codec_test(codec_name="reqresp_request", input={"sszData": "0x01020304"})
 
 
-def test_request_varint_one_byte_max(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_varint_one_byte_max(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Request with 127-byte payload. Largest single-byte varint prefix."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_request",
         input={"sszData": "0x" + "ab" * 127},
     )
 
 
-def test_request_varint_two_byte_min(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_varint_two_byte_min(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Request with 128-byte payload. Smallest two-byte varint prefix."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_request",
         input={"sszData": "0x" + "cd" * 128},
     )
 
 
-def test_request_compressible(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_compressible(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Request with 1 KB of repeated data. Exercises Snappy copy tags."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_request",
         input={"sszData": "0x" + "deadbeef" * 256},
     )
 
 
-def test_request_sequential(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_sequential(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Request with 256 sequential bytes. Low compression ratio."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_request",
         input={"sszData": "0x" + bytes(range(256)).hex()},
     )
 
 
-def test_request_all_zeros(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_all_zeros(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Request with 32 zero bytes. Tests CRC32C on uniform input."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_request",
         input={"sszData": "0x" + "00" * 32},
     )
@@ -62,65 +62,65 @@ def test_request_all_zeros(networking_codec: NetworkingCodecTestFiller) -> None:
 # --- Response encoding ---
 
 
-def test_response_success_small(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_response_success_small(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """SUCCESS response with 4-byte SSZ payload."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={"responseCode": 0, "sszData": "0x01020304"},
     )
 
 
-def test_response_success_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_response_success_empty(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """SUCCESS response with empty payload."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={"responseCode": 0, "sszData": "0x"},
     )
 
 
-def test_response_invalid_request(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_response_invalid_request(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """INVALID_REQUEST response with UTF-8 error message."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={"responseCode": 1, "sszData": "0x" + b"bad request".hex()},
     )
 
 
-def test_response_server_error(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_response_server_error(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """SERVER_ERROR response with UTF-8 error message."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={"responseCode": 2, "sszData": "0x" + b"internal error".hex()},
     )
 
 
-def test_response_resource_unavailable(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_response_resource_unavailable(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """RESOURCE_UNAVAILABLE response with UTF-8 error message."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={"responseCode": 3, "sszData": "0x" + b"block not found".hex()},
     )
 
 
-def test_response_success_sequential(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_response_success_sequential(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """SUCCESS response with 256 sequential bytes."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={"responseCode": 0, "sszData": "0x" + bytes(range(256)).hex()},
     )
 
 
-def test_response_success_compressible(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_response_success_compressible(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """SUCCESS response with 1 KB of repeated data."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={"responseCode": 0, "sszData": "0x" + "cafebabe" * 256},
     )
 
 
-def test_response_success_all_ff(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_response_success_all_ff(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """SUCCESS response with 32 bytes of 0xFF."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={"responseCode": 0, "sszData": "0x" + "ff" * 32},
     )
@@ -148,49 +148,49 @@ BLOCKS_BY_ROOT_EMPTY_SSZ = "0x04000000"
 """BlocksByRootRequest with empty root list (4-byte SSZ offset only)."""
 
 
-def test_request_status(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_status(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Status request through the full wire pipeline. Protocol: /leanconsensus/req/status/1."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_request",
         input={"sszData": STATUS_SSZ},
     )
 
 
-def test_response_status(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_response_status(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Status SUCCESS response through the full wire pipeline."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={"responseCode": 0, "sszData": STATUS_SSZ},
     )
 
 
-def test_request_blocks_by_root(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_blocks_by_root(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """BlocksByRoot request with two roots. Protocol: /leanconsensus/req/blocks_by_root/1."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_request",
         input={"sszData": BLOCKS_BY_ROOT_SSZ},
     )
 
 
-def test_request_blocks_by_root_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_blocks_by_root_empty(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """BlocksByRoot request with empty root list. Minimal 4-byte SSZ payload."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_request",
         input={"sszData": BLOCKS_BY_ROOT_EMPTY_SSZ},
     )
 
 
-def test_request_snappy_chunk_boundary(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_snappy_chunk_boundary(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Request at Snappy chunk boundary (65536 bytes). Exercises multi-chunk framing."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_request",
         input={"sszData": "0x" + "ab" * 65536},
     )
 
 
-def test_request_multi_chunk(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_request_multi_chunk(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Request spanning 2+ Snappy chunks (65537 bytes)."""
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_request",
         input={"sszData": "0x" + "cd" * 65537},
     )

--- a/tests/consensus/lstar/networking/test_reqresp_error_utf8.py
+++ b/tests/consensus/lstar/networking/test_reqresp_error_utf8.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_reqresp_error_at_max_error_message_size(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     Error response carrying a payload at the maximum error-message size roundtrips.
@@ -18,7 +18,7 @@ def test_reqresp_error_at_max_error_message_size(
     bytes without loss.
     """
     payload = b"e" * 256
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={
             "responseCode": 1,
@@ -28,7 +28,7 @@ def test_reqresp_error_at_max_error_message_size(
 
 
 def test_reqresp_error_with_multi_byte_utf8(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     Error response carrying multi-byte UTF-8 text roundtrips byte-for-byte.
@@ -38,7 +38,7 @@ def test_reqresp_error_with_multi_byte_utf8(
     preserve the original bytes even when they are not ASCII-only.
     """
     payload = "errür😀fail".encode()
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={
             "responseCode": 2,
@@ -48,7 +48,7 @@ def test_reqresp_error_with_multi_byte_utf8(
 
 
 def test_reqresp_error_resource_unavailable_with_informational_text(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     Error code 3 response carrying a short descriptive message roundtrips.
@@ -57,7 +57,7 @@ def test_reqresp_error_resource_unavailable_with_informational_text(
     informational error string alongside the RESOURCE_UNAVAILABLE code.
     """
     payload = b"block not found"
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response",
         input={
             "responseCode": 3,

--- a/tests/consensus/lstar/networking/test_reqresp_rejections.py
+++ b/tests/consensus/lstar/networking/test_reqresp_rejections.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_reqresp_decode_rejects_empty_request(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     Decoding an empty request is rejected with CodecError.
@@ -24,7 +24,7 @@ def test_reqresp_decode_rejects_empty_request(
     compressed payload. Zero input carries neither, so the decoder must
     refuse before any downstream parsing.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "reqresp_request", "bytes": "0x"},
         expect_exception=CodecError,
@@ -32,7 +32,7 @@ def test_reqresp_decode_rejects_empty_request(
 
 
 def test_reqresp_decode_rejects_invalid_varint_prefix(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     A request whose length prefix is a malformed varint is rejected with CodecError.
@@ -41,7 +41,7 @@ def test_reqresp_decode_rejects_invalid_varint_prefix(
     The decoder wraps the underlying varint error in CodecError so clients
     can uniformly treat wire-level framing errors as a single class.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "reqresp_request", "bytes": "0x8080"},
         expect_exception=CodecError,
@@ -49,7 +49,7 @@ def test_reqresp_decode_rejects_invalid_varint_prefix(
 
 
 def test_reqresp_decode_rejects_declared_length_above_max(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     A request whose declared length exceeds the ten-mebibyte cap is rejected.
@@ -58,7 +58,7 @@ def test_reqresp_decode_rejects_declared_length_above_max(
     ten-mebibyte protocol cap. Refusing before decompression prevents a
     sender from forcing resource allocation proportional to a claimed size.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "reqresp_request", "bytes": "0x81808005"},
         expect_exception=CodecError,

--- a/tests/consensus/lstar/networking/test_reqresp_response_stream.py
+++ b/tests/consensus/lstar/networking/test_reqresp_response_stream.py
@@ -13,7 +13,7 @@ from consensus_testing import NetworkingCodecTestFiller
 pytestmark = pytest.mark.valid_until("Lstar")
 
 
-def test_stream_two_success_chunks(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_stream_two_success_chunks(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """
     Stream with two SUCCESS chunks carrying distinct payload bytes.
 
@@ -21,7 +21,7 @@ def test_stream_two_success_chunks(networking_codec: NetworkingCodecTestFiller) 
     must read both records before signalling EOF, so a receiver that
     stops after the first chunk drops half the response.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response_stream",
         input={
             "chunks": [
@@ -33,7 +33,7 @@ def test_stream_two_success_chunks(networking_codec: NetworkingCodecTestFiller) 
 
 
 def test_stream_success_then_resource_unavailable(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     A SUCCESS chunk followed by a RESOURCE_UNAVAILABLE terminator.
@@ -43,7 +43,7 @@ def test_stream_success_then_resource_unavailable(
     concatenation so clients surface both the delivered payload and
     the error terminator.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response_stream",
         input={
             "chunks": [
@@ -55,7 +55,7 @@ def test_stream_success_then_resource_unavailable(
 
 
 def test_stream_three_success_chunks_with_compressible_payloads(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     Three SUCCESS chunks whose payloads compress well.
@@ -65,7 +65,7 @@ def test_stream_three_success_chunks_with_compressible_payloads(
     stream-level parsers that reset snappy state between chunks must
     produce identical output to stateful parsers.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="reqresp_response_stream",
         input={
             "chunks": [

--- a/tests/consensus/lstar/networking/test_snappy_codec.py
+++ b/tests/consensus/lstar/networking/test_snappy_codec.py
@@ -15,59 +15,59 @@ pytestmark = pytest.mark.valid_until("Lstar")
 # --- Raw Snappy block format ---
 
 
-def test_snappy_block_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_block_empty(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Empty input. Compressed output is just the varint-encoded uncompressed length (0)."""
-    networking_codec(codec_name="snappy_block", input={"data": "0x"})
+    networking_codec_test(codec_name="snappy_block", input={"data": "0x"})
 
 
-def test_snappy_block_single_byte(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_block_single_byte(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Single byte. Too short for copy commands, must use a literal."""
-    networking_codec(codec_name="snappy_block", input={"data": "0x42"})
+    networking_codec_test(codec_name="snappy_block", input={"data": "0x42"})
 
 
-def test_snappy_block_short_string(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_block_short_string(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Short ASCII string (17 bytes). Verifies literal encoding for small payloads."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_block",
         input={"data": "0x" + b"Hello, Ethereum!".hex()},
     )
 
 
-def test_snappy_block_repeated_data(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_block_repeated_data(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """1000 identical bytes. Highly compressible via copy commands."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_block",
         input={"data": "0x" + (b"\x41" * 1000).hex()},
     )
 
 
-def test_snappy_block_alternating_pattern(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_block_alternating_pattern(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Alternating two-byte pattern (1000 bytes). Tests copy offset=2 back-references."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_block",
         input={"data": "0x" + (b"\xab\xcd" * 500).hex()},
     )
 
 
-def test_snappy_block_incompressible(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_block_incompressible(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Sequential bytes 0x00-0xFF (256 bytes). Low compressibility, mostly literals."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_block",
         input={"data": "0x" + bytes(range(256)).hex()},
     )
 
 
-def test_snappy_block_at_block_boundary(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_block_at_block_boundary(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Exactly 65536 bytes of repeated data. Tests behavior at the Snappy block size limit."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_block",
         input={"data": "0x" + (b"\xfe" * 65536).hex()},
     )
 
 
-def test_snappy_block_multi_block(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_block_multi_block(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """65537 bytes (one past block boundary). Forces multi-block handling."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_block",
         input={"data": "0x" + (b"\xfe" * 65537).hex()},
     )
@@ -76,56 +76,56 @@ def test_snappy_block_multi_block(networking_codec: NetworkingCodecTestFiller) -
 # --- Snappy framing format (Ethereum wire format) ---
 
 
-def test_snappy_frame_empty(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_frame_empty(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Empty payload. Output is just the stream identifier chunk."""
-    networking_codec(codec_name="snappy_frame", input={"data": "0x"})
+    networking_codec_test(codec_name="snappy_frame", input={"data": "0x"})
 
 
-def test_snappy_frame_short(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_frame_short(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Short payload (16 bytes). Fits in a single compressed chunk."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_frame",
         input={"data": "0x" + b"Ethereum Snappy!".hex()},
     )
 
 
-def test_snappy_frame_compressible(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_frame_compressible(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Highly compressible data (2048 repeated bytes). Single compressed chunk."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_frame",
         input={"data": "0x" + (b"\x00" * 2048).hex()},
     )
 
 
-def test_snappy_frame_incompressible(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_frame_incompressible(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Sequential bytes (256). May produce an uncompressed chunk if expansion occurs."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_frame",
         input={"data": "0x" + bytes(range(256)).hex()},
     )
 
 
-def test_snappy_frame_at_chunk_boundary(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_frame_at_chunk_boundary(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Exactly 65536 bytes. Tests chunk size limit in framing format."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_frame",
         input={"data": "0x" + (b"\xab" * 65536).hex()},
     )
 
 
-def test_snappy_frame_multi_chunk(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_frame_multi_chunk(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """65537 bytes. Forces multiple framing chunks."""
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_frame",
         input={"data": "0x" + (b"\xab" * 65537).hex()},
     )
 
 
-def test_snappy_frame_ssz_like_payload(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_snappy_frame_ssz_like_payload(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Realistic SSZ-like payload: fixed header + repeated zero padding (512 bytes)."""
     header = bytes(range(64))
     padding = b"\x00" * 448
-    networking_codec(
+    networking_codec_test(
         codec_name="snappy_frame",
         input={"data": "0x" + (header + padding).hex()},
     )

--- a/tests/consensus/lstar/networking/test_snappy_frame_rejections.py
+++ b/tests/consensus/lstar/networking/test_snappy_frame_rejections.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_snappy_frame_decode_rejects_empty_input(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     Empty input is not a valid snappy frame and must be rejected.
@@ -18,7 +18,7 @@ def test_snappy_frame_decode_rejects_empty_input(
     Zero bytes cannot satisfy that minimum so the decoder aborts early
     with SnappyDecompressionError.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "snappy_frame", "bytes": "0x"},
         expect_exception=SnappyDecompressionError,
@@ -26,7 +26,7 @@ def test_snappy_frame_decode_rejects_empty_input(
 
 
 def test_snappy_frame_decode_rejects_wrong_stream_identifier(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     A stream whose opening bytes do not spell the snappy magic is rejected.
@@ -36,7 +36,7 @@ def test_snappy_frame_decode_rejects_wrong_stream_identifier(
     the length check but carry the wrong magic, so the decoder rejects
     the stream at the identifier check.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "snappy_frame", "bytes": "0x" + "00" * 10},
         expect_exception=SnappyDecompressionError,
@@ -44,7 +44,7 @@ def test_snappy_frame_decode_rejects_wrong_stream_identifier(
 
 
 def test_snappy_frame_decode_rejects_unknown_unskippable_chunk(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     A chunk of an unassigned unskippable type is rejected.
@@ -56,7 +56,7 @@ def test_snappy_frame_decode_rejects_unknown_unskippable_chunk(
     """
     stream_identifier = "ff060000734e61507059"
     unknown_chunk = "03000000"
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "snappy_frame", "bytes": "0x" + stream_identifier + unknown_chunk},
         expect_exception=SnappyDecompressionError,

--- a/tests/consensus/lstar/networking/test_varint.py
+++ b/tests/consensus/lstar/networking/test_varint.py
@@ -9,80 +9,80 @@ pytestmark = pytest.mark.valid_until("Lstar")
 # --- Single-byte values (0-127) ---
 
 
-def test_varint_zero(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_zero(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint zero encodes as a single 0x00 byte."""
-    networking_codec(codec_name="varint", input={"value": 0})
+    networking_codec_test(codec_name="varint", input={"value": 0})
 
 
-def test_varint_one(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_one(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint one encodes as 0x01."""
-    networking_codec(codec_name="varint", input={"value": 1})
+    networking_codec_test(codec_name="varint", input={"value": 1})
 
 
-def test_varint_max_one_byte(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_max_one_byte(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 127 is the largest value fitting in a single byte."""
-    networking_codec(codec_name="varint", input={"value": 127})
+    networking_codec_test(codec_name="varint", input={"value": 127})
 
 
 # --- Two-byte values (128-16383) ---
 
 
-def test_varint_min_two_bytes(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_min_two_bytes(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 128 is the smallest value requiring two bytes."""
-    networking_codec(codec_name="varint", input={"value": 128})
+    networking_codec_test(codec_name="varint", input={"value": 128})
 
 
-def test_varint_150(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_150(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 150. Classic protobuf documentation example."""
-    networking_codec(codec_name="varint", input={"value": 150})
+    networking_codec_test(codec_name="varint", input={"value": 150})
 
 
-def test_varint_255(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_255(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 255. Max Uint8 boundary."""
-    networking_codec(codec_name="varint", input={"value": 255})
+    networking_codec_test(codec_name="varint", input={"value": 255})
 
 
-def test_varint_256(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_256(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 256. First value past Uint8 range."""
-    networking_codec(codec_name="varint", input={"value": 256})
+    networking_codec_test(codec_name="varint", input={"value": 256})
 
 
-def test_varint_300(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_300(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 300. The example from the module docstring."""
-    networking_codec(codec_name="varint", input={"value": 300})
+    networking_codec_test(codec_name="varint", input={"value": 300})
 
 
-def test_varint_max_two_bytes(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_max_two_bytes(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 16383 is the largest value fitting in two bytes."""
-    networking_codec(codec_name="varint", input={"value": 16383})
+    networking_codec_test(codec_name="varint", input={"value": 16383})
 
 
 # --- Multi-byte boundaries ---
 
 
-def test_varint_min_three_bytes(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_min_three_bytes(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 16384 is the smallest value requiring three bytes."""
-    networking_codec(codec_name="varint", input={"value": 16384})
+    networking_codec_test(codec_name="varint", input={"value": 16384})
 
 
-def test_varint_max_three_bytes(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_max_three_bytes(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 2097151 is the largest value fitting in three bytes."""
-    networking_codec(codec_name="varint", input={"value": 2097151})
+    networking_codec_test(codec_name="varint", input={"value": 2097151})
 
 
-def test_varint_max_four_bytes(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_max_four_bytes(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 268435455 is the largest value fitting in four bytes."""
-    networking_codec(codec_name="varint", input={"value": 268435455})
+    networking_codec_test(codec_name="varint", input={"value": 268435455})
 
 
 # --- Large values ---
 
 
-def test_varint_uint32_max(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_uint32_max(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 2^32 - 1. Maximum 32-bit unsigned integer."""
-    networking_codec(codec_name="varint", input={"value": 2**32 - 1})
+    networking_codec_test(codec_name="varint", input={"value": 2**32 - 1})
 
 
-def test_varint_uint64_max(networking_codec: NetworkingCodecTestFiller) -> None:
+def test_varint_uint64_max(networking_codec_test: NetworkingCodecTestFiller) -> None:
     """Varint 2^64 - 1. Maximum 64-bit value, requires 10 bytes."""
-    networking_codec(codec_name="varint", input={"value": 2**64 - 1})
+    networking_codec_test(codec_name="varint", input={"value": 2**64 - 1})

--- a/tests/consensus/lstar/networking/test_varint_invalid.py
+++ b/tests/consensus/lstar/networking/test_varint_invalid.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_varint_truncated_mid_stream_rejected(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     A varint whose final byte still has the continuation bit set is rejected.
@@ -18,7 +18,7 @@ def test_varint_truncated_mid_stream_rejected(
     further bytes to complete the value. The decoder must raise
     `VarintError("Truncated varint")`.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "varint", "bytes": "0x8080"},
         expect_exception=VarintError,
@@ -26,7 +26,7 @@ def test_varint_truncated_mid_stream_rejected(
 
 
 def test_varint_longer_than_ten_bytes_rejected(
-    networking_codec: NetworkingCodecTestFiller,
+    networking_codec_test: NetworkingCodecTestFiller,
 ) -> None:
     """
     A varint running eleven continuation bytes exceeds the 64-bit cap and is rejected.
@@ -35,7 +35,7 @@ def test_varint_longer_than_ten_bytes_rejected(
     continuation bytes means the decoder cannot represent the value and must
     raise `VarintError("Varint too long")`.
     """
-    networking_codec(
+    networking_codec_test(
         codec_name="decode_failure",
         input={"decoder": "varint", "bytes": "0x" + "80" * 11},
         expect_exception=VarintError,

--- a/tests/consensus/lstar/poseidon/test_permutation_width16.py
+++ b/tests/consensus/lstar/poseidon/test_permutation_width16.py
@@ -17,7 +17,7 @@ WIDTH: int = 16
 
 
 def test_permutation_width16_all_zero(
-    poseidon_permutation: PoseidonPermutationTestFiller,
+    poseidon_permutation_test: PoseidonPermutationTestFiller,
 ) -> None:
     """
     Input state of all zeros pins the round-constant-only output.
@@ -27,14 +27,14 @@ def test_permutation_width16_all_zero(
     the round constants and the MDS matrix, making this vector a
     sensitive diff for tables-of-constants drift.
     """
-    poseidon_permutation(
+    poseidon_permutation_test(
         width=WIDTH,
         input={"inputState": ["0"] * WIDTH},
     )
 
 
 def test_permutation_width16_all_one(
-    poseidon_permutation: PoseidonPermutationTestFiller,
+    poseidon_permutation_test: PoseidonPermutationTestFiller,
 ) -> None:
     """
     Input state of all ones exercises uniform non-zero entries.
@@ -43,14 +43,14 @@ def test_permutation_width16_all_one(
     multiplications see a state vector whose entries all carry the same
     contribution, pinning the first-row linearity of the permutation.
     """
-    poseidon_permutation(
+    poseidon_permutation_test(
         width=WIDTH,
         input={"inputState": ["1"] * WIDTH},
     )
 
 
 def test_permutation_width16_incremental_index(
-    poseidon_permutation: PoseidonPermutationTestFiller,
+    poseidon_permutation_test: PoseidonPermutationTestFiller,
 ) -> None:
     """
     Input state filled with 0, 1, 2, ..., WIDTH - 1.
@@ -59,14 +59,14 @@ def test_permutation_width16_incremental_index(
     off-by-one in MDS row indexing or round-constant slicing perturbs
     the output noticeably.
     """
-    poseidon_permutation(
+    poseidon_permutation_test(
         width=WIDTH,
         input={"inputState": [str(i) for i in range(WIDTH)]},
     )
 
 
 def test_permutation_width16_p_minus_one_and_near_zero(
-    poseidon_permutation: PoseidonPermutationTestFiller,
+    poseidon_permutation_test: PoseidonPermutationTestFiller,
 ) -> None:
     """
     Mix of field-boundary values P - 1 and small values across the state.
@@ -76,7 +76,7 @@ def test_permutation_width16_p_minus_one_and_near_zero(
     path for the widest intermediates generated inside the S-box.
     """
     state = [str(P - 1) if i % 2 == 0 else str(i) for i in range(WIDTH)]
-    poseidon_permutation(
+    poseidon_permutation_test(
         width=WIDTH,
         input={"inputState": state},
     )

--- a/tests/consensus/lstar/poseidon/test_permutation_width24.py
+++ b/tests/consensus/lstar/poseidon/test_permutation_width24.py
@@ -17,7 +17,7 @@ WIDTH: int = 24
 
 
 def test_permutation_width24_all_zero(
-    poseidon_permutation: PoseidonPermutationTestFiller,
+    poseidon_permutation_test: PoseidonPermutationTestFiller,
 ) -> None:
     """
     Input state of all zeros pins the round-constant-only output at width 24.
@@ -27,38 +27,38 @@ def test_permutation_width24_all_zero(
     round constants and MDS matrix, making this vector sensitive to
     tables-of-constants drift at the larger width.
     """
-    poseidon_permutation(
+    poseidon_permutation_test(
         width=WIDTH,
         input={"inputState": ["0"] * WIDTH},
     )
 
 
 def test_permutation_width24_all_one(
-    poseidon_permutation: PoseidonPermutationTestFiller,
+    poseidon_permutation_test: PoseidonPermutationTestFiller,
 ) -> None:
     """Input state of all ones exercises uniform non-zero entries at width 24."""
-    poseidon_permutation(
+    poseidon_permutation_test(
         width=WIDTH,
         input={"inputState": ["1"] * WIDTH},
     )
 
 
 def test_permutation_width24_incremental_index(
-    poseidon_permutation: PoseidonPermutationTestFiller,
+    poseidon_permutation_test: PoseidonPermutationTestFiller,
 ) -> None:
     """Input state filled with 0, 1, 2, ..., 23 pins per-slot MDS behaviour."""
-    poseidon_permutation(
+    poseidon_permutation_test(
         width=WIDTH,
         input={"inputState": [str(i) for i in range(WIDTH)]},
     )
 
 
 def test_permutation_width24_p_minus_one_and_near_zero(
-    poseidon_permutation: PoseidonPermutationTestFiller,
+    poseidon_permutation_test: PoseidonPermutationTestFiller,
 ) -> None:
     """Alternating P - 1 and small positives stress reduction at width 24."""
     state = [str(P - 1) if i % 2 == 0 else str(i) for i in range(WIDTH)]
-    poseidon_permutation(
+    poseidon_permutation_test(
         width=WIDTH,
         input={"inputState": state},
     )

--- a/tests/consensus/lstar/ssz/test_basic_types.py
+++ b/tests/consensus/lstar/ssz/test_basic_types.py
@@ -77,205 +77,205 @@ class SampleBytes32List8(SSZList[Bytes32]):
 # --- Boolean ---
 
 
-def test_boolean_false(ssz: SSZTestFiller) -> None:
+def test_boolean_false(ssz_test: SSZTestFiller) -> None:
     """Boolean false encodes as 0x00."""
-    ssz(type_name="Boolean", value=Boolean(False))
+    ssz_test(type_name="Boolean", value=Boolean(False))
 
 
-def test_boolean_true(ssz: SSZTestFiller) -> None:
+def test_boolean_true(ssz_test: SSZTestFiller) -> None:
     """Boolean true encodes as 0x01."""
-    ssz(type_name="Boolean", value=Boolean(True))
+    ssz_test(type_name="Boolean", value=Boolean(True))
 
 
 # --- Uint8 ---
 
 
-def test_uint8_zero(ssz: SSZTestFiller) -> None:
+def test_uint8_zero(ssz_test: SSZTestFiller) -> None:
     """Uint8 lower bound (0)."""
-    ssz(type_name="Uint8", value=Uint8(0))
+    ssz_test(type_name="Uint8", value=Uint8(0))
 
 
-def test_uint8_one(ssz: SSZTestFiller) -> None:
+def test_uint8_one(ssz_test: SSZTestFiller) -> None:
     """Uint8 smallest nonzero value (1)."""
-    ssz(type_name="Uint8", value=Uint8(1))
+    ssz_test(type_name="Uint8", value=Uint8(1))
 
 
-def test_uint8_mid(ssz: SSZTestFiller) -> None:
+def test_uint8_mid(ssz_test: SSZTestFiller) -> None:
     """Uint8 midpoint with high bit set (128)."""
-    ssz(type_name="Uint8", value=Uint8(128))
+    ssz_test(type_name="Uint8", value=Uint8(128))
 
 
-def test_uint8_max(ssz: SSZTestFiller) -> None:
+def test_uint8_max(ssz_test: SSZTestFiller) -> None:
     """Uint8 upper bound (255)."""
-    ssz(type_name="Uint8", value=Uint8(2**8 - 1))
+    ssz_test(type_name="Uint8", value=Uint8(2**8 - 1))
 
 
 # --- Uint16 ---
 
 
-def test_uint16_zero(ssz: SSZTestFiller) -> None:
+def test_uint16_zero(ssz_test: SSZTestFiller) -> None:
     """Uint16 lower bound (0)."""
-    ssz(type_name="Uint16", value=Uint16(0))
+    ssz_test(type_name="Uint16", value=Uint16(0))
 
 
-def test_uint16_one(ssz: SSZTestFiller) -> None:
+def test_uint16_one(ssz_test: SSZTestFiller) -> None:
     """Uint16 smallest nonzero value (1)."""
-    ssz(type_name="Uint16", value=Uint16(1))
+    ssz_test(type_name="Uint16", value=Uint16(1))
 
 
-def test_uint16_mid(ssz: SSZTestFiller) -> None:
+def test_uint16_mid(ssz_test: SSZTestFiller) -> None:
     """Uint16 midpoint with high bit set (32768). Tests little-endian byte order."""
-    ssz(type_name="Uint16", value=Uint16(32768))
+    ssz_test(type_name="Uint16", value=Uint16(32768))
 
 
-def test_uint16_max(ssz: SSZTestFiller) -> None:
+def test_uint16_max(ssz_test: SSZTestFiller) -> None:
     """Uint16 upper bound (65535)."""
-    ssz(type_name="Uint16", value=Uint16(2**16 - 1))
+    ssz_test(type_name="Uint16", value=Uint16(2**16 - 1))
 
 
 # --- Uint32 ---
 
 
-def test_uint32_zero(ssz: SSZTestFiller) -> None:
+def test_uint32_zero(ssz_test: SSZTestFiller) -> None:
     """Uint32 lower bound (0)."""
-    ssz(type_name="Uint32", value=Uint32(0))
+    ssz_test(type_name="Uint32", value=Uint32(0))
 
 
-def test_uint32_one(ssz: SSZTestFiller) -> None:
+def test_uint32_one(ssz_test: SSZTestFiller) -> None:
     """Uint32 smallest nonzero value (1)."""
-    ssz(type_name="Uint32", value=Uint32(1))
+    ssz_test(type_name="Uint32", value=Uint32(1))
 
 
-def test_uint32_mid(ssz: SSZTestFiller) -> None:
+def test_uint32_mid(ssz_test: SSZTestFiller) -> None:
     """Uint32 midpoint with high bit set (2^31). Tests 4-byte little-endian layout."""
-    ssz(type_name="Uint32", value=Uint32(2147483648))
+    ssz_test(type_name="Uint32", value=Uint32(2147483648))
 
 
-def test_uint32_max(ssz: SSZTestFiller) -> None:
+def test_uint32_max(ssz_test: SSZTestFiller) -> None:
     """Uint32 upper bound (2^32 - 1)."""
-    ssz(type_name="Uint32", value=Uint32(2**32 - 1))
+    ssz_test(type_name="Uint32", value=Uint32(2**32 - 1))
 
 
 # --- Uint64 ---
 
 
-def test_uint64_zero(ssz: SSZTestFiller) -> None:
+def test_uint64_zero(ssz_test: SSZTestFiller) -> None:
     """Uint64 lower bound (0)."""
-    ssz(type_name="Uint64", value=Uint64(0))
+    ssz_test(type_name="Uint64", value=Uint64(0))
 
 
-def test_uint64_one(ssz: SSZTestFiller) -> None:
+def test_uint64_one(ssz_test: SSZTestFiller) -> None:
     """Uint64 smallest nonzero value (1)."""
-    ssz(type_name="Uint64", value=Uint64(1))
+    ssz_test(type_name="Uint64", value=Uint64(1))
 
 
-def test_uint64_mid(ssz: SSZTestFiller) -> None:
+def test_uint64_mid(ssz_test: SSZTestFiller) -> None:
     """Uint64 midpoint with high bit set (2^63). Tests 8-byte little-endian layout."""
-    ssz(type_name="Uint64", value=Uint64(2**63))
+    ssz_test(type_name="Uint64", value=Uint64(2**63))
 
 
-def test_uint64_max(ssz: SSZTestFiller) -> None:
+def test_uint64_max(ssz_test: SSZTestFiller) -> None:
     """Uint64 upper bound (2^64 - 1). All bytes 0xFF."""
-    ssz(type_name="Uint64", value=Uint64(2**64 - 1))
+    ssz_test(type_name="Uint64", value=Uint64(2**64 - 1))
 
 
 # --- Bytes4 ---
 
 
-def test_bytes4_zero(ssz: SSZTestFiller) -> None:
+def test_bytes4_zero(ssz_test: SSZTestFiller) -> None:
     """Bytes4 all zeros. Minimal content, still pads to 32-byte chunk."""
-    ssz(type_name="Bytes4", value=Bytes4(b"\x00" * 4))
+    ssz_test(type_name="Bytes4", value=Bytes4(b"\x00" * 4))
 
 
-def test_bytes4_typical(ssz: SSZTestFiller) -> None:
+def test_bytes4_typical(ssz_test: SSZTestFiller) -> None:
     """Bytes4 with nonzero content (0xDEADBEEF)."""
-    ssz(type_name="Bytes4", value=Bytes4(b"\xde\xad\xbe\xef"))
+    ssz_test(type_name="Bytes4", value=Bytes4(b"\xde\xad\xbe\xef"))
 
 
 # --- Bytes32 ---
 
 
-def test_bytes32_zero(ssz: SSZTestFiller) -> None:
+def test_bytes32_zero(ssz_test: SSZTestFiller) -> None:
     """Bytes32 all zeros. One full chunk of zero bytes."""
-    ssz(type_name="Bytes32", value=Bytes32.zero())
+    ssz_test(type_name="Bytes32", value=Bytes32.zero())
 
 
-def test_bytes32_typical(ssz: SSZTestFiller) -> None:
+def test_bytes32_typical(ssz_test: SSZTestFiller) -> None:
     """Bytes32 with uniform nonzero content (0xAB repeated)."""
-    ssz(type_name="Bytes32", value=Bytes32(b"\xab" * 32))
+    ssz_test(type_name="Bytes32", value=Bytes32(b"\xab" * 32))
 
 
-def test_bytes32_incremental(ssz: SSZTestFiller) -> None:
+def test_bytes32_incremental(ssz_test: SSZTestFiller) -> None:
     """Bytes32 with every byte distinct (0x00..0x1F). Catches byte-swap errors."""
-    ssz(type_name="Bytes32", value=Bytes32(bytes(range(32))))
+    ssz_test(type_name="Bytes32", value=Bytes32(bytes(range(32))))
 
 
 # --- Bytes52 ---
 
 
-def test_bytes52_zero(ssz: SSZTestFiller) -> None:
+def test_bytes52_zero(ssz_test: SSZTestFiller) -> None:
     """Bytes52 all zeros. Two chunks, second chunk partially zero-padded."""
-    ssz(type_name="Bytes52", value=Bytes52.zero())
+    ssz_test(type_name="Bytes52", value=Bytes52.zero())
 
 
-def test_bytes52_typical(ssz: SSZTestFiller) -> None:
+def test_bytes52_typical(ssz_test: SSZTestFiller) -> None:
     """Bytes52 with uniform nonzero content (0xCD repeated)."""
-    ssz(type_name="Bytes52", value=Bytes52(b"\xcd" * 52))
+    ssz_test(type_name="Bytes52", value=Bytes52(b"\xcd" * 52))
 
 
 # --- Bytes64 ---
 
 
-def test_bytes64_zero(ssz: SSZTestFiller) -> None:
+def test_bytes64_zero(ssz_test: SSZTestFiller) -> None:
     """Bytes64 all zeros. Two full chunks of zero bytes."""
-    ssz(type_name="Bytes64", value=Bytes64.zero())
+    ssz_test(type_name="Bytes64", value=Bytes64.zero())
 
 
-def test_bytes64_typical(ssz: SSZTestFiller) -> None:
+def test_bytes64_typical(ssz_test: SSZTestFiller) -> None:
     """Bytes64 with uniform nonzero content (0xEF repeated)."""
-    ssz(type_name="Bytes64", value=Bytes64(b"\xef" * 64))
+    ssz_test(type_name="Bytes64", value=Bytes64(b"\xef" * 64))
 
 
 # --- ByteList512KiB ---
 
 
-def test_bytelist_empty(ssz: SSZTestFiller) -> None:
+def test_bytelist_empty(ssz_test: SSZTestFiller) -> None:
     """Empty byte list. Zero-length content with length mix-in of zero."""
-    ssz(type_name="ByteList512KiB", value=ByteList512KiB(data=b""))
+    ssz_test(type_name="ByteList512KiB", value=ByteList512KiB(data=b""))
 
 
-def test_bytelist_small(ssz: SSZTestFiller) -> None:
+def test_bytelist_small(ssz_test: SSZTestFiller) -> None:
     """Byte list with 4 bytes. Fits within a single 32-byte chunk."""
-    ssz(type_name="ByteList512KiB", value=ByteList512KiB(data=b"\x01\x02\x03\x04"))
+    ssz_test(type_name="ByteList512KiB", value=ByteList512KiB(data=b"\x01\x02\x03\x04"))
 
 
-def test_bytelist_medium(ssz: SSZTestFiller) -> None:
+def test_bytelist_medium(ssz_test: SSZTestFiller) -> None:
     """Byte list with 256 bytes. Spans 8 full chunks."""
-    ssz(type_name="ByteList512KiB", value=ByteList512KiB(data=bytes(range(256))))
+    ssz_test(type_name="ByteList512KiB", value=ByteList512KiB(data=bytes(range(256))))
 
 
 # --- Bitvector ---
 
 
-def test_bitvector8_all_zero(ssz: SSZTestFiller) -> None:
+def test_bitvector8_all_zero(ssz_test: SSZTestFiller) -> None:
     """8-bit bitvector, all bits clear (0x00)."""
-    ssz(
+    ssz_test(
         type_name="SampleBitvector8",
         value=SampleBitvector8(data=[Boolean(False)] * 8),
     )
 
 
-def test_bitvector8_all_one(ssz: SSZTestFiller) -> None:
+def test_bitvector8_all_one(ssz_test: SSZTestFiller) -> None:
     """8-bit bitvector, all bits set (0xFF)."""
-    ssz(
+    ssz_test(
         type_name="SampleBitvector8",
         value=SampleBitvector8(data=[Boolean(True)] * 8),
     )
 
 
-def test_bitvector8_mixed(ssz: SSZTestFiller) -> None:
+def test_bitvector8_mixed(ssz_test: SSZTestFiller) -> None:
     """8-bit bitvector, alternating bits (0x55). Tests per-bit placement."""
-    ssz(
+    ssz_test(
         type_name="SampleBitvector8",
         value=SampleBitvector8(
             data=[
@@ -292,25 +292,25 @@ def test_bitvector8_mixed(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_bitvector64_all_zero(ssz: SSZTestFiller) -> None:
+def test_bitvector64_all_zero(ssz_test: SSZTestFiller) -> None:
     """64-bit bitvector, all bits clear. 8 zero bytes."""
-    ssz(
+    ssz_test(
         type_name="SampleBitvector64",
         value=SampleBitvector64(data=[Boolean(False)] * 64),
     )
 
 
-def test_bitvector64_all_one(ssz: SSZTestFiller) -> None:
+def test_bitvector64_all_one(ssz_test: SSZTestFiller) -> None:
     """64-bit bitvector, all bits set. 8 bytes of 0xFF."""
-    ssz(
+    ssz_test(
         type_name="SampleBitvector64",
         value=SampleBitvector64(data=[Boolean(True)] * 64),
     )
 
 
-def test_bitvector64_mixed(ssz: SSZTestFiller) -> None:
+def test_bitvector64_mixed(ssz_test: SSZTestFiller) -> None:
     """64-bit bitvector, alternating bits. Tests bit ordering across byte boundaries."""
-    ssz(
+    ssz_test(
         type_name="SampleBitvector64",
         value=SampleBitvector64(data=[Boolean(i % 2 == 0) for i in range(64)]),
     )
@@ -319,41 +319,41 @@ def test_bitvector64_mixed(ssz: SSZTestFiller) -> None:
 # --- Bitlist ---
 
 
-def test_bitlist_empty(ssz: SSZTestFiller) -> None:
+def test_bitlist_empty(ssz_test: SSZTestFiller) -> None:
     """Empty bitlist. Sentinel-only encoding (0x01)."""
-    ssz(
+    ssz_test(
         type_name="SampleBitlist16",
         value=SampleBitlist16(data=[]),
     )
 
 
-def test_bitlist_single_true(ssz: SSZTestFiller) -> None:
+def test_bitlist_single_true(ssz_test: SSZTestFiller) -> None:
     """Bitlist with one set bit. Sentinel immediately follows the data bit."""
-    ssz(
+    ssz_test(
         type_name="SampleBitlist16",
         value=SampleBitlist16(data=[Boolean(True)]),
     )
 
 
-def test_bitlist_single_false(ssz: SSZTestFiller) -> None:
+def test_bitlist_single_false(ssz_test: SSZTestFiller) -> None:
     """Bitlist with one clear bit. The sentinel is the only set bit in the byte."""
-    ssz(
+    ssz_test(
         type_name="SampleBitlist16",
         value=SampleBitlist16(data=[Boolean(False)]),
     )
 
 
-def test_bitlist_at_limit(ssz: SSZTestFiller) -> None:
+def test_bitlist_at_limit(ssz_test: SSZTestFiller) -> None:
     """Bitlist filled to its 16-bit limit. Sentinel lands in a new byte."""
-    ssz(
+    ssz_test(
         type_name="SampleBitlist16",
         value=SampleBitlist16(data=[Boolean(True)] * 16),
     )
 
 
-def test_bitlist_mixed(ssz: SSZTestFiller) -> None:
+def test_bitlist_mixed(ssz_test: SSZTestFiller) -> None:
     """Bitlist with 5 mixed bits. Partial fill below the 16-bit limit."""
-    ssz(
+    ssz_test(
         type_name="SampleBitlist16",
         value=SampleBitlist16(
             data=[
@@ -370,33 +370,33 @@ def test_bitlist_mixed(ssz: SSZTestFiller) -> None:
 # --- SSZVector ---
 
 
-def test_uint16_vector3_zero(ssz: SSZTestFiller) -> None:
+def test_uint16_vector3_zero(ssz_test: SSZTestFiller) -> None:
     """3-element Uint16 vector, all zeros. 6 bytes total, padded to one chunk."""
-    ssz(
+    ssz_test(
         type_name="SampleUint16Vector3",
         value=SampleUint16Vector3(data=[Uint16(0), Uint16(0), Uint16(0)]),
     )
 
 
-def test_uint16_vector3_typical(ssz: SSZTestFiller) -> None:
+def test_uint16_vector3_typical(ssz_test: SSZTestFiller) -> None:
     """3-element Uint16 vector with mixed values, including the maximum (65535)."""
-    ssz(
+    ssz_test(
         type_name="SampleUint16Vector3",
         value=SampleUint16Vector3(data=[Uint16(100), Uint16(200), Uint16(65535)]),
     )
 
 
-def test_uint64_vector4_zero(ssz: SSZTestFiller) -> None:
+def test_uint64_vector4_zero(ssz_test: SSZTestFiller) -> None:
     """4-element Uint64 vector, all zeros. Fills exactly one 32-byte chunk."""
-    ssz(
+    ssz_test(
         type_name="SampleUint64Vector4",
         value=SampleUint64Vector4(data=[Uint64(0), Uint64(0), Uint64(0), Uint64(0)]),
     )
 
 
-def test_uint64_vector4_typical(ssz: SSZTestFiller) -> None:
+def test_uint64_vector4_typical(ssz_test: SSZTestFiller) -> None:
     """4-element Uint64 vector spanning the full value range per element."""
-    ssz(
+    ssz_test(
         type_name="SampleUint64Vector4",
         value=SampleUint64Vector4(
             data=[
@@ -412,49 +412,49 @@ def test_uint64_vector4_typical(ssz: SSZTestFiller) -> None:
 # --- SSZList ---
 
 
-def test_uint32_list_empty(ssz: SSZTestFiller) -> None:
+def test_uint32_list_empty(ssz_test: SSZTestFiller) -> None:
     """Empty Uint32 list. Length mix-in is zero, data tree is all-zero."""
-    ssz(
+    ssz_test(
         type_name="SampleUint32List16",
         value=SampleUint32List16(data=[]),
     )
 
 
-def test_uint32_list_single(ssz: SSZTestFiller) -> None:
+def test_uint32_list_single(ssz_test: SSZTestFiller) -> None:
     """Uint32 list with one element. Minimal non-empty list."""
-    ssz(
+    ssz_test(
         type_name="SampleUint32List16",
         value=SampleUint32List16(data=[Uint32(42)]),
     )
 
 
-def test_uint32_list_multiple(ssz: SSZTestFiller) -> None:
+def test_uint32_list_multiple(ssz_test: SSZTestFiller) -> None:
     """Uint32 list with three elements spanning the full value range."""
-    ssz(
+    ssz_test(
         type_name="SampleUint32List16",
         value=SampleUint32List16(data=[Uint32(0), Uint32(100), Uint32(2**32 - 1)]),
     )
 
 
-def test_bytes32_list_empty(ssz: SSZTestFiller) -> None:
+def test_bytes32_list_empty(ssz_test: SSZTestFiller) -> None:
     """Empty Bytes32 list. Each element would occupy one full chunk."""
-    ssz(
+    ssz_test(
         type_name="SampleBytes32List8",
         value=SampleBytes32List8(data=[]),
     )
 
 
-def test_bytes32_list_single(ssz: SSZTestFiller) -> None:
+def test_bytes32_list_single(ssz_test: SSZTestFiller) -> None:
     """Bytes32 list with one element. Single chunk plus length mix-in."""
-    ssz(
+    ssz_test(
         type_name="SampleBytes32List8",
         value=SampleBytes32List8(data=[Bytes32(b"\xaa" * 32)]),
     )
 
 
-def test_bytes32_list_multiple(ssz: SSZTestFiller) -> None:
+def test_bytes32_list_multiple(ssz_test: SSZTestFiller) -> None:
     """Bytes32 list with three elements. Tests multi-chunk Merkle tree with mix-in."""
-    ssz(
+    ssz_test(
         type_name="SampleBytes32List8",
         value=SampleBytes32List8(
             data=[
@@ -469,37 +469,37 @@ def test_bytes32_list_multiple(ssz: SSZTestFiller) -> None:
 # --- Fp ---
 
 
-def test_fp_zero(ssz: SSZTestFiller) -> None:
+def test_fp_zero(ssz_test: SSZTestFiller) -> None:
     """Field element zero. The additive identity."""
-    ssz(type_name="Fp", value=Fp(0))
+    ssz_test(type_name="Fp", value=Fp(0))
 
 
-def test_fp_one(ssz: SSZTestFiller) -> None:
+def test_fp_one(ssz_test: SSZTestFiller) -> None:
     """Field element one. The multiplicative identity."""
-    ssz(type_name="Fp", value=Fp(1))
+    ssz_test(type_name="Fp", value=Fp(1))
 
 
-def test_fp_max(ssz: SSZTestFiller) -> None:
+def test_fp_max(ssz_test: SSZTestFiller) -> None:
     """Field element p-1. The largest valid element in the field."""
-    ssz(type_name="Fp", value=Fp(P - 1))
+    ssz_test(type_name="Fp", value=Fp(P - 1))
 
 
 # --- Domain Bitvectors ---
 
 
-def test_attestation_subnets_none(ssz: SSZTestFiller) -> None:
+def test_attestation_subnets_none(ssz_test: SSZTestFiller) -> None:
     """Attestation subnets with no subscriptions (all 64 bits clear)."""
-    ssz(type_name="AttestationSubnets", value=AttestationSubnets.none())
+    ssz_test(type_name="AttestationSubnets", value=AttestationSubnets.none())
 
 
-def test_attestation_subnets_all(ssz: SSZTestFiller) -> None:
+def test_attestation_subnets_all(ssz_test: SSZTestFiller) -> None:
     """Attestation subnets with all 64 subscriptions active."""
-    ssz(type_name="AttestationSubnets", value=AttestationSubnets.all())
+    ssz_test(type_name="AttestationSubnets", value=AttestationSubnets.all())
 
 
-def test_attestation_subnets_partial(ssz: SSZTestFiller) -> None:
+def test_attestation_subnets_partial(ssz_test: SSZTestFiller) -> None:
     """Attestation subnets with 5 selected IDs spanning the full 64-bit range."""
-    ssz(
+    ssz_test(
         type_name="AttestationSubnets",
         value=AttestationSubnets.from_subnet_ids([0, 7, 15, 31, 63]),
     )

--- a/tests/consensus/lstar/ssz/test_consensus_containers.py
+++ b/tests/consensus/lstar/ssz/test_consensus_containers.py
@@ -57,14 +57,14 @@ def _typical_attestation_data() -> AttestationData:
 # --- Checkpoint ---
 
 
-def test_checkpoint_zero(ssz: SSZTestFiller) -> None:
+def test_checkpoint_zero(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Checkpoint with zero values."""
-    ssz(type_name="Checkpoint", value=_zero_checkpoint())
+    ssz_test(type_name="Checkpoint", value=_zero_checkpoint())
 
 
-def test_checkpoint_typical(ssz: SSZTestFiller) -> None:
+def test_checkpoint_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Checkpoint with typical values."""
-    ssz(
+    ssz_test(
         type_name="Checkpoint",
         value=Checkpoint(root=Bytes32(b"\xab" * 32), slot=Slot(12345)),
     )
@@ -73,30 +73,30 @@ def test_checkpoint_typical(ssz: SSZTestFiller) -> None:
 # --- AttestationData ---
 
 
-def test_attestation_data_zero(ssz: SSZTestFiller) -> None:
+def test_attestation_data_zero(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for AttestationData with zero values."""
-    ssz(type_name="AttestationData", value=_zero_attestation_data())
+    ssz_test(type_name="AttestationData", value=_zero_attestation_data())
 
 
-def test_attestation_data_typical(ssz: SSZTestFiller) -> None:
+def test_attestation_data_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for AttestationData with typical values."""
-    ssz(type_name="AttestationData", value=_typical_attestation_data())
+    ssz_test(type_name="AttestationData", value=_typical_attestation_data())
 
 
 # --- Attestation ---
 
 
-def test_attestation_zero(ssz: SSZTestFiller) -> None:
+def test_attestation_zero(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Attestation with zero values."""
-    ssz(
+    ssz_test(
         type_name="Attestation",
         value=Attestation(validator_index=ValidatorIndex(0), data=_zero_attestation_data()),
     )
 
 
-def test_attestation_typical(ssz: SSZTestFiller) -> None:
+def test_attestation_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Attestation with typical values."""
-    ssz(
+    ssz_test(
         type_name="Attestation",
         value=Attestation(validator_index=ValidatorIndex(42), data=_typical_attestation_data()),
     )
@@ -105,9 +105,9 @@ def test_attestation_typical(ssz: SSZTestFiller) -> None:
 # --- SignedAttestation ---
 
 
-def test_signed_attestation_minimal(ssz: SSZTestFiller) -> None:
+def test_signed_attestation_minimal(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for SignedAttestation with minimal values."""
-    ssz(
+    ssz_test(
         type_name="SignedAttestation",
         value=SignedAttestation(
             validator_index=ValidatorIndex(0),
@@ -120,9 +120,9 @@ def test_signed_attestation_minimal(ssz: SSZTestFiller) -> None:
 # --- AggregatedAttestation ---
 
 
-def test_aggregated_attestation_single(ssz: SSZTestFiller) -> None:
+def test_aggregated_attestation_single(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for AggregatedAttestation with single validator."""
-    ssz(
+    ssz_test(
         type_name="AggregatedAttestation",
         value=AggregatedAttestation(
             aggregation_bits=AggregationBits(data=[Boolean(True)]),
@@ -131,9 +131,9 @@ def test_aggregated_attestation_single(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_aggregated_attestation_multiple(ssz: SSZTestFiller) -> None:
+def test_aggregated_attestation_multiple(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for AggregatedAttestation with multiple validators."""
-    ssz(
+    ssz_test(
         type_name="AggregatedAttestation",
         value=AggregatedAttestation(
             aggregation_bits=AggregationBits(
@@ -147,17 +147,17 @@ def test_aggregated_attestation_multiple(ssz: SSZTestFiller) -> None:
 # --- BlockBody ---
 
 
-def test_block_body_empty(ssz: SSZTestFiller) -> None:
+def test_block_body_empty(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for BlockBody with no attestations."""
-    ssz(
+    ssz_test(
         type_name="BlockBody",
         value=BlockBody(attestations=AggregatedAttestations(data=[])),
     )
 
 
-def test_block_body_with_attestation(ssz: SSZTestFiller) -> None:
+def test_block_body_with_attestation(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for BlockBody with attestations."""
-    ssz(
+    ssz_test(
         type_name="BlockBody",
         value=BlockBody(
             attestations=AggregatedAttestations(
@@ -175,9 +175,9 @@ def test_block_body_with_attestation(ssz: SSZTestFiller) -> None:
 # --- BlockHeader ---
 
 
-def test_block_header_zero(ssz: SSZTestFiller) -> None:
+def test_block_header_zero(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for BlockHeader with zero values."""
-    ssz(
+    ssz_test(
         type_name="BlockHeader",
         value=BlockHeader(
             slot=Slot(0),
@@ -189,9 +189,9 @@ def test_block_header_zero(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_block_header_typical(ssz: SSZTestFiller) -> None:
+def test_block_header_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for BlockHeader with typical values."""
-    ssz(
+    ssz_test(
         type_name="BlockHeader",
         value=BlockHeader(
             slot=Slot(100),
@@ -206,9 +206,9 @@ def test_block_header_typical(ssz: SSZTestFiller) -> None:
 # --- Block ---
 
 
-def test_block_empty_body(ssz: SSZTestFiller) -> None:
+def test_block_empty_body(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Block with empty body."""
-    ssz(
+    ssz_test(
         type_name="Block",
         value=Block(
             slot=Slot(0),
@@ -220,9 +220,9 @@ def test_block_empty_body(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_block_typical(ssz: SSZTestFiller) -> None:
+def test_block_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Block with attestations."""
-    ssz(
+    ssz_test(
         type_name="Block",
         value=Block(
             slot=Slot(100),
@@ -246,7 +246,7 @@ def test_block_typical(ssz: SSZTestFiller) -> None:
 # --- SignedBlock ---
 
 
-def test_signed_block_minimal(ssz: SSZTestFiller) -> None:
+def test_signed_block_minimal(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for SignedBlock with empty proof bytes."""
     block = Block(
         slot=Slot(1),
@@ -255,7 +255,7 @@ def test_signed_block_minimal(ssz: SSZTestFiller) -> None:
         state_root=Bytes32.zero(),
         body=BlockBody(attestations=AggregatedAttestations(data=[])),
     )
-    ssz(
+    ssz_test(
         type_name="SignedBlock",
         value=SignedBlock(
             block=block,
@@ -264,7 +264,7 @@ def test_signed_block_minimal(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_signed_block_with_proof_bytes(ssz: SSZTestFiller) -> None:
+def test_signed_block_with_proof_bytes(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for SignedBlock with non-empty proof bytes."""
     block = Block(
         slot=Slot(2),
@@ -273,7 +273,7 @@ def test_signed_block_with_proof_bytes(ssz: SSZTestFiller) -> None:
         state_root=Bytes32(b"\x02" * 32),
         body=BlockBody(attestations=AggregatedAttestations(data=[])),
     )
-    ssz(
+    ssz_test(
         type_name="SignedBlock",
         value=SignedBlock(
             block=block,
@@ -285,22 +285,22 @@ def test_signed_block_with_proof_bytes(ssz: SSZTestFiller) -> None:
 # --- Config ---
 
 
-def test_config_zero(ssz: SSZTestFiller) -> None:
+def test_config_zero(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Config with zero genesis time."""
-    ssz(type_name="Config", value=GenesisConfig(genesis_time=Uint64(0)))
+    ssz_test(type_name="Config", value=GenesisConfig(genesis_time=Uint64(0)))
 
 
-def test_config_typical(ssz: SSZTestFiller) -> None:
+def test_config_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Config with typical genesis time."""
-    ssz(type_name="Config", value=GenesisConfig(genesis_time=Uint64(1609459200)))
+    ssz_test(type_name="Config", value=GenesisConfig(genesis_time=Uint64(1609459200)))
 
 
 # --- Validator ---
 
 
-def test_validator_zero(ssz: SSZTestFiller) -> None:
+def test_validator_zero(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Validator with zero values."""
-    ssz(
+    ssz_test(
         type_name="Validator",
         value=Validator(
             attestation_public_key=Bytes52.zero(),
@@ -310,9 +310,9 @@ def test_validator_zero(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_validator_typical(ssz: SSZTestFiller) -> None:
+def test_validator_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Validator with typical values."""
-    ssz(
+    ssz_test(
         type_name="Validator",
         value=Validator(
             attestation_public_key=Bytes52(b"\xab" * 52),
@@ -325,7 +325,7 @@ def test_validator_typical(ssz: SSZTestFiller) -> None:
 # --- State ---
 
 
-def test_state_minimal(ssz: SSZTestFiller) -> None:
+def test_state_minimal(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for State with minimal values."""
     zero_cp = _zero_checkpoint()
     zero_header = BlockHeader(
@@ -335,7 +335,7 @@ def test_state_minimal(ssz: SSZTestFiller) -> None:
         state_root=Bytes32.zero(),
         body_root=Bytes32.zero(),
     )
-    ssz(
+    ssz_test(
         type_name="State",
         value=State(
             config=GenesisConfig(genesis_time=Uint64(0)),
@@ -360,9 +360,9 @@ def test_state_minimal(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_state_with_validators(ssz: SSZTestFiller) -> None:
+def test_state_with_validators(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for State with multiple validators and history."""
-    ssz(
+    ssz_test(
         type_name="State",
         value=State(
             config=GenesisConfig(genesis_time=Uint64(1609459200)),
@@ -415,10 +415,10 @@ def test_state_with_validators(ssz: SSZTestFiller) -> None:
 # --- SignedAggregatedAttestation ---
 
 
-def test_signed_aggregated_attestation_minimal(ssz: SSZTestFiller) -> None:
+def test_signed_aggregated_attestation_minimal(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for SignedAggregatedAttestation with one participant and empty proof."""
     data = _zero_attestation_data()
-    ssz(
+    ssz_test(
         type_name="SignedAggregatedAttestation",
         value=SignedAggregatedAttestation(
             data=data,
@@ -430,11 +430,11 @@ def test_signed_aggregated_attestation_minimal(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_signed_aggregated_attestation_typical(ssz: SSZTestFiller) -> None:
+def test_signed_aggregated_attestation_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for SignedAggregatedAttestation with mixed participation bits."""
     data = _typical_attestation_data()
     wire = b"\xca\xfe\xba\xbe\xde\xad"
-    ssz(
+    ssz_test(
         type_name="SignedAggregatedAttestation",
         value=SignedAggregatedAttestation(
             data=data,
@@ -451,17 +451,17 @@ def test_signed_aggregated_attestation_typical(ssz: SSZTestFiller) -> None:
 # --- Boundary-value tests ---
 
 
-def test_checkpoint_max_slot(ssz: SSZTestFiller) -> None:
+def test_checkpoint_max_slot(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Checkpoint at the maximum 64-bit slot and all-0xff root."""
-    ssz(
+    ssz_test(
         type_name="Checkpoint",
         value=Checkpoint(root=Bytes32(b"\xff" * 32), slot=Slot(2**64 - 1)),
     )
 
 
-def test_block_body_max_attestations(ssz: SSZTestFiller) -> None:
+def test_block_body_max_attestations(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for BlockBody with four attestations of varying aggregation sizes."""
-    ssz(
+    ssz_test(
         type_name="BlockBody",
         value=BlockBody(
             attestations=AggregatedAttestations(
@@ -497,9 +497,9 @@ def test_block_body_max_attestations(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_validator_max_index(ssz: SSZTestFiller) -> None:
+def test_validator_max_index(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Validator at the maximum 64-bit index with all-0xff public keys."""
-    ssz(
+    ssz_test(
         type_name="Validator",
         value=Validator(
             attestation_public_key=Bytes52(b"\xff" * 52),
@@ -509,9 +509,9 @@ def test_validator_max_index(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_state_with_full_history(ssz: SSZTestFiller) -> None:
+def test_state_with_full_history(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for State with five block hashes, eight justification bits, and three roots."""
-    ssz(
+    ssz_test(
         type_name="State",
         value=State(
             config=GenesisConfig(genesis_time=Uint64(1700000000)),

--- a/tests/consensus/lstar/ssz/test_decode_failure_smoke.py
+++ b/tests/consensus/lstar/ssz/test_decode_failure_smoke.py
@@ -21,7 +21,7 @@ class SmokeBitlist8(BaseBitlist):
     LIMIT: ClassVar[int] = 8
 
 
-def test_ssz_decode_failure_bitlist_exceeds_limit(ssz: SSZTestFiller) -> None:
+def test_ssz_decode_failure_bitlist_exceeds_limit(ssz_test: SSZTestFiller) -> None:
     """
     Decoding a bitlist whose contents imply a length above its LIMIT raises.
 
@@ -29,7 +29,7 @@ def test_ssz_decode_failure_bitlist_exceeds_limit(ssz: SSZTestFiller) -> None:
     on the decoder type is 8, so SSZ decode must reject. This pins the new
     `raw_bytes` + `expect_exception` path on the ssz fixture.
     """
-    ssz(
+    ssz_test(
         type_name="SmokeBitlist8",
         value=SmokeBitlist8(data=[Boolean(False)]),
         raw_bytes="0x0010",

--- a/tests/consensus/lstar/ssz/test_decode_rejections.py
+++ b/tests/consensus/lstar/ssz/test_decode_rejections.py
@@ -30,7 +30,7 @@ class DecodeBitvector16(BaseBitvector):
     LENGTH: ClassVar[int] = 16
 
 
-def test_bitlist_decode_rejects_empty_input(ssz: SSZTestFiller) -> None:
+def test_bitlist_decode_rejects_empty_input(ssz_test: SSZTestFiller) -> None:
     """
     Bitlist decoding of zero bytes has no delimiter bit and must be rejected.
 
@@ -38,7 +38,7 @@ def test_bitlist_decode_rejects_empty_input(ssz: SSZTestFiller) -> None:
     bit-length. Empty input carries no such sentinel, so the decoder cannot
     determine how many bits the value was supposed to hold.
     """
-    ssz(
+    ssz_test(
         type_name="DecodeBitlist8",
         value=DecodeBitlist8(data=[Boolean(False)]),
         raw_bytes="0x",
@@ -46,7 +46,7 @@ def test_bitlist_decode_rejects_empty_input(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_bitlist_decode_rejects_missing_delimiter(ssz: SSZTestFiller) -> None:
+def test_bitlist_decode_rejects_missing_delimiter(ssz_test: SSZTestFiller) -> None:
     """
     Bitlist bytes with no set bits carry no sentinel and must be rejected.
 
@@ -54,7 +54,7 @@ def test_bitlist_decode_rejects_missing_delimiter(ssz: SSZTestFiller) -> None:
     end of the logical bitlist. The decoder needs the sentinel to know
     where the payload stops.
     """
-    ssz(
+    ssz_test(
         type_name="DecodeBitlist8",
         value=DecodeBitlist8(data=[Boolean(False)]),
         raw_bytes="0x00",
@@ -62,7 +62,7 @@ def test_bitlist_decode_rejects_missing_delimiter(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_bitlist_decode_rejects_length_above_limit(ssz: SSZTestFiller) -> None:
+def test_bitlist_decode_rejects_length_above_limit(ssz_test: SSZTestFiller) -> None:
     """
     Bitlist whose sentinel implies a bit-length beyond the type limit must be rejected.
 
@@ -70,7 +70,7 @@ def test_bitlist_decode_rejects_length_above_limit(ssz: SSZTestFiller) -> None:
     nine-bit bitlist. The type caps at eight bits, so the decoder must
     refuse to widen past its own limit.
     """
-    ssz(
+    ssz_test(
         type_name="DecodeBitlist8",
         value=DecodeBitlist8(data=[Boolean(False)]),
         raw_bytes="0x0002",
@@ -78,7 +78,7 @@ def test_bitlist_decode_rejects_length_above_limit(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_bitvector_decode_rejects_wrong_byte_length(ssz: SSZTestFiller) -> None:
+def test_bitvector_decode_rejects_wrong_byte_length(ssz_test: SSZTestFiller) -> None:
     """
     Fixed-width bitvector decoding rejects inputs whose byte count does not match LENGTH.
 
@@ -86,7 +86,7 @@ def test_bitvector_decode_rejects_wrong_byte_length(ssz: SSZTestFiller) -> None:
     input underfills the vector. The fixed-size decode path requires an
     exact byte match, so the decoder must reject.
     """
-    ssz(
+    ssz_test(
         type_name="DecodeBitvector16",
         value=DecodeBitvector16(data=[Boolean(False)] * 16),
         raw_bytes="0x00",
@@ -94,7 +94,7 @@ def test_bitvector_decode_rejects_wrong_byte_length(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_bytes4_decode_rejects_extra_trailing_bytes(ssz: SSZTestFiller) -> None:
+def test_bytes4_decode_rejects_extra_trailing_bytes(ssz_test: SSZTestFiller) -> None:
     """
     Fixed-size byte arrays reject inputs longer than their declared LENGTH.
 
@@ -102,7 +102,7 @@ def test_bytes4_decode_rejects_extra_trailing_bytes(ssz: SSZTestFiller) -> None:
     trailing byte has no slot in the type, so the decoder must raise
     rather than silently ignore the overflow.
     """
-    ssz(
+    ssz_test(
         type_name="Bytes4",
         value=Bytes4(b"\x00\x00\x00\x00"),
         raw_bytes="0x0102030405",
@@ -110,7 +110,7 @@ def test_bytes4_decode_rejects_extra_trailing_bytes(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_uint32_decode_rejects_wrong_byte_length(ssz: SSZTestFiller) -> None:
+def test_uint32_decode_rejects_wrong_byte_length(ssz_test: SSZTestFiller) -> None:
     """
     Fixed-size uint types reject input whose byte length does not match the type.
 
@@ -118,7 +118,7 @@ def test_uint32_decode_rejects_wrong_byte_length(ssz: SSZTestFiller) -> None:
     and cannot be safely widened. The decoder raises rather than guessing
     a padding convention.
     """
-    ssz(
+    ssz_test(
         type_name="Uint32",
         value=Uint32(0),
         raw_bytes="0x010203",

--- a/tests/consensus/lstar/ssz/test_merkleization_boundaries.py
+++ b/tests/consensus/lstar/ssz/test_merkleization_boundaries.py
@@ -67,75 +67,75 @@ class BoundaryUint64List32(SSZList[Uint64]):
     ELEMENT_TYPE = Uint64
 
 
-def test_bitvector_length_one_all_set(ssz: SSZTestFiller) -> None:
+def test_bitvector_length_one_all_set(ssz_test: SSZTestFiller) -> None:
     """Single-bit vector with the bit set pins the minimal Merkle chunk layout."""
-    ssz(
+    ssz_test(
         type_name="BoundaryBitvector1",
         value=BoundaryBitvector1(data=[Boolean(True)]),
     )
 
 
-def test_bitvector_length_seven_all_set(ssz: SSZTestFiller) -> None:
+def test_bitvector_length_seven_all_set(ssz_test: SSZTestFiller) -> None:
     """Seven-bit vector exercises the pre-byte-boundary pad bit."""
-    ssz(
+    ssz_test(
         type_name="BoundaryBitvector7",
         value=BoundaryBitvector7(data=[Boolean(True)] * 7),
     )
 
 
-def test_bitvector_length_nine_all_set(ssz: SSZTestFiller) -> None:
+def test_bitvector_length_nine_all_set(ssz_test: SSZTestFiller) -> None:
     """Nine-bit vector straddles the single-byte boundary."""
-    ssz(
+    ssz_test(
         type_name="BoundaryBitvector9",
         value=BoundaryBitvector9(data=[Boolean(True)] * 9),
     )
 
 
-def test_bitvector_length_255_all_set(ssz: SSZTestFiller) -> None:
+def test_bitvector_length_255_all_set(ssz_test: SSZTestFiller) -> None:
     """255-bit vector is one bit shy of a full 32-byte Merkle chunk."""
-    ssz(
+    ssz_test(
         type_name="BoundaryBitvector255",
         value=BoundaryBitvector255(data=[Boolean(True)] * 255),
     )
 
 
-def test_bitvector_length_256_all_set(ssz: SSZTestFiller) -> None:
+def test_bitvector_length_256_all_set(ssz_test: SSZTestFiller) -> None:
     """256-bit vector fills exactly one Merkle chunk with no padding."""
-    ssz(
+    ssz_test(
         type_name="BoundaryBitvector256",
         value=BoundaryBitvector256(data=[Boolean(True)] * 256),
     )
 
 
-def test_bitvector_length_257_all_set(ssz: SSZTestFiller) -> None:
+def test_bitvector_length_257_all_set(ssz_test: SSZTestFiller) -> None:
     """257-bit vector forces a second Merkle chunk holding a single bit."""
-    ssz(
+    ssz_test(
         type_name="BoundaryBitvector257",
         value=BoundaryBitvector257(data=[Boolean(True)] * 257),
     )
 
 
-def test_bitlist_filled_to_chunk_boundary_limit(ssz: SSZTestFiller) -> None:
+def test_bitlist_filled_to_chunk_boundary_limit(ssz_test: SSZTestFiller) -> None:
     """
     Bitlist filled to a 256-bit limit places the sentinel at the start of a fresh byte.
 
     The trailing sentinel crosses into a new chunk, exercising the length-mixin
     ordering for bitlists whose limit sits on a Merkle-chunk edge.
     """
-    ssz(
+    ssz_test(
         type_name="BoundaryBitlist256",
         value=BoundaryBitlist256(data=[Boolean(True)] * 256),
     )
 
 
-def test_uint64_list_with_misaligned_chunk_count(ssz: SSZTestFiller) -> None:
+def test_uint64_list_with_misaligned_chunk_count(ssz_test: SSZTestFiller) -> None:
     """
     Three uint64 entries occupy 24 bytes, one byte shy of a full Merkle chunk.
 
     Pins the zero-pad / length-mixin behaviour for variable-length lists of
     fixed-size elements whose serialized length is not a multiple of 32.
     """
-    ssz(
+    ssz_test(
         type_name="BoundaryUint64List32",
         value=BoundaryUint64List32(data=[Uint64(1), Uint64(2), Uint64(3)]),
     )

--- a/tests/consensus/lstar/ssz/test_networking_containers.py
+++ b/tests/consensus/lstar/ssz/test_networking_containers.py
@@ -17,9 +17,9 @@ pytestmark = pytest.mark.valid_until("Lstar")
 # --- Status ---
 
 
-def test_status_zero(ssz: SSZTestFiller) -> None:
+def test_status_zero(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Status with zero values."""
-    ssz(
+    ssz_test(
         type_name="Status",
         value=Status(
             finalized=Checkpoint(root=Bytes32.zero(), slot=Slot(0)),
@@ -28,9 +28,9 @@ def test_status_zero(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_status_typical(ssz: SSZTestFiller) -> None:
+def test_status_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Status with typical values."""
-    ssz(
+    ssz_test(
         type_name="Status",
         value=Status(
             finalized=Checkpoint(root=Bytes32(b"\x01" * 32), slot=Slot(100)),
@@ -42,25 +42,25 @@ def test_status_typical(ssz: SSZTestFiller) -> None:
 # --- BlocksByRootRequest ---
 
 
-def test_blocks_by_root_request_empty(ssz: SSZTestFiller) -> None:
+def test_blocks_by_root_request_empty(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for BlocksByRootRequest with no roots."""
-    ssz(
+    ssz_test(
         type_name="BlocksByRootRequest",
         value=BlocksByRootRequest(roots=RequestedBlockRoots(data=[])),
     )
 
 
-def test_blocks_by_root_request_single(ssz: SSZTestFiller) -> None:
+def test_blocks_by_root_request_single(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for BlocksByRootRequest with single root."""
-    ssz(
+    ssz_test(
         type_name="BlocksByRootRequest",
         value=BlocksByRootRequest(roots=RequestedBlockRoots(data=[Bytes32(b"\xab" * 32)])),
     )
 
 
-def test_blocks_by_root_request_multiple(ssz: SSZTestFiller) -> None:
+def test_blocks_by_root_request_multiple(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for BlocksByRootRequest with multiple roots."""
-    ssz(
+    ssz_test(
         type_name="BlocksByRootRequest",
         value=BlocksByRootRequest(
             roots=RequestedBlockRoots(
@@ -70,9 +70,9 @@ def test_blocks_by_root_request_multiple(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_blocks_by_root_request_max_roots(ssz: SSZTestFiller) -> None:
+def test_blocks_by_root_request_max_roots(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for BlocksByRootRequest with ten distinct roots."""
-    ssz(
+    ssz_test(
         type_name="BlocksByRootRequest",
         value=BlocksByRootRequest(
             roots=RequestedBlockRoots(data=[Bytes32(bytes([i]) * 32) for i in range(1, 11)])

--- a/tests/consensus/lstar/ssz/test_xmss_containers.py
+++ b/tests/consensus/lstar/ssz/test_xmss_containers.py
@@ -40,9 +40,9 @@ def _zero_parameter() -> Parameter:
 # --- PublicKey ---
 
 
-def test_public_key_zero(ssz: SSZTestFiller) -> None:
+def test_public_key_zero(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for PublicKey with zero values."""
-    ssz(
+    ssz_test(
         type_name="PublicKey",
         value=PublicKey(root=_zero_hash_digest_vector(), parameter=_zero_parameter()),
     )
@@ -51,18 +51,18 @@ def test_public_key_zero(ssz: SSZTestFiller) -> None:
 # --- Signature ---
 
 
-def test_signature_zero(ssz: SSZTestFiller) -> None:
+def test_signature_zero(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for Signature with zero values."""
-    ssz(type_name="Signature", value=create_dummy_signature())
+    ssz_test(type_name="Signature", value=create_dummy_signature())
 
 
-def test_signature_actual(ssz: SSZTestFiller) -> None:
+def test_signature_actual(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for a real Signature produced by the XMSS signing algorithm."""
     key_manager = XmssKeyManager.shared()
     scheme = key_manager.scheme
     secret_key = key_manager[ValidatorIndex(0)].attestation_keypair.secret_key
     signature = scheme.sign(secret_key, Slot(0), Bytes32(b"\x42" * 32))
-    ssz(type_name="Signature", value=signature)
+    ssz_test(type_name="Signature", value=signature)
 
 
 # --- SingleMessageAggregate / MultiMessageAggregate ---
@@ -73,9 +73,9 @@ def _bits(participants: list[bool]) -> AggregationBits:
     return AggregationBits(data=[Boolean(b) for b in participants])
 
 
-def test_single_message_aggregate_empty(ssz: SSZTestFiller) -> None:
+def test_single_message_aggregate_empty(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for a single-message aggregate proof with empty proof bytes."""
-    ssz(
+    ssz_test(
         type_name="SingleMessageAggregate",
         value=SingleMessageAggregate(
             participants=_bits([True]),
@@ -84,10 +84,10 @@ def test_single_message_aggregate_empty(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_single_message_aggregate_with_proof(ssz: SSZTestFiller) -> None:
+def test_single_message_aggregate_with_proof(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for a single-message aggregate proof with non-empty proof bytes."""
     wire = b"\xde\xad\xbe\xef"
-    ssz(
+    ssz_test(
         type_name="SingleMessageAggregate",
         value=SingleMessageAggregate(
             participants=_bits([True, False, True]),
@@ -96,10 +96,10 @@ def test_single_message_aggregate_with_proof(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_multi_message_aggregate_roundtrip(ssz: SSZTestFiller) -> None:
+def test_multi_message_aggregate_roundtrip(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for a multi-message aggregate proof envelope."""
     wire = b"\x01\x02\x03"
-    ssz(
+    ssz_test(
         type_name="MultiMessageAggregate",
         value=MultiMessageAggregate(proof=ByteList512KiB(data=wire)),
     )
@@ -108,9 +108,9 @@ def test_multi_message_aggregate_roundtrip(ssz: SSZTestFiller) -> None:
 # --- PublicKey ---
 
 
-def test_public_key_typical(ssz: SSZTestFiller) -> None:
+def test_public_key_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for PublicKey with ascending non-zero field elements."""
-    ssz(
+    ssz_test(
         type_name="PublicKey",
         value=PublicKey(
             root=HashDigestVector(
@@ -124,17 +124,17 @@ def test_public_key_typical(ssz: SSZTestFiller) -> None:
 # --- HashTreeOpening ---
 
 
-def test_hash_tree_opening_empty(ssz: SSZTestFiller) -> None:
+def test_hash_tree_opening_empty(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for HashTreeOpening with no sibling digests."""
-    ssz(
+    ssz_test(
         type_name="HashTreeOpening",
         value=HashTreeOpening(siblings=HashDigestList(data=[])),
     )
 
 
-def test_hash_tree_opening_typical(ssz: SSZTestFiller) -> None:
+def test_hash_tree_opening_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for HashTreeOpening with three sibling digest vectors."""
-    ssz(
+    ssz_test(
         type_name="HashTreeOpening",
         value=HashTreeOpening(
             siblings=HashDigestList(
@@ -154,9 +154,9 @@ def test_hash_tree_opening_typical(ssz: SSZTestFiller) -> None:
 # --- HashTreeLayer ---
 
 
-def test_hash_tree_layer_zero(ssz: SSZTestFiller) -> None:
+def test_hash_tree_layer_zero(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for HashTreeLayer at index zero with no nodes."""
-    ssz(
+    ssz_test(
         type_name="HashTreeLayer",
         value=HashTreeLayer(
             start_index=Uint64(0),
@@ -165,9 +165,9 @@ def test_hash_tree_layer_zero(ssz: SSZTestFiller) -> None:
     )
 
 
-def test_hash_tree_layer_typical(ssz: SSZTestFiller) -> None:
+def test_hash_tree_layer_typical(ssz_test: SSZTestFiller) -> None:
     """SSZ roundtrip for HashTreeLayer at index 42 with two node digest vectors."""
-    ssz(
+    ssz_test(
         type_name="HashTreeLayer",
         value=HashTreeLayer(
             start_index=Uint64(42),

--- a/tests/consensus/lstar/state_transition/test_justifiability.py
+++ b/tests/consensus/lstar/state_transition/test_justifiability.py
@@ -20,184 +20,184 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_delta_0_finalized_slot_itself(
-    justifiability: JustifiabilityTestFiller,
+    justifiability_test: JustifiabilityTestFiller,
 ) -> None:
     """Delta 0: the finalized slot itself is always justifiable."""
-    justifiability(slot=10, finalized_slot=10)
+    justifiability_test(slot=10, finalized_slot=10)
 
 
-def test_delta_1(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_1(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 1: immediate window."""
-    justifiability(slot=1, finalized_slot=0)
+    justifiability_test(slot=1, finalized_slot=0)
 
 
-def test_delta_2(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_2(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 2: immediate window (also a pronic: 1*2)."""
-    justifiability(slot=2, finalized_slot=0)
+    justifiability_test(slot=2, finalized_slot=0)
 
 
-def test_delta_3(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_3(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 3: immediate window."""
-    justifiability(slot=3, finalized_slot=0)
+    justifiability_test(slot=3, finalized_slot=0)
 
 
-def test_delta_4(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_4(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 4: immediate window (also a perfect square: 2^2)."""
-    justifiability(slot=4, finalized_slot=0)
+    justifiability_test(slot=4, finalized_slot=0)
 
 
-def test_delta_5(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_5(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 5: last slot in the immediate window."""
-    justifiability(slot=5, finalized_slot=0)
+    justifiability_test(slot=5, finalized_slot=0)
 
 
 # --- First gap: delta 6 is pronic (2*3), delta 7-8 are not justifiable ---
 
 
-def test_delta_6_pronic(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_6_pronic(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 6: pronic number (2*3). First justifiable slot outside the immediate window."""
-    justifiability(slot=6, finalized_slot=0)
+    justifiability_test(slot=6, finalized_slot=0)
 
 
-def test_delta_7_not_justifiable(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_7_not_justifiable(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 7: not square, not pronic, outside window. First non-justifiable delta."""
-    justifiability(slot=7, finalized_slot=0)
+    justifiability_test(slot=7, finalized_slot=0)
 
 
-def test_delta_8_not_justifiable(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_8_not_justifiable(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 8: not square, not pronic."""
-    justifiability(slot=8, finalized_slot=0)
+    justifiability_test(slot=8, finalized_slot=0)
 
 
 # --- Perfect squares ---
 
 
-def test_delta_9_square(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_9_square(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 9: perfect square (3^2)."""
-    justifiability(slot=9, finalized_slot=0)
+    justifiability_test(slot=9, finalized_slot=0)
 
 
-def test_delta_16_square(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_16_square(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 16: perfect square (4^2)."""
-    justifiability(slot=16, finalized_slot=0)
+    justifiability_test(slot=16, finalized_slot=0)
 
 
-def test_delta_25_square(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_25_square(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 25: perfect square (5^2)."""
-    justifiability(slot=25, finalized_slot=0)
+    justifiability_test(slot=25, finalized_slot=0)
 
 
-def test_delta_36_square(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_36_square(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 36: perfect square (6^2)."""
-    justifiability(slot=36, finalized_slot=0)
+    justifiability_test(slot=36, finalized_slot=0)
 
 
-def test_delta_49_square(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_49_square(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 49: perfect square (7^2)."""
-    justifiability(slot=49, finalized_slot=0)
+    justifiability_test(slot=49, finalized_slot=0)
 
 
-def test_delta_64_square(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_64_square(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 64: perfect square (8^2)."""
-    justifiability(slot=64, finalized_slot=0)
+    justifiability_test(slot=64, finalized_slot=0)
 
 
-def test_delta_100_square(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_100_square(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 100: perfect square (10^2)."""
-    justifiability(slot=100, finalized_slot=0)
+    justifiability_test(slot=100, finalized_slot=0)
 
 
 # --- Pronic numbers n*(n+1) ---
 
 
-def test_delta_12_pronic(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_12_pronic(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 12: pronic number (3*4)."""
-    justifiability(slot=12, finalized_slot=0)
+    justifiability_test(slot=12, finalized_slot=0)
 
 
-def test_delta_20_pronic(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_20_pronic(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 20: pronic number (4*5)."""
-    justifiability(slot=20, finalized_slot=0)
+    justifiability_test(slot=20, finalized_slot=0)
 
 
-def test_delta_30_pronic(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_30_pronic(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 30: pronic number (5*6)."""
-    justifiability(slot=30, finalized_slot=0)
+    justifiability_test(slot=30, finalized_slot=0)
 
 
-def test_delta_42_pronic(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_42_pronic(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 42: pronic number (6*7)."""
-    justifiability(slot=42, finalized_slot=0)
+    justifiability_test(slot=42, finalized_slot=0)
 
 
-def test_delta_56_pronic(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_56_pronic(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 56: pronic number (7*8)."""
-    justifiability(slot=56, finalized_slot=0)
+    justifiability_test(slot=56, finalized_slot=0)
 
 
-def test_delta_72_pronic(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_72_pronic(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 72: pronic number (8*9)."""
-    justifiability(slot=72, finalized_slot=0)
+    justifiability_test(slot=72, finalized_slot=0)
 
 
-def test_delta_110_pronic(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_110_pronic(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 110: pronic number (10*11)."""
-    justifiability(slot=110, finalized_slot=0)
+    justifiability_test(slot=110, finalized_slot=0)
 
 
 # --- Non-justifiable deltas (between squares/pronics) ---
 
 
-def test_delta_10_not_justifiable(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_10_not_justifiable(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 10: between square 9 and pronic 12."""
-    justifiability(slot=10, finalized_slot=0)
+    justifiability_test(slot=10, finalized_slot=0)
 
 
-def test_delta_11_not_justifiable(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_11_not_justifiable(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 11: between square 9 and pronic 12."""
-    justifiability(slot=11, finalized_slot=0)
+    justifiability_test(slot=11, finalized_slot=0)
 
 
-def test_delta_13_not_justifiable(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_13_not_justifiable(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 13: between pronic 12 and square 16."""
-    justifiability(slot=13, finalized_slot=0)
+    justifiability_test(slot=13, finalized_slot=0)
 
 
-def test_delta_15_not_justifiable(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_15_not_justifiable(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 15: between pronic 12 and square 16."""
-    justifiability(slot=15, finalized_slot=0)
+    justifiability_test(slot=15, finalized_slot=0)
 
 
-def test_delta_17_not_justifiable(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_17_not_justifiable(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 17: between square 16 and pronic 20."""
-    justifiability(slot=17, finalized_slot=0)
+    justifiability_test(slot=17, finalized_slot=0)
 
 
-def test_delta_50_not_justifiable(justifiability: JustifiabilityTestFiller) -> None:
+def test_delta_50_not_justifiable(justifiability_test: JustifiabilityTestFiller) -> None:
     """Delta 50: between square 49 and pronic 56."""
-    justifiability(slot=50, finalized_slot=0)
+    justifiability_test(slot=50, finalized_slot=0)
 
 
 # --- Non-zero finalized slot ---
 
 
-def test_nonzero_finalized_delta_1(justifiability: JustifiabilityTestFiller) -> None:
+def test_nonzero_finalized_delta_1(justifiability_test: JustifiabilityTestFiller) -> None:
     """Finalized at slot 100, candidate at 101. Delta 1: immediate window."""
-    justifiability(slot=101, finalized_slot=100)
+    justifiability_test(slot=101, finalized_slot=100)
 
 
-def test_nonzero_finalized_delta_9(justifiability: JustifiabilityTestFiller) -> None:
+def test_nonzero_finalized_delta_9(justifiability_test: JustifiabilityTestFiller) -> None:
     """Finalized at slot 100, candidate at 109. Delta 9: perfect square."""
-    justifiability(slot=109, finalized_slot=100)
+    justifiability_test(slot=109, finalized_slot=100)
 
 
-def test_nonzero_finalized_delta_7(justifiability: JustifiabilityTestFiller) -> None:
+def test_nonzero_finalized_delta_7(justifiability_test: JustifiabilityTestFiller) -> None:
     """Finalized at slot 100, candidate at 107. Delta 7: not justifiable."""
-    justifiability(slot=107, finalized_slot=100)
+    justifiability_test(slot=107, finalized_slot=100)
 
 
 def test_nonzero_finalized_delta_12(
-    justifiability: JustifiabilityTestFiller,
+    justifiability_test: JustifiabilityTestFiller,
 ) -> None:
     """Finalized at slot 500, candidate at 512. Delta 12: pronic (3*4)."""
-    justifiability(slot=512, finalized_slot=500)
+    justifiability_test(slot=512, finalized_slot=500)

--- a/tests/consensus/lstar/sync/test_checkpoint_verify.py
+++ b/tests/consensus/lstar/sync/test_checkpoint_verify.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.valid_until("Lstar")
 
 
 def test_checkpoint_verify_rejects_empty_validator_set(
-    sync: SyncTestFiller,
+    sync_test: SyncTestFiller,
 ) -> None:
     """
     A checkpoint state with zero validators is rejected.
@@ -23,14 +23,14 @@ def test_checkpoint_verify_rejects_empty_validator_set(
     fork-choice store with it would be useless and mask configuration
     errors. Clients must refuse the anchor before any store setup.
     """
-    sync(
+    sync_test(
         operation="verify_checkpoint",
         input={"numValidators": 0},
     )
 
 
 def test_checkpoint_verify_accepts_small_validator_set(
-    sync: SyncTestFiller,
+    sync_test: SyncTestFiller,
 ) -> None:
     """
     A checkpoint state with a small in-range validator set is accepted.
@@ -39,14 +39,14 @@ def test_checkpoint_verify_accepts_small_validator_set(
     test suite. Pins the happy path of the verifier so clients observe
     the accepted branch in addition to the rejection branch above.
     """
-    sync(
+    sync_test(
         operation="verify_checkpoint",
         input={"numValidators": 4},
     )
 
 
 def test_checkpoint_verify_accepts_eight_validator_set(
-    sync: SyncTestFiller,
+    sync_test: SyncTestFiller,
 ) -> None:
     """
     Eight-validator anchor state is accepted at the key-manager limit.
@@ -55,7 +55,7 @@ def test_checkpoint_verify_accepts_eight_validator_set(
     and signature-verification suites. Pins the verdict at the upper
     end of the practical test envelope.
     """
-    sync(
+    sync_test(
         operation="verify_checkpoint",
         input={"numValidators": 8},
     )

--- a/tests/consensus/lstar/sync/test_checkpoint_verify_advanced.py
+++ b/tests/consensus/lstar/sync/test_checkpoint_verify_advanced.py
@@ -13,7 +13,7 @@ from consensus_testing import SyncTestFiller
 pytestmark = pytest.mark.valid_until("Lstar")
 
 
-def test_checkpoint_verify_advanced_slot_three(sync: SyncTestFiller) -> None:
+def test_checkpoint_verify_advanced_slot_three(sync_test: SyncTestFiller) -> None:
     """
     Advanced anchor state at slot 3 with four validators is accepted.
 
@@ -21,13 +21,13 @@ def test_checkpoint_verify_advanced_slot_three(sync: SyncTestFiller) -> None:
     carries non-empty historical_block_hashes and a non-zero latest
     block header. Pins the accepted verdict plus the exact SSZ bytes.
     """
-    sync(
+    sync_test(
         operation="verify_checkpoint",
         input={"numValidators": 4, "anchorSlot": 3},
     )
 
 
-def test_checkpoint_verify_advanced_slot_ten(sync: SyncTestFiller) -> None:
+def test_checkpoint_verify_advanced_slot_ten(sync_test: SyncTestFiller) -> None:
     """
     Advanced anchor state at slot 10 with four validators is accepted.
 
@@ -35,20 +35,20 @@ def test_checkpoint_verify_advanced_slot_ten(sync: SyncTestFiller) -> None:
     with longer lists. Pins the verdict and state bytes at a larger
     history than the slot-three case.
     """
-    sync(
+    sync_test(
         operation="verify_checkpoint",
         input={"numValidators": 4, "anchorSlot": 10},
     )
 
 
-def test_checkpoint_verify_advanced_eight_validators(sync: SyncTestFiller) -> None:
+def test_checkpoint_verify_advanced_eight_validators(sync_test: SyncTestFiller) -> None:
     """
     Advanced anchor state at slot 5 with eight validators is accepted.
 
     Exercises the combination of larger validator set with a non-zero
     anchor slot so clients diff both axes in a single vector.
     """
-    sync(
+    sync_test(
         operation="verify_checkpoint",
         input={"numValidators": 8, "anchorSlot": 5},
     )


### PR DESCRIPTION
## Motivation

The Tier-4 consistency batch from the `packages/testing/` audit — seven small inconsistencies, fixed in one pass.

## Changes

1. **`format_name` suffix unified**: 5 classes had `_test`, 8 didn't. The 8 bare names (`ssz`, `sync`, `slot_clock`, `justifiability`, `poseidon_permutation`, `networking_codec`, `gossipsub_handler`, `api_endpoint`) gain the suffix, and their pytest fixture parameters in tests follow (`ssz(...)` → `ssz_test(...)`). Direction chosen to minimize churn: the 5 suffixed categories own most test files. **Output directories are unchanged** — the path builder strips the suffix — only the `_info.fixtureFormat` metadata and test-id strings change for the 8 categories.
2. **"Returns a copy" docstrings fixed** on 4 `make_fixture` implementations that return `self`.
3. **NumPy-style docstrings** (`Parameters:` with `----` underlines) in the two step serializers converted to Google style.
4. **`typing.Type` aliases** → builtin `type[...]` (13 filler aliases).
5. **Bare `= {}` mutable defaults** on fixture output fields → `Field(default_factory=dict)` (7 fields; pydantic deep-copies either way, but this matches the repo standard).
6. **Dead `hash_only` parameter** removed from `json_dict_with_info` (never passed by any caller).
7. **Hand-rolled expect-exception ladders** in `StateTransitionTest` and `VerifySignaturesTest` now route through the base `assert_expected_outcome`, which gains an optional exact-message argument — one implementation of the comparison instead of three.

## Verification

- `just check` passes (ruff, format, ty, codespell, mdformat)
- Filled every renamed category plus the two rerouted exception paths: **324/324 pass**; output tree names unchanged (`fixtures/consensus/ssz/...` etc.), test ids now carry the unified format names

🤖 Generated with [Claude Code](https://claude.com/claude-code)