### PR TITLE
docs(spec): fix duplicated phrasing and filler in lstar docs

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/aggregation.py
@@ -132,7 +132,7 @@ class SingleMessageAggregate(Container):
         slot: Slot,
     ) -> None:
         """
-        Verify this single-message single-message aggregate proof against a public_key set.
+        Verify this single-message aggregate proof against a set of public keys.
 
         Args:
             public_keys: PublicKeys for the validators named by participants.

--- a/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
+++ b/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
@@ -11,7 +11,7 @@ from lean_spec.spec.ssz import Bytes32, Container
 
 class Checkpoint(Container):
     """
-    Represents a checkpoint in the chain's history.
+    A checkpoint in the chain's history.
 
     A checkpoint marks a specific moment in the chain.
 

--- a/src/lean_spec/spec/forks/lstar/containers/identifiers.py
+++ b/src/lean_spec/spec/forks/lstar/containers/identifiers.py
@@ -10,7 +10,7 @@ class SubnetId(Uint64):
 
 
 class ValidatorIndex(Uint64):
-    """Represents a validator's unique index as a 64-bit unsigned integer."""
+    """A validator's index in the registry, as a 64-bit unsigned integer."""
 
     @classmethod
     def proposer_for_slot(cls, slot: Slot, num_validators: Uint64) -> "ValidatorIndex":

--- a/src/lean_spec/spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/spec/forks/lstar/containers/validator.py
@@ -6,7 +6,7 @@ from lean_spec.spec.ssz import Bytes52, Container, SSZList
 
 
 class Validator(Container):
-    """Represents a validator's static metadata and operational interface."""
+    """A validator's static metadata and operational interface."""
 
     attestation_public_key: Bytes52
     """XMSS public key for signing attestations."""

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -394,7 +394,7 @@ class ForkChoiceMixin(LstarSpecBase):
             for validator_index in validator_indices
         ]
 
-        # Verify the single-message aggregate single-message aggregated proof.
+        # Verify the single-message aggregate proof.
         try:
             aggregated_proof.verify(
                 public_keys=public_keys,

--- a/src/lean_spec/spec/forks/lstar/slot.py
+++ b/src/lean_spec/spec/forks/lstar/slot.py
@@ -16,7 +16,7 @@ IMMEDIATE_JUSTIFICATION_WINDOW: Final = 5
 
 
 class Slot(Uint64):
-    """Represents a slot number as a 64-bit unsigned integer."""
+    """A slot number, as a 64-bit unsigned integer."""
 
     def justified_index_after(self, finalized_slot: "Slot") -> int | None:
         """
@@ -36,7 +36,7 @@ class Slot(Uint64):
         Checks if this slot is a valid candidate for justification after a given finalized slot.
 
         According to the 3SF-mini specification, a slot is justifiable if its
-        distance (`delta`) from the last finalized slot is:
+        distance (delta) from the last finalized slot is:
           1. Less than or equal to 5.
           2. A perfect square (e.g., 9, 16, 25...).
           3. A pronic number (of the form x^2 + x, e.g., 6, 12, 20...).


### PR DESCRIPTION
## Summary

Pure documentation cleanup across lstar — no behavior change.

- **Doubled phrasing** (a stray find/replace artifact): "single-message single-message aggregate proof" and "single-message aggregate single-message aggregated proof" → "single-message aggregate proof", in `containers/aggregation.py` (verify docstring) and `fork_choice.py` (comment). Also reworded "against a public_key set" → "against a set of public keys" to avoid referencing the parameter name in prose.
- **"Represents a …" filler summaries** → noun-phrase summaries, per the docstring rules: `Slot`, `ValidatorIndex`, `Validator`, `Checkpoint`.
- **Banned backticks** around `delta` removed from the justifiability docstring in `slot.py`.

## Testing
- `just check` passes (lint, format, type check, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)