### PR TITLE
refactor(ssz): drop redundant bytearray copy in byte coercion

### DIFF
--- a/src/lean_spec/spec/ssz/byte_arrays.py
+++ b/src/lean_spec/spec/ssz/byte_arrays.py
@@ -67,7 +67,7 @@ class BaseBytes(bytes, SSZType):
             case str():
                 return bytes.fromhex(value.removeprefix("0x"))
             case Iterable():
-                return bytes(bytearray(value))
+                return bytes(value)
             case _:
                 raise TypeError(f"Cannot coerce {type(value).__name__} to bytes")
 


### PR DESCRIPTION
## Summary

In the iterable branch of byte coercion, `bytes(bytearray(value))` wraps the input in a `bytearray` before producing the immutable result. `bytes(iterable_of_ints)` already materializes and range-checks each element directly, so the intermediate `bytearray` is a needless allocation and copy. Behavior (including the out-of-range `ValueError`) is identical.

## Note: a second audit item was dropped as a false positive
The audit also flagged `BaseByteList.hex()` as dead code to delete. It is **not** dead — it has test callers, and removing it makes `ty check` fail with `unresolved-attribute`. It exists deliberately to give the variable-length byte-list type the same `.hex()` affordance that the fixed `BaseBytes` gets natively (the list type is not a `bytes` subclass). `test_json_dumpable_via_hex` documents this parity by calling `.hex()` uniformly across `Bytes32`, `Bytes4`, and a `ByteList`. Left in place.

## Testing
- `just check` passes (lint, format, type check, codespell, mdformat).
- `test_byte_arrays.py`: 87 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)