### PR TITLE
test: add property-based tests for fork choice head and SSZ round trips

### DIFF
--- a/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
+++ b/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from consensus_testing.keys import XmssKeyManager
 from hypothesis import given, settings, strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
 
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import AggregationBits, Checkpoint, Interval, Slot, ValidatorIndex
@@ -35,6 +36,7 @@ from tests.lean_spec.helpers import (
     make_bytes32,
     make_checkpoint,
     make_empty_block_body,
+    make_genesis_data,
     make_mock_signature,
     make_signed_block,
     make_signed_block_from_store,
@@ -2106,3 +2108,89 @@ class TestAttestationProcessingTiming:
         # Should be no-op
         assert len(sample_store.latest_new_aggregated_payloads) == 0
         assert len(sample_store.latest_known_aggregated_payloads) == initial_known_payloads
+
+
+class StoreHeadMachine(RuleBasedStateMachine):
+    """
+    Drive the store with random block trees and head votes.
+
+    Rules grow a block tree and inject votes without cryptography.
+    Invariants re-derive the head through the spec after every step.
+    """
+
+    def __init__(self) -> None:
+        """Start from a keyed genesis store with four validators."""
+        super().__init__()
+        self.spec = LstarSpec()
+        genesis = make_genesis_data(num_validators=4, key_manager=XmssKeyManager.shared())
+        self.store = genesis.store
+        self.block_roots = [hash_tree_root(genesis.block)]
+        self.next_slot = 1
+        self.next_state_seed = 1
+
+    @rule(data=st.data())
+    def add_block(self, data: st.DataObject) -> None:
+        """Attach a new block to a randomly chosen parent."""
+        parent_root = data.draw(st.sampled_from(self.block_roots))
+        self.store, block_root = _add_known_block(
+            self.store,
+            Slot(self.next_slot),
+            ValidatorIndex(self.next_slot % 4),
+            parent_root,
+            self.next_state_seed,
+        )
+        self.block_roots.append(block_root)
+        self.next_slot += 1
+        self.next_state_seed += 1
+
+    @rule(data=st.data())
+    def cast_head_vote(self, data: st.DataObject) -> None:
+        """Record one validator's head vote for a randomly chosen block."""
+        validator_index = ValidatorIndex(data.draw(st.integers(min_value=0, max_value=3)))
+        voted_root = data.draw(st.sampled_from(self.block_roots))
+        voted_block = self.store.blocks[voted_root]
+
+        attestation_data = AttestationData(
+            slot=voted_block.slot,
+            head=Checkpoint(root=voted_root, slot=voted_block.slot),
+            target=Checkpoint(root=voted_root, slot=voted_block.slot),
+            source=self.store.latest_justified,
+        )
+        # Head weights only read the participant bits, never the proof bytes.
+        vote = SingleMessageAggregate(
+            participants=AggregationBits.from_indices([validator_index]),
+            proof=ByteList512KiB(data=b""),
+        )
+        merged_payloads = {
+            **self.store.latest_known_aggregated_payloads,
+            attestation_data: {
+                *self.store.latest_known_aggregated_payloads.get(attestation_data, set()),
+                vote,
+            },
+        }
+        self.store = self.store.model_copy(
+            update={"latest_known_aggregated_payloads": merged_payloads}
+        )
+
+    @invariant()
+    def head_is_a_known_descendant_of_justified(self) -> None:
+        """The head exists, descends from justified, and recomputes identically."""
+        head_root = self.spec.update_head(self.store).head
+        assert head_root in self.store.blocks
+
+        # Walk parents from head; the justified root must be reachable.
+        justified_root = self.store.latest_justified.root
+        ancestor_root = head_root
+        while ancestor_root != justified_root and ancestor_root in self.store.blocks:
+            ancestor_root = self.store.blocks[ancestor_root].parent_root
+        assert ancestor_root == justified_root
+
+        # Determinism: recomputing from the same store yields the same head.
+        assert self.spec.update_head(self.store).head == head_root
+
+
+StoreHeadMachine.TestCase.settings = settings(
+    max_examples=25, stateful_step_count=15, deadline=None
+)
+
+TestStoreHeadProperties = StoreHeadMachine.TestCase

--- a/tests/lean_spec/spec/ssz/test_bitfields.py
+++ b/tests/lean_spec/spec/ssz/test_bitfields.py
@@ -5,6 +5,7 @@ import re
 from typing import Any
 
 import pytest
+from hypothesis import given, strategies as st
 from pydantic import BaseModel, ValidationError
 
 from lean_spec.spec.ssz.bitfields import BaseBitlist, BaseBitvector
@@ -455,3 +456,17 @@ class TestBitfieldSSZ:
             match=re.escape("Bitlist16: expected 2 bytes, got 1"),
         ):
             Bitlist16.deserialize(stream, scope=2)
+
+
+@given(bits=st.lists(st.booleans(), max_size=8))
+def test_bitlist_round_trip_random_bits(bits: list[bool]) -> None:
+    """Any bit pattern up to the limit, including empty, round-trips unchanged."""
+    instance = Bitlist8(data=tuple(Boolean(bit) for bit in bits))
+    assert Bitlist8.decode_bytes(instance.encode_bytes()) == instance
+
+
+@given(bits=st.lists(st.booleans(), min_size=4, max_size=4))
+def test_bitvector_round_trip_random_bits(bits: list[bool]) -> None:
+    """Any fixed-length bit pattern round-trips unchanged."""
+    instance = Bitvector4(data=tuple(Boolean(bit) for bit in bits))
+    assert Bitvector4.decode_bytes(instance.encode_bytes()) == instance

--- a/tests/lean_spec/spec/ssz/test_uint.py
+++ b/tests/lean_spec/spec/ssz/test_uint.py
@@ -7,6 +7,7 @@ from itertools import permutations
 from typing import Any, Type
 
 import pytest
+from hypothesis import given, strategies as st
 from pydantic import BaseModel, ValidationError
 
 from lean_spec.spec.ssz import Uint8, Uint16, Uint32, Uint64
@@ -792,3 +793,12 @@ class TestCrossWidthEqualityIsStrict:
     ) -> None:
         """Equal-by-value instances of different widths hash differently."""
         assert hash(type_a(5)) != hash(type_b(5))
+
+
+@pytest.mark.parametrize("uint_class", ALL_UINT_TYPES)
+@given(data=st.data())
+def test_encode_decode_round_trip_random_values(uint_class: Type[BaseUint], data) -> None:
+    """Any in-range value survives an encode and decode round trip unchanged."""
+    raw_value = data.draw(st.integers(min_value=0, max_value=2**uint_class.BITS - 1))
+    instance = uint_class(raw_value)
+    assert uint_class.decode_bytes(instance.encode_bytes()) == instance


### PR DESCRIPTION
## Motivation

Item 17 of the `packages/testing/` audit: hand-written vectors prove *specific known cases*; property tests search for the case nobody thought of. Any counterexample Hypothesis finds can be hand-promoted into a curated cross-client vector. Per the audit's hard rule, randomness stays **strictly on the unit-test side** — emitted fixtures remain fully deterministic.

## Changes

**1. Fork-choice store state machine** (`test_fork_choice.py`): a Hypothesis `RuleBasedStateMachine` with two rules and one invariant —

- `add_block`: attaches a new block to a randomly chosen parent, growing arbitrary tree shapes (linear chains, wide forks, deep sibling races)
- `cast_head_vote`: records a validator's head vote for a random block, injected through the aggregated-payload pool. No cryptography needed: head weighting only reads the participant bits, never the proof bytes — so each of the 25 scenarios × 15 steps runs in microseconds
- invariant after **every** step: the spec-computed head is a known block, **descends from the latest justified checkpoint**, and recomputing from the same store yields the identical head (determinism)

This exercises head selection over vote-replacement, equal-weight tiebreaks, orphan-pressure and fork shapes that no curated scenario enumerates.

**2. SSZ round-trip properties** (mirrored test files, per the test-structure rule):
- `test_uint.py`: any in-range random value survives encode→decode for every uint width
- `test_bitfields.py`: bitlists round-trip any pattern up to the limit **including empty** (the delimiter-bit edge case the audit called out), bitvectors any fixed-length pattern

## Verification

- `just check` passes (ruff, format, ty, codespell, mdformat)
- The 7 new property tests pass in **0.93s** total — well inside the unit-suite budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)