### PR TITLE
refactor(spec): drop unused fork-registry name lookup

### DIFF
--- a/src/lean_spec/spec/forks/registry.py
+++ b/src/lean_spec/spec/forks/registry.py
@@ -36,28 +36,8 @@ class ForkRegistry:
             raise ValueError(f"Fork names must be unique: {names}")
 
         self._forks = forks
-        self._by_name = {f.NAME: f for f in forks}
 
     @property
     def current(self) -> ForkProtocol:
         """Return the latest (highest version) fork."""
         return self._forks[-1]
-
-    def get_fork(self, name: str) -> ForkProtocol:
-        """
-        Look up a fork by name.
-
-        Args:
-            name: Fork name (e.g. 'lstar').
-
-        Returns:
-            The matching ForkProtocol instance.
-
-        Raises:
-            KeyError: If no fork matches the name.
-        """
-        try:
-            return self._by_name[name]
-        except KeyError as exception:
-            known = sorted(self._by_name)
-            raise KeyError(f"Unknown fork: {name!r}. Known: {known}") from exception

--- a/tests/lean_spec/spec/forks/test_registry.py
+++ b/tests/lean_spec/spec/forks/test_registry.py
@@ -33,18 +33,6 @@ class TestForkRegistry:
         registry = ForkRegistry([LstarSpec(), _NextSpec()])
         assert registry.current.NAME == _NextSpec.NAME
 
-    def test_get_fork_by_name(self) -> None:
-        """ForkRegistry.get_fork looks up by fork NAME."""
-        registry = ForkRegistry([LstarSpec(), _NextSpec()])
-        assert registry.get_fork("lstar").NAME == "lstar"
-        assert registry.get_fork("next").NAME == "next"
-
-    def test_get_fork_unknown_raises(self) -> None:
-        """ForkRegistry.get_fork raises KeyError for unknown forks."""
-        registry = ForkRegistry([LstarSpec()])
-        with pytest.raises(KeyError, match="Unknown fork: 'missing'"):
-            registry.get_fork("missing")
-
     def test_empty_forks_raises(self) -> None:
         """ForkRegistry requires at least one fork."""
         with pytest.raises(ValueError, match="at least one fork"):


### PR DESCRIPTION
## Summary

The fork registry's by-name lookup (`get_fork`) has no caller outside its own tests — verified across `src/`, `tests/`, and `packages/`. The only production use of the registry is the `current` (latest-fork) accessor. The `_by_name` map existed solely to back that lookup.

Removing it does not weaken any validation: the name-uniqueness check in `__init__` builds its own `set(names)` independently, so `test_duplicate_name_rejected` still passes.

- Deleted `ForkRegistry.get_fork` and the `_by_name` map.
- Deleted its two tests (`test_get_fork_by_name`, `test_get_fork_unknown_raises`).

When a second fork lands and a name-based lookup is actually needed, it's a trivial few lines to reintroduce — there's no reason to carry it dead in the meantime.

## Testing
- `just check` passes (lint, format, type check, codespell, mdformat).
- `test_registry.py`: 6 passed (the remaining registry tests, including the name-collision check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)