### PR TITLE
test: extend SSZ round-trip properties to every type family

### DIFF
--- a/tests/lean_spec/spec/ssz/test_boolean.py
+++ b/tests/lean_spec/spec/ssz/test_boolean.py
@@ -5,6 +5,7 @@ import re
 from typing import Any, Callable
 
 import pytest
+from hypothesis import given, strategies as st
 from pydantic import BaseModel, ValidationError
 
 from lean_spec.spec.ssz.boolean import Boolean
@@ -323,3 +324,10 @@ class TestBooleanSSZ:
         stream = io.BytesIO(b"")  # Empty stream
         with pytest.raises(SSZSerializationError, match=r"^Boolean: expected 1 byte, got 0$"):
             Boolean.deserialize(stream, scope=1)
+
+
+@given(boolean_value=st.booleans())
+def test_encode_decode_round_trip_random_values(boolean_value: bool) -> None:
+    """Either truth value survives an encode and decode round trip unchanged."""
+    instance = Boolean(boolean_value)
+    assert Boolean.decode_bytes(instance.encode_bytes()) == instance

--- a/tests/lean_spec/spec/ssz/test_byte_arrays.py
+++ b/tests/lean_spec/spec/ssz/test_byte_arrays.py
@@ -7,6 +7,7 @@ import re
 from typing import Any
 
 import pytest
+from hypothesis import given, strategies as st
 from pydantic import BaseModel
 
 from lean_spec.spec.ssz.byte_arrays import (
@@ -505,3 +506,17 @@ def test_json_dumpable_via_hex() -> None:
         "payload": ByteList5(data=b"\x00\x01\x02").hex(),
     }
     assert json.loads(json.dumps(hex_encoded_fields)) == hex_encoded_fields
+
+
+@given(raw_bytes=st.binary(min_size=32, max_size=32))
+def test_byte_vector_round_trip_random_bytes(raw_bytes: bytes) -> None:
+    """Any fixed-length byte pattern survives an encode and decode round trip."""
+    instance = Bytes32(raw_bytes)
+    assert Bytes32.decode_bytes(instance.encode_bytes()) == instance
+
+
+@given(raw_bytes=st.binary(max_size=16))
+def test_byte_list_round_trip_random_bytes(raw_bytes: bytes) -> None:
+    """Any byte pattern up to the limit, including empty, round-trips unchanged."""
+    instance = ByteList16(data=raw_bytes)
+    assert ByteList16.decode_bytes(instance.encode_bytes()) == instance

--- a/tests/lean_spec/spec/ssz/test_collections.py
+++ b/tests/lean_spec/spec/ssz/test_collections.py
@@ -4,6 +4,7 @@ import re
 from typing import Any, cast
 
 import pytest
+from hypothesis import given, strategies as st
 from pydantic import BaseModel, ValidationError
 
 from lean_spec.spec.crypto.koalabear import Fp
@@ -965,3 +966,17 @@ class TestJsonSerialization:
         )
 
         assert instance.model_dump(mode="json") == {"data": [{"a": 1, "b": 2}, {"a": 3, "b": 4}]}
+
+
+@given(values=st.lists(st.integers(min_value=0, max_value=2**16 - 1), max_size=4))
+def test_list_round_trip_random_values(values: list[int]) -> None:
+    """Any element sequence up to the limit, including empty, round-trips unchanged."""
+    instance = Uint16List4(data=[Uint16(value) for value in values])
+    assert Uint16List4.decode_bytes(instance.encode_bytes()) == instance
+
+
+@given(values=st.lists(st.integers(min_value=0, max_value=255), min_size=4, max_size=4))
+def test_vector_round_trip_random_values(values: list[int]) -> None:
+    """Any fixed-length element sequence round-trips unchanged."""
+    instance = Uint8Vector4(data=[Uint8(value) for value in values])
+    assert Uint8Vector4.decode_bytes(instance.encode_bytes()) == instance

--- a/tests/lean_spec/spec/ssz/test_container.py
+++ b/tests/lean_spec/spec/ssz/test_container.py
@@ -3,6 +3,7 @@
 import io
 
 import pytest
+from hypothesis import given, strategies as st
 from pydantic import ValidationError
 
 from lean_spec.spec.ssz.collections import SSZList
@@ -430,3 +431,22 @@ class TestHexStringValidator:
             }
         )
         assert outer == OuterFixedNested(z=Uint64(7), inner=InnerFixed(x=Uint64(1), y=Uint64(2)))
+
+
+@given(
+    a=st.integers(min_value=0, max_value=2**64 - 1),
+    b=st.lists(st.integers(min_value=0, max_value=2**16 - 1), max_size=4),
+    c=st.integers(min_value=0, max_value=2**32 - 1),
+    d=st.lists(st.integers(min_value=0, max_value=2**16 - 1), max_size=4),
+)
+def test_mixed_container_round_trip_random_values(
+    a: int, b: list[int], c: int, d: list[int]
+) -> None:
+    """Any mix of fixed and variable field values round-trips unchanged."""
+    instance = Mixed(
+        a=Uint64(a),
+        b=Uint16List4(data=[Uint16(value) for value in b]),
+        c=Uint32(c),
+        d=Uint16List4(data=[Uint16(value) for value in d]),
+    )
+    assert Mixed.decode_bytes(instance.encode_bytes()) == instance


### PR DESCRIPTION
## Motivation

Follow-up to #865, which added round-trip properties for only 2 of the 6 SSZ type families (uints and bitfields). The remaining families are equally property-testable — there was no reason for the gap.

## Changes

One round-trip property per remaining family, each in its mirrored test file, reusing the file's existing test types:

| Family | File | Property |
|---|---|---|
| Boolean | `test_boolean.py` | either truth value round-trips |
| Byte vector | `test_byte_arrays.py` | any 32-byte pattern (`Bytes32`) round-trips |
| Byte list | `test_byte_arrays.py` | any pattern up to the limit, **including empty**, round-trips |
| Element list | `test_collections.py` | any `Uint16` sequence up to the limit, **including empty**, round-trips |
| Element vector | `test_collections.py` | any fixed-length `Uint8` sequence round-trips |
| Container | `test_container.py` | the canonical mixed fixed/variable shape (`Mixed`: uint–list–uint–list) round-trips under random field values — exercises the offset-table encoding paths |

With #865 that's all six families: uint, boolean, bitfields, byte arrays, collections, containers.

## Verification

- `just check` passes (ruff, format, ty, codespell, mdformat)
- All 12 SSZ property tests (6 prior + 6 new) pass in **1.3s**

🤖 Generated with [Claude Code](https://claude.com/claude-code)