### PR TITLE
refactor(spec): simplify attestation bounds check and vote marking

### DIFF
--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -61,11 +61,8 @@ def attestation_data_matches_chain(
     source_slot = int(attestation_data.source.slot)
     target_slot = int(attestation_data.target.slot)
     head_slot = int(attestation_data.head.slot)
-    if source_slot >= len(historical_block_hashes):
-        return False
-    if target_slot >= len(historical_block_hashes):
-        return False
-    if head_slot >= len(historical_block_hashes):
+    chain_length = len(historical_block_hashes)
+    if source_slot >= chain_length or target_slot >= chain_length or head_slot >= chain_length:
         return False
 
     # All checkpoint roots must match the chain at their slot.
@@ -450,11 +447,10 @@ class StateTransitionMixin(LstarSpecBase):
 
             # Mark that each validator in this aggregation has voted for the target.
             #
-            # A vote is represented as a boolean flag.
-            # If it was previously absent, flip it to True.
+            # A vote is a boolean flag set to True.
+            # Re-marking an existing voter is idempotent, so no guard is needed.
             for validator_index in attestation.aggregation_bits.to_validator_indices():
-                if not justifications[target.root][validator_index]:
-                    justifications[target.root][validator_index] = Boolean(True)
+                justifications[target.root][validator_index] = Boolean(True)
 
             # Check whether the vote count crosses the supermajority threshold.
             #


### PR DESCRIPTION
## Summary

Two small behavior-preserving simplifications in the lstar state transition.

1. **Bounds check** (`attestation_data_matches_chain`) — collapse the three identical `>= len(historical_block_hashes)` guards into one `or` chain and hoist the repeated `len()` into a `chain_length` local. This mirrors the zero-hash trio directly above it, which already uses the `or`-chain form.
2. **Vote marking** (`process_attestations`) — drop the `if not justifications[...][i]:` guard before setting a validator's vote flag. Setting an already-`True` flag to `True` is idempotent, so the unconditional assignment is equivalent and removes a branch + a redundant read. Comment updated to state why no guard is needed.

## Note: one proposed change was dropped as incorrect
A related audit item suggested replacing `sum(bool(justified) for justified in justifications[target.root])` with `sum(justifications[target.root])`. That would **break** — `Boolean` explicitly disables arithmetic (`__add__`/`__radd__` raise `TypeError`), so `sum` over `Boolean` values fails. The `bool(...)` wrapper converts to plain `int` first and is required. Left unchanged.

## Testing
- `just check` passes (lint, format, type check, codespell, mdformat).
- `test_state_transition.py` + `test_fork_choice.py`: 65 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)