### PR TITLE
refactor(spec): typed rejections replace prose-matched classification

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -74,6 +74,35 @@ If removing the comment would not confuse a future reader, do not write it.
 Never remove or rewrite a comment or docstring unless the documented behavior actually changed.
 Removing valid docs creates diff noise and destroys context.
 
+### 6. One-line docstrings by default
+
+A class, function, or constant of ordinary complexity gets exactly one summary line.
+Add a body only when a non-obvious design choice or invariant must be explained.
+A body that restates what the summary already implies is noise.
+
+### 7. Docstring summaries are noun phrases, not questions
+
+Never open a docstring with "Why ..." or any question-style phrasing.
+Name the thing plainly, the way a human would label it.
+
+### 8. Never enumerate the container's contents in its docstring
+
+Do not list members, variants, or fields in a class or enum docstring.
+The list rots the moment the class changes.
+Stay generic; each member documents itself.
+
+Bad:
+```python
+class RejectionReason(StrEnum):
+    """Why the spec rejects an invalid block, attestation, or wire message."""
+```
+
+Good:
+```python
+class RejectionReason(StrEnum):
+    """Language-neutral reason the spec rejects an invalid input."""
+```
+
 ## Style requirements
 
 ### Sentences

--- a/packages/testing/src/consensus_testing/rejection.py
+++ b/packages/testing/src/consensus_testing/rejection.py
@@ -1,54 +1,7 @@
 """Classification of spec rejections into language-neutral reasons."""
 
-from lean_spec.spec.forks import RejectionReason
+from lean_spec.spec.forks import RejectionReason, SpecRejectionError
 from lean_spec.spec.forks.lstar.containers import AggregationError
-
-_REASON_BY_MESSAGE_FRAGMENT: list[tuple[str, RejectionReason]] = [
-    ("Target slot must be in the future", RejectionReason.BLOCK_SLOT_NOT_IN_FUTURE),
-    ("Block is older than latest header", RejectionReason.BLOCK_OLDER_THAN_LATEST_HEADER),
-    ("Block slot mismatch", RejectionReason.BLOCK_SLOT_MISMATCH),
-    ("Block parent root mismatch", RejectionReason.PARENT_ROOT_MISMATCH),
-    ("Invalid block state root", RejectionReason.STATE_ROOT_MISMATCH),
-    ("Parent state not found", RejectionReason.UNKNOWN_PARENT_BLOCK),
-    ("Sync parent chain", RejectionReason.UNKNOWN_PARENT_BLOCK),
-    ("Proposer index out of range", RejectionReason.PROPOSER_INDEX_OUT_OF_RANGE),
-    ("is not the proposer for slot", RejectionReason.WRONG_PROPOSER),
-    ("Incorrect block proposer", RejectionReason.WRONG_PROPOSER),
-    (
-        "Aggregated attestation must reference at least one validator",
-        RejectionReason.EMPTY_AGGREGATION_BITS,
-    ),
-    ("distinct AttestationData entries", RejectionReason.TOO_MANY_ATTESTATION_DATA),
-    ("duplicate AttestationData", RejectionReason.DUPLICATE_ATTESTATION_DATA),
-    ("Unknown source block", RejectionReason.UNKNOWN_SOURCE_BLOCK),
-    ("Unknown target block", RejectionReason.UNKNOWN_TARGET_BLOCK),
-    ("Unknown head block", RejectionReason.UNKNOWN_HEAD_BLOCK),
-    ("Source checkpoint slot must not exceed target", RejectionReason.SOURCE_AFTER_TARGET),
-    ("Head checkpoint must not be older than target", RejectionReason.HEAD_OLDER_THAN_TARGET),
-    ("Source checkpoint slot mismatch", RejectionReason.SOURCE_SLOT_MISMATCH),
-    ("Target checkpoint slot mismatch", RejectionReason.TARGET_SLOT_MISMATCH),
-    ("Head checkpoint slot mismatch", RejectionReason.HEAD_SLOT_MISMATCH),
-    (
-        "Source checkpoint must be ancestor of target",
-        RejectionReason.SOURCE_NOT_ANCESTOR_OF_TARGET,
-    ),
-    (
-        "Target checkpoint must be ancestor of head",
-        RejectionReason.TARGET_NOT_ANCESTOR_OF_HEAD,
-    ),
-    ("Attestation too far in future", RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE),
-    ("not found in state", RejectionReason.VALIDATOR_NOT_IN_STATE),
-    ("Validator index out of range", RejectionReason.VALIDATOR_INDEX_OUT_OF_RANGE),
-    ("Signature verification failed", RejectionReason.INVALID_SIGNATURE),
-    ("Block proof verification failed", RejectionReason.INVALID_SIGNATURE),
-    ("Anchor block state root must match", RejectionReason.ANCHOR_STATE_ROOT_MISMATCH),
-]
-"""
-Ordered mapping from spec rejection messages to reasons.
-
-The first fragment contained in the exception message wins.
-Fragments mirror the spec's assertion messages one-to-one.
-"""
 
 
 def classify_rejection(exception: Exception) -> RejectionReason:
@@ -62,19 +15,18 @@ def classify_rejection(exception: Exception) -> RejectionReason:
         The reason emitted into the test vector.
 
     Raises:
-        ValueError: If the rejection is not in the vocabulary yet.
+        ValueError: If the exception carries no reason.
     """
+    # Typed rejections carry their reason directly.
+    if isinstance(exception, SpecRejectionError):
+        return exception.reason
+
     # Aggregate proof failures carry library-specific messages.
     # The type alone identifies them as signature verification failures.
     if isinstance(exception, AggregationError):
         return RejectionReason.INVALID_SIGNATURE
 
-    message = str(exception)
-    for message_fragment, reason in _REASON_BY_MESSAGE_FRAGMENT:
-        if message_fragment in message:
-            return reason
-
     raise ValueError(
-        f"no rejection reason mapped for {type(exception).__name__}: {message}\n"
-        "Add the new rejection to the reason vocabulary and this mapping."
+        f"no rejection reason carried by {type(exception).__name__}: {exception}\n"
+        "Spec rejections must raise the typed rejection error with a reason."
     )

--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -234,3 +234,34 @@ class BaseTestSpec(CamelModel):
                 f"but the test expects {self.expected_rejection.reason}"
             )
         return classified_reason
+
+    def assert_decode_rejection(
+        self,
+        exception_raised: Exception | None,
+        decoder_name: str,
+    ) -> RejectionReason:
+        """
+        Check a decode-failure outcome and resolve the emitted reason.
+
+        Decode failures never reach the rejection classifier.
+        The authored expectation is the only source of the emitted reason.
+
+        Args:
+            exception_raised: The exception the decoder raised, or None on success.
+            decoder_name: Decoder label for failure messages.
+
+        Returns:
+            The reason emitted into the test vector.
+
+        Raises:
+            ValueError: When the authored expectation is missing.
+            AssertionError: When decoding succeeds or contradicts the expectation.
+        """
+        if self.expected_rejection is None:
+            raise ValueError("decode-failure vectors require expected_rejection to be set")
+        if exception_raised is None:
+            raise AssertionError(
+                f"Expected {decoder_name} to reject the input, but decoding succeeded"
+            )
+        self.assert_expected_outcome(exception_raised)
+        return self.expected_rejection.reason

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -26,9 +26,16 @@ from consensus_testing.test_types import (
 from lean_spec.config import LEAN_ENV
 from lean_spec.node.chain.clock import SlotClock
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Interval, RejectionReason, Slot, ValidatorIndex
+from lean_spec.spec.forks import (
+    Interval,
+    RejectionReason,
+    Slot,
+    SpecRejectionError,
+    ValidatorIndex,
+)
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestations,
+    AggregationError,
     Block,
     BlockBody,
     SignedAggregatedAttestation,
@@ -302,14 +309,15 @@ class ForkChoiceTest(BaseTestSpec):
                                 )
                             block_registry[step.block.label] = filled_block
 
-                        # Advance time to the block's slot.
-                        # Store rejects blocks from the future.
+                        # Advance time to the block's slot unless the test
+                        # delivers the block ahead of the store clock.
                         # This tick includes a block (has proposal).
                         # Always act as aggregator to ensure gossip signatures are aggregated
-                        target_interval = Interval.from_slot(filled_block.slot)
-                        store, _ = spec.on_tick(
-                            store, target_interval, has_proposal=True, is_aggregator=True
-                        )
+                        if step.tick_to_slot:
+                            target_interval = Interval.from_slot(filled_block.slot)
+                            store, _ = spec.on_tick(
+                                store, target_interval, has_proposal=True, is_aggregator=True
+                            )
 
                         # Process the block through Store.
                         # This validates, applies state transition, and updates the store's head.
@@ -360,9 +368,10 @@ class ForkChoiceTest(BaseTestSpec):
                         old_head=old_head,
                     )
 
-            except Exception as exception:
+            except (SpecRejectionError, AggregationError) as exception:
                 # Handle expected failures.
-                # Steps marked valid=False should raise exceptions.
+                # Steps marked valid=False should raise spec rejections.
+                # Harness bugs raise other types and propagate unswallowed.
                 if step.valid:
                     raise AssertionError(
                         f"Step {step_index} ({type(step).__name__}) "
@@ -404,6 +413,7 @@ class ForkChoiceTest(BaseTestSpec):
                             rejection_reason=rejection_reason,
                             checks=step.checks,
                             store_snapshot=store_snapshot,
+                            tick_to_slot=step.tick_to_slot,
                             block=filled_block,
                             block_root_label=step.block.label,
                         )
@@ -462,18 +472,19 @@ class ForkChoiceTest(BaseTestSpec):
             "steps must be empty when anchor_valid is False: "
             "Store.from_anchor is expected to fail before any step can run"
         )
+        # Why: a vector saying only "reject this anchor" lets a client
+        # reject for the wrong reason and still pass.
+        assert self.expected_rejection is not None, (
+            "anchor_valid=False requires expected_rejection to be set"
+        )
         try:
             spec.create_store(
                 self.anchor_state,
                 anchor_block,
                 validator_index=ValidatorIndex(0),
             )
-        except AssertionError as exception:
-            expected_substring = (
-                self.expected_rejection.message_substring
-                if self.expected_rejection is not None
-                else None
-            )
+        except SpecRejectionError as exception:
+            expected_substring = self.expected_rejection.message_substring
             if expected_substring is not None and expected_substring not in str(exception):
                 raise AssertionError(
                     "Store.from_anchor failed with wrong error.\n"

--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -774,32 +774,12 @@ class NetworkingCodecTest(BaseTestSpec):
     def generate(self) -> NetworkingCodecFixture:
         """Run the codec case and emit the vector."""
         if isinstance(self.codec, DecodeFailure):
-            return self._generate_decode_failure(self.codec)
-        return NetworkingCodecFixture(codec=self.codec, output=self.codec.run())
-
-    def _generate_decode_failure(self, decode_failure: DecodeFailure) -> NetworkingCodecFixture:
-        """
-        Assert the decoder rejects the malformed input and emit the rejection vector.
-
-        Raises:
-            AssertionError: If the decoder succeeds or the rejection
-                contradicts the authored expectation.
-            ValueError: If the expected rejection is unset.
-        """
-        if self.expected_rejection is None:
-            raise ValueError("decode_failure codec requires expected_rejection to be set")
-
-        exception_raised = decode_failure.attempt_decode()
-        if exception_raised is None:
-            raise AssertionError(
-                f"Expected {decode_failure.decoder!r} decode to reject the input, "
-                "but decode succeeded"
+            # Emit the language-neutral reason clients assert against.
+            return NetworkingCodecFixture(
+                codec=self.codec,
+                output=DecodeFailureOutput(decoder=self.codec.decoder),
+                rejection_reason=self.assert_decode_rejection(
+                    self.codec.attempt_decode(), self.codec.decoder
+                ),
             )
-        self.assert_expected_outcome(exception_raised)
-
-        # Emit the language-neutral reason clients assert against.
-        return NetworkingCodecFixture(
-            codec=decode_failure,
-            output=DecodeFailureOutput(decoder=decode_failure.decoder),
-            rejection_reason=self.expected_rejection.reason,
-        )
+        return NetworkingCodecFixture(codec=self.codec, output=self.codec.run())

--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -140,7 +140,6 @@ class SSZTest(BaseTestSpec):
             AssertionError: If the decoder succeeds.
             ValueError: If `raw_bytes` is missing.
         """
-        assert self.expected_rejection is not None
         if self.raw_bytes is None:
             raise ValueError("raw_bytes is required when expected_rejection is set")
 
@@ -152,18 +151,13 @@ class SSZTest(BaseTestSpec):
         except Exception as exception:
             exception_raised = exception
 
-        if exception_raised is None:
-            raise AssertionError(
-                f"Expected {decoder.__name__}.decode_bytes to reject the input, "
-                "but decode succeeded"
-            )
-        self.assert_expected_outcome(exception_raised)
-
         return SSZFixture(
             type_name=self.type_name,
             value=self.value,
             raw_bytes=self.raw_bytes,
             serialized="0x" + raw.hex(),
             root="",
-            rejection_reason=self.expected_rejection.reason,
+            rejection_reason=self.assert_decode_rejection(
+                exception_raised, f"{decoder.__name__}.decode_bytes"
+            ),
         )

--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -2,14 +2,14 @@
 
 from typing import ClassVar
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from consensus_testing.genesis import generate_pre_state
 from consensus_testing.keys import XmssKeyManager
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
 from consensus_testing.test_types import AggregatedAttestationSpec, BlockSpec, StateExpectation
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import AggregationBits
+from lean_spec.spec.forks import AggregationBits, SpecRejectionError
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
     AggregatedAttestations,
@@ -62,6 +62,10 @@ class StateTransitionTest(BaseTestSpec):
     - Invalid blocks
 
     Tests everything through the main state_transition() public API.
+
+    The state transition assumes signatures were verified upstream.
+    Invalid-signature scenarios belong to the fork choice and signature
+    verification formats, never to this one.
     """
 
     format_name: ClassVar[str] = "state_transition_test"
@@ -93,6 +97,19 @@ class StateTransitionTest(BaseTestSpec):
     Only fields explicitly set in the StateExpectation will be validated.
     If None, no post-state validation is performed (e.g., for invalid tests).
     """
+
+    @model_validator(mode="after")
+    def validate_signatures_are_out_of_scope(self) -> "StateTransitionTest":
+        """Reject signature-flavored attestation fields at construction."""
+        for block_spec in self.blocks:
+            for attestation_spec in block_spec.attestations or []:
+                if not attestation_spec.valid_signature or attestation_spec.signer_ids is not None:
+                    raise ValueError(
+                        "state transition assumes signatures were verified upstream; "
+                        "author invalid-signature scenarios through the fork choice "
+                        "or signature verification formats"
+                    )
+        return self
 
     def generate(self) -> StateTransitionFixture:
         """
@@ -140,7 +157,7 @@ class StateTransitionTest(BaseTestSpec):
                     state = spec.state_transition(state, block=block)
 
             actual_post_state = state
-        except (AssertionError, ValueError) as exception:
+        except SpecRejectionError as exception:
             exception_raised = exception
 
         # Validate exception expectations
@@ -316,13 +333,6 @@ class StateTransitionTest(BaseTestSpec):
         payloads: dict[AttestationData, set[SingleMessageAggregate]] = {}
 
         for spec in attestation_specs:
-            if not spec.valid_signature:
-                raise NotImplementedError(
-                    "valid_signature=False not yet supported in StateTransitionTest"
-                )
-            if spec.signer_ids is not None:
-                raise NotImplementedError("signer_ids not yet supported in StateTransitionTest")
-
             attestation_data = spec.build_attestation_data(block_registry, state.latest_justified)
             proof = key_manager.sign_and_aggregate(spec.validator_indices, attestation_data)
             payloads.setdefault(attestation_data, set()).add(proof)

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
@@ -17,6 +17,7 @@ from lean_spec.spec.forks import (
     ValidatorIndex,
 )
 from lean_spec.spec.forks.lstar.containers import (
+    AggregationError,
     AttestationData,
     MultiMessageAggregate,
     SingleMessageAggregate,
@@ -251,11 +252,11 @@ class VerifySingleMessageProofsTest(BaseTestSpec):
         # Phase 3: self-verify and assert the outcome against the configured expectation.
         candidate = SingleMessageAggregate(participants=aggregation_bits, proof=proof)
         exception_raised: Exception | None = None
-        # Catch any exception so a verifier raising the wrong type still produces
-        # a comparable "expected X got Y" message instead of crashing the filler.
+        # Why this catch: the aggregation layer raises exactly one error type.
+        # Anything else is a harness bug and propagates unswallowed.
         try:
             candidate.verify(public_keys, message, slot)
-        except Exception as exception:
+        except AggregationError as exception:
             exception_raised = exception
         self.assert_expected_outcome(exception_raised)
 
@@ -506,14 +507,14 @@ class VerifyMultiMessageProofsTest(BaseTestSpec):
 
         # Phase 4: self-verify and assert the outcome against the configured expectation.
         exception_raised: Exception | None = None
-        # Catch any exception so a verifier raising the wrong type still produces
-        # a comparable "expected X got Y" message instead of crashing the filler.
+        # Why this catch: the aggregation layer raises exactly one error type.
+        # Anything else is a harness bug and propagates unswallowed.
         try:
             merged.verify(
                 public_keys_per_message=public_keys_per_message,
                 messages=list(zip(messages, slots, strict=True)),
             )
-        except Exception as exception:
+        except AggregationError as exception:
             exception_raised = exception
         self.assert_expected_outcome(exception_raised)
 

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -11,7 +11,13 @@ from consensus_testing.keys import XmssKeyManager
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
 from consensus_testing.test_types import BlockSpec
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import AggregationBits, Checkpoint, Slot, ValidatorIndex
+from lean_spec.spec.forks import (
+    AggregationBits,
+    Checkpoint,
+    Slot,
+    SpecRejectionError,
+    ValidatorIndex,
+)
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
     AggregatedAttestations,
@@ -172,7 +178,7 @@ class VerifySignaturesTest(BaseTestSpec):
         # Verify signatures
         try:
             LstarSpec().verify_signatures(signed_block, self.anchor_state.validators)
-        except AssertionError as exception:
+        except SpecRejectionError as exception:
             exception_raised = exception
 
         # Validate exception expectations

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -39,10 +39,8 @@ class BaseForkChoiceStep(CamelModel):
     """
     Expected rejection when valid=False.
 
-    When set, the classified reason must match and the exception message
-    must contain the optional substring.
-    When None and valid=False, any spec rejection is accepted.
-    Ignored when valid=True.
+    The classified reason must match.
+    The exception message must contain the optional substring.
     Never serialized: the emitted contract is the filled step's reason field.
     """
 
@@ -54,6 +52,18 @@ class BaseForkChoiceStep(CamelModel):
     these checks after executing the step.
     Only fields that are explicitly set will be validated.
     """
+
+    @model_validator(mode="after")
+    def validate_rejection_is_declared(self) -> "BaseForkChoiceStep":
+        """
+        Require a declared rejection on every step expected to fail.
+
+        Why: a vector saying only "reject this" lets a client reject
+        for the wrong reason and still pass.
+        """
+        if not self.valid and self.expected_rejection is None:
+            raise ValueError("steps with valid=False must declare their expected_rejection")
+        return self
 
 
 class TickStep(BaseForkChoiceStep):
@@ -105,6 +115,15 @@ class BlockStep(BaseForkChoiceStep):
 
     Tests provide a BlockSpec with required slot and optional field overrides.
     Generation fills a complete Block and emits it in the filled step.
+    """
+
+    tick_to_slot: bool = True
+    """
+    Whether to advance the store clock to the block's slot before import.
+
+    Default True matches a node whose clock reached the slot already.
+    Set False to deliver the block while the store clock lags behind,
+    pinning how clients treat a block ahead of their local time.
     """
 
 
@@ -213,6 +232,9 @@ class FilledBlockStep(BaseFilledStep):
 
     step_type: Literal["block"] = "block"
     """Discriminator field for serialization."""
+
+    tick_to_slot: bool
+    """Whether the store clock advanced to the block's slot before import."""
 
     block: Block
     """The filled Block, processed through the spec."""

--- a/src/lean_spec/spec/forks/__init__.py
+++ b/src/lean_spec/spec/forks/__init__.py
@@ -26,7 +26,7 @@ from lean_spec.spec.forks.lstar.containers import (
     ValidatorIndices,
     Validators,
 )
-from lean_spec.spec.forks.lstar.rejection_reason import RejectionReason
+from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
 from lean_spec.spec.forks.lstar.spec import LstarSpec, LstarStore
 from lean_spec.spec.forks.protocol import ForkProtocol, SpecStateType, SpecStoreType
 from lean_spec.spec.forks.registry import ForkRegistry
@@ -61,6 +61,7 @@ __all__ = [
     "LstarSpec",
     "LstarStore",
     "RejectionReason",
+    "SpecRejectionError",
     "SignedAggregatedAttestation",
     "SignedAttestation",
     "SignedBlock",

--- a/src/lean_spec/spec/forks/lstar/containers/participation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/participation.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 
 from lean_spec.spec.forks.lstar.config import VALIDATOR_REGISTRY_LIMIT
 from lean_spec.spec.forks.lstar.containers.identifiers import ValidatorIndex, ValidatorIndices
+from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
 from lean_spec.spec.ssz import Boolean
 from lean_spec.spec.ssz.bitfields import BaseBitlist
 
@@ -32,11 +33,17 @@ class AggregationBits(BaseBitlist):
 
         # Require at least one validator for a valid aggregation.
         if not ids:
-            raise AssertionError("Aggregated attestation must reference at least one validator")
+            raise SpecRejectionError(
+                RejectionReason.EMPTY_AGGREGATION_BITS,
+                "Aggregated attestation must reference at least one validator",
+            )
 
         # Validate bounds: max index must be within registry limit.
         if (max_id := max(ids)) >= cls.LIMIT:
-            raise AssertionError("Validator index out of range for aggregation bits")
+            raise SpecRejectionError(
+                RejectionReason.VALIDATOR_INDEX_OUT_OF_RANGE,
+                "Validator index out of range for aggregation bits",
+            )
 
         # Build bit list:
         # - True at positions present in indices,
@@ -56,6 +63,9 @@ class AggregationBits(BaseBitlist):
         # Extract indices where bit is set; fail if none found.
         indices = [ValidatorIndex(i) for i, bit in enumerate(self.data) if bit]
         if not indices:
-            raise AssertionError("Aggregated attestation must reference at least one validator")
+            raise SpecRejectionError(
+                RejectionReason.EMPTY_AGGREGATION_BITS,
+                "Aggregated attestation must reference at least one validator",
+            )
 
         return ValidatorIndices(data=indices)

--- a/src/lean_spec/spec/forks/lstar/errors.py
+++ b/src/lean_spec/spec/forks/lstar/errors.py
@@ -1,15 +1,10 @@
-"""Language-neutral rejection reasons for invalid consensus inputs."""
+"""Rejection reasons and the typed error that carries them."""
 
 from enum import StrEnum
 
 
 class RejectionReason(StrEnum):
-    """
-    Why the spec rejects an invalid block, attestation, or wire message.
-
-    Test vectors emit these instead of Python exception details.
-    Clients in any language assert the reason, not an English message.
-    """
+    """Language-neutral reason the spec rejects an invalid input."""
 
     # Block validation
     BLOCK_SLOT_NOT_IN_FUTURE = "BLOCK_SLOT_NOT_IN_FUTURE"
@@ -87,7 +82,10 @@ class RejectionReason(StrEnum):
 
     # Cryptographic verification
     INVALID_SIGNATURE = "INVALID_SIGNATURE"
-    """A signature or aggregate proof fails cryptographic verification."""
+    """An attestation signature or aggregate proof fails cryptographic verification."""
+
+    INVALID_BLOCK_PROOF = "INVALID_BLOCK_PROOF"
+    """The block's multi-message aggregate proof fails verification."""
 
     # Anchor initialization
     ANCHOR_STATE_ROOT_MISMATCH = "ANCHOR_STATE_ROOT_MISMATCH"
@@ -96,3 +94,22 @@ class RejectionReason(StrEnum):
     # Wire decoding
     DECODE_ERROR = "DECODE_ERROR"
     """The input bytes cannot be decoded into the expected structure."""
+
+
+class SpecRejectionError(AssertionError):
+    """
+    A rejection carrying its language-neutral reason.
+
+    Subclassing the assertion error keeps existing rejection handlers working.
+    """
+
+    def __init__(self, reason: RejectionReason, message: str) -> None:
+        """
+        Bind the rejection to its reason.
+
+        Args:
+            reason: Language-neutral reason clients assert against.
+            message: Human-readable explanation for logs and debugging.
+        """
+        super().__init__(message)
+        self.reason = reason

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -25,6 +25,7 @@ from lean_spec.spec.forks.lstar.containers import (
     State,
     ValidatorIndex,
 )
+from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
 from lean_spec.spec.forks.protocol import SpecBlockType, SpecStateType
 from lean_spec.spec.observability import (
     observe_on_attestation,
@@ -90,9 +91,11 @@ class ForkChoiceMixin(LstarSpecBase):
         # Check that the block actually points to this state.
         #
         # If this fails, the caller has supplied inconsistent inputs.
-        assert anchor_block.state_root == computed_state_root, (
-            "Anchor block state root must match anchor state hash"
-        )
+        if anchor_block.state_root != computed_state_root:
+            raise SpecRejectionError(
+                RejectionReason.ANCHOR_STATE_ROOT_MISMATCH,
+                "Anchor block state root must match anchor state hash",
+            )
 
         # Compute the SSZ root of the anchor block itself.
         #
@@ -185,26 +188,36 @@ class ForkChoiceMixin(LstarSpecBase):
         # Availability Check
         #
         # We cannot count a vote if we haven't seen the blocks involved.
-        assert source_checkpoint.root in store.blocks, (
-            f"Unknown source block: {source_checkpoint.root.hex()}"
-        )
-        assert target_checkpoint.root in store.blocks, (
-            f"Unknown target block: {target_checkpoint.root.hex()}"
-        )
-        assert head_checkpoint.root in store.blocks, (
-            f"Unknown head block: {head_checkpoint.root.hex()}"
-        )
+        if source_checkpoint.root not in store.blocks:
+            raise SpecRejectionError(
+                RejectionReason.UNKNOWN_SOURCE_BLOCK,
+                f"Unknown source block: {source_checkpoint.root.hex()}",
+            )
+        if target_checkpoint.root not in store.blocks:
+            raise SpecRejectionError(
+                RejectionReason.UNKNOWN_TARGET_BLOCK,
+                f"Unknown target block: {target_checkpoint.root.hex()}",
+            )
+        if head_checkpoint.root not in store.blocks:
+            raise SpecRejectionError(
+                RejectionReason.UNKNOWN_HEAD_BLOCK,
+                f"Unknown head block: {head_checkpoint.root.hex()}",
+            )
 
         # Topology Check
         #
         # History is linear and monotonic: source <= target <= head.
         # The second check implies head >= source by transitivity.
-        assert source_checkpoint.slot <= target_checkpoint.slot, (
-            "Source checkpoint slot must not exceed target"
-        )
-        assert head_checkpoint.slot >= target_checkpoint.slot, (
-            "Head checkpoint must not be older than target"
-        )
+        if source_checkpoint.slot > target_checkpoint.slot:
+            raise SpecRejectionError(
+                RejectionReason.SOURCE_AFTER_TARGET,
+                "Source checkpoint slot must not exceed target",
+            )
+        if head_checkpoint.slot < target_checkpoint.slot:
+            raise SpecRejectionError(
+                RejectionReason.HEAD_OLDER_THAN_TARGET,
+                "Head checkpoint must not be older than target",
+            )
 
         # Consistency Check
         #
@@ -212,20 +225,33 @@ class ForkChoiceMixin(LstarSpecBase):
         source_block = store.blocks[source_checkpoint.root]
         target_block = store.blocks[target_checkpoint.root]
         head_block = store.blocks[head_checkpoint.root]
-        assert source_block.slot == source_checkpoint.slot, "Source checkpoint slot mismatch"
-        assert target_block.slot == target_checkpoint.slot, "Target checkpoint slot mismatch"
-        assert head_block.slot == head_checkpoint.slot, "Head checkpoint slot mismatch"
+        if source_block.slot != source_checkpoint.slot:
+            raise SpecRejectionError(
+                RejectionReason.SOURCE_SLOT_MISMATCH, "Source checkpoint slot mismatch"
+            )
+        if target_block.slot != target_checkpoint.slot:
+            raise SpecRejectionError(
+                RejectionReason.TARGET_SLOT_MISMATCH, "Target checkpoint slot mismatch"
+            )
+        if head_block.slot != head_checkpoint.slot:
+            raise SpecRejectionError(
+                RejectionReason.HEAD_SLOT_MISMATCH, "Head checkpoint slot mismatch"
+            )
 
         # Ancestry Check
         #
         # Why: fork-choice weight accrues to every ancestor of the attested head.
         # A sibling head would steer that weight onto a non-canonical branch.
-        assert self._checkpoint_is_ancestor(store, source_checkpoint, target_checkpoint), (
-            "Source checkpoint must be ancestor of target"
-        )
-        assert self._checkpoint_is_ancestor(store, target_checkpoint, head_checkpoint), (
-            "Target checkpoint must be ancestor of head"
-        )
+        if not self._checkpoint_is_ancestor(store, source_checkpoint, target_checkpoint):
+            raise SpecRejectionError(
+                RejectionReason.SOURCE_NOT_ANCESTOR_OF_TARGET,
+                "Source checkpoint must be ancestor of target",
+            )
+        if not self._checkpoint_is_ancestor(store, target_checkpoint, head_checkpoint):
+            raise SpecRejectionError(
+                RejectionReason.TARGET_NOT_ANCESTOR_OF_HEAD,
+                "Target checkpoint must be ancestor of head",
+            )
 
         # Time Check
         #
@@ -237,9 +263,10 @@ class ForkChoiceMixin(LstarSpecBase):
         # honest validator.
         attestation_start_interval = Interval.from_slot(attestation_data.slot)
         gossip_disparity = Interval(int(GOSSIP_DISPARITY_INTERVALS))
-        assert attestation_start_interval <= store.time + gossip_disparity, (
-            "Attestation too far in future"
-        )
+        if attestation_start_interval > store.time + gossip_disparity:
+            raise SpecRejectionError(
+                RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE, "Attestation too far in future"
+            )
 
     def on_gossip_attestation(
         self,
@@ -286,15 +313,20 @@ class ForkChoiceMixin(LstarSpecBase):
                 f"No state available to verify attestation signature for target block "
                 f"{attestation_data.target.root.hex()}"
             )
-            assert validator_index.is_within_registry(Uint64(len(key_state.validators))), (
-                f"Validator {validator_index} not found in state "
-                f"{attestation_data.target.root.hex()}"
-            )
+            if not validator_index.is_within_registry(Uint64(len(key_state.validators))):
+                raise SpecRejectionError(
+                    RejectionReason.VALIDATOR_NOT_IN_STATE,
+                    f"Validator {validator_index} not found in state "
+                    f"{attestation_data.target.root.hex()}",
+                )
             public_key = key_state.validators[validator_index].get_attestation_public_key()
 
-            assert TARGET_SIGNATURE_SCHEME.verify(
+            if not TARGET_SIGNATURE_SCHEME.verify(
                 public_key, attestation_data.slot, hash_tree_root(attestation_data), signature
-            ), "Signature verification failed"
+            ):
+                raise SpecRejectionError(
+                    RejectionReason.INVALID_SIGNATURE, "Signature verification failed"
+                )
 
             # Non-aggregator nodes validate and drop — they never store gossip signatures.
             if not is_aggregator:
@@ -347,10 +379,12 @@ class ForkChoiceMixin(LstarSpecBase):
         # Ensure all participants exist in the active set
         validators = key_state.validators
         for validator_index in validator_indices:
-            assert validator_index.is_within_registry(Uint64(len(validators))), (
-                f"Validator {validator_index} not found in state "
-                f"{attestation_data.target.root.hex()}"
-            )
+            if not validator_index.is_within_registry(Uint64(len(validators))):
+                raise SpecRejectionError(
+                    RejectionReason.VALIDATOR_NOT_IN_STATE,
+                    f"Validator {validator_index} not found in state "
+                    f"{attestation_data.target.root.hex()}",
+                )
 
         # Prepare public keys for verification
         public_keys = [
@@ -414,23 +448,29 @@ class ForkChoiceMixin(LstarSpecBase):
             # The parent state must exist before processing this block.
             # If missing, the node must sync the parent chain first.
             parent_state = store.states.get(block.parent_root)
-            assert parent_state is not None, (
-                f"Parent state not found (root={block.parent_root.hex()}). "
-                f"Sync parent chain before processing block at slot {block.slot}."
-            )
+            if parent_state is None:
+                raise SpecRejectionError(
+                    RejectionReason.UNKNOWN_PARENT_BLOCK,
+                    f"Parent state not found (root={block.parent_root.hex()}). "
+                    f"Sync parent chain before processing block at slot {block.slot}.",
+                )
 
             # The block body constrains how many distinct AttestationData
             # entries it may carry.
             aggregated_attestations = block.body.attestations
             attestation_data_set = {attestation.data for attestation in aggregated_attestations}
-            assert len(attestation_data_set) == len(aggregated_attestations), (
-                "Block contains duplicate AttestationData entries; "
-                "each AttestationData must appear at most once"
-            )
-            assert len(attestation_data_set) <= int(MAX_ATTESTATIONS_DATA), (
-                f"Block contains {len(attestation_data_set)} distinct AttestationData entries; "
-                f"maximum is {MAX_ATTESTATIONS_DATA}"
-            )
+            if len(attestation_data_set) != len(aggregated_attestations):
+                raise SpecRejectionError(
+                    RejectionReason.DUPLICATE_ATTESTATION_DATA,
+                    "Block contains duplicate AttestationData entries; "
+                    "each AttestationData must appear at most once",
+                )
+            if len(attestation_data_set) > int(MAX_ATTESTATIONS_DATA):
+                raise SpecRejectionError(
+                    RejectionReason.TOO_MANY_ATTESTATION_DATA,
+                    f"Block contains {len(attestation_data_set)} distinct AttestationData "
+                    f"entries; maximum is {MAX_ATTESTATIONS_DATA}",
+                )
 
             # Validate cryptographic signatures.
             #

--- a/src/lean_spec/spec/forks/lstar/signatures.py
+++ b/src/lean_spec/spec/forks/lstar/signatures.py
@@ -9,6 +9,7 @@ from lean_spec.spec.forks.lstar.containers import (
     Slot,
     Validators,
 )
+from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
 from lean_spec.spec.ssz import Bytes32, Uint64
 
 
@@ -58,9 +59,11 @@ class SignatureMixin(LstarSpecBase):
         for aggregated_attestation in aggregated_attestations:
             validator_indices = aggregated_attestation.aggregation_bits.to_validator_indices()
             for validator_index in validator_indices:
-                assert validator_index.is_within_registry(num_validators), (
-                    "Validator index out of range"
-                )
+                if not validator_index.is_within_registry(num_validators):
+                    raise SpecRejectionError(
+                        RejectionReason.VALIDATOR_INDEX_OUT_OF_RANGE,
+                        "Validator index out of range",
+                    )
 
             public_keys_per_message.append(
                 [
@@ -81,7 +84,10 @@ class SignatureMixin(LstarSpecBase):
         # This proves the proposer endorsed this specific block.
         # It is a single-participant entry, distinct from the vote entries.
         proposer_index = block.proposer_index
-        assert proposer_index.is_within_registry(num_validators), "Proposer index out of range"
+        if not proposer_index.is_within_registry(num_validators):
+            raise SpecRejectionError(
+                RejectionReason.PROPOSER_INDEX_OUT_OF_RANGE, "Proposer index out of range"
+            )
 
         public_keys_per_message.append([validators[proposer_index].get_proposal_public_key()])
         message_bindings.append((hash_tree_root(block), block.slot))
@@ -92,6 +98,9 @@ class SignatureMixin(LstarSpecBase):
                 messages=message_bindings,
             )
         except AggregationError as exception:
-            raise AssertionError(f"Block proof verification failed: {exception}") from exception
+            raise SpecRejectionError(
+                RejectionReason.INVALID_BLOCK_PROOF,
+                f"Block proof verification failed: {exception}",
+            ) from exception
 
         return True

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -19,6 +19,7 @@ from lean_spec.spec.forks.lstar.containers import (
     ValidatorIndex,
     Validators,
 )
+from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
 from lean_spec.spec.forks.protocol import SpecStateType
 from lean_spec.spec.observability import (
     observe_state_transition,
@@ -134,7 +135,10 @@ class StateTransitionMixin(LstarSpecBase):
             AssertionError: If target_slot is not in the future.
         """
         # The target must be strictly greater than the current slot.
-        assert state.slot < target_slot, "Target slot must be in the future"
+        if state.slot >= target_slot:
+            raise SpecRejectionError(
+                RejectionReason.BLOCK_SLOT_NOT_IN_FUTURE, "Target slot must be in the future"
+            )
 
         # Step through each missing slot.
         while state.slot < target_slot:
@@ -192,23 +196,31 @@ class StateTransitionMixin(LstarSpecBase):
         # Verify the block corresponds to the current state slot.
         #
         # To move to this slot, we have processed any intermediate slots before.
-        assert block.slot == state.slot, "Block slot mismatch"
+        if block.slot != state.slot:
+            raise SpecRejectionError(RejectionReason.BLOCK_SLOT_MISMATCH, "Block slot mismatch")
 
         # The block must be newer than the current latest header.
-        assert block.slot > parent_header.slot, "Block is older than latest header"
+        if block.slot <= parent_header.slot:
+            raise SpecRejectionError(
+                RejectionReason.BLOCK_OLDER_THAN_LATEST_HEADER, "Block is older than latest header"
+            )
 
         # Verify the block proposer.
         #
         # Ensures the block was proposed by the assigned validator for this round.
-        assert block.proposer_index == ValidatorIndex.proposer_for_slot(
+        if block.proposer_index != ValidatorIndex.proposer_for_slot(
             slot=state.slot,
             num_validators=Uint64(len(state.validators)),
-        ), "Incorrect block proposer"
+        ):
+            raise SpecRejectionError(RejectionReason.WRONG_PROPOSER, "Incorrect block proposer")
 
         # Verify the chain link.
         #
         # The block must cryptographically point to the known parent.
-        assert block.parent_root == parent_root, "Block parent root mismatch"
+        if block.parent_root != parent_root:
+            raise SpecRejectionError(
+                RejectionReason.PARENT_ROOT_MISMATCH, "Block parent root mismatch"
+            )
 
         # Checkpoint Updates
 
@@ -569,6 +581,8 @@ class StateTransitionMixin(LstarSpecBase):
             # Validate that the block's state root matches the computed state
             computed_state_root = hash_tree_root(new_state)
             if block.state_root != computed_state_root:
-                raise AssertionError("Invalid block state root")
+                raise SpecRejectionError(
+                    RejectionReason.STATE_ROOT_MISMATCH, "Invalid block state root"
+                )
 
         return new_state

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -14,6 +14,7 @@ from lean_spec.spec.forks.lstar.containers import (
     Slot,
     ValidatorIndex,
 )
+from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
 from lean_spec.spec.ssz import Bytes32, Uint64
 
 
@@ -155,9 +156,11 @@ class ValidatorDutiesMixin(LstarSpecBase):
         # Only one validator may propose per slot.
         # Unauthorized proposals would be rejected by other nodes.
         num_validators = Uint64(len(head_state.validators))
-        assert validator_index == ValidatorIndex.proposer_for_slot(slot, num_validators), (
-            f"Validator {validator_index} is not the proposer for slot {slot}"
-        )
+        if validator_index != ValidatorIndex.proposer_for_slot(slot, num_validators):
+            raise SpecRejectionError(
+                RejectionReason.WRONG_PROPOSER,
+                f"Validator {validator_index} is not the proposer for slot {slot}",
+            )
 
         # Build the block.
         #

--- a/tests/consensus/lstar/fc/test_early_block_arrival.py
+++ b/tests/consensus/lstar/fc/test_early_block_arrival.py
@@ -1,0 +1,64 @@
+"""
+Test vectors for blocks delivered ahead of the store clock.
+
+Block import has no arrival-time gate: a block whose slot has not begun
+on the local clock still imports and becomes head. These vectors pin
+that behavior so clients agree on early-block handling bit-for-bit.
+"""
+
+import pytest
+
+from consensus_testing import (
+    BlockSpec,
+    BlockStep,
+    ForkChoiceTestFiller,
+    StoreChecks,
+    TickStep,
+)
+from lean_spec.spec.forks import Interval, Slot
+
+pytestmark = pytest.mark.valid_until("Lstar")
+
+
+def test_block_ahead_of_store_clock_is_imported(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    A slot-1 block delivered while the clock sits at genesis still imports.
+
+    Fixture state: the store clock never ticks, so store time stays at
+    interval 0 while the head advances to the early block.
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1)),
+                tick_to_slot=False,
+                checks=StoreChecks(time=Interval(0), head_slot=Slot(1)),
+            ),
+        ],
+    )
+
+
+def test_early_block_then_clock_catches_up(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    The clock reaching the early block's slot leaves the head unchanged.
+
+    Fixture state: slot-1 block imports at interval 0, then a tick to
+    the start of slot 2 only advances time.
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1)),
+                tick_to_slot=False,
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            TickStep(
+                interval=10,
+                checks=StoreChecks(time=Interval(10), head_slot=Slot(1)),
+            ),
+        ],
+    )

--- a/tests/consensus/lstar/verify_signatures/test_invalid_signatures.py
+++ b/tests/consensus/lstar/verify_signatures/test_invalid_signatures.py
@@ -44,7 +44,7 @@ def test_invalid_proposer_signature(
             attestations=[],
             valid_signature=False,
         ),
-        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_SIGNATURE),
+        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_BLOCK_PROOF),
     )
 
 
@@ -96,5 +96,5 @@ def test_invalid_aggregated_attestation_signature(
                 ),
             ],
         ),
-        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_SIGNATURE),
+        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_BLOCK_PROOF),
     )

--- a/tests/consensus/lstar/verify_signatures/test_structural_rejections.py
+++ b/tests/consensus/lstar/verify_signatures/test_structural_rejections.py
@@ -56,7 +56,7 @@ def test_corrupt_proof_rejected(
         anchor_state=generate_pre_state(num_validators=1),
         block=BlockSpec(slot=Slot(1), attestations=[]),
         tamper=CorruptProof(),
-        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_SIGNATURE),
+        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_BLOCK_PROOF),
     )
 
 
@@ -89,7 +89,7 @@ def test_proof_component_count_mismatch_rejected(
         anchor_state=generate_pre_state(num_validators=1),
         block=BlockSpec(slot=Slot(1), attestations=[]),
         tamper=AppendPhantomAttestation(),
-        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_SIGNATURE),
+        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_BLOCK_PROOF),
     )
 
 
@@ -125,7 +125,7 @@ def test_proof_reused_under_different_message_rejected(
         anchor_state=generate_pre_state(num_validators=1),
         block=BlockSpec(slot=Slot(1), attestations=[]),
         tamper=MutateStateRoot(),
-        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_SIGNATURE),
+        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_BLOCK_PROOF),
     )
 
 
@@ -161,5 +161,5 @@ def test_attestation_proof_order_mismatch_rejected(
             ],
         ),
         tamper=SwapFirstTwoAttestations(),
-        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_SIGNATURE),
+        expected_rejection=ExpectedRejection(reason=RejectionReason.INVALID_BLOCK_PROOF),
     )


### PR DESCRIPTION
## Summary

Fifth PR from the `packages/testing/` audit — the highest consensus-safety item. A wrong client could previously pass "must-reject" vectors by rejecting for the wrong reason: the framework derived `rejectionReason` by substring-matching the *English text* of spec assertions, so any reword silently re-bucketed vectors or crashed fills, and distinct conditions collapsed into shared buckets.

### Spec side (the real fix)

- **`SpecRejectionError(AssertionError)`** carries a `RejectionReason`. Subclassing `AssertionError` keeps every existing rejection handler and unit test working; the framework reads `exception.reason` instead of grepping prose.
- **All 29 rejection assert sites converted** (`state_transition`, `fork_choice`, `signatures`, `validator_duties`, `containers/participation`) — messages preserved verbatim for humans.
- **Bucket split:** a failing block-level multi-message proof now emits **`INVALID_BLOCK_PROOF`**, distinct from a failing gossip-attestation signature (`INVALID_SIGNATURE`). The other suspected collapse ("Parent state not found" / "Sync parent chain") turned out to be a single assert site with one message — no split needed.
- Module renamed `rejection_reason.py` → **`errors.py`** since it now carries the error type alongside the vocabulary.

### Framework side

- **The fragment table is deleted.** `classify_rejection` reads the typed reason; only the `AggregationError` by-type fallback remains. Spec rewording can never re-bucket a vector again.
- **`valid=False` requires `expected_rejection`** (model validator on steps; guard on the invalid-anchor path). A vector saying only "reject this" lets a client reject for the wrong reason and pass.
- **Catches narrowed everywhere**: fork-choice steps catch `(SpecRejectionError, AggregationError)`; state transition catches `SpecRejectionError` only (the old broad catch could freeze a harness `KeyError`/`ValidationError`/duplicate-label `ValueError` into a vector as an "expected rejection"). Harness bugs now propagate.
- **`tick_to_slot: bool = True` on `BlockStep`**, emitted on the filled step so replaying clients know the clock behavior. New `test_early_block_arrival.py` vectors pin the discovered semantics: **block import has no arrival-time gate** — a block ahead of the store clock imports and becomes head while time stays at genesis.
- **`StateTransitionTest` signature fields** (`valid_signature=False`, `signer_ids`) fail at construction with a clear message instead of `NotImplementedError` deep inside generation; the class documents the "signatures are verified upstream" boundary.
- **Decode-failure assertion logic deduplicated** into one `assert_decode_rejection` base helper that resolves the emitted reason centrally; ssz and networking both route through it.

### Vector vocabulary change

`verify_signatures` vectors whose fault is the block proof now emit `INVALID_BLOCK_PROOF` instead of `INVALID_SIGNATURE` (6 vectors); fork-choice `block` steps gain a `tickToSlot` field. Fixture trees are regenerated artifacts.

## Test plan

- `just check` passes (lint, format, ty, codespell, mdformat, lock)
- One fill run of all 98 affected negative vectors (state transition, fork-choice validation, anchor, verify_signatures, verify_proofs, ssz/networking decode, the new early-block scenarios) — all pass with the typed reasons
- Existing unit tests expecting `AssertionError` from the converted sites keep passing by subclassing

🤖 Generated with [Claude Code](https://claude.com/claude-code)