### PR TITLE
chore(testing): packaging and tooling hygiene for the testing framework

### DIFF
--- a/.github/workflows/generate-keys.yml
+++ b/.github/workflows/generate-keys.yml
@@ -38,10 +38,10 @@ jobs:
         run: uv sync --no-progress
 
       - name: Generate test scheme keys
-        run: uv run python -m consensus_testing.keys_cli --scheme test
+        run: uv run keys --scheme test
 
       - name: Generate prod scheme keys
-        run: LEAN_ENV=prod uv run python -m consensus_testing.keys_cli --scheme prod
+        run: LEAN_ENV=prod uv run keys --scheme prod
 
       - name: Publish to leansig-test-keys
         run: |

--- a/.github/workflows/prod-vectors.yml
+++ b/.github/workflows/prod-vectors.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Download keys
         if: steps.key-cache.outputs.cache-hit != 'true'
-        run: uv run python -m consensus_testing.keys_cli --download --scheme prod
+        run: uv run keys --download --scheme prod
 
       - name: Save key cache
         if: steps.key-cache.outputs.cache-hit != 'true'

--- a/packages/testing/pyproject.toml
+++ b/packages/testing/pyproject.toml
@@ -36,9 +36,21 @@ Issues = "https://github.com/leanEthereum/lean-spec/issues"
 [project.scripts]
 fill = "framework.cli.fill:fill"
 apitest = "framework.cli.apitest:apitest"
+keys = "consensus_testing.keys_cli:keys"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+# Ship only the committed test-scheme keys.
+# Prod-scheme keys are large local downloads and are fetched on demand.
+# Why explicit opt-out: the default sweeps every file in package
+# directories, including multi-megabyte locally downloaded prod keys.
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools.package-data]
+consensus_testing = ["py.typed", "test_keys/test_scheme/*.json"]
+framework = ["cli/pytest_ini_files/*.ini"]
 
 [tool.uv.sources]
 lean-spec = { workspace = true }

--- a/packages/testing/src/consensus_testing/forks/__init__.py
+++ b/packages/testing/src/consensus_testing/forks/__init__.py
@@ -1,8 +1,7 @@
 """Fork definitions for consensus layer testing."""
 
-from framework.forks import BaseFork
-
 from consensus_testing.forks.forks import Lstar
+from framework.forks import BaseFork
 
 FORKS_BY_NAME: dict[str, type[BaseFork]] = {"lstar": Lstar}
 """Registered consensus forks, keyed by lowercase fork name."""

--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -269,7 +269,7 @@ class XmssKeyManager:
             if not self._keys_directory.exists():
                 raise FileNotFoundError(
                     f"Keys directory not found: {self._keys_directory} - "
-                    f"Run: python -m consensus_testing.keys_cli --scheme {self.scheme_name}"
+                    f"Run: uv run keys --scheme {self.scheme_name}"
                 )
 
             # Each JSON file is named by its validator index (e.g. "0.json").
@@ -282,7 +282,7 @@ class XmssKeyManager:
             if not self._available_indices:
                 raise FileNotFoundError(
                     f"No key files found in: {self._keys_directory} - "
-                    f"Run: python -m consensus_testing.keys_cli --scheme {self.scheme_name}"
+                    f"Run: uv run keys --scheme {self.scheme_name}"
                 )
         return self._available_indices
 

--- a/packages/testing/src/consensus_testing/keys_cli.py
+++ b/packages/testing/src/consensus_testing/keys_cli.py
@@ -3,19 +3,18 @@ CLI for generating or downloading the pre-generated XMSS test keys.
 
 Downloading Pre-generated Keys:
 
-    python -m consensus_testing.keys_cli --download --scheme test    # test scheme
-    python -m consensus_testing.keys_cli --download --scheme prod    # prod scheme
+    uv run keys --download --scheme test    # test scheme
+    uv run keys --download --scheme prod    # prod scheme
 
 Regenerating Keys:
 
-    python -m consensus_testing.keys_cli                   # defaults
-    python -m consensus_testing.keys_cli --count 20        # more validators
-    python -m consensus_testing.keys_cli --max-slot 200    # longer lifetime
+    uv run keys                   # defaults
+    uv run keys --count 20        # more validators
+    uv run keys --max-slot 200    # longer lifetime
 """
 
 from __future__ import annotations
 
-import argparse
 import hashlib
 import os
 import shutil
@@ -27,6 +26,8 @@ import urllib.request
 from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 from pathlib import Path
+
+import click
 
 from consensus_testing.keys import (
     LEAN_ENV_TO_SCHEMES,
@@ -255,45 +256,43 @@ def download_keys(scheme: str) -> None:
     print("Download complete!")
 
 
-def main() -> None:
-    """CLI entry point for generating or downloading test keys."""
-    parser = argparse.ArgumentParser(
-        description="Generate XMSS key pairs for consensus testing",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    parser.add_argument(
-        "--download",
-        action="store_true",
-        help="Download pre-generated keys from a GitHub release",
-    )
-    parser.add_argument(
-        "--scheme",
-        choices=LEAN_ENV_TO_SCHEMES.keys(),
-        default="test",
-        help="XMSS scheme to use",
-    )
-    parser.add_argument(
-        "--count",
-        type=int,
-        default=NUM_VALIDATORS,
-        help="Number of validator key pairs",
-    )
-    parser.add_argument(
-        "--max-slot",
-        type=int,
-        default=int(CLI_DEFAULT_MAX_SLOT),
-        help="Maximum slot (key lifetime = max_slot + 1)",
-    )
-    args = parser.parse_args()
-
+@click.command()
+@click.option(
+    "--download",
+    is_flag=True,
+    help="Download pre-generated keys from a GitHub release",
+)
+@click.option(
+    "--scheme",
+    type=click.Choice(list(LEAN_ENV_TO_SCHEMES)),
+    default="test",
+    show_default=True,
+    help="XMSS scheme to use",
+)
+@click.option(
+    "--count",
+    type=int,
+    default=NUM_VALIDATORS,
+    show_default=True,
+    help="Number of validator key pairs",
+)
+@click.option(
+    "--max-slot",
+    type=int,
+    default=int(CLI_DEFAULT_MAX_SLOT),
+    show_default=True,
+    help="Maximum slot (key lifetime = max_slot + 1)",
+)
+def keys(download: bool, scheme: str, count: int, max_slot: int) -> None:
+    """Generate XMSS key pairs for consensus testing."""
     # Download pre-generated keys instead of generating locally.
-    if args.download:
-        download_keys(scheme=args.scheme)
+    if download:
+        download_keys(scheme=scheme)
         return
 
     # Generate fresh keys with the specified parameters.
-    _generate_keys(lean_env=args.scheme, count=args.count, max_slot=args.max_slot)
+    _generate_keys(lean_env=scheme, count=count, max_slot=max_slot)
 
 
 if __name__ == "__main__":
-    main()
+    keys()

--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -5,10 +5,10 @@ import json
 from functools import cached_property
 from typing import Any, ClassVar
 
-from framework.forks import BaseFork
 from pydantic import Field
 
 from consensus_testing.keys import XmssKeyManager
+from framework.forks import BaseFork
 from lean_spec.base import CamelModel
 from lean_spec.config import LEAN_ENV
 from lean_spec.spec.forks import RejectionReason

--- a/packages/testing/src/framework/cli/apitest.py
+++ b/packages/testing/src/framework/cli/apitest.py
@@ -1,8 +1,8 @@
 """CLI command for running API conformance tests against an external server."""
 
 import sys
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 import click
 import pytest

--- a/packages/testing/src/framework/cli/fill.py
+++ b/packages/testing/src/framework/cli/fill.py
@@ -2,8 +2,8 @@
 
 import os
 import sys
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 import click
 import pytest

--- a/packages/testing/src/framework/pytest_plugins/filler.py
+++ b/packages/testing/src/framework/pytest_plugins/filler.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
 from consensus_testing.forks import FORKS_BY_NAME
 from consensus_testing.keys import DEFAULT_MAX_SLOT, XmssKeyManager
 from consensus_testing.test_fixtures import (
@@ -26,7 +27,6 @@ from consensus_testing.test_fixtures import (
     VerifySignaturesTest,
     VerifySingleMessageProofsTest,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.ssz import Bytes32
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ ban-relative-imports = "all"
 [tool.ruff.lint.isort]
 combine-as-imports = true
 force-single-line = false
-known-first-party = ["lean_spec"]
+known-first-party = ["lean_spec", "consensus_testing", "framework"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D"]

--- a/tests/consensus/lstar/api/test_api_endpoints.py
+++ b/tests/consensus/lstar/api/test_api_endpoints.py
@@ -6,6 +6,7 @@ API server returns the exact same response given the same genesis parameters.
 """
 
 import pytest
+
 from consensus_testing import ApiEndpointTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/api/test_api_post_genesis.py
+++ b/tests/consensus/lstar/api/test_api_post_genesis.py
@@ -7,6 +7,7 @@ so clients' response shapes at non-zero slots are also captured.
 """
 
 import pytest
+
 from consensus_testing import ApiEndpointTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/api/test_metrics_endpoint.py
+++ b/tests/consensus/lstar/api/test_metrics_endpoint.py
@@ -1,6 +1,7 @@
 """API endpoint: /metrics scrape contract vector."""
 
 import pytest
+
 from consensus_testing import ApiEndpointTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/chain/test_slot_clock.py
+++ b/tests/consensus/lstar/chain/test_slot_clock.py
@@ -7,6 +7,7 @@ for a 4-second slot with 5 intervals of 800 ms each.
 """
 
 import pytest
+
 from consensus_testing import SlotClockTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_attestation_source_divergence.py
+++ b/tests/consensus/lstar/fc/test_attestation_source_divergence.py
@@ -1,6 +1,7 @@
 """Fork Choice: Attestation Source Under Justified Divergence"""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationCheck,
     AggregatedAttestationSpec,
@@ -9,7 +10,6 @@ from consensus_testing import (
     ForkChoiceTestFiller,
     StoreChecks,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_attestation_target_selection.py
+++ b/tests/consensus/lstar/fc/test_attestation_target_selection.py
@@ -1,6 +1,7 @@
 """Attestation Target Selection and Safe Target Computation"""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -8,7 +9,6 @@ from consensus_testing import (
     ForkChoiceTestFiller,
     StoreChecks,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import JUSTIFICATION_LOOKBACK_SLOTS
 

--- a/tests/consensus/lstar/fc/test_block_attestation_limits.py
+++ b/tests/consensus/lstar/fc/test_block_attestation_limits.py
@@ -1,6 +1,7 @@
 """Fork Choice: Block attestation data limits."""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -9,7 +10,6 @@ from consensus_testing import (
     ForkChoiceTestFiller,
     StoreChecks,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import MAX_ATTESTATIONS_DATA
 

--- a/tests/consensus/lstar/fc/test_block_production.py
+++ b/tests/consensus/lstar/fc/test_block_production.py
@@ -3,6 +3,7 @@
 import math
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationCheck,
     AggregatedAttestationSpec,
@@ -14,7 +15,6 @@ from consensus_testing import (
     StoreChecks,
     TickStep,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import (
     INTERVALS_PER_SLOT,

--- a/tests/consensus/lstar/fc/test_checkpoint_sync.py
+++ b/tests/consensus/lstar/fc/test_checkpoint_sync.py
@@ -1,6 +1,7 @@
 """Checkpoint sync (non-genesis anchor) tests."""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -10,7 +11,6 @@ from consensus_testing import (
     TickStep,
     build_anchor,
 )
-
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import INTERVALS_PER_SLOT, SECONDS_PER_SLOT

--- a/tests/consensus/lstar/fc/test_duplicate_attestation_data.py
+++ b/tests/consensus/lstar/fc/test_duplicate_attestation_data.py
@@ -1,6 +1,7 @@
 """Fork Choice: Duplicate AttestationData Rejection."""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -8,7 +9,6 @@ from consensus_testing import (
     ForkChoiceTestFiller,
     StoreChecks,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_equivocation.py
+++ b/tests/consensus/lstar/fc/test_equivocation.py
@@ -1,6 +1,7 @@
 """Equivocating Proposer Tests."""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     AttestationCheck,
@@ -14,7 +15,6 @@ from consensus_testing import (
     TickStep,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_finalization_mid_processing.py
+++ b/tests/consensus/lstar/fc/test_finalization_mid_processing.py
@@ -8,6 +8,7 @@ Reference: https://github.com/leanEthereum/leanSpec/pull/443
 """
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -15,7 +16,6 @@ from consensus_testing import (
     ForkChoiceTestFiller,
     StoreChecks,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_fork_choice_head.py
+++ b/tests/consensus/lstar/fc/test_fork_choice_head.py
@@ -1,6 +1,7 @@
 """Fork Choice Head Selection (LMD-GHOST Algorithm)"""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -9,7 +10,6 @@ from consensus_testing import (
     StoreChecks,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_fork_choice_reorgs.py
+++ b/tests/consensus/lstar/fc/test_fork_choice_reorgs.py
@@ -1,6 +1,7 @@
 """Fork Choice Chain Reorganizations (Reorgs)"""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -9,7 +10,6 @@ from consensus_testing import (
     StoreChecks,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_aggregated_attestation_validation.py
@@ -1,6 +1,7 @@
 """Gossip aggregated attestation validation vectors."""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -10,7 +11,6 @@ from consensus_testing import (
     StoreChecks,
     TickStep,
 )
-
 from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.ssz import Bytes32

--- a/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
+++ b/tests/consensus/lstar/fc/test_gossip_attestation_validation.py
@@ -1,6 +1,7 @@
 """Test vectors for gossip attestation validation."""
 
 import pytest
+
 from consensus_testing import (
     AttestationStep,
     BlockSpec,
@@ -10,7 +11,6 @@ from consensus_testing import (
     StoreChecks,
     TickStep,
 )
-
 from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import GOSSIP_DISPARITY_INTERVALS
 from lean_spec.spec.ssz import Bytes32

--- a/tests/consensus/lstar/fc/test_lexicographic_tiebreaker.py
+++ b/tests/consensus/lstar/fc/test_lexicographic_tiebreaker.py
@@ -6,13 +6,13 @@ competing forks have equal attestation weight.
 """
 
 import pytest
+
 from consensus_testing import (
     BlockSpec,
     BlockStep,
     ForkChoiceTestFiller,
     StoreChecks,
 )
-
 from lean_spec.spec.forks import Slot
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_safe_target.py
+++ b/tests/consensus/lstar/fc/test_safe_target.py
@@ -1,6 +1,7 @@
 """Safe target update tests."""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     AttestationCheck,
@@ -12,7 +13,6 @@ from consensus_testing import (
     TickStep,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_signature_aggregation.py
+++ b/tests/consensus/lstar/fc/test_signature_aggregation.py
@@ -1,6 +1,7 @@
 """Signature Aggregation Tests for Fork Choice"""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationCheck,
     AggregatedAttestationSpec,
@@ -9,7 +10,6 @@ from consensus_testing import (
     ForkChoiceTestFiller,
     StoreChecks,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_store_pruning.py
+++ b/tests/consensus/lstar/fc/test_store_pruning.py
@@ -1,6 +1,7 @@
 """Fork Choice: Store pruning on finalization."""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     AttestationCheck,
@@ -14,7 +15,6 @@ from consensus_testing import (
     TickStep,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/fc/test_tick_system.py
+++ b/tests/consensus/lstar/fc/test_tick_system.py
@@ -1,6 +1,7 @@
 """Fork choice tick interval progression tests."""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     AttestationCheck,
@@ -11,7 +12,6 @@ from consensus_testing import (
     StoreChecks,
     TickStep,
 )
-
 from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_decode_failure_smoke.py
+++ b/tests/consensus/lstar/networking/test_decode_failure_smoke.py
@@ -6,6 +6,7 @@ independently of later negative-path content PRs.
 """
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_enr_and_peer_id.py
+++ b/tests/consensus/lstar/networking/test_enr_and_peer_id.py
@@ -1,6 +1,7 @@
 """Test vectors for ENR encoding and PeerId derivation."""
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_enr_non_canonical.py
+++ b/tests/consensus/lstar/networking/test_enr_non_canonical.py
@@ -8,8 +8,8 @@ wire, breaking the signature covenant.
 """
 
 import pytest
-from consensus_testing import NetworkingCodecTestFiller
 
+from consensus_testing import NetworkingCodecTestFiller
 from lean_spec.node.networking.enr.rlp import encode_rlp
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_enr_rejections.py
+++ b/tests/consensus/lstar/networking/test_enr_rejections.py
@@ -1,6 +1,7 @@
 """ENR RLP decoder: malformed-input rejection vectors."""
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_gossip_message_id.py
+++ b/tests/consensus/lstar/networking/test_gossip_message_id.py
@@ -1,6 +1,7 @@
 """Test vectors for gossipsub message ID computation."""
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_gossip_topic.py
+++ b/tests/consensus/lstar/networking/test_gossip_topic.py
@@ -1,6 +1,7 @@
 """Test vectors for gossipsub topic string encoding and parsing."""
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_gossip_topic_fork.py
+++ b/tests/consensus/lstar/networking/test_gossip_topic_fork.py
@@ -8,6 +8,7 @@ wrong-fork messages into their subscriptions.
 """
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_gossipsub_handlers.py
+++ b/tests/consensus/lstar/networking/test_gossipsub_handlers.py
@@ -1,6 +1,7 @@
 """Test vectors for gossipsub handler protocol decisions."""
 
 import pytest
+
 from consensus_testing import GossipsubHandlerTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_gossipsub_rpc.py
+++ b/tests/consensus/lstar/networking/test_gossipsub_rpc.py
@@ -1,6 +1,7 @@
 """Test vectors for gossipsub RPC protobuf encoding."""
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_gossipsub_rpc_rejections.py
+++ b/tests/consensus/lstar/networking/test_gossipsub_rpc_rejections.py
@@ -1,8 +1,8 @@
 """Gossipsub RPC decoder: malformed-protobuf rejection vectors."""
 
 import pytest
-from consensus_testing import NetworkingCodecTestFiller
 
+from consensus_testing import NetworkingCodecTestFiller
 from lean_spec.node.networking.gossipsub.rpc import ProtobufDecodeError
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_reqresp_codec.py
+++ b/tests/consensus/lstar/networking/test_reqresp_codec.py
@@ -1,6 +1,7 @@
 """Test vectors for req/resp wire format encoding."""
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_reqresp_error_utf8.py
+++ b/tests/consensus/lstar/networking/test_reqresp_error_utf8.py
@@ -1,6 +1,7 @@
 """Req/resp error-response payload roundtrip at size and UTF-8 boundaries."""
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_reqresp_rejections.py
+++ b/tests/consensus/lstar/networking/test_reqresp_rejections.py
@@ -7,8 +7,8 @@ peer sends malformed framing.
 """
 
 import pytest
-from consensus_testing import NetworkingCodecTestFiller
 
+from consensus_testing import NetworkingCodecTestFiller
 from lean_spec.node.networking.reqresp.codec import CodecError
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_reqresp_response_stream.py
+++ b/tests/consensus/lstar/networking/test_reqresp_response_stream.py
@@ -8,6 +8,7 @@ and produce the same ordered list of (code, sszData) records.
 """
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_snappy_codec.py
+++ b/tests/consensus/lstar/networking/test_snappy_codec.py
@@ -7,6 +7,7 @@ produces identical output before integrating with reqresp or gossip.
 """
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_snappy_frame_rejections.py
+++ b/tests/consensus/lstar/networking/test_snappy_frame_rejections.py
@@ -1,8 +1,8 @@
 """Snappy framing decoder: malformed-input rejection vectors."""
 
 import pytest
-from consensus_testing import NetworkingCodecTestFiller
 
+from consensus_testing import NetworkingCodecTestFiller
 from lean_spec.node.snappy.decompress import SnappyDecompressionError
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_varint.py
+++ b/tests/consensus/lstar/networking/test_varint.py
@@ -1,6 +1,7 @@
 """Test vectors for LEB128 varint encoding."""
 
 import pytest
+
 from consensus_testing import NetworkingCodecTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/networking/test_varint_invalid.py
+++ b/tests/consensus/lstar/networking/test_varint_invalid.py
@@ -1,8 +1,8 @@
 """Varint decoder: invalid-input rejection vectors."""
 
 import pytest
-from consensus_testing import NetworkingCodecTestFiller
 
+from consensus_testing import NetworkingCodecTestFiller
 from lean_spec.node.networking.varint import VarintError
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/poseidon/test_permutation_width16.py
+++ b/tests/consensus/lstar/poseidon/test_permutation_width16.py
@@ -7,8 +7,8 @@ must produce identical output states bit-for-bit.
 """
 
 import pytest
-from consensus_testing import PoseidonPermutationTestFiller
 
+from consensus_testing import PoseidonPermutationTestFiller
 from lean_spec.spec.crypto.koalabear import P
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/poseidon/test_permutation_width24.py
+++ b/tests/consensus/lstar/poseidon/test_permutation_width24.py
@@ -7,8 +7,8 @@ the width-16 coverage on the larger parameter set.
 """
 
 import pytest
-from consensus_testing import PoseidonPermutationTestFiller
 
+from consensus_testing import PoseidonPermutationTestFiller
 from lean_spec.spec.crypto.koalabear import P
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/ssz/test_basic_types.py
+++ b/tests/consensus/lstar/ssz/test_basic_types.py
@@ -3,8 +3,8 @@
 from typing import ClassVar
 
 import pytest
-from consensus_testing import SSZTestFiller
 
+from consensus_testing import SSZTestFiller
 from lean_spec.node.networking.enr.eth2 import AttestationSubnets
 from lean_spec.spec.crypto.koalabear import Fp, P
 from lean_spec.spec.ssz import (

--- a/tests/consensus/lstar/ssz/test_consensus_containers.py
+++ b/tests/consensus/lstar/ssz/test_consensus_containers.py
@@ -1,9 +1,9 @@
 """SSZ conformance tests for consensus containers."""
 
 import pytest
+
 from consensus_testing import SSZTestFiller
 from consensus_testing.keys import create_dummy_signature
-
 from lean_spec.spec.forks import AggregationBits, Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import State
 from lean_spec.spec.forks.lstar.containers import (

--- a/tests/consensus/lstar/ssz/test_decode_failure_smoke.py
+++ b/tests/consensus/lstar/ssz/test_decode_failure_smoke.py
@@ -8,8 +8,8 @@ change is covered independently of later negative-path content PRs.
 from typing import ClassVar
 
 import pytest
-from consensus_testing import SSZTestFiller
 
+from consensus_testing import SSZTestFiller
 from lean_spec.spec.ssz import BaseBitlist, Boolean
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/ssz/test_decode_rejections.py
+++ b/tests/consensus/lstar/ssz/test_decode_rejections.py
@@ -10,8 +10,8 @@ the roundtrip contract covered by the basic-types vectors.
 from typing import ClassVar
 
 import pytest
-from consensus_testing import SSZTestFiller
 
+from consensus_testing import SSZTestFiller
 from lean_spec.spec.ssz import BaseBitlist, BaseBitvector, Boolean, Bytes4, Uint32
 from lean_spec.spec.ssz.exceptions import SSZSerializationError, SSZValueError
 

--- a/tests/consensus/lstar/ssz/test_merkleization_boundaries.py
+++ b/tests/consensus/lstar/ssz/test_merkleization_boundaries.py
@@ -3,8 +3,8 @@
 from typing import ClassVar
 
 import pytest
-from consensus_testing import SSZTestFiller
 
+from consensus_testing import SSZTestFiller
 from lean_spec.spec.ssz import BaseBitlist, BaseBitvector, Boolean, SSZList, Uint64
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/ssz/test_networking_containers.py
+++ b/tests/consensus/lstar/ssz/test_networking_containers.py
@@ -1,8 +1,8 @@
 """SSZ conformance tests for networking containers."""
 
 import pytest
-from consensus_testing import SSZTestFiller
 
+from consensus_testing import SSZTestFiller
 from lean_spec.node.networking.reqresp.message import (
     BlocksByRootRequest,
     RequestedBlockRoots,

--- a/tests/consensus/lstar/ssz/test_xmss_containers.py
+++ b/tests/consensus/lstar/ssz/test_xmss_containers.py
@@ -1,9 +1,9 @@
 """SSZ conformance tests for XMSS containers."""
 
 import pytest
+
 from consensus_testing import SSZTestFiller
 from consensus_testing.keys import XmssKeyManager, create_dummy_signature
-
 from lean_spec.spec.crypto.koalabear import Fp
 from lean_spec.spec.crypto.xmss import PublicKey
 from lean_spec.spec.crypto.xmss.constants import TARGET_CONFIG

--- a/tests/consensus/lstar/state_transition/test_block_processing.py
+++ b/tests/consensus/lstar/state_transition/test_block_processing.py
@@ -1,13 +1,13 @@
 """State Transition: Block Processing"""
 
 import pytest
+
 from consensus_testing import (
     BlockSpec,
     StateExpectation,
     StateTransitionTestFiller,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import JustifiedSlots
 from lean_spec.spec.forks.lstar.spec import LstarSpec

--- a/tests/consensus/lstar/state_transition/test_finalization.py
+++ b/tests/consensus/lstar/state_transition/test_finalization.py
@@ -1,6 +1,7 @@
 """State Transition: Finalization"""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -8,7 +9,6 @@ from consensus_testing import (
     StateTransitionTestFiller,
     generate_pre_state,
 )
-
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import (

--- a/tests/consensus/lstar/state_transition/test_genesis.py
+++ b/tests/consensus/lstar/state_transition/test_genesis.py
@@ -8,6 +8,7 @@ Tests for genesis state generation and initialization.
 """
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -15,7 +16,6 @@ from consensus_testing import (
     StateTransitionTestFiller,
     generate_pre_state,
 )
-
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import VALIDATOR_REGISTRY_LIMIT, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import (

--- a/tests/consensus/lstar/state_transition/test_justifiability.py
+++ b/tests/consensus/lstar/state_transition/test_justifiability.py
@@ -11,6 +11,7 @@ independently of the full state transition machinery.
 """
 
 import pytest
+
 from consensus_testing import JustifiabilityTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/state_transition/test_justification.py
+++ b/tests/consensus/lstar/state_transition/test_justification.py
@@ -1,6 +1,7 @@
 """State Transition: Justification"""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -8,7 +9,6 @@ from consensus_testing import (
     StateTransitionTestFiller,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import (
     JustificationRoots,

--- a/tests/consensus/lstar/state_transition/test_slot_monotonicity.py
+++ b/tests/consensus/lstar/state_transition/test_slot_monotonicity.py
@@ -1,12 +1,12 @@
 """State Transition: Block Slot Monotonicity Rejections."""
 
 import pytest
+
 from consensus_testing import (
     BlockSpec,
     StateTransitionTestFiller,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot
 from lean_spec.spec.forks.lstar.spec import LstarSpec
 

--- a/tests/consensus/lstar/sync/test_checkpoint_verify.py
+++ b/tests/consensus/lstar/sync/test_checkpoint_verify.py
@@ -8,6 +8,7 @@ store.
 """
 
 import pytest
+
 from consensus_testing import SyncTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/sync/test_checkpoint_verify_advanced.py
+++ b/tests/consensus/lstar/sync/test_checkpoint_verify_advanced.py
@@ -8,6 +8,7 @@ historical_block_hashes path that real checkpoint-sync downloads hit.
 """
 
 import pytest
+
 from consensus_testing import SyncTestFiller
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/verify_proofs/test_multi_message_invalid.py
+++ b/tests/consensus/lstar/verify_proofs/test_multi_message_invalid.py
@@ -1,6 +1,7 @@
 """Multi-message aggregate proof verification vectors — rejection cases."""
 
 import pytest
+
 from consensus_testing import (
     DropMessageBinding,
     IncrementEmittedSlot,
@@ -9,7 +10,6 @@ from consensus_testing import (
     SwapParticipantPublicKey,
     VerifyMultiMessageProofsTestFiller,
 )
-
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import AggregationError, AttestationData
 from lean_spec.spec.ssz import Bytes32

--- a/tests/consensus/lstar/verify_proofs/test_multi_message_valid.py
+++ b/tests/consensus/lstar/verify_proofs/test_multi_message_valid.py
@@ -1,8 +1,8 @@
 """Multi-message aggregate proof verification vectors — valid cases."""
 
 import pytest
-from consensus_testing import VerifyMultiMessageProofsTestFiller
 
+from consensus_testing import VerifyMultiMessageProofsTestFiller
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import AttestationData
 from lean_spec.spec.ssz import Bytes32

--- a/tests/consensus/lstar/verify_proofs/test_single_message_invalid.py
+++ b/tests/consensus/lstar/verify_proofs/test_single_message_invalid.py
@@ -1,13 +1,13 @@
 """Single-message aggregate proof verification vectors — rejection cases."""
 
 import pytest
+
 from consensus_testing import (
     IncrementEmittedSlot,
     RebindToAlternateHeadRoot,
     SwapParticipantPublicKey,
     VerifySingleMessageProofsTestFiller,
 )
-
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import AggregationError, AttestationData
 from lean_spec.spec.ssz import Bytes32

--- a/tests/consensus/lstar/verify_proofs/test_single_message_recursion.py
+++ b/tests/consensus/lstar/verify_proofs/test_single_message_recursion.py
@@ -1,12 +1,12 @@
 """Single-message aggregate proof verification vectors — recursive aggregation cases."""
 
 import pytest
+
 from consensus_testing import (
     IncrementEmittedSlot,
     RebindToAlternateHeadRoot,
     VerifySingleMessageProofsTestFiller,
 )
-
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import AggregationError, AttestationData
 from lean_spec.spec.ssz import Bytes32

--- a/tests/consensus/lstar/verify_proofs/test_single_message_valid.py
+++ b/tests/consensus/lstar/verify_proofs/test_single_message_valid.py
@@ -1,8 +1,8 @@
 """Single-message aggregate proof verification vectors — valid cases."""
 
 import pytest
-from consensus_testing import VerifySingleMessageProofsTestFiller
 
+from consensus_testing import VerifySingleMessageProofsTestFiller
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import AttestationData
 from lean_spec.spec.ssz import Bytes32

--- a/tests/consensus/lstar/verify_signatures/test_empty_aggregation_bits.py
+++ b/tests/consensus/lstar/verify_signatures/test_empty_aggregation_bits.py
@@ -1,6 +1,7 @@
 """Signature verification: empty aggregation_bits rejection vector."""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
@@ -8,7 +9,6 @@ from consensus_testing import (
     VerifySignaturesTestFiller,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/verify_signatures/test_index_out_of_range.py
+++ b/tests/consensus/lstar/verify_signatures/test_index_out_of_range.py
@@ -1,12 +1,12 @@
 """Signature Verification: Out-of-Range Attestation Validator Index."""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
     VerifySignaturesTestFiller,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/verify_signatures/test_invalid_signatures.py
+++ b/tests/consensus/lstar/verify_signatures/test_invalid_signatures.py
@@ -1,13 +1,13 @@
 """Invalid signature verification tests"""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
     VerifySignaturesTestFiller,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/verify_signatures/test_proposer_index_bounds.py
+++ b/tests/consensus/lstar/verify_signatures/test_proposer_index_bounds.py
@@ -1,13 +1,13 @@
 """Signature verification: proposer-index bounds rejection vector."""
 
 import pytest
+
 from consensus_testing import (
     BlockSpec,
     SetProposerIndex,
     VerifySignaturesTestFiller,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/consensus/lstar/verify_signatures/test_structural_rejections.py
+++ b/tests/consensus/lstar/verify_signatures/test_structural_rejections.py
@@ -10,6 +10,7 @@ builder upholds by construction:
 """
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     AppendPhantomAttestation,
@@ -21,7 +22,6 @@ from consensus_testing import (
     build_anchor,
     generate_pre_state,
 )
-
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Slot, ValidatorIndex
 

--- a/tests/consensus/lstar/verify_signatures/test_valid_signatures.py
+++ b/tests/consensus/lstar/verify_signatures/test_valid_signatures.py
@@ -1,13 +1,13 @@
 """Valid signature verification tests"""
 
 import pytest
+
 from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
     VerifySignaturesTestFiller,
     generate_pre_state,
 )
-
 from lean_spec.spec.forks import Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")

--- a/tests/lean_spec/cli/test_bootstrap.py
+++ b/tests/lean_spec/cli/test_bootstrap.py
@@ -8,12 +8,12 @@ from typing import Callable
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 from Crypto.Hash import keccak
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed, decode_dss_signature
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.cli import CliValidationError, NodeBootstrap, parse_args
 from lean_spec.node.api import ApiServerConfig
 from lean_spec.node.networking.enr.rlp import RLPItem, encode_rlp

--- a/tests/lean_spec/cli/test_run.py
+++ b/tests/lean_spec/cli/test_run.py
@@ -7,8 +7,8 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.cli import NodeBootstrap
 from lean_spec.cli.run import _build_event_source
 from lean_spec.node.genesis import GenesisConfig

--- a/tests/lean_spec/conftest.py
+++ b/tests/lean_spec/conftest.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import State, Store
 from lean_spec.spec.forks.lstar.containers import Block

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from typing import NamedTuple, cast
 
 from consensus_testing.keys import XmssKeyManager
-
 from lean_spec.node.chain.clock import SlotClock
 from lean_spec.node.networking import PeerId
 from lean_spec.node.networking.peer import PeerInfo

--- a/tests/lean_spec/node/sync/test_service.py
+++ b/tests/lean_spec/node/sync/test_service.py
@@ -6,8 +6,8 @@ from types import MappingProxyType
 from typing import cast
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.node.networking import PeerId
 from lean_spec.node.networking.reqresp.message import Status
 from lean_spec.node.storage.database import Database

--- a/tests/lean_spec/node/test_node.py
+++ b/tests/lean_spec/node/test_node.py
@@ -8,8 +8,8 @@ import signal
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.node.api import ApiServerConfig
 from lean_spec.node.node import Node, NodeConfig
 from lean_spec.node.storage.sqlite import SQLiteDatabase

--- a/tests/lean_spec/node/validator/test_registry.py
+++ b/tests/lean_spec/node/validator/test_registry.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 import pytest
 import yaml
-from consensus_testing.keys import XmssKeyManager
 from pydantic import ValidationError
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.node.validator import ValidatorRegistry
 from lean_spec.node.validator.registry import (
     ValidatorEntry,

--- a/tests/lean_spec/node/validator/test_service.py
+++ b/tests/lean_spec/node/validator/test_service.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.node.chain.clock import SlotClock
 from lean_spec.node.sync.block_cache import BlockCache
 from lean_spec.node.sync.peer_manager import PeerManager

--- a/tests/lean_spec/spec/crypto/xmss/test_containers.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_containers.py
@@ -3,9 +3,9 @@
 import json
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 from pydantic import ValidationError
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.spec.crypto.koalabear import P_BYTES
 from lean_spec.spec.crypto.xmss.constants import TEST_CONFIG
 from lean_spec.spec.crypto.xmss.containers import (

--- a/tests/lean_spec/spec/forks/lstar/conftest.py
+++ b/tests/lean_spec/spec/forks/lstar/conftest.py
@@ -8,8 +8,8 @@ timeline, aggregation, and container tests.
 from __future__ import annotations
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.spec.forks import Interval, Slot
 from lean_spec.spec.forks.lstar import Store
 from tests.lean_spec.helpers import TEST_VALIDATOR_INDEX, make_store

--- a/tests/lean_spec/spec/forks/lstar/containers/test_aggregation.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_aggregation.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import (

--- a/tests/lean_spec/spec/forks/lstar/test_aggregation.py
+++ b/tests/lean_spec/spec/forks/lstar/test_aggregation.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from consensus_testing.keys import XmssKeyManager
-
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import AggregationBits, Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import AttestationSignatureEntry

--- a/tests/lean_spec/spec/forks/lstar/test_block_production.py
+++ b/tests/lean_spec/spec/forks/lstar/test_block_production.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from consensus_testing.keys import XmssKeyManager
-
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import (

--- a/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
+++ b/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 from hypothesis import given, settings, strategies as st
 from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import AggregationBits, Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import AttestationSignatureEntry, Store

--- a/tests/lean_spec/spec/forks/lstar/test_validator_duties.py
+++ b/tests/lean_spec/spec/forks/lstar/test_validator_duties.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from consensus_testing.keys import XmssKeyManager
 
+from consensus_testing.keys import XmssKeyManager
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import AttestationSignatureEntry, Store


### PR DESCRIPTION
## Summary

First PR from an audit of `packages/testing/`: packaging and tooling hygiene fixes. No behavior change to fixture generation.

### Latent wheel breaks fixed

- **Package data was undeclared.** The key manager resolves `test_keys/*.json` relative to the module file, and both CLIs load `pytest_ini_files/*.ini` the same way — but `packages/testing/pyproject.toml` declared no `[tool.setuptools.package-data]`, so a built wheel omitted all of them and broke on first use. The committed test-scheme keys, `py.typed`, and both ini files now ship.
- **Explicit `include-package-data = false`.** The pyproject-mode default is `true`, which sweeps *every* file in package directories — verified to pull ~400 MB of locally downloaded prod-scheme keys into the wheel. With the explicit mapping the wheel is 140 KB and contains exactly the committed data; prod keys remain download-on-demand.

### CLI consistency

- The keys CLI is converted from argparse to **click**, matching `fill` and `apitest`, and exposed as a `keys` console script (`uv run keys --download --scheme prod`). The `python -m consensus_testing.keys_cli` invocation still works.
- Error messages in the key manager and the two CI workflows now use the console script instead of the hard-coded module invocation.

### Tooling

- `consensus_testing` and `framework` are registered as first-party packages for import sorting (`known-first-party`); imports across the repo re-sorted accordingly — this is the bulk of the diff and is purely mechanical.
- `Sequence` imported from `collections.abc` instead of the deprecated `typing` location in the two CLI modules.

## Test plan

- `just check` passes (lint, format, ty, codespell, mdformat, lock).
- `uv run keys --help`, `uv run fill --help`, `uv run apitest --help`, and `python -m consensus_testing.keys_cli --help` all work.
- Wheel build verified: contains the 8 committed test-scheme keys, both ini files, and `py.typed`; zero prod keys.
- End-to-end smoke: `uv run fill --fork=lstar` on a single test file fills and emits the fixture JSON correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)