### PR TITLE
refactor(testing): use the spec's proposer scheduler in genesis

### DIFF
--- a/packages/testing/src/consensus_testing/genesis.py
+++ b/packages/testing/src/consensus_testing/genesis.py
@@ -125,7 +125,7 @@ def build_anchor(
     # justification tracking) that a real mid-chain state would have.
     for next_slot in range(1, int(anchor_slot) + 1):
         slot = Slot(next_slot)
-        proposer_index = ValidatorIndex(int(slot) % int(num_validators_u64))
+        proposer_index = ValidatorIndex.proposer_for_slot(slot, num_validators_u64)
         current_block, state, _, _ = fork.build_block(
             state,
             slot=slot,


### PR DESCRIPTION
## Summary

The anchor builder in `genesis.py` reimplemented round-robin proposer selection by hand (`ValidatorIndex(int(slot) % int(num_validators_u64))`). It now delegates to the spec's own `ValidatorIndex.proposer_for_slot`, so the test helper cannot drift from the real selection rule.

Behavior is identical — same round-robin arithmetic, no abstraction added.

## Test plan

- `just check` passes (lint, format, ty, codespell, mdformat, lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)