### PR TITLE
refactor(spec): clarify names and bind repeated block lookups once

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/interface.py
+++ b/src/lean_spec/spec/crypto/xmss/interface.py
@@ -317,17 +317,17 @@ class GeneralizedXmssScheme(StrictBaseModel):
 
         # Phase 3: finish each chain from the released hash to its endpoint.
         chain_ends: list[HashDigestVector] = []
-        for chain_index, xi in enumerate(codeword):
-            # The signature provides the digest after xi steps along the chain.
-            # We hash the remaining BASE - 1 - xi times to reach the endpoint.
+        for chain_index, digit in enumerate(codeword):
+            # The signature provides the digest after digit steps along the chain.
+            # We hash the remaining BASE - 1 - digit times to reach the endpoint.
             start_digest = signature.hashes[chain_index]
             end_digest = self.poseidon.hash_chain(
                 config=config,
                 parameter=public_key.parameter,
                 epoch=slot,
                 chain_index=chain_index,
-                start_step=xi,
-                num_steps=config.BASE - 1 - xi,
+                start_step=digit,
+                num_steps=config.BASE - 1 - digit,
                 start_digest=start_digest,
             )
             chain_ends.append(end_digest)

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -552,8 +552,11 @@ class ForkChoiceMixin(LstarSpecBase):
         for attestation_data, proofs in aggregated_payloads.items():
             for proof in proofs:
                 for validator_index in proof.participants.to_validator_indices():
-                    existing = attestations.get(validator_index)
-                    if existing is None or existing.slot < attestation_data.slot:
+                    current_attestation_data = attestations.get(validator_index)
+                    if (
+                        current_attestation_data is None
+                        or current_attestation_data.slot < attestation_data.slot
+                    ):
                         attestations[validator_index] = attestation_data
         return attestations
 
@@ -666,7 +669,7 @@ class ForkChoiceMixin(LstarSpecBase):
         # Descend the tree, choosing the heaviest branch at every fork.
         while children := children_map.get(head):
             # Choose best child: most attestations, then lexicographically highest hash
-            head = max(children, key=lambda x: (weights[x], x))
+            head = max(children, key=lambda child_root: (weights[child_root], child_root))
 
         return head
 

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -68,8 +68,9 @@ class ValidatorDutiesMixin(LstarSpecBase):
         # This keeps the target from advancing too far ahead of the safe target.
         # It balances liveness against safety.
         for _ in range(int(JUSTIFICATION_LOOKBACK_SLOTS)):
-            if store.blocks[target_block_root].slot > lower_bound_slot:
-                target_block_root = store.blocks[target_block_root].parent_root
+            target_block = store.blocks[target_block_root]
+            if target_block.slot > lower_bound_slot:
+                target_block_root = target_block.parent_root
             else:
                 break
 
@@ -77,8 +78,10 @@ class ValidatorDutiesMixin(LstarSpecBase):
         #
         # Walk back until we find a slot that satisfies justifiability rules
         # relative to the latest finalized checkpoint.
-        while store.blocks[target_block_root].slot > finalized_slot:
+        while True:
             target_block = store.blocks[target_block_root]
+            if target_block.slot <= finalized_slot:
+                break
             if target_block.slot.is_justifiable_after(finalized_slot):
                 break
             target_block_root = target_block.parent_root

--- a/src/lean_spec/spec/ssz/collections.py
+++ b/src/lean_spec/spec/ssz/collections.py
@@ -599,15 +599,18 @@ class SSZList[T: SSZType](_SSZSequence[T]):
         first_offset = int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
         if first_offset > scope or first_offset % BYTES_PER_LENGTH_OFFSET != 0:
             raise SSZSerializationError(f"{cls.__name__}: invalid offset {first_offset}")
-        count = first_offset // BYTES_PER_LENGTH_OFFSET
-        if count > cls.LIMIT:
-            raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {count}")
+        num_elements = first_offset // BYTES_PER_LENGTH_OFFSET
+        if num_elements > cls.LIMIT:
+            raise SSZValueError(f"{cls.__name__} exceeds limit of {cls.LIMIT}, got {num_elements}")
 
         # Read the remaining offsets, append scope as the final boundary,
         # then pairwise-iterate the boundary list to yield each body's byte span.
         offsets = [
             first_offset,
-            *(int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET)) for _ in range(count - 1)),
+            *(
+                int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
+                for _ in range(num_elements - 1)
+            ),
             scope,
         ]
         _validate_offsets(offsets, scope, cls.__name__)


### PR DESCRIPTION
## Summary

Cosmetic, behavior-preserving readability cleanups across a few modules.

### Naming
- `fork_choice.py` — `existing` → `current_attestation_data` (a vague name that hid what it held); LMD-GHOST tie-break lambda param `x` → `child_root`.
- `collections.py` — the variable-size list element count `count` → `num_elements`, matching the name the fixed-size branch already uses for the same quantity.
- `crypto/xmss/interface.py` — chain-completion loop variable `xi` → `digit` (the codeword digit it represents), including the two comments that referenced it.

### Bind-once
- `validator_duties.py` — the two safe-target ancestor walks indexed `store.blocks[target_block_root]` two or three times per iteration; now bound once into a local. The justifiability walk becomes a `while True` with explicit break conditions so the single lookup serves both the loop guard and the body.

## Testing
- `just check` passes (lint, format, type check, codespell, mdformat).
- `test_fork_choice.py`, `test_validator_duties.py`, `test_collections.py`, `xmss/test_interface.py`: 201 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)