### PR TITLE
refactor(spec): small stdlib and arithmetic cleanups

### DIFF
--- a/src/lean_spec/spec/crypto/koalabear.py
+++ b/src/lean_spec/spec/crypto/koalabear.py
@@ -1,5 +1,6 @@
 """Core definition of the KoalaBear prime field Fp."""
 
+import math
 from typing import IO, Any, Final, NoReturn, Self, override
 
 from pydantic.annotated_handlers import GetCoreSchemaHandler
@@ -22,7 +23,7 @@ The prime is chosen because the cube map (x -> x^3) is an automorphism of the mu
 P_BITS: Final = 31
 """The number of bits in the prime P."""
 
-P_BYTES: Final = (P_BITS + 7) // 8
+P_BYTES: Final = math.ceil(P_BITS / 8)
 """The size of a KoalaBear field element in bytes."""
 
 

--- a/src/lean_spec/spec/crypto/xmss/poseidon.py
+++ b/src/lean_spec/spec/crypto/xmss/poseidon.py
@@ -140,9 +140,10 @@ class PoseidonXmss(StrictBaseModel):
         state[:cap_length] = capacity_value
 
         # Phase 2: absorb each chunk by overwriting the rate slots.
+        #
+        # Padding makes every chunk exactly rate wide, so the slice always matches.
         for chunk in batched(padded_input, rate):
-            for j, chunk_element in enumerate(chunk):
-                state[cap_length + j] = chunk_element
+            state[cap_length : cap_length + rate] = chunk
             state = engine.permute(state)
 
         # Phase 3: squeeze rate slots, permuting until enough output is available.

--- a/src/lean_spec/spec/forks/lstar/slot.py
+++ b/src/lean_spec/spec/forks/lstar/slot.py
@@ -57,8 +57,7 @@ class Slot(Uint64):
         # Convert to int for pure arithmetic operations below.
         delta = int(self - finalized_slot)
 
-        # Pronic check uses the discriminant 4*delta + 1, computed once.
-        # For pronic delta = n(n+1) this equals (2n+1)^2, an odd perfect square.
+        # Compute the pronic discriminant and its integer square root once.
         pronic_discriminant = 4 * delta + 1
         discriminant_root = math.isqrt(pronic_discriminant)
 
@@ -75,6 +74,8 @@ class Slot(Uint64):
             # Rule 3: Slots at pronic number distances are justifiable.
             #
             # Pronic numbers have the form n(n+1): 2, 6, 12, 20, 30, 42, 56, ...
-            # Check: the discriminant is an odd perfect square.
+            # Mathematical insight: For pronic delta = n(n+1), we have:
+            #   4*delta + 1 = 4n(n+1) + 1 = (2n+1)^2
+            # Check: 4*delta+1 is an odd perfect square
             or (discriminant_root**2 == pronic_discriminant and discriminant_root % 2 == 1)
         )

--- a/src/lean_spec/spec/forks/lstar/slot.py
+++ b/src/lean_spec/spec/forks/lstar/slot.py
@@ -57,6 +57,11 @@ class Slot(Uint64):
         # Convert to int for pure arithmetic operations below.
         delta = int(self - finalized_slot)
 
+        # Pronic check uses the discriminant 4*delta + 1, computed once.
+        # For pronic delta = n(n+1) this equals (2n+1)^2, an odd perfect square.
+        pronic_discriminant = 4 * delta + 1
+        discriminant_root = math.isqrt(pronic_discriminant)
+
         return (
             # Rule 1: The first N slots after finalization are always justifiable.
             #
@@ -70,11 +75,6 @@ class Slot(Uint64):
             # Rule 3: Slots at pronic number distances are justifiable.
             #
             # Pronic numbers have the form n(n+1): 2, 6, 12, 20, 30, 42, 56, ...
-            # Mathematical insight: For pronic delta = n(n+1), we have:
-            #   4*delta + 1 = 4n(n+1) + 1 = (2n+1)^2
-            # Check: 4*delta+1 is an odd perfect square
-            or (
-                math.isqrt(4 * delta + 1) ** 2 == 4 * delta + 1
-                and math.isqrt(4 * delta + 1) % 2 == 1
-            )
+            # Check: the discriminant is an odd perfect square.
+            or (discriminant_root**2 == pronic_discriminant and discriminant_root % 2 == 1)
         )

--- a/src/lean_spec/spec/ssz/bitfields.py
+++ b/src/lean_spec/spec/ssz/bitfields.py
@@ -127,7 +127,7 @@ class BaseBitvector(SSZModel):
         """
         # Build the packed bits as one integer, then split into little-endian bytes.
         packed_bits = sum(1 << i for i, bit in enumerate(self.data) if bit)
-        return packed_bits.to_bytes(math.ceil(self.LENGTH / 8), "little")
+        return packed_bits.to_bytes(self.get_byte_length(), "little")
 
     @classmethod
     @override


### PR DESCRIPTION
## Summary

Four small, behavior-preserving cleanups.

- **`slot.py` justifiability** — the pronic check recomputed `math.isqrt(4*delta+1)` twice and `4*delta+1` three times in one boolean. Hoisted into `pronic_discriminant` / `discriminant_root` locals, computed once. The `(2n+1)²` math insight is preserved in the hoist comment.
- **`koalabear.py`** — `(P_BITS + 7) // 8` → `math.ceil(P_BITS / 8)`, matching the bitfield code and the project's stated preference over the manual ceiling idiom.
- **`bitfields.py`** — the Bitvector's `encode_bytes` recomputed `math.ceil(self.LENGTH / 8)`; now reuses `self.get_byte_length()` so the width formula lives in one place.
- **`poseidon.py` sponge** — replaced the inner index-assignment loop with a single slice assignment `state[cap_length : cap_length + rate] = chunk`. Padding guarantees every chunk is exactly `rate` wide, so the slice always matches.

## Testing
- `just check` passes (lint, format, type check, codespell, mdformat).
- Crypto/bitfield/poseidon/interface/merkleization tests: 259 passed.
- Verified the justifiability refactor is behavior-identical to the original formula for every `delta` in 0..5000 (zero mismatches), and `P_BYTES` still equals 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)