### PR TITLE
fix(crypto): reject oversized inputs in base-P decomposition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,13 @@ subspecifications that the Lean Ethereum protocol relies on.
     for `Interval` (in `spec/forks/lstar/containers/interval.py`) belong in
     `tests/lean_spec/spec/forks/lstar/containers/test_interval.py`, never in
     `node/chain/test_clock.py`.
+- **CRITICAL - ASSERT THE COMPLETE ERROR MESSAGE**: This is a STRICT requirement. When a test
+  checks a raised exception, assert the FULL message with string equality, never a substring or
+  partial regex. A partial match lets the rest of the message drift or regress unnoticed.
+  - Use `with pytest.raises(SomeError) as exception_info:` then
+    `assert str(exception_info.value) == "the entire expected message"`.
+  - Do NOT use `pytest.raises(SomeError, match="fragment")` to assert a fragment. If you use
+    `match=`, it must anchor the whole message (`match=r"^...full message...$"` with regex
+    metacharacters escaped); prefer the explicit full-equality assertion above.
+  - This mirrors the full-equality rule for ordinary assertions: assert the whole object, never a
+    piece of it.

--- a/src/lean_spec/spec/crypto/xmss/field.py
+++ b/src/lean_spec/spec/crypto/xmss/field.py
@@ -8,12 +8,26 @@ from lean_spec.spec.crypto.xmss.types import HashDigestVector, Parameter
 
 
 def int_to_base_p(value: int, num_limbs: int) -> list[Fp]:
-    """Decompose an integer into a fixed-size list of base-P field elements."""
+    """
+    Decompose a non-negative integer into a fixed-size list of base-P field elements.
+
+    The integer must be small enough to fit in the requested number of limbs.
+
+    Raises:
+        ValueError: When the integer is too large to fit in the requested limbs.
+    """
     remaining_value = value
     limbs: list[Fp] = []
     for _ in range(num_limbs):
         limbs.append(Fp(value=remaining_value))
         remaining_value //= P
+
+    # A nonzero remainder means the integer was wider than the requested limbs.
+    # Dropping the high part would silently change the resulting hash.
+    # Reject it instead of returning a truncated decomposition.
+    if remaining_value != 0:
+        raise ValueError(f"value does not fit in {num_limbs} base-P limbs")
+
     return limbs
 
 

--- a/tests/lean_spec/spec/crypto/xmss/test_field.py
+++ b/tests/lean_spec/spec/crypto/xmss/test_field.py
@@ -33,14 +33,20 @@ def test_int_to_base_p_known_decomposition(
     assert int_to_base_p(integer_value, num_limbs) == [Fp(value=limb) for limb in expected_limbs]
 
 
-def test_int_to_base_p_zero_limbs_returns_empty() -> None:
-    """Requesting zero limbs yields an empty list."""
-    assert int_to_base_p(12345, 0) == []
+def test_int_to_base_p_zero_limbs_accepts_only_zero() -> None:
+    """Zero fits in zero limbs and yields an empty list."""
+    assert int_to_base_p(0, 0) == []
 
 
-def test_int_to_base_p_truncates_high_limbs() -> None:
-    """A value wider than the requested limbs drops its high digits."""
-    assert int_to_base_p(P**2 + P + 7, 1) == [Fp(value=7)]
+def test_int_to_base_p_rejects_overflow() -> None:
+    """A value wider than the requested limbs is rejected, not truncated."""
+    with pytest.raises(ValueError) as exception_info:
+        int_to_base_p(P**2 + P + 7, 1)
+    assert str(exception_info.value) == "value does not fit in 1 base-P limbs"
+
+    with pytest.raises(ValueError) as exception_info:
+        int_to_base_p(12345, 0)
+    assert str(exception_info.value) == "value does not fit in 0 base-P limbs"
 
 
 def test_int_to_base_p_roundtrip_is_reversible() -> None:


### PR DESCRIPTION
## Summary

`int_to_base_p(value, num_limbs)` divided by `P` exactly `num_limbs` times and kept the remainders, **silently discarding the high part** when `value >= P ** num_limbs` (and `Fp(...)` reduces each limb mod P). For a hash-input encoder, an out-of-range input would change the resulting digest with no error.

This PR makes it raise instead of truncate.

### Is it reachable today? No — but the margin is thin
I traced every caller with exact bit-width math (P ≈ 2³¹, so P² ≈ 2⁶², P⁹ ≈ 2²⁷⁹):

| Caller | max value | limbs | capacity | headroom |
|---|---|---|---|---|
| `encode_message` | < 2²⁵⁶ | 9 | 2²⁷⁹ | ~23 bits |
| `encode_epoch` | < 2⁴⁰ | 2 | 2⁶² | ~22 bits |
| `safe_domain_separator` | < 2¹²⁸ | 24 | 2⁷⁴³ | huge |
| `packed_tweak` (ChainTweak) | < 2⁵⁷ | 2 | 2⁶² | **~6 bits** |
| `packed_tweak` (TreeTweak) | < 2⁴⁶ | 2 | 2⁶² | ~16 bits |

With both shipped configs (PROD `LOG_LIFETIME=32`, TEST `8`) every input provably fits, so the truncation path is **currently unreachable**. But the chain-tweak case packs `epoch << 24` into 2 limbs with only ~6 bits of slack — a `LOG_LIFETIME >= 38` would silently truncate and corrupt chain hashes with no error. The guard converts that latent footgun into a loud failure and changes **no reachable behavior** (so it can't affect any fixture or interop vector, regardless of how the Rust reference handles overflow).

### Test changes
The two tests that documented the old truncation now assert the rejection. `int_to_base_p(0, 0)` still returns `[]` (zero fits in zero limbs); a nonzero value in zero limbs now raises.

### Project rule added
Added a CLAUDE.md rule (bundled here with its first application): tests must assert the **complete** error message with string equality, never a substring or partial regex — a partial match lets the rest of the message regress unnoticed. The new overflow test follows it.

## Testing
- `just check` passes (lint, format, type check, codespell, mdformat).
- Full XMSS suite (sign/verify/hash flows exercising every caller): 179 passed — the guard never fires on valid inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)