### PR TITLE
refactor(lstar): tidy container docs and simplify state accounting

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -9,7 +9,7 @@ from consensus_testing.keys import XmssKeyManager, create_dummy_signature
 from consensus_testing.test_types.attestation_specs import AggregatedAttestationSpec
 from lean_spec.base import CamelModel
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.crypto.xmss.containers import Signature
+from lean_spec.spec.crypto.xmss.containers import PublicKey, Signature
 from lean_spec.spec.forks import AggregationBits, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
@@ -299,7 +299,9 @@ class BlockSpec(CamelModel):
 
             public_keys_per_aggregate: list[list] = [
                 [
-                    state.validators[validator_index].get_attestation_public_key()
+                    PublicKey.decode_bytes(
+                        bytes(state.validators[validator_index].attestation_public_key)
+                    )
                     for validator_index in attestation_proof.participants.to_validator_indices()
                 ]
                 for attestation_proof in attestation_proofs

--- a/src/lean_spec/node/sync/service.py
+++ b/src/lean_spec/node/sync/service.py
@@ -558,12 +558,18 @@ class SyncService:
         for attestation in block_attestations:
             public_keys_per_message.append(
                 [
-                    validators[validator_index].get_attestation_public_key()
+                    PublicKey.decode_bytes(
+                        bytes(validators[validator_index].attestation_public_key)
+                    )
                     for validator_index in attestation.aggregation_bits.to_validator_indices()
                 ]
             )
         public_keys_per_message.append(
-            [validators[block.block.proposer_index].get_proposal_public_key()]
+            [
+                PublicKey.decode_bytes(
+                    bytes(validators[block.block.proposer_index].proposal_public_key)
+                )
+            ]
         )
 
         # Index local partial single-message aggregate proofs by AttestationData root. Equivalent
@@ -620,7 +626,9 @@ class SyncService:
                             (
                                 child,
                                 [
-                                    validators[validator_index].get_attestation_public_key()
+                                    PublicKey.decode_bytes(
+                                        bytes(validators[validator_index].attestation_public_key)
+                                    )
                                     for validator_index in child.participants.to_validator_indices()
                                 ],
                             )

--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -452,7 +452,9 @@ class ValidatorService:
         validators = key_state.validators
         if not validator_index.is_within_registry(Uint64(len(validators))):
             raise ValueError(f"Validator {validator_index} not found in state validators")
-        proposer_public_key = validators[validator_index].get_proposal_public_key()
+        proposer_public_key = PublicKey.decode_bytes(
+            bytes(validators[validator_index].proposal_public_key)
+        )
 
         # Wrap the proposer's raw XMSS signature into a singleton single-message aggregate.
         # The single fresh entry carries the proposer index alongside its key and signature.
@@ -481,7 +483,9 @@ class ValidatorService:
                         f"active set has {num_validators} validators"
                     )
                 participant_public_keys.append(
-                    validators[validator_index].get_attestation_public_key()
+                    PublicKey.decode_bytes(
+                        bytes(validators[validator_index].attestation_public_key)
+                    )
                 )
             public_keys_per_aggregate.append(participant_public_keys)
         public_keys_per_aggregate.append([proposer_public_key])

--- a/src/lean_spec/spec/forks/lstar/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/aggregation.py
@@ -1,6 +1,7 @@
 """Lstar fork — attestation aggregation."""
 
 from lean_spec.spec.crypto.merkleization import hash_tree_root
+from lean_spec.spec.crypto.xmss.containers import PublicKey
 from lean_spec.spec.forks.lstar._base import LstarSpecBase, LstarStore
 from lean_spec.spec.forks.lstar.containers import (
     SignedAggregatedAttestation,
@@ -141,7 +142,9 @@ class AggregationMixin(LstarSpecBase):
             raw_signatures = [
                 (
                     signature_entry.validator_index,
-                    validators[signature_entry.validator_index].get_attestation_public_key(),
+                    PublicKey.decode_bytes(
+                        bytes(validators[signature_entry.validator_index].attestation_public_key)
+                    ),
                     signature_entry.signature,
                 )
                 for signature_entry in sorted(
@@ -171,7 +174,9 @@ class AggregationMixin(LstarSpecBase):
                 (
                     child_proof,
                     [
-                        validators[validator_index].get_attestation_public_key()
+                        PublicKey.decode_bytes(
+                            bytes(validators[validator_index].attestation_public_key)
+                        )
                         for validator_index in child_proof.participants.to_validator_indices()
                     ],
                 )

--- a/src/lean_spec/spec/forks/lstar/block_production.py
+++ b/src/lean_spec/spec/forks/lstar/block_production.py
@@ -3,6 +3,7 @@
 from collections.abc import Set as AbstractSet
 
 from lean_spec.spec.crypto.merkleization import hash_tree_root
+from lean_spec.spec.crypto.xmss.containers import PublicKey
 from lean_spec.spec.forks.lstar._base import LstarSpecBase
 from lean_spec.spec.forks.lstar.aggregation import select_proofs_for_coverage
 from lean_spec.spec.forks.lstar.config import (
@@ -245,7 +246,9 @@ class BlockProductionMixin(LstarSpecBase):
                         (
                             proof,
                             [
-                                state.validators[validator_index].get_attestation_public_key()
+                                PublicKey.decode_bytes(
+                                    bytes(state.validators[validator_index].attestation_public_key)
+                                )
                                 for validator_index in proof.participants.to_validator_indices()
                             ],
                         )

--- a/src/lean_spec/spec/forks/lstar/containers/__init__.py
+++ b/src/lean_spec/spec/forks/lstar/containers/__init__.py
@@ -6,7 +6,8 @@ The types are split across submodules by domain role:
 
 - interval, identifiers, participation: scalar units and registry index sets
 - aggregation: post-quantum signature aggregation proofs
-- validator: genesis configuration and the validator registry
+- genesis: chain configuration committed into the state
+- validator: the validator registry
 - checkpoint: Casper-FFG checkpoints and the attestation vote they anchor
 - attestation, block: vote envelopes and the blocks that carry them
 - state, store: per-block consensus state and the node's fork-choice view
@@ -32,6 +33,7 @@ from lean_spec.spec.forks.lstar.containers.block import (
     SignedBlock,
 )
 from lean_spec.spec.forks.lstar.containers.checkpoint import AttestationData, Checkpoint
+from lean_spec.spec.forks.lstar.containers.genesis import GenesisConfig
 from lean_spec.spec.forks.lstar.containers.identifiers import (
     SubnetId,
     ValidatorIndex,
@@ -48,7 +50,6 @@ from lean_spec.spec.forks.lstar.containers.state import (
 )
 from lean_spec.spec.forks.lstar.containers.store import AttestationSignatureEntry, Store
 from lean_spec.spec.forks.lstar.containers.validator import (
-    GenesisConfig,
     Validator,
     Validators,
 )

--- a/src/lean_spec/spec/forks/lstar/containers/attestation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/attestation.py
@@ -33,11 +33,7 @@ class AggregatedAttestation(Container):
     """Bitfield indicating which validators participated in the aggregation."""
 
     data: AttestationData
-    """Combined attestation data similar to the beacon chain format.
-
-    Multiple validator attestations are aggregated here without the complexity of
-    committee assignments.
-    """
+    """Attestation data common to every validator in the aggregate."""
 
 
 class SignedAggregatedAttestation(Container):
@@ -48,7 +44,7 @@ class SignedAggregatedAttestation(Container):
     """
 
     data: AttestationData
-    """Combined attestation data similar to the beacon chain format."""
+    """Attestation data common to every validator in the aggregate."""
 
     proof: SingleMessageAggregate
     """Aggregated single-message proof covering all participating validators."""

--- a/src/lean_spec/spec/forks/lstar/containers/block.py
+++ b/src/lean_spec/spec/forks/lstar/containers/block.py
@@ -15,12 +15,7 @@ class BlockBody(Container):
 
 
 class BlockHeader(Container):
-    """
-    Metadata summarizing a block.
-
-    Contains parent reference, state root, and body hash.
-    Smaller than full blocks.
-    """
+    """Metadata summarizing a block without its body."""
 
     slot: Slot
     """The slot in which the block was proposed."""
@@ -32,7 +27,7 @@ class BlockHeader(Container):
     """The root of the parent block."""
 
     state_root: Bytes32
-    """The root of the state after applying transactions in this block."""
+    """The root of the state after applying this block."""
 
     body_root: Bytes32
     """The root of the block body."""
@@ -51,7 +46,7 @@ class Block(Container):
     """The root of the parent block."""
 
     state_root: Bytes32
-    """The root of the state after applying transactions in this block."""
+    """The root of the state after applying this block."""
 
     body: BlockBody
     """The block's payload."""
@@ -61,9 +56,8 @@ class SignedBlock(Container):
     """
     Envelope carrying a block with a single aggregated proof for all signatures.
 
-    The proof is a multi-message aggregate multi-message proof.
-    It binds every attestation in the body plus the proposer's signature
-    over the block root.
+    The single proof binds every attestation in the body.
+    It also binds the proposer signature over the block root.
     """
 
     block: Block

--- a/src/lean_spec/spec/forks/lstar/containers/genesis.py
+++ b/src/lean_spec/spec/forks/lstar/containers/genesis.py
@@ -1,0 +1,10 @@
+"""Chain configuration committed into the consensus state."""
+
+from lean_spec.spec.ssz import Container, Uint64
+
+
+class GenesisConfig(Container):
+    """Chain configuration committed into consensus state."""
+
+    genesis_time: Uint64
+    """The timestamp of the genesis block."""

--- a/src/lean_spec/spec/forks/lstar/containers/state.py
+++ b/src/lean_spec/spec/forks/lstar/containers/state.py
@@ -5,7 +5,8 @@ from typing import Self
 from lean_spec.spec.forks.lstar.config import HISTORICAL_ROOTS_LIMIT, VALIDATOR_REGISTRY_LIMIT
 from lean_spec.spec.forks.lstar.containers.block import BlockHeader
 from lean_spec.spec.forks.lstar.containers.checkpoint import Checkpoint
-from lean_spec.spec.forks.lstar.containers.validator import GenesisConfig, Validators
+from lean_spec.spec.forks.lstar.containers.genesis import GenesisConfig
+from lean_spec.spec.forks.lstar.containers.validator import Validators
 from lean_spec.spec.forks.lstar.slot import Slot
 from lean_spec.spec.ssz import Boolean, Bytes32, Container, SSZList
 from lean_spec.spec.ssz.bitfields import BaseBitlist
@@ -66,63 +67,11 @@ class JustifiedSlots(BaseBitlist):
                 f"(finalized_boundary={finalized_slot}, tracked_length={len(self)})"
             ) from e
 
-    def with_justified(
-        self,
-        finalized_slot: Slot,
-        target_slot: Slot,
-        value: Boolean,
-    ) -> Self:
-        """
-        Return a new bitfield with the justification status updated.
-
-        This method follows the immutable pattern:
-        - Returns 'self' if the slot is finalized (immutable).
-        - Returns a clone with the specific bit updated for active slots.
-
-        Args:
-            finalized_slot: The anchor point for the tracking window.
-            target_slot: The slot to update.
-            value: The new justification status.
-
-        Returns:
-            A new, updated JustifiedSlots instance.
-
-        Raises:
-            IndexError: If the target slot is active but outside the tracked range.
-        """
-        # Determine the position of the target relative to the anchor.
-        #
-        # If the slot is behind the finalized boundary, we return 'self' unchanged.
-        # We cannot modify the status of finalized history, and treating it as a
-        # no-op preserves the immutability of the conceptual chain history.
-        if (relative_index := target_slot.justified_index_after(finalized_slot)) is None:
-            return self
-
-        # Ensure we are not trying to write to a future slot that does not exist
-        # in our tracking list yet. The state must be explicitly extended first.
-        if relative_index >= len(self):
-            raise IndexError(
-                f"Slot {target_slot} is outside the tracked range "
-                f"(finalized_boundary={finalized_slot}, tracked_length={len(self)})"
-            )
-
-        # Clone and update in one smooth operation.
-        #
-        # 1. Create a shallow copy of the data list to avoid mutating the original.
-        # 2. Update the specific bit in the copy.
-        # 3. Construct a new instance with the updated data.
-        new_data = list(self.data)
-        new_data[relative_index] = value
-
-        return type(self)(data=new_data)
-
     def extend_to_slot(self, finalized_slot: Slot, target_slot: Slot) -> Self:
         """
         Extend the tracking capacity to cover a new target slot.
 
-        This prepares the state to process a new block by ensuring the
-        bitfield is long enough to store its justification status.
-        Gaps are filled with False (unjustified).
+        Slots between the old end and the target are filled with False.
 
         Args:
             finalized_slot: The anchor point for the tracking window.
@@ -131,10 +80,7 @@ class JustifiedSlots(BaseBitlist):
         Returns:
             A new instance with sufficient capacity.
         """
-        # Calculate the index required to store the status of the target.
-        #
-        # If the target is already finalized, no extension is needed because
-        # we don't track finalized data.
+        # A finalized target has no tracked index, so nothing to extend.
         if (relative_index := target_slot.justified_index_after(finalized_slot)) is None:
             return self
 
@@ -151,32 +97,12 @@ class JustifiedSlots(BaseBitlist):
         # We extend the existing data with False values to bridge the gap.
         return type(self)(data=list(self.data) + [Boolean(False)] * gap_size)
 
-    def shift_window(self, delta: int) -> Self:
-        """
-        Advance the tracking window by dropping slots that became finalized.
-
-        A non-positive delta keeps the tracking window unchanged.
-        """
-        # If the boundary hasn't moved forward, the window stays the same.
-        if delta <= 0:
-            return self
-
-        # Return a new instance containing only the relevant subset of data.
-        return type(self)(data=self.data[delta:])
-
 
 class JustificationValidators(BaseBitlist):
-    """
-    Per-root validator vote bitfields, concatenated into one flat bitlist.
-
-    Each tracked root contributes one bit per registered validator.
-    The cap is the maximum tracked roots times the validator registry limit.
-
-    Why this product: a larger cap inflates the bitlist's merkle tree depth.
-    That changes the state root for identical data, so this limit is consensus-critical.
-    """
+    """Per-root validator vote bitfields, concatenated into one flat bitlist."""
 
     LIMIT = int(HISTORICAL_ROOTS_LIMIT) * int(VALIDATOR_REGISTRY_LIMIT)
+    """One bit per tracked-root and registered-validator pair."""
 
 
 class State(Container):

--- a/src/lean_spec/spec/forks/lstar/containers/store.py
+++ b/src/lean_spec/spec/forks/lstar/containers/store.py
@@ -1,4 +1,4 @@
-"""Fork-choice store: the node's LMD-GHOST local view of the chain."""
+"""Fork-choice store: the node's local view of the chain."""
 
 from typing import NamedTuple
 
@@ -8,41 +8,24 @@ from lean_spec.base import StrictBaseModel
 from lean_spec.spec.crypto.xmss.containers import Signature
 from lean_spec.spec.forks.lstar.containers.aggregation import SingleMessageAggregate
 from lean_spec.spec.forks.lstar.containers.checkpoint import AttestationData, Checkpoint
+from lean_spec.spec.forks.lstar.containers.genesis import GenesisConfig
 from lean_spec.spec.forks.lstar.containers.identifiers import ValidatorIndex
 from lean_spec.spec.forks.lstar.containers.interval import Interval
-from lean_spec.spec.forks.lstar.containers.validator import GenesisConfig
 from lean_spec.spec.ssz import Bytes32, Container
 
 
 class AttestationSignatureEntry(NamedTuple):
-    """
-    Single validator's XMSS signature for an attestation.
-
-    Used as an element in the attestation_signatures map: one entry per validator
-    that attested to the same AttestationData.
-    """
+    """One validator paired with its signature for an attestation."""
 
     validator_index: ValidatorIndex
+    """Index of the validator that produced the signature."""
+
     signature: Signature
+    """Signature over the attestation."""
 
 
 class Store[StateT: Container, BlockT: Container](StrictBaseModel):
-    """
-    Forkchoice store tracking chain state and validator attestations.
-
-    This is the "local view" that a node uses to run LMD GHOST. It contains:
-
-    - which blocks and states are known,
-    - which checkpoints are justified and finalized,
-    - which block is currently considered the head,
-    - and, for each validator, their latest attestation that should influence fork choice.
-
-    The `Store` is updated whenever:
-    - a new block is processed,
-    - an attestation is received (via a block or gossip),
-    - an interval tick occurs (activating new attestations),
-    - or when the head is recomputed.
-    """
+    """A node's local view of the chain for running fork choice."""
 
     time: Interval
     """Current time in intervals since genesis."""
@@ -51,90 +34,41 @@ class Store[StateT: Container, BlockT: Container](StrictBaseModel):
     """Chain configuration parameters."""
 
     head: Bytes32
-    """
-    Root of the current canonical chain head block.
-
-    This is the result of running the fork choice algorithm on the current contents of the `Store`.
-    """
+    """Root of the head block that fork choice currently selects."""
 
     safe_target: Bytes32
-    """
-    Root of the current safe target for attestation.
-
-    This can be used by higher-level logic to restrict which blocks are
-    considered safe to attest to, based on additional safety conditions.
-    """
+    """Root of the block a validator is currently safe to attest to."""
 
     latest_justified: Checkpoint
-    """
-    Highest slot justified checkpoint known to the store.
-
-    LMD GHOST starts from this checkpoint when computing the head.
-
-    Only descendants of this checkpoint are considered viable.
-    """
+    """Highest-slot justified checkpoint observed so far."""
 
     latest_finalized: Checkpoint
-    """
-    Highest slot finalized checkpoint known to the store.
-
-    Everything strictly before this checkpoint can be considered immutable.
-
-    Fork choice will never revert finalized history.
-    """
+    """Highest-slot finalized checkpoint observed so far."""
 
     blocks: dict[Bytes32, BlockT] = Field(default_factory=dict)
     """
-    Mapping from block root to Block objects.
+    Known blocks indexed by their root.
 
-    This is the set of blocks that the node currently knows about.
-
-    Every block that might participate in fork choice must appear here.
+    Every block eligible to participate in fork choice appears here.
     """
 
     states: dict[Bytes32, StateT] = Field(default_factory=dict)
-    """
-    Mapping from block root to State objects.
-
-    For each known block, we keep its post-state.
-
-    These states carry justified and finalized checkpoints that we use to update the
-    `Store`'s latest justified and latest finalized checkpoints.
-    """
+    """Post-state of each known block, indexed by block root."""
 
     validator_index: ValidatorIndex | None
-    """Index of the validator running this store instance."""
+    """Index of the validator that owns this view, or none for an observer."""
 
     attestation_signatures: dict[AttestationData, set[AttestationSignatureEntry]] = Field(
         default_factory=dict
     )
-    """
-    Per-validator XMSS signatures learned from committee attesters.
-
-    Keyed by AttestationData.
-    """
+    """Per-validator signatures observed, grouped by the vote they sign."""
 
     latest_new_aggregated_payloads: dict[AttestationData, set[SingleMessageAggregate]] = Field(
         default_factory=dict
     )
-    """
-    Aggregated signature proofs pending processing.
-
-    These payloads are "new" and do not yet contribute to fork choice.
-    They migrate to known payloads via interval ticks.
-    Populated from gossip aggregated attestations.
-    Block import does not feed individual proofs into this map directly.
-    The block-level proof is a merged multi-message aggregate blob verified as a whole.
-    On gossip-block import, any validator deconstructs that multi-message aggregate into
-    per-message proofs, writes them back here, and gossips the aggregate.
-    """
+    """Pending single-message proofs awaiting promotion, grouped by the vote they support."""
 
     latest_known_aggregated_payloads: dict[AttestationData, set[SingleMessageAggregate]] = Field(
         default_factory=dict
     )
-    """
-    Aggregated signature proofs that have been processed.
-
-    These payloads are "known" and contribute to fork choice weights.
-    Used for recursive signature aggregation when building blocks.
-    """
+    """Single-message proofs counted toward fork choice, grouped by the vote they support."""

--- a/src/lean_spec/spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/spec/forks/lstar/containers/validator.py
@@ -1,21 +1,8 @@
-"""Genesis configuration and the validator registry."""
+"""The validator registry tracked in the consensus state."""
 
-from lean_spec.spec.crypto.xmss.containers import PublicKey
 from lean_spec.spec.forks.lstar.config import VALIDATOR_REGISTRY_LIMIT
 from lean_spec.spec.forks.lstar.containers.identifiers import ValidatorIndex
-from lean_spec.spec.ssz import Bytes52, Container, SSZList, Uint64
-
-
-class GenesisConfig(Container):
-    """
-    Holds temporary configuration properties for simplified consensus.
-
-    Note: These fields support a simplified round-robin block production
-    in the absence of more complex mechanisms like RANDAO or deposits.
-    """
-
-    genesis_time: Uint64
-    """The timestamp of the genesis block."""
+from lean_spec.spec.ssz import Bytes52, Container, SSZList
 
 
 class Validator(Container):
@@ -29,14 +16,6 @@ class Validator(Container):
 
     index: ValidatorIndex = ValidatorIndex(0)
     """Validator index in the registry."""
-
-    def get_attestation_public_key(self) -> PublicKey:
-        """Get the XMSS public key used for attestation verification."""
-        return PublicKey.decode_bytes(bytes(self.attestation_public_key))
-
-    def get_proposal_public_key(self) -> PublicKey:
-        """Get the XMSS public key used for proposer attestation verification."""
-        return PublicKey.decode_bytes(bytes(self.proposal_public_key))
 
 
 class Validators(SSZList[Validator]):

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -4,6 +4,7 @@ import math
 from collections import defaultdict
 
 from lean_spec.spec.crypto.merkleization import hash_tree_root
+from lean_spec.spec.crypto.xmss.containers import PublicKey
 from lean_spec.spec.crypto.xmss.interface import TARGET_SIGNATURE_SCHEME
 from lean_spec.spec.forks.lstar._base import LstarSpecBase, LstarStore
 from lean_spec.spec.forks.lstar.config import (
@@ -319,7 +320,9 @@ class ForkChoiceMixin(LstarSpecBase):
                     f"Validator {validator_index} not found in state "
                     f"{attestation_data.target.root.hex()}",
                 )
-            public_key = key_state.validators[validator_index].get_attestation_public_key()
+            public_key = PublicKey.decode_bytes(
+                bytes(key_state.validators[validator_index].attestation_public_key)
+            )
 
             if not TARGET_SIGNATURE_SCHEME.verify(
                 public_key, attestation_data.slot, hash_tree_root(attestation_data), signature
@@ -388,7 +391,7 @@ class ForkChoiceMixin(LstarSpecBase):
 
         # Prepare public keys for verification
         public_keys = [
-            validators[validator_index].get_attestation_public_key()
+            PublicKey.decode_bytes(bytes(validators[validator_index].attestation_public_key))
             for validator_index in validator_indices
         ]
 

--- a/src/lean_spec/spec/forks/lstar/signatures.py
+++ b/src/lean_spec/spec/forks/lstar/signatures.py
@@ -67,7 +67,9 @@ class SignatureMixin(LstarSpecBase):
 
             public_keys_per_message.append(
                 [
-                    validators[validator_index].get_attestation_public_key()
+                    PublicKey.decode_bytes(
+                        bytes(validators[validator_index].attestation_public_key)
+                    )
                     for validator_index in validator_indices
                 ]
             )
@@ -89,7 +91,9 @@ class SignatureMixin(LstarSpecBase):
                 RejectionReason.PROPOSER_INDEX_OUT_OF_RANGE, "Proposer index out of range"
             )
 
-        public_keys_per_message.append([validators[proposer_index].get_proposal_public_key()])
+        public_keys_per_message.append(
+            [PublicKey.decode_bytes(bytes(validators[proposer_index].proposal_public_key))]
+        )
         message_bindings.append((hash_tree_root(block), block.slot))
 
         try:

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -476,11 +476,15 @@ class StateTransitionMixin(LstarSpecBase):
                 # drag latest_justified backwards.
                 if target.slot > latest_justified.slot:
                     latest_justified = target
-                justified_slots = justified_slots.with_justified(
-                    finalized_slot,
-                    target.slot,
-                    Boolean(True),
-                )
+
+                # The justifiable filter above guarantees an in-range index.
+                justified_index = target.slot.justified_index_after(finalized_slot)
+                assert justified_index is not None
+
+                # Rebind to a copy so the pre-state bitfield is never mutated.
+                updated_justified_bits = list(justified_slots.data)
+                updated_justified_bits[justified_index] = Boolean(True)
+                justified_slots = JustifiedSlots(data=updated_justified_bits)
 
                 # There is no longer any need to track individual votes for this block.
                 del justifications[target.root]
@@ -516,7 +520,7 @@ class StateTransitionMixin(LstarSpecBase):
                     # is now finalized (latest <= finalized_slot).
                     delta = int(finalized_slot - old_finalized_slot)
                     if delta > 0:
-                        justified_slots = justified_slots.shift_window(delta)
+                        justified_slots = JustifiedSlots(data=justified_slots.data[delta:])
                         assert all(root in root_to_slot for root in justifications), (
                             "Justification root missing from root_to_slot"
                         )

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -22,7 +22,7 @@ from lean_spec.node.sync.service import SyncService
 from lean_spec.spec.crypto.koalabear import Fp
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.crypto.xmss.constants import TARGET_CONFIG
-from lean_spec.spec.crypto.xmss.containers import Signature
+from lean_spec.spec.crypto.xmss.containers import PublicKey, Signature
 from lean_spec.spec.crypto.xmss.types import (
     HashDigestList,
     HashDigestVector,
@@ -464,12 +464,16 @@ def make_signed_block_from_store(
     head_state = new_store.states[new_store.head]
     public_keys_per_aggregate: list[list] = [
         [
-            head_state.validators[validator_index].get_attestation_public_key()
+            PublicKey.decode_bytes(
+                bytes(head_state.validators[validator_index].attestation_public_key)
+            )
             for validator_index in attestation_proof.participants.to_validator_indices()
         ]
         for attestation_proof in attestation_proofs
     ]
-    proposer_public_key = head_state.validators[proposer_index].get_proposal_public_key()
+    proposer_public_key = PublicKey.decode_bytes(
+        bytes(head_state.validators[proposer_index].proposal_public_key)
+    )
     public_keys_per_aggregate.append([proposer_public_key])
 
     proposer_signature = key_manager.sign_block_root(proposer_index, slot, block_root)

--- a/tests/lean_spec/spec/forks/lstar/containers/test_genesis.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_genesis.py
@@ -1,0 +1,17 @@
+"""Tests for the GenesisConfig container."""
+
+import pytest
+from pydantic import ValidationError
+
+from lean_spec.spec.forks.lstar.containers import GenesisConfig
+from lean_spec.spec.ssz import Uint64
+
+
+class TestGenesisConfigImmutability:
+    """Frozen-model semantics forbid post-construction mutation."""
+
+    def test_assigning_genesis_time_raises(self) -> None:
+        """Assigning a new genesis time on a constructed config raises."""
+        config = GenesisConfig(genesis_time=Uint64(1_700_000_000))
+        with pytest.raises(ValidationError, match="frozen"):
+            config.genesis_time = Uint64(1_700_000_001)

--- a/tests/lean_spec/spec/forks/lstar/containers/test_state.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_state.py
@@ -5,15 +5,265 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from lean_spec.spec.forks import Slot
+from lean_spec.spec.forks import Checkpoint, Slot
+from lean_spec.spec.forks.lstar.config import HISTORICAL_ROOTS_LIMIT, VALIDATOR_REGISTRY_LIMIT
+from lean_spec.spec.forks.lstar.containers.state import (
+    HistoricalBlockHashes,
+    JustificationRoots,
+    JustificationValidators,
+    JustifiedSlots,
+    State,
+)
+from lean_spec.spec.ssz import Boolean, Bytes32
+from lean_spec.spec.ssz.exceptions import SSZValueError
 from tests.lean_spec.helpers import make_genesis_state
 
 
-def test_is_slot_justified_raises_on_out_of_bounds() -> None:
-    # For slots > finalized_slot, the bitfield must be long enough to cover the slot.
-    # If it is not, this indicates an inconsistent state and should fail fast.
-    with pytest.raises(IndexError):
-        make_genesis_state(num_validators=1).justified_slots.is_slot_justified(Slot(0), Slot(1))
+class TestJustifiedSlotsIsSlotJustified:
+    """Justification lookups against the tracked slot bitfield."""
+
+    def test_target_at_finalized_boundary_is_implicitly_justified(self) -> None:
+        """A target equal to the finalized boundary is justified without consulting bits."""
+        justified_slots = JustifiedSlots(data=[])
+        assert justified_slots.is_slot_justified(Slot(4), Slot(4)) == Boolean(True)
+
+    def test_target_before_finalized_boundary_is_implicitly_justified(self) -> None:
+        """A target below the finalized boundary is justified without consulting bits."""
+        justified_slots = JustifiedSlots(data=[])
+        assert justified_slots.is_slot_justified(Slot(4), Slot(1)) == Boolean(True)
+
+    def test_target_after_finalized_with_bit_set_true(self) -> None:
+        """A future target whose tracked bit is set reads back as justified."""
+        justified_slots = JustifiedSlots(data=[Boolean(True), Boolean(False)])
+        assert justified_slots.is_slot_justified(Slot(0), Slot(1)) == Boolean(True)
+
+    def test_target_after_finalized_with_bit_set_false(self) -> None:
+        """A future target whose tracked bit is clear reads back as not justified."""
+        justified_slots = JustifiedSlots(data=[Boolean(True), Boolean(False)])
+        assert justified_slots.is_slot_justified(Slot(0), Slot(2)) == Boolean(False)
+
+    def test_nonzero_finalized_anchor_offsets_the_relative_index(self) -> None:
+        """A non-zero finalized anchor shifts which tracked bit a future slot maps to."""
+        # Finalized boundary 3 maps slot 4 to index 0 and slot 6 to index 2.
+        justified_slots = JustifiedSlots(data=[Boolean(False), Boolean(True), Boolean(True)])
+        assert justified_slots.is_slot_justified(Slot(3), Slot(4)) == Boolean(False)
+        assert justified_slots.is_slot_justified(Slot(3), Slot(5)) == Boolean(True)
+        assert justified_slots.is_slot_justified(Slot(3), Slot(6)) == Boolean(True)
+
+    def test_target_beyond_tracked_length_raises_with_boundary_and_length(self) -> None:
+        """A future target past the tracked range raises naming the boundary and length."""
+        justified_slots = JustifiedSlots(data=[Boolean(True)])
+        with pytest.raises(
+            IndexError,
+            match=r"Slot 5 is outside the tracked range "
+            r"\(finalized_boundary=0, tracked_length=1\)",
+        ):
+            justified_slots.is_slot_justified(Slot(0), Slot(5))
+
+    def test_target_beyond_tracked_length_with_nonzero_anchor_reports_anchor(self) -> None:
+        """The out-of-range error reports the non-zero finalized anchor and the length."""
+        justified_slots = JustifiedSlots(data=[Boolean(True), Boolean(False)])
+        with pytest.raises(
+            IndexError,
+            match=r"Slot 7 is outside the tracked range "
+            r"\(finalized_boundary=2, tracked_length=2\)",
+        ):
+            justified_slots.is_slot_justified(Slot(2), Slot(7))
+
+    def test_empty_bitfield_future_target_raises(self) -> None:
+        """An empty bitfield cannot answer any future slot and raises."""
+        justified_slots = JustifiedSlots(data=[])
+        with pytest.raises(
+            IndexError,
+            match=r"Slot 1 is outside the tracked range "
+            r"\(finalized_boundary=0, tracked_length=0\)",
+        ):
+            justified_slots.is_slot_justified(Slot(0), Slot(1))
+
+
+class TestJustifiedSlotsExtendToSlot:
+    """Capacity growth that keeps the tracked slot bitfield addressable."""
+
+    def test_finalized_target_returns_same_instance_unchanged(self) -> None:
+        """A target at or below the finalized boundary needs no growth and is returned as is."""
+        justified_slots = JustifiedSlots(data=[Boolean(True)])
+        assert justified_slots.extend_to_slot(Slot(5), Slot(2)) is justified_slots
+
+    def test_exact_boundary_capacity_returns_same_instance(self) -> None:
+        """A target that fits the last existing index exactly triggers no growth."""
+        # Finalized 0, target 2 maps to index 1, which the two stored bits already cover.
+        justified_slots = JustifiedSlots(data=[Boolean(True), Boolean(False)])
+        assert justified_slots.extend_to_slot(Slot(0), Slot(2)) is justified_slots
+
+    def test_surplus_capacity_returns_same_instance(self) -> None:
+        """A target well within the existing capacity triggers no growth."""
+        justified_slots = JustifiedSlots(data=[Boolean(True), Boolean(False), Boolean(True)])
+        assert justified_slots.extend_to_slot(Slot(0), Slot(1)) is justified_slots
+
+    def test_growth_by_one_appends_single_false_and_preserves_bits(self) -> None:
+        """Growing by one index appends one False bit and keeps the existing bits."""
+        justified_slots = JustifiedSlots(data=[Boolean(True)])
+        extended_slots = justified_slots.extend_to_slot(Slot(0), Slot(2))
+        assert extended_slots == JustifiedSlots(data=[Boolean(True), Boolean(False)])
+
+    def test_growth_by_several_appends_only_false_bits(self) -> None:
+        """Growing by several indices appends only False bits and keeps the existing bits."""
+        justified_slots = JustifiedSlots(data=[Boolean(True)])
+        extended_slots = justified_slots.extend_to_slot(Slot(0), Slot(4))
+        assert extended_slots == JustifiedSlots(
+            data=[Boolean(True), Boolean(False), Boolean(False), Boolean(False)]
+        )
+
+    def test_growth_from_empty_bitfield(self) -> None:
+        """Growing an empty bitfield yields all False up to the required index."""
+        justified_slots = JustifiedSlots(data=[])
+        extended_slots = justified_slots.extend_to_slot(Slot(0), Slot(3))
+        assert extended_slots == JustifiedSlots(
+            data=[Boolean(False), Boolean(False), Boolean(False)]
+        )
+
+    def test_growth_with_nonzero_finalized_anchor(self) -> None:
+        """A non-zero anchor offsets the required index when computing the gap to fill."""
+        # Finalized 2, target 5 maps to index 2, so two False bits are appended.
+        justified_slots = JustifiedSlots(data=[Boolean(True)])
+        extended_slots = justified_slots.extend_to_slot(Slot(2), Slot(5))
+        assert extended_slots == JustifiedSlots(
+            data=[Boolean(True), Boolean(False), Boolean(False)]
+        )
+
+    def test_extended_slots_are_queryable_as_not_justified(self) -> None:
+        """Slots filled by growth report as not justified until their bit is set."""
+        justified_slots = JustifiedSlots(data=[Boolean(True)])
+        extended_slots = justified_slots.extend_to_slot(Slot(0), Slot(3))
+        assert extended_slots.is_slot_justified(Slot(0), Slot(1)) == Boolean(True)
+        assert extended_slots.is_slot_justified(Slot(0), Slot(3)) == Boolean(False)
+
+
+class TestSlotBitfieldLimits:
+    """Construction and limit enforcement for the slot-tracking SSZ types."""
+
+    @pytest.mark.parametrize(
+        "slot_tracking_type",
+        [HistoricalBlockHashes, JustificationRoots],
+        ids=["historical_block_hashes", "justification_roots"],
+    )
+    def test_root_lists_share_historical_roots_limit(
+        self, slot_tracking_type: type[HistoricalBlockHashes] | type[JustificationRoots]
+    ) -> None:
+        """Both root lists cap their length at the historical roots limit."""
+        assert slot_tracking_type.LIMIT == int(HISTORICAL_ROOTS_LIMIT)
+
+    def test_justified_slots_limit_is_historical_roots_limit(self) -> None:
+        """The justified-slot bitfield caps at the historical roots limit."""
+        assert JustifiedSlots.LIMIT == int(HISTORICAL_ROOTS_LIMIT)
+
+    def test_justification_validators_limit_is_product_of_both_limits(self) -> None:
+        """The flattened validator vote bitfield caps at roots times registry size."""
+        assert JustificationValidators.LIMIT == int(HISTORICAL_ROOTS_LIMIT) * int(
+            VALIDATOR_REGISTRY_LIMIT
+        )
+
+    @pytest.mark.parametrize(
+        "slot_tracking_type",
+        [HistoricalBlockHashes, JustificationRoots],
+        ids=["historical_block_hashes", "justification_roots"],
+    )
+    def test_root_lists_construct_empty(
+        self, slot_tracking_type: type[HistoricalBlockHashes] | type[JustificationRoots]
+    ) -> None:
+        """Both root lists construct as empty collections."""
+        assert list(slot_tracking_type(data=[]).data) == []
+
+    @pytest.mark.parametrize(
+        "slot_tracking_type",
+        [HistoricalBlockHashes, JustificationRoots],
+        ids=["historical_block_hashes", "justification_roots"],
+    )
+    def test_root_lists_construct_populated(
+        self, slot_tracking_type: type[HistoricalBlockHashes] | type[JustificationRoots]
+    ) -> None:
+        """Both root lists hold the exact roots they were built from."""
+        roots = [Bytes32(bytes([7]) * 32), Bytes32(bytes([9]) * 32)]
+        assert list(slot_tracking_type(data=roots).data) == roots
+
+    @pytest.mark.parametrize(
+        "bitfield_type",
+        [JustifiedSlots, JustificationValidators],
+        ids=["justified_slots", "justification_validators"],
+    )
+    def test_bitfields_construct_empty(
+        self, bitfield_type: type[JustifiedSlots] | type[JustificationValidators]
+    ) -> None:
+        """Both bitfields construct as empty collections."""
+        assert list(bitfield_type(data=[]).data) == []
+
+    @pytest.mark.parametrize(
+        "bitfield_type",
+        [JustifiedSlots, JustificationValidators],
+        ids=["justified_slots", "justification_validators"],
+    )
+    def test_bitfields_construct_populated(
+        self, bitfield_type: type[JustifiedSlots] | type[JustificationValidators]
+    ) -> None:
+        """Both bitfields coerce their inputs into the booleans they were built from."""
+        assert list(bitfield_type(data=[True, False, True]).data) == [
+            Boolean(True),
+            Boolean(False),
+            Boolean(True),
+        ]
+
+    def test_justified_slots_exceeding_limit_raises(self) -> None:
+        """A justified-slot bitfield longer than its limit is rejected."""
+        with pytest.raises(SSZValueError, match=r"exceeds limit"):
+            JustifiedSlots(data=[Boolean(False)] * (int(HISTORICAL_ROOTS_LIMIT) + 1))
+
+    def test_justified_slots_at_limit_constructs(self) -> None:
+        """A justified-slot bitfield exactly at its limit constructs successfully."""
+        at_limit_slots = JustifiedSlots(data=[Boolean(False)] * int(HISTORICAL_ROOTS_LIMIT))
+        assert len(at_limit_slots.data) == int(HISTORICAL_ROOTS_LIMIT)
+
+
+class TestStateGenesis:
+    """Field values present in a freshly generated genesis state."""
+
+    def test_genesis_slot_is_zero(self) -> None:
+        """Genesis starts at slot zero."""
+        assert make_genesis_state(num_validators=1).slot == Slot(0)
+
+    def test_genesis_history_collections_are_empty(self) -> None:
+        """Genesis carries no historical hashes, justified slots, or justification tracking."""
+        genesis_state = make_genesis_state(num_validators=4)
+        assert genesis_state.historical_block_hashes == HistoricalBlockHashes(data=[])
+        assert genesis_state.justified_slots == JustifiedSlots(data=[])
+        assert genesis_state.justifications_roots == JustificationRoots(data=[])
+        assert genesis_state.justifications_validators == JustificationValidators(data=[])
+
+    def test_genesis_checkpoints_anchor_at_zero(self) -> None:
+        """Genesis justified and finalized checkpoints both point at the zero anchor."""
+        genesis_state = make_genesis_state(num_validators=2)
+        genesis_anchor_checkpoint = Checkpoint(root=Bytes32.zero(), slot=Slot(0))
+        assert genesis_state.latest_justified == genesis_anchor_checkpoint
+        assert genesis_state.latest_finalized == genesis_anchor_checkpoint
+
+    @pytest.mark.parametrize("num_validators", [1, 3, 16], ids=["one", "three", "sixteen"])
+    def test_genesis_validator_registry_length_matches_request(self, num_validators: int) -> None:
+        """The genesis validator registry length matches the requested validator count."""
+        assert len(make_genesis_state(num_validators=num_validators).validators.data) == (
+            num_validators
+        )
+
+    def test_genesis_config_records_genesis_time(self) -> None:
+        """The genesis configuration records the supplied genesis time."""
+        assert int(make_genesis_state(num_validators=1, genesis_time=42).config.genesis_time) == 42
+
+
+class TestStateSerialization:
+    """SSZ wire-format round-tripping for the State container."""
+
+    def test_genesis_state_roundtrips_through_ssz_bytes(self) -> None:
+        """Encoding genesis to SSZ bytes and decoding back reproduces the same state."""
+        genesis_state = make_genesis_state(num_validators=3)
+        assert State.decode_bytes(genesis_state.encode_bytes()) == genesis_state
 
 
 class TestStateImmutability:

--- a/tests/lean_spec/spec/forks/lstar/containers/test_validator.py
+++ b/tests/lean_spec/spec/forks/lstar/containers/test_validator.py
@@ -1,20 +1,10 @@
-"""Tests for the GenesisConfig and Validator containers."""
+"""Tests for the Validator containers."""
 
 import pytest
 from pydantic import ValidationError
 
-from lean_spec.spec.forks.lstar.containers import GenesisConfig, Validator
-from lean_spec.spec.ssz import Bytes52, Uint64
-
-
-class TestGenesisConfigImmutability:
-    """Frozen-model semantics forbid post-construction mutation."""
-
-    def test_assigning_genesis_time_raises(self) -> None:
-        """Assigning a new genesis time on a constructed config raises."""
-        config = GenesisConfig(genesis_time=Uint64(1_700_000_000))
-        with pytest.raises(ValidationError, match="frozen"):
-            config.genesis_time = Uint64(1_700_000_001)
+from lean_spec.spec.forks.lstar.containers import Validator
+from lean_spec.spec.ssz import Bytes52
 
 
 class TestValidatorImmutability:

--- a/tests/lean_spec/spec/forks/lstar/test_aggregation.py
+++ b/tests/lean_spec/spec/forks/lstar/test_aggregation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from consensus_testing.keys import XmssKeyManager
 from lean_spec.spec.crypto.merkleization import hash_tree_root
+from lean_spec.spec.crypto.xmss.containers import PublicKey
 from lean_spec.spec.forks import AggregationBits, Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import AttestationSignatureEntry
 from lean_spec.spec.forks.lstar.aggregation import select_proofs_for_coverage
@@ -499,7 +500,10 @@ def test_aggregated_signatures_prefers_full_gossip_payload(
     }
 
     public_keys = [
-        head_state.validators[ValidatorIndex(i)].get_attestation_public_key() for i in range(2)
+        PublicKey.decode_bytes(
+            bytes(head_state.validators[ValidatorIndex(i)].attestation_public_key)
+        )
+        for i in range(2)
     ]
     aggregated_attestations[0].proof.verify(
         public_keys=public_keys,

--- a/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
+++ b/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
@@ -8,6 +8,7 @@ from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
 
 from consensus_testing.keys import XmssKeyManager
 from lean_spec.spec.crypto.merkleization import hash_tree_root
+from lean_spec.spec.crypto.xmss.containers import PublicKey
 from lean_spec.spec.forks import AggregationBits, Checkpoint, Interval, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar import AttestationSignatureEntry, Store
 from lean_spec.spec.forks.lstar.config import (
@@ -1573,7 +1574,9 @@ class TestIntegrationScenarios:
         head_state = store.states[store.head]
         public_keys_per_aggregate: list[list] = [
             [
-                head_state.validators[validator_index].get_attestation_public_key()
+                PublicKey.decode_bytes(
+                    bytes(head_state.validators[validator_index].attestation_public_key)
+                )
                 for validator_index in proof.participants.to_validator_indices()
             ]
             for proof in signatures


### PR DESCRIPTION
## Summary

A documentation and readability pass over the lstar container family, plus the small code simplifications it surfaced.

### Documentation
- Bring docstrings across the container family in line with the project /doc rules: one-line by default, one sentence per line, no backticks, no field rosters in class docstrings, no identifier names in prose.
- Touched `block.py`, `attestation.py`, `state.py`, `store.py`, and the new `genesis.py`.
- Fixed two factually wrong docstrings: the attestation data "beacon chain format" comparison, and the `GenesisConfig` note that claimed it drives round-robin block production (proposer selection is `slot % num_validators`; `genesis_time` plays no part).

### Simplification
- Inline the single-use `JustifiedSlots.with_justified` and `shift_window` helpers at their one call site in the state transition, dropping the defensive branches the call site already guarantees.
- Remove `Validator.get_attestation_public_key` / `get_proposal_public_key` and inline the SSZ public-key decode at every call site, so the conversion is explicit in the spec (no behavior change).
- Split `GenesisConfig` out of `validator.py` into its own `genesis` module — it is chain configuration committed into the state, unrelated to the validator registry. The public container surface (package re-exports) is unchanged.

### Tests
- Expand the `State` container unit tests from 2 to 39 cases: `is_slot_justified`, `extend_to_slot`, slot-tracking limits, genesis field values, and SSZ round-trip. `state.py` reaches 100% line/branch coverage.
- Move the `GenesisConfig` test into a mirrored `test_genesis.py` alongside the module move.

## Test plan
- `just check` passes clean (ruff, ruff format, ty, codespell, mdformat).
- Impacted unit test modules pass (state, validator, genesis, validator_duties, aggregation, fork_choice, node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)