### PR TITLE
refactor(testing): reuse spec logic instead of reimplementing it

### DIFF
--- a/packages/testing/src/consensus_testing/genesis.py
+++ b/packages/testing/src/consensus_testing/genesis.py
@@ -64,6 +64,19 @@ def generate_pre_state(
     return fork.generate_genesis(genesis_time=genesis_time, validators=validators)
 
 
+def genesis_block_for(state: State) -> Block:
+    """Reconstruct the slot-zero block fully determined by a genesis state."""
+    # The genesis block is determined entirely by the state's stored header.
+    # Its state root is the root of the state it produced.
+    return Block(
+        slot=state.latest_block_header.slot,
+        proposer_index=state.latest_block_header.proposer_index,
+        parent_root=state.latest_block_header.parent_root,
+        state_root=hash_tree_root(state),
+        body=BlockBody(attestations=AggregatedAttestations(data=[])),
+    )
+
+
 def build_anchor(
     num_validators: int,
     anchor_slot: Slot,
@@ -105,16 +118,7 @@ def build_anchor(
     fork = fork or LstarSpec()
     state = generate_pre_state(fork=fork, genesis_time=genesis_time, num_validators=num_validators)
 
-    # Reconstruct the genesis block from the state's latest header.
-    # The genesis block is fully determined by the genesis state.
-    genesis_block = Block(
-        slot=state.latest_block_header.slot,
-        proposer_index=state.latest_block_header.proposer_index,
-        parent_root=state.latest_block_header.parent_root,
-        state_root=hash_tree_root(state),
-        body=BlockBody(attestations=AggregatedAttestations(data=[])),
-    )
-    current_block = genesis_block
+    current_block = genesis_block_for(state)
     parent_root = hash_tree_root(current_block)
 
     num_validators_u64 = Uint64(num_validators)
@@ -125,7 +129,7 @@ def build_anchor(
     # justification tracking) that a real mid-chain state would have.
     for next_slot in range(1, int(anchor_slot) + 1):
         slot = Slot(next_slot)
-        proposer_index = ValidatorIndex(int(slot) % int(num_validators_u64))
+        proposer_index = ValidatorIndex.proposer_for_slot(slot, num_validators_u64)
         current_block, state, _, _ = fork.build_block(
             state,
             slot=slot,

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -6,7 +6,7 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from consensus_testing.genesis import generate_pre_state
+from consensus_testing.genesis import generate_pre_state, genesis_block_for
 from consensus_testing.keys import XmssKeyManager
 from consensus_testing.rejection import classify_rejection
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
@@ -23,7 +23,6 @@ from consensus_testing.test_types import (
     StoreSnapshot,
     TickStep,
 )
-from lean_spec.config import LEAN_ENV
 from lean_spec.node.chain.clock import SlotClock
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import (
@@ -34,16 +33,18 @@ from lean_spec.spec.forks import (
     ValidatorIndex,
 )
 from lean_spec.spec.forks.lstar.containers import (
-    AggregatedAttestations,
     AggregationError,
     Block,
-    BlockBody,
     SignedAggregatedAttestation,
     SignedAttestation,
     State,
     Validators,
 )
 from lean_spec.spec.forks.lstar.spec import LstarSpec
+from lean_spec.spec.ssz import Bytes32
+
+_resynced_anchor_states: dict[tuple[Bytes32, str], State] = {}
+"""Anchor states with validator keys resynced, keyed by state root and key set digest."""
 
 
 class ForkChoiceFixture(BaseConsensusFixture):
@@ -140,17 +141,7 @@ class ForkChoiceTest(BaseTestSpec):
         """
         if self.anchor_block is not None:
             return self.anchor_block
-        # Build a minimal genesis block from the state's header fields.
-        #
-        # The state already contains the block header.
-        # We extract its fields to create a matching Block.
-        return Block(
-            slot=self.anchor_state.latest_block_header.slot,
-            proposer_index=self.anchor_state.latest_block_header.proposer_index,
-            parent_root=self.anchor_state.latest_block_header.parent_root,
-            state_root=hash_tree_root(self.anchor_state),
-            body=BlockBody(attestations=AggregatedAttestations(data=[])),
-        )
+        return genesis_block_for(self.anchor_state)
 
     def _resolved_max_slot(self) -> Slot:
         """
@@ -170,7 +161,7 @@ class ForkChoiceTest(BaseTestSpec):
         # Keys must be generated up to this slot before signing.
         for step in self.steps:
             if isinstance(step, BlockStep):
-                max_slot_value = max(max_slot_value, step.block.slot)
+                max_slot_value = max(max_slot_value, step.block.max_referenced_slot())
             elif isinstance(step, AttestationStep):
                 max_slot_value = max(max_slot_value, step.attestation.slot)
             elif isinstance(step, GossipAggregatedAttestationStep):
@@ -215,26 +206,32 @@ class ForkChoiceTest(BaseTestSpec):
         # Test states use placeholder public_keys.
         # We must replace them with the key manager's actual keys.
         # Otherwise signature verification will fail.
-        updated_validators = []
-        for validator_position, validator in enumerate(self.anchor_state.validators):
-            validator_index = ValidatorIndex(validator_position)
-            attestation_public_key, proposal_public_key = key_manager.get_public_keys(
-                validator_index
-            )
-            updated_validators.append(
-                validator.model_copy(
-                    update={
-                        "attestation_public_key": attestation_public_key.encode_bytes(),
-                        "proposal_public_key": proposal_public_key.encode_bytes(),
-                    }
+        # The result is memoized: repeated fills of the same anchor against
+        # the same key set reuse the rebuilt registry instead of recopying it.
+        memo_key = (hash_tree_root(self.anchor_state), key_manager.key_set_digest())
+        anchor_state = _resynced_anchor_states.get(memo_key)
+        if anchor_state is None:
+            updated_validators = []
+            for validator_position, validator in enumerate(self.anchor_state.validators):
+                validator_index = ValidatorIndex(validator_position)
+                attestation_public_key, proposal_public_key = key_manager.get_public_keys(
+                    validator_index
                 )
+                updated_validators.append(
+                    validator.model_copy(
+                        update={
+                            "attestation_public_key": attestation_public_key.encode_bytes(),
+                            "proposal_public_key": proposal_public_key.encode_bytes(),
+                        }
+                    )
+                )
+            anchor_state = self.anchor_state.model_copy(
+                update={"validators": Validators(data=updated_validators)}
             )
+            _resynced_anchor_states[memo_key] = anchor_state
 
         # Updating validators changes the state root.
         # We must also update the anchor block to match.
-        anchor_state = self.anchor_state.model_copy(
-            update={"validators": Validators(data=updated_validators)}
-        )
         anchor_block = anchor_block.model_copy(update={"state_root": hash_tree_root(anchor_state)})
 
         # Store initialization
@@ -295,7 +292,7 @@ class ForkChoiceTest(BaseTestSpec):
                         # Build a complete signed block from the lightweight spec.
                         # The spec contains minimal fields; we fill the rest.
                         signed_block, store = step.block.build_signed_block_with_store(
-                            store, block_registry, key_manager, LEAN_ENV
+                            store, block_registry, key_manager
                         )
                         filled_block = signed_block.block
 

--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -9,7 +9,7 @@ from consensus_testing.keys import XmssKeyManager
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
 from consensus_testing.test_types import AggregatedAttestationSpec, BlockSpec, StateExpectation
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import AggregationBits, SpecRejectionError
+from lean_spec.spec.forks import AggregationBits, Slot, SpecRejectionError
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
     AggregatedAttestations,
@@ -125,6 +125,13 @@ class StateTransitionTest(BaseTestSpec):
         exception_raised: Exception | None = None
         spec = LstarSpec()
 
+        # Provision XMSS keys once for every slot any block or attestation references.
+        max_slot = max(
+            (block_spec.max_referenced_slot() for block_spec in self.blocks),
+            default=Slot(0),
+        )
+        key_manager = XmssKeyManager.shared(max_slot=max_slot)
+
         # Filled blocks accumulate as we process, even if a later block fails.
         # This ensures the test fixture includes all blocks that were attempted.
         filled_blocks: list[Block] = []
@@ -134,7 +141,9 @@ class StateTransitionTest(BaseTestSpec):
 
             for block_spec in self.blocks:
                 # Build block and optionally get cached post-state to avoid redundant transitions
-                block, cached_state = self._build_block_from_spec(block_spec, state, block_registry)
+                block, cached_state = self._build_block_from_spec(
+                    block_spec, state, block_registry, key_manager
+                )
 
                 # Store the filled Block for serialization
                 filled_blocks.append(block)
@@ -191,6 +200,7 @@ class StateTransitionTest(BaseTestSpec):
         block_spec: BlockSpec,
         state: State,
         block_registry: dict[str, Block],
+        key_manager: XmssKeyManager,
     ) -> tuple[Block, State | None]:
         """
         Build a Block from a BlockSpec, optionally caching the post-state.
@@ -209,6 +219,7 @@ class StateTransitionTest(BaseTestSpec):
             block_spec: Block specification with optional field overrides.
             state: Current state to build against.
             block_registry: Labeled blocks for parent and target resolution.
+            key_manager: Key manager covering every referenced slot.
 
         Returns:
             Block and cached post-state (None if not computed).
@@ -257,7 +268,7 @@ class StateTransitionTest(BaseTestSpec):
             aggregated_payloads: dict[AttestationData, set[SingleMessageAggregate]] = {}
             if block_spec.attestations:
                 aggregated_payloads = StateTransitionTest._build_aggregated_payloads_from_spec(
-                    block_spec.attestations, state, block_registry
+                    block_spec.attestations, state, block_registry, key_manager
                 )
 
             known_block_roots = frozenset(
@@ -300,12 +311,13 @@ class StateTransitionTest(BaseTestSpec):
                 }
             )
 
-            # The body changed, so re-run the transition to get the correct
-            # post-state and state root.
+            # The body changed, so recompute the root and re-derive the
+            # post-state through the public transition a client runs.
             if post_state is not None:
                 post_state = fork.process_slots(state, block_spec.slot)
                 post_state = fork.process_block(post_state, block)
                 block = block.model_copy(update={"state_root": hash_tree_root(post_state)})
+                post_state = fork.state_transition(state, block=block)
 
         return block, post_state
 
@@ -314,6 +326,7 @@ class StateTransitionTest(BaseTestSpec):
         attestation_specs: list[AggregatedAttestationSpec],
         state: State,
         block_registry: dict[str, Block],
+        key_manager: XmssKeyManager,
     ) -> dict[AttestationData, set[SingleMessageAggregate]]:
         """
         Build aggregated signature payloads from attestation specifications.
@@ -322,14 +335,11 @@ class StateTransitionTest(BaseTestSpec):
             attestation_specs: Attestation specifications from the block spec.
             state: Current state for source checkpoint lookup.
             block_registry: Labels to blocks for resolving target roots.
+            key_manager: Key manager covering every referenced slot.
 
         Returns:
             Aggregated payloads keyed by attestation data.
         """
-        # Compute max slot across all attestation specs for XMSS key lifetime.
-        # XMSS keys require precomputation up to the highest slot used.
-        max_slot = max(spec.slot for spec in attestation_specs)
-        key_manager = XmssKeyManager.shared(max_slot=max_slot)
         payloads: dict[AttestationData, set[SingleMessageAggregate]] = {}
 
         for spec in attestation_specs:

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 from collections import defaultdict
 
+from consensus_testing.genesis import genesis_block_for
 from consensus_testing.keys import XmssKeyManager, create_dummy_signature
 from consensus_testing.test_types.attestation_specs import AggregatedAttestationSpec
 from lean_spec.base import CamelModel
@@ -26,7 +27,7 @@ from lean_spec.spec.forks.lstar.containers import (
     Store,
 )
 from lean_spec.spec.forks.lstar.spec import LstarSpec
-from lean_spec.spec.ssz import ByteList512KiB, Bytes32
+from lean_spec.spec.ssz import ByteList512KiB, Bytes32, Uint64
 
 
 class BlockSpec(CamelModel):
@@ -128,8 +129,20 @@ class BlockSpec(CamelModel):
     """
 
     def resolve_proposer_index(self, num_validators: int) -> ValidatorIndex:
-        """Return the proposer index, falling back to round-robin by slot."""
-        return self.proposer_index or ValidatorIndex(int(self.slot) % num_validators)
+        """Return the pinned proposer index, or the spec's scheduled proposer."""
+        if self.proposer_index is not None:
+            return self.proposer_index
+        return ValidatorIndex.proposer_for_slot(self.slot, Uint64(num_validators))
+
+    def max_referenced_slot(self) -> Slot:
+        """Return the highest slot this block or any attestation it carries needs keys for."""
+        # XMSS keys are slot-bound.
+        # Every signed message under this block must be covered.
+        attestation_slots = [attestation_spec.slot for attestation_spec in self.attestations or []]
+        forced_attestation_slots = [
+            forced_attestation.slot for forced_attestation in self.forced_attestations or []
+        ]
+        return max([self.slot, *attestation_slots, *forced_attestation_slots])
 
     def resolve_parent_root(
         self,
@@ -339,14 +352,7 @@ class BlockSpec(CamelModel):
         proposer_index = self.resolve_proposer_index(len(state.validators))
 
         # Build a genesis block registry so attestation specs can resolve labels.
-        anchor_block = Block(
-            slot=state.latest_block_header.slot,
-            proposer_index=state.latest_block_header.proposer_index,
-            parent_root=state.latest_block_header.parent_root,
-            state_root=hash_tree_root(state),
-            body=BlockBody(attestations=AggregatedAttestations(data=[])),
-        )
-        block_registry: dict[str, Block] = {"genesis": anchor_block}
+        block_registry: dict[str, Block] = {"genesis": genesis_block_for(state)}
 
         # Resolve the parent root.
         # The default is the latest block header from the slot-advanced state.
@@ -435,7 +441,6 @@ class BlockSpec(CamelModel):
         store: Store,
         block_registry: dict[str, Block],
         key_manager: XmssKeyManager,
-        lean_env: str,
     ) -> tuple[SignedBlock, Store]:
         """
         Build a complete signed block through the Store's attestation pipeline.
@@ -443,27 +448,28 @@ class BlockSpec(CamelModel):
         Simulates what a real node does when proposing a block.
         Replays the gossip, aggregation, and proposal pipeline through the Store.
 
-        Returns a Store enriched with the aggregated single-message aggregate payloads built
-        during the simulated pipeline. The caller can persist these so future
-        block builds can re-aggregate the same attestations rather than
-        reconstructing them from on-chain block bodies (which would require
-        splitting the block-level multi-message aggregate proof — a heavy and, in the test
-        recursive-aggregation mode, unreliable operation). Other fields of
-        the original Store (gossip signatures, time, head, etc.) are
-        preserved so the simulated build does not consume state the caller
-        is tracking separately.
+        Returns a Store enriched with the aggregated single-message aggregate
+        payloads built during the simulated pipeline.
+        The caller persists these so future block builds can re-aggregate the
+        same attestations without splitting the block-level merged proof.
+
+        Why the payloads merge into the known pool directly: a real node
+        recovers them through the sync layer's deconstruct-on-import path,
+        which defers acceptance by one tick.
+        The harness keeps them immediately known so a block authored for the
+        very next slot can already build on them.
 
         Args:
             store: Fork choice store for head state lookup and gossip processing.
             block_registry: Labeled blocks for fork creation.
             key_manager: Key manager for signing.
-            lean_env: Signature scheme environment name ("test" or "prod").
 
         Returns:
             The signed block and the Store with new known payloads merged in.
         """
         spec = LstarSpec()
-        proposer_index = self.resolve_proposer_index(len(store.states[store.head].validators))
+        num_validators = len(store.states[store.head].validators)
+        proposer_index = self.resolve_proposer_index(num_validators)
 
         # Resolve parent block.
         # Parent can be specified by label (for forks) or defaults to head.
@@ -516,22 +522,35 @@ class BlockSpec(CamelModel):
                 is_aggregator=True,
             )
 
-        # Trigger Store aggregation to merge gossip signatures into known payloads.
+        # Trigger Store aggregation to merge gossip signatures into payloads.
         # Aggregation runs on a local clone: gossip pools mutate here, but the
         # caller's gossip-signature view must not be consumed by this simulated
         # build. Only the freshly aggregated single-message aggregate payloads propagate back.
         aggregation_store, _ = spec.aggregate(store)
-        merged_store = spec.accept_new_attestations(aggregation_store)
 
-        # Build the block through the spec's State.build_block().
-        final_block, _, _, block_proofs = spec.build_block(
-            parent_state,
-            slot=self.slot,
-            proposer_index=proposer_index,
-            parent_root=parent_root,
-            known_block_roots=set(store.blocks.keys()),
-            aggregated_payloads=merged_store.latest_known_aggregated_payloads,
-        )
+        # A real proposer builds on the canonical head as the scheduled validator.
+        scheduled_proposer = ValidatorIndex.proposer_for_slot(self.slot, Uint64(num_validators))
+        if parent_root == store.head and proposer_index == scheduled_proposer:
+            # Honest-node path: the spec's propose entry advances the clock,
+            # accepts pending attestations, checks proposer authorization,
+            # builds the block, and enforces the justified-divergence invariant.
+            # Its persistence lands on the throwaway clone and is discarded;
+            # the real import happens later through on_block.
+            merged_store, final_block, block_proofs = spec.produce_block_with_signatures(
+                aggregation_store, self.slot, proposer_index
+            )
+        else:
+            # Fork building or a pinned non-scheduled proposer.
+            # No honest node proposes here, so the propose entry cannot apply.
+            merged_store = spec.accept_new_attestations(aggregation_store)
+            final_block, _, _, block_proofs = spec.build_block(
+                parent_state,
+                slot=self.slot,
+                proposer_index=proposer_index,
+                parent_root=parent_root,
+                known_block_roots=set(store.blocks.keys()),
+                aggregated_payloads=merged_store.latest_known_aggregated_payloads,
+            )
 
         # Merge new known payloads (built locally) back into the caller's
         # store while leaving every other field untouched.
@@ -574,10 +593,12 @@ class BlockSpec(CamelModel):
                     }
                 )
 
-            # Recompute state root with the modified body.
+            # Recompute the state root with the modified body, then replay the
+            # public transition a client runs so the stamped root is validated.
             post_state = spec.process_slots(parent_state, self.slot)
             post_state = spec.process_block(post_state, final_block)
             final_block = final_block.model_copy(update={"state_root": hash_tree_root(post_state)})
+            spec.state_transition(parent_state, block=final_block)
 
         signed_block = self._sign_block(
             final_block, block_proofs, proposer_index, key_manager, parent_state


### PR DESCRIPTION
## Summary

Seventh PR from the `packages/testing/` audit, and the one squarely aimed at its core principle: **the harness must reuse the spec, never reimplement it** — every duplicate is a drift risk that can mask client bugs. Designed with a three-agent study (architecture, consensus semantics, test-suite impact) whose findings corrected the audit in three places (below).

### Spec reuse, per duplicate

- **Block production** now routes through the spec's single propose entry point, `produce_block_with_signatures`, whenever the authored step describes what a real proposer does (building on the canonical head as the scheduled validator — the vast majority of steps). Fixtures thereby exercise proposal-head selection, proposer authorization, and the justified-divergence invariant exactly as a client does. The direct `build_block` escape hatch survives only for the two features fork-choice tests actually use — `parent_label` forks and pinned proposers — cases where *no honest node proposes*, so no spec path can exist. The dead `lean_env` parameter is gone.
- **Round-robin proposer ×3 → `ValidatorIndex.proposer_for_slot`**, plus a latent bug fix: a pinned proposer of index 0 was silently dropped by a falsy `or`-check; now `is not None`.
- **Genesis block ×4 → one `genesis_block_for(state)`** reading the state's stored header.
- **Max-slot ×2 → `BlockSpec.max_referenced_slot()`**, recursing into in-block and forced attestations — closing the XMSS key under-provisioning gap. `StateTransitionTest` provisions the key manager once per generation instead of per payload-build.
- **Forced-attestation tails** in both fixtures replay the public `state_transition` after stamping the recomputed root (byte-identical post-states, and the root-validation branch is now exercised).
- **Anchor validator-key resync memoized** by `(state_root, key_set_digest)` so repeated fills reuse the rebuilt registry.

### Where the study corrected the audit

1. **The "unreliable proof-splitting" docstring claim was unsupported** — `split_by_message` is exercised reliably by the sync service in both schemes. The real reasons the harness merges payloads directly are per-attestation proving cost and pool-timing fidelity; the docstring now says so.
2. **The merged-payload write-back is NOT redundant** — the spec's `on_block` registers in-block attestation data with *empty* proof sets (zero weight until sync-layer deconstruct + the next acceptance tick). Removing the merge would have silently broken the known-pool semantics one test pins. It stays, honestly documented.
3. **No validator resync for `StateTransitionTest`** — its generator already installs real keys (a resync is a byte-identical no-op), and the one custom-pre test (4096 placeholder validators vs 8 available keys) would crash under a blanket resync. The audit's "shared mixin" premise dissolved; the memoization landed where the resync actually lives.

### Residual note

The honest propose path lets the head move when freshly accepted attestations shift it — real-node behavior the hand pipeline didn't model. A few fork-choice vectors may emit different parents/bodies on the next full fill; their own `StoreChecks` will surface any case where the authored expectation disagrees with spec truth.

## Test plan

- `just check` passes (lint, format, ty, codespell, mdformat, lock)
- Single-file fill smoke through the new propose branch passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)