### PR TITLE
refactor(testing): close the observable gaps in the store snapshot

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -262,7 +262,7 @@ class ForkChoiceTest(BaseTestSpec):
         for step_index, step in enumerate(self.steps):
             old_head = store.head
             rejection_reason: RejectionReason | None = None
-            store_snapshot: StoreSnapshot | None = None
+            store_snapshot: StoreSnapshot
             filled_block: Block | None = None
             filled_attestation: SignedAttestation | None = None
             filled_aggregated: SignedAggregatedAttestation | None = None
@@ -380,6 +380,10 @@ class ForkChoiceTest(BaseTestSpec):
 
                 rejection_reason = self._classify_step_rejection(step, step_index, exception)
 
+                # The rejected call returned nothing, so the store is unchanged.
+                # Snapshot it anyway: clients must verify the no-op.
+                store_snapshot = StoreSnapshot.from_store(store)
+
             else:
                 # Handle unexpected success.
                 # If we expected failure but the step succeeded, that's a test bug.
@@ -389,7 +393,7 @@ class ForkChoiceTest(BaseTestSpec):
                     )
 
             # Emit the filled counterpart of this step.
-            # Expected failures keep their built payload but no snapshot.
+            # Expected failures keep their built payload and the unchanged store.
             match step:
                 case TickStep():
                     filled_steps.append(

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -201,13 +201,13 @@ class BaseFilledStep(CamelModel):
     checks: StoreChecks | None = None
     """Store state checks the step was validated against."""
 
-    store_snapshot: StoreSnapshot | None = None
+    store_snapshot: StoreSnapshot
     """
     Canonical store observables after this step.
 
-    Populated for every successful step.
-    Stays None for steps expected to fail, where the resulting
-    store state is implementation-defined.
+    Populated for every step, including rejected ones.
+    A rejected input leaves the store unchanged, and the snapshot
+    pins that no-op so a client cannot corrupt state on rejection.
     """
 
 

--- a/packages/testing/src/consensus_testing/test_types/store_snapshot.py
+++ b/packages/testing/src/consensus_testing/test_types/store_snapshot.py
@@ -1,16 +1,63 @@
 """Canonical store snapshot emitted after every fork choice step."""
 
-from lean_spec.base import CamelModel
+from lean_spec.base import StrictBaseModel
+from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Interval
-from lean_spec.spec.forks.lstar.containers import Checkpoint, Store
+from lean_spec.spec.forks.lstar.containers import (
+    AttestationData,
+    Checkpoint,
+    SingleMessageAggregate,
+    Store,
+)
+from lean_spec.spec.forks.lstar.spec import LstarSpec
 from lean_spec.spec.ssz import Bytes32
 
 
-class StoreSnapshot(CamelModel):
+class BlockWeightEntry(StrictBaseModel):
+    """Fork-choice weight of one block above the finalized slot."""
+
+    root: Bytes32
+    """Block root the weight accrues to."""
+
+    weight: int
+    """Accumulated attestation weight."""
+
+
+class AttestationPoolEntry(StrictBaseModel):
+    """
+    Validator coverage of one attestation data in the raw signature pool.
+
+    Signature bytes are excluded: coverage is the consensus-relevant
+    observable, and it keeps vectors lean.
+    """
+
+    data_root: Bytes32
+    """Hash tree root of the attestation data."""
+
+    validator_indices: list[int]
+    """Validators whose signatures the pool holds, ascending."""
+
+
+class AggregatedPoolEntry(StrictBaseModel):
+    """
+    Participant coverage of one attestation data in an aggregated payload pool.
+
+    Proof bytes are excluded: the aggregation prover is randomized,
+    so they differ between two fills of identical inputs.
+    """
+
+    data_root: Bytes32
+    """Hash tree root of the attestation data."""
+
+    participant_sets: list[list[int]]
+    """One ascending validator list per payload, sorted lexicographically."""
+
+
+class StoreSnapshot(StrictBaseModel):
     """
     Canonical store observables captured after a fork choice step.
 
-    Recorded by the framework after every successful step.
+    Recorded by the framework after every step, including rejected ones.
     Clients must reproduce every field, not just authored checks.
 
     Why explicit fields instead of an opaque digest:
@@ -33,13 +80,97 @@ class StoreSnapshot(CamelModel):
     latest_finalized: Checkpoint
     """Highest slot finalized checkpoint known to the store."""
 
+    block_roots: list[Bytes32]
+    """
+    Every block root the store retains, ascending.
+
+    Why: pruning behavior stays invisible without the full membership.
+    An over- or under-pruning client must fail here.
+    """
+
+    block_weights: list[BlockWeightEntry]
+    """
+    Fork-choice weight per block above the finalized slot, ascending by root.
+
+    Zero-weight blocks are included.
+    Why: two clients can agree on the head while holding divergent
+    weights, then split on the next attestation. The weights drive
+    head selection and must match exactly.
+    """
+
+    attestation_signatures: list[AttestationPoolEntry]
+    """Raw signature pool coverage, ascending by data root."""
+
+    new_aggregated_payloads: list[AggregatedPoolEntry]
+    """
+    Pending aggregated payload pool, ascending by data root.
+
+    These payloads do not contribute to fork choice yet.
+    The new-to-known migration timing is consensus-relevant.
+    """
+
+    known_aggregated_payloads: list[AggregatedPoolEntry]
+    """Processed aggregated payload pool, ascending by data root."""
+
     @classmethod
     def from_store(cls, store: Store) -> "StoreSnapshot":
         """Capture the canonical observables of a store."""
+        finalized_slot = store.latest_finalized.slot
+        weights = LstarSpec().compute_block_weights(store)
+
         return cls(
             time=store.time,
             head_root=store.head,
             safe_target_root=store.safe_target,
             latest_justified=store.latest_justified,
             latest_finalized=store.latest_finalized,
+            block_roots=sorted(store.blocks),
+            block_weights=[
+                BlockWeightEntry(root=root, weight=weights.get(root, 0))
+                for root in sorted(store.blocks)
+                if store.blocks[root].slot > finalized_slot
+            ],
+            attestation_signatures=[
+                AttestationPoolEntry(
+                    data_root=data_root,
+                    validator_indices=sorted(
+                        int(entry.validator_index) for entry in signature_entries
+                    ),
+                )
+                for data_root, signature_entries in sorted(
+                    (
+                        (hash_tree_root(attestation_data), signature_entries)
+                        for attestation_data, signature_entries in (
+                            store.attestation_signatures.items()
+                        )
+                    ),
+                    key=lambda entry: entry[0],
+                )
+            ],
+            new_aggregated_payloads=_aggregated_pool_entries(store.latest_new_aggregated_payloads),
+            known_aggregated_payloads=_aggregated_pool_entries(
+                store.latest_known_aggregated_payloads
+            ),
         )
+
+
+def _aggregated_pool_entries(
+    pool: dict[AttestationData, set[SingleMessageAggregate]],
+) -> list[AggregatedPoolEntry]:
+    """Convert an aggregated payload pool into sorted coverage entries."""
+    return [
+        AggregatedPoolEntry(
+            data_root=data_root,
+            participant_sets=sorted(
+                sorted(int(index) for index in payload.participants.to_validator_indices())
+                for payload in payloads
+            ),
+        )
+        for data_root, payloads in sorted(
+            (
+                (hash_tree_root(attestation_data), payloads)
+                for attestation_data, payloads in pool.items()
+            ),
+            key=lambda entry: entry[0],
+        )
+    ]


### PR DESCRIPTION
## Summary

Sixth PR from the `packages/testing/` audit: the "passes by luck" gaps. The canonical `StoreSnapshot` captured only `time`, `headRoot`, `safeTargetRoot`, and the two checkpoints — everything else the store holds was unobserved, so a divergent client could pass every vector while carrying wrong weights, a mispruned block tree, or corrupted attestation pools.

### What the snapshot now pins

1. **`blockWeights`** *(the audit's single highest-value addition)* — one `{root, weight}` entry per block above the finalized slot, ascending by root, **zero-weight blocks included** so the weighted set is unambiguous. Computed through the spec's own `compute_block_weights`. Two clients can agree on the head while holding divergent weights, then split on the next attestation; the weights drive head selection and must match exactly.
2. **`blockRoots`** — full sorted store membership on every step. Over/under-pruning was previously invisible unless an author opted into `labels_in_store`.
3. **Pool coverage** — `attestationSignatures`, `newAggregatedPayloads`, `knownAggregatedPayloads` as sorted `{dataRoot, validator/participant sets}` entries. Structured entries instead of the audit's suggested digest: it matches the snapshot's explicit-fields philosophy, pools are pruned small, and a digest would require a spec-defined canonical encoding. **Proof bytes are excluded by design** — the aggregation prover is randomized (two fills of identical inputs differ), so they can never be a reproducibility target; signature bytes likewise, since coverage is the consensus-relevant observable. The new→known migration timing is now checked on every step by default.
4. **Store-unchanged-on-reject** — `storeSnapshot` is now **required on every filled step, including rejected ones**. The spec's immutable functions leave the store untouched on rejection; the emitted snapshot pins that no-op, so a client that corrupts its store on a rejected input fails the comparison. The "implementation-defined" escape hatch in the step docs is gone. (The audit's harness-side equality assert is structurally vacuous in Python — immutability means the local binding cannot have changed — so the enforcement lives in the emitted contract where it matters.)

`StoreSnapshot` and the three new entry models are frozen `StrictBaseModel`s. All orderings are explicitly ascending for cross-fill determinism. Fork-choice vectors grow five snapshot fields; fixture trees are regenerated artifacts.

## Test plan

- `just check` passes (lint, format, ty, codespell, mdformat, lock)
- Single-file fill smoke: snapshot emits all ten fields, the early-imported block appears in `blockWeights` with weight 0, empty pools serialize as stable empty lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)