### PR TITLE
refactor(lstar): clean up fork-choice docs, simplify pool updates, harden attestation tests

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -153,8 +153,11 @@ They are the shared vocabulary for navigating doc-heavy code.
 - **Performance** — complexity, allocation behavior, hot-path notes.
 - **Invariants** — preconditions and rules the caller must preserve.
 - **Args / Returns / Raises** — Google style, one bullet per item.
-- **Why X** — load-bearing rationale that deserves a header instead of being buried in prose.
-  Examples: "Why this threshold", "Why we skip the first byte", "Why a delimiter".
+
+Do NOT title a section "Why ..." (for example "# Why the finalized slot is the cutoff").
+That phrasing reads as AI-generated filler.
+Write the rationale as plain prose, the way a human engineer would explain it to a colleague.
+The reasoning still belongs in the doc — just state it directly, without a question-style banner over it.
 
 ## Inline comment patterns
 
@@ -226,6 +229,8 @@ No floating explanation blocks separated from the code they describe.
 - Padding simple module or file headers with prose.
 - Describing individual methods inside the class header — each gets its own docstring.
 - Banner-style separator comments such as `# =====` or `# -----`.
+- "Why ..."-titled section headers (e.g. "# Why the finalized slot is the cutoff") — they read as AI filler; state the reasoning in plain prose instead.
+- Marketing or salesy tone of any kind — write plain, human, engineer-to-engineer wording.
 - Dense prose blocks longer than three contiguous lines — break into bullets or labeled sub-sections.
 - Algorithm recap in the docstring when the body already has labeled phase comments.
 - Skipping the WHY comment when behavior is non-obvious from code.

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -38,8 +38,11 @@ When a header doc grows past one overview line, organize the detail under these 
 - **Algorithm** — step-by-step, only for genuinely non-obvious math or CS concepts.
 - **Performance** — complexity, allocation, hot-path notes.
 - **Invariants** — preconditions and rules the caller must preserve.
-- **Why X** — load-bearing rationale that deserves a header instead of buried prose.
 - **Args / Returns / Raises** — Google style, bullets.
+
+Never title a section "Why ..." (for example "# Why the finalized slot is the cutoff").
+That phrasing reads as AI filler.
+State the rationale as plain prose, the way an engineer would explain it to a colleague.
 
 ## Workflow
 
@@ -96,7 +99,7 @@ These are the failure modes most likely to slip into leanSpec PRs:
 ## Gold-standard exemplar
 
 The target style for a well-documented Python function in this project.
-Note the tight one-sentence-per-line header, the structured WHY section, the phase-labeled body, and the ASCII layout diagram.
+Note the tight one-sentence-per-line header, the plain-prose rationale, the phase-labeled body, and the ASCII layout diagram.
 
 ```python
 def encode_bitlist(bits: Sequence[Boolean]) -> bytes:
@@ -109,10 +112,8 @@ def encode_bitlist(bits: Sequence[Boolean]) -> bytes:
     A single 1 bit is placed immediately after the last data bit.
     The trailing bit lets the decoder recover the original count.
 
-    # Why a delimiter
-
     SSZ encodes bitlists as raw bytes with no length prefix.
-    Without a marker, [1, 0] and [1, 0, 0, 0, 0, 0, 0, 0] would share the byte 0x01.
+    Without that trailing bit, [1, 0] and [1, 0, 0, 0, 0, 0, 0, 0] would share the byte 0x01.
     A trailing 1 bit is the smallest sentinel that disambiguates them.
 
     # Layout

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -379,7 +379,7 @@ class StoreChecks(SelectiveCheck):
                     label = "in latest_known"
 
                 extracted_attestations = LstarSpec().extract_attestations_from_aggregated_payloads(
-                    store, payloads
+                    payloads
                 )
                 if attestation_check.validator not in extracted_attestations:
                     raise AssertionError(

--- a/src/lean_spec/node/sync/service.py
+++ b/src/lean_spec/node/sync/service.py
@@ -558,18 +558,12 @@ class SyncService:
         for attestation in block_attestations:
             public_keys_per_message.append(
                 [
-                    PublicKey.decode_bytes(
-                        bytes(validators[validator_index].attestation_public_key)
-                    )
+                    PublicKey.decode_bytes(validators[validator_index].attestation_public_key)
                     for validator_index in attestation.aggregation_bits.to_validator_indices()
                 ]
             )
         public_keys_per_message.append(
-            [
-                PublicKey.decode_bytes(
-                    bytes(validators[block.block.proposer_index].proposal_public_key)
-                )
-            ]
+            [PublicKey.decode_bytes(validators[block.block.proposer_index].proposal_public_key)]
         )
 
         # Index local partial single-message aggregate proofs by AttestationData root. Equivalent
@@ -627,7 +621,7 @@ class SyncService:
                                 child,
                                 [
                                     PublicKey.decode_bytes(
-                                        bytes(validators[validator_index].attestation_public_key)
+                                        validators[validator_index].attestation_public_key
                                     )
                                     for validator_index in child.participants.to_validator_indices()
                                 ],

--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -453,7 +453,7 @@ class ValidatorService:
         if not validator_index.is_within_registry(Uint64(len(validators))):
             raise ValueError(f"Validator {validator_index} not found in state validators")
         proposer_public_key = PublicKey.decode_bytes(
-            bytes(validators[validator_index].proposal_public_key)
+            validators[validator_index].proposal_public_key
         )
 
         # Wrap the proposer's raw XMSS signature into a singleton single-message aggregate.
@@ -483,9 +483,7 @@ class ValidatorService:
                         f"active set has {num_validators} validators"
                     )
                 participant_public_keys.append(
-                    PublicKey.decode_bytes(
-                        bytes(validators[validator_index].attestation_public_key)
-                    )
+                    PublicKey.decode_bytes(validators[validator_index].attestation_public_key)
                 )
             public_keys_per_aggregate.append(participant_public_keys)
         public_keys_per_aggregate.append([proposer_public_key])

--- a/src/lean_spec/spec/forks/lstar/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/aggregation.py
@@ -143,7 +143,7 @@ class AggregationMixin(LstarSpecBase):
                 (
                     signature_entry.validator_index,
                     PublicKey.decode_bytes(
-                        bytes(validators[signature_entry.validator_index].attestation_public_key)
+                        validators[signature_entry.validator_index].attestation_public_key
                     ),
                     signature_entry.signature,
                 )
@@ -174,9 +174,7 @@ class AggregationMixin(LstarSpecBase):
                 (
                     child_proof,
                     [
-                        PublicKey.decode_bytes(
-                            bytes(validators[validator_index].attestation_public_key)
-                        )
+                        PublicKey.decode_bytes(validators[validator_index].attestation_public_key)
                         for validator_index in child_proof.participants.to_validator_indices()
                     ],
                 )

--- a/src/lean_spec/spec/forks/lstar/block_production.py
+++ b/src/lean_spec/spec/forks/lstar/block_production.py
@@ -258,7 +258,7 @@ class BlockProductionMixin(LstarSpecBase):
                             proof,
                             [
                                 PublicKey.decode_bytes(
-                                    bytes(state.validators[validator_index].attestation_public_key)
+                                    state.validators[validator_index].attestation_public_key
                                 )
                                 for validator_index in proof.participants.to_validator_indices()
                             ],

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -45,23 +45,43 @@ class ForkChoiceMixin(LstarSpecBase):
         descendant: Checkpoint,
     ) -> bool:
         """
-        Return whether the ancestor checkpoint lies on the descendant's parent chain.
+        Decide whether one checkpoint lies on the other's chain of ancestors.
 
-        Walks parent links from the descendant down to the ancestor's slot.
-        Conservative: a skipped slot or a block missing from the store yields False.
+        Args:
+            store: Fork-choice store holding the known block tree.
+            ancestor: Candidate ancestor checkpoint, expected at or below the descendant's slot.
+            descendant: Checkpoint whose parent chain is searched.
+
+        Returns:
+            True when the ancestor block lies on the descendant's parent chain.
         """
+        # An ancestor can never sit later in time than its descendant.
         if ancestor.slot > descendant.slot:
             return False
 
+        # Climb parent links from the descendant toward genesis.
+        #
+        # The walk stops the moment a root is absent from the local view.
         current_root = descendant.root
         while current_root in store.blocks:
             current_block = store.blocks[current_root]
+
+            # Landed on the ancestor's slot.
+            # - It lies on the chain only when the roots also match.
+            # - A different root here means the checkpoints are on forked branches.
             if current_block.slot == ancestor.slot:
                 return current_root == ancestor.root
+
+            # Climbed past the ancestor's slot without landing on it.
+            # That slot held no block on this chain, so the ancestor is off it.
             if current_block.slot < ancestor.slot:
                 return False
+
+            # Still above the ancestor's slot.
+            # Step to the parent and keep climbing.
             current_root = current_block.parent_root
 
+        # The chain left the known tree before reaching the ancestor's slot.
         return False
 
     def create_store(
@@ -105,24 +125,13 @@ class ForkChoiceMixin(LstarSpecBase):
         # - the root of the initial checkpoints.
         anchor_root = hash_tree_root(anchor_block)
 
-        # Read the slot at which the anchor block was proposed.
-        anchor_slot = anchor_block.slot
-
-        # Seed both checkpoints from the anchor block itself.
-        #
-        # The store treats the anchor as the new genesis for fork choice:
-        # all history below it is pruned. The justified and finalized checkpoints
-        # therefore point at the anchor block with the anchor's own slot,
-        # regardless of what the anchor state's embedded checkpoints say.
-        anchor_checkpoint = Checkpoint(root=anchor_root, slot=anchor_slot)
-
         return self.store_class(
-            time=Interval.from_slot(anchor_slot),
+            time=Interval.from_slot(anchor_block.slot),
             config=state.config,
             head=anchor_root,
             safe_target=anchor_root,
-            latest_justified=anchor_checkpoint,
-            latest_finalized=anchor_checkpoint,
+            latest_justified=Checkpoint(root=anchor_root, slot=anchor_block.slot),
+            latest_finalized=Checkpoint(root=anchor_root, slot=anchor_block.slot),
             blocks={anchor_root: anchor_block},
             states={anchor_root: state},
             validator_index=validator_index,
@@ -130,22 +139,22 @@ class ForkChoiceMixin(LstarSpecBase):
 
     def prune_stale_attestation_data(self, store: LstarStore) -> LstarStore:
         """
-        Remove attestation data that can no longer influence fork choice.
+        Drop attestation data whose head can no longer influence fork choice.
 
-        An attestation becomes stale when its head checkpoint falls at or before
-        the finalized slot. Such attestations cannot affect chain selection since
-        the head is already finalized.
+        Fork choice only ever descends from the latest finalized block.
+        A vote whose head sits at or below the finalized slot cannot name a descendant of it.
+        Such a vote carries no fork-choice weight.
+        Dropping it never changes the chosen chain.
 
-        Pruning removes all attestation-related data:
+        The same cutoff prunes all three attestation-keyed pools:
 
-        - Attestation signatures
-        - Pending aggregated payloads
-        - Processed aggregated payloads
+        - Per-validator attestation signatures.
+        - Pending aggregated proofs not yet counted.
+        - Aggregated proofs already counted toward fork choice.
         """
-        # Filter out stale entries from all attestation-related mappings.
+        # Keep only entries whose attested head sits strictly above the finalized slot.
         #
-        # Each mapping is keyed by attestation data, so we check the attested
-        # head slot against the finalized slot.
+        # Every pool shares the same vote key, so one staleness test filters all three.
         return store.model_copy(
             update={
                 "attestation_signatures": {
@@ -222,25 +231,22 @@ class ForkChoiceMixin(LstarSpecBase):
         # Consistency Check
         #
         # Validate checkpoint slots match block slots.
-        source_block = store.blocks[source_checkpoint.root]
-        target_block = store.blocks[target_checkpoint.root]
-        head_block = store.blocks[head_checkpoint.root]
-        if source_block.slot != source_checkpoint.slot:
+        if store.blocks[source_checkpoint.root].slot != source_checkpoint.slot:
             raise SpecRejectionError(
                 RejectionReason.SOURCE_SLOT_MISMATCH, "Source checkpoint slot mismatch"
             )
-        if target_block.slot != target_checkpoint.slot:
+        if store.blocks[target_checkpoint.root].slot != target_checkpoint.slot:
             raise SpecRejectionError(
                 RejectionReason.TARGET_SLOT_MISMATCH, "Target checkpoint slot mismatch"
             )
-        if head_block.slot != head_checkpoint.slot:
+        if store.blocks[head_checkpoint.root].slot != head_checkpoint.slot:
             raise SpecRejectionError(
                 RejectionReason.HEAD_SLOT_MISMATCH, "Head checkpoint slot mismatch"
             )
 
         # Ancestry Check
         #
-        # Why: fork-choice weight accrues to every ancestor of the attested head.
+        # Fork-choice weight accrues to every ancestor of the attested head.
         # A sibling head would steer that weight onto a non-canonical branch.
         if not self._checkpoint_is_ancestor(store, source_checkpoint, target_checkpoint):
             raise SpecRejectionError(
@@ -255,15 +261,17 @@ class ForkChoiceMixin(LstarSpecBase):
 
         # Time Check
         #
-        # Honest validators emit votes only after their slot has begun.
-        # Allow a small disparity margin for clock skew between peers.
+        # Reject votes whose slot has not started, with a small clock-skew margin.
+        # The margin is one interval, not a whole slot.
         #
-        # The bound is in intervals, not slots: a whole-slot margin would
-        # let an adversary pre-publish next-slot aggregates ahead of any
-        # honest validator.
+        # With 5 intervals per slot, slot 10 begins at interval 50:
+        #
+        #     interval 49  ->  admitted by the one-interval margin (correct)
+        #     interval 45  ->  admitted only by a whole-slot margin, a full slot early
+        #
+        # The early window lets an adversary pre-publish next-slot aggregates.
         attestation_start_interval = Interval.from_slot(attestation_data.slot)
-        gossip_disparity = Interval(int(GOSSIP_DISPARITY_INTERVALS))
-        if attestation_start_interval > store.time + gossip_disparity:
+        if attestation_start_interval > store.time + Interval(GOSSIP_DISPARITY_INTERVALS):
             raise SpecRejectionError(
                 RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE, "Attestation too far in future"
             )
@@ -275,44 +283,65 @@ class ForkChoiceMixin(LstarSpecBase):
         is_aggregator: bool = False,
     ) -> LstarStore:
         """
-        Process a signed attestation received via gossip network.
+        Verify a gossiped attestation and, for aggregators, record its signature.
 
-        This method:
+        Steps:
+            1. Validate the vote: known blocks, matching slots, ancestry, and timing.
+            2. Verify the signature against the validator's key.
+            3. Record the signature, but only when this node aggregates.
 
-        1. Verifies the XMSS signature
-        2. Stores the signature when the node is in aggregator mode
-
-        Subnet filtering happens at the p2p subscription layer — only
-        attestations from subscribed subnets reach this method. No
-        additional subnet check is needed here.
+        Subnet filtering happens at the p2p subscription layer.
+        Only attestations from subscribed subnets arrive here, so no subnet check is repeated.
 
         Args:
-            store: The current forkchoice store.
-            signed_attestation: The signed attestation to process.
-            is_aggregator: True if the node is an aggregator.
+            store: Current fork-choice store.
+            signed_attestation: The signed vote to process.
+            is_aggregator: Whether this node aggregates signatures.
 
         Returns:
-            A new store with the attestation signature recorded when in
-            aggregator mode, otherwise the input store unchanged.
+            A new store with the signature recorded when aggregating.
+            The input store unchanged otherwise.
 
         Raises:
             SpecRejectionError: VALIDATOR_NOT_IN_STATE if the validator is not in the state.
             SpecRejectionError: INVALID_SIGNATURE if signature verification fails.
         """
         with observe_on_attestation():
+            # Unpack the gossiped vote:
+            # - the voter,
+            # - the vote,
+            # - the binding signature.
             validator_index = signed_attestation.validator_index
             attestation_data = signed_attestation.data
             signature = signed_attestation.signature
 
-            # Validate the attestation first so unknown blocks are rejected cleanly
-            # (instead of raising a raw KeyError when state is missing).
+            # Validate the attestation data before verifying.
+            #
+            # It checks that:
+            # - the source, target, and head blocks are all known in the store,
+            # - their slots are ordered source <= target <= head,
+            # - each checkpoint slot matches its block's actual slot from the store,
+            # - source, target, and head lie on one parent chain,
+            # - the vote's slot has already started locally with a small margin.
             self.validate_attestation(store, attestation_data)
 
+            # Resolve the signer's public key from the target block's post-state:
+            #
+            #     target root -> post-state -> validators[voter index] -> public key
+            #
+            # The state always exists.
+            #
+            # Validation proved:
+            # - the block is known,
+            # - blocks are stored together with their post-state.
             key_state = store.states.get(attestation_data.target.root)
             assert key_state is not None, (
                 f"No state available to verify attestation signature for target block "
                 f"{attestation_data.target.root.hex()}"
             )
+
+            # The validator index must fall inside that registry.
+            # An out-of-range index names a validator the target state never knew.
             if not validator_index.is_within_registry(Uint64(len(key_state.validators))):
                 raise SpecRejectionError(
                     RejectionReason.VALIDATOR_NOT_IN_STATE,
@@ -320,9 +349,13 @@ class ForkChoiceMixin(LstarSpecBase):
                     f"{attestation_data.target.root.hex()}",
                 )
             public_key = PublicKey.decode_bytes(
-                bytes(key_state.validators[validator_index].attestation_public_key)
+                key_state.validators[validator_index].attestation_public_key
             )
 
+            # Verify the signature.
+            #
+            # The scheme binds the signature to the public key, the slot, and the vote hash.
+            # None of those can be swapped out after signing.
             if not TARGET_SIGNATURE_SCHEME.verify(
                 public_key, attestation_data.slot, hash_tree_root(attestation_data), signature
             ):
@@ -330,20 +363,30 @@ class ForkChoiceMixin(LstarSpecBase):
                     RejectionReason.INVALID_SIGNATURE, "Signature verification failed"
                 )
 
-            # Non-aggregator nodes validate and drop — they never store gossip signatures.
+            # Non-aggregators stop here.
+            # - They validate and relay the vote.
+            # - They never keep its signature.
             if not is_aggregator:
                 return store
 
-            # Aggregators store all received gossip signatures.
-            # The p2p layer only delivers attestations from subscribed subnets,
-            # so subnet filtering happens at subscription time, not here.
-            # Copy the inner sets so the caller's store is left untouched.
-            new_attestation_signatures = {
-                data: set(signatures) for data, signatures in store.attestation_signatures.items()
-            }
-            new_attestation_signatures.setdefault(attestation_data, set()).add(
+            # Record the signature in the aggregator's pool.
+            #
+            # The pool groups signatures by the exact vote they sign:
+            #
+            #     vote A  ->  { (validator 3, signature), (validator 7, signature) }
+            #     vote B  ->  { (validator 7, signature) }
+            #
+            # Add the entry to a fresh copy of this vote's set.
+            # The union builds a new set, so the caller's set is never touched.
+            signatures_for_vote = store.attestation_signatures.get(attestation_data, set()) | {
                 AttestationSignatureEntry(validator_index, signature)
-            )
+            }
+
+            # Merge that one set back into a new map, sharing the other votes' sets.
+            # Only the changed vote allocates; everything else stays immutable.
+            new_attestation_signatures = store.attestation_signatures | {
+                attestation_data: signatures_for_vote
+            }
 
             return store.model_copy(update={"attestation_signatures": new_attestation_signatures})
 
@@ -353,32 +396,61 @@ class ForkChoiceMixin(LstarSpecBase):
         signed_attestation: SignedAggregatedAttestation,
     ) -> LstarStore:
         """
-        Process a signed aggregated attestation received via aggregation topic.
+        Verify a gossiped aggregated attestation and record its proof.
 
-        This method:
-        1. Verifies the aggregated attestation
-        2. Stores the aggregation in aggregation_payloads map
+        One aggregated attestation carries a single proof that stands in for many
+        validators who all signed the same vote.
+
+        Steps:
+            1. Validate the vote: known blocks, matching slots, ancestry, and timing.
+            2. Verify the aggregate proof against every participant's key.
+            3. Record the proof in the pending pool.
+
+        Args:
+            store: Current fork-choice store.
+            signed_attestation: The signed aggregated vote to process.
+
+        Returns:
+            A new store with the proof recorded in the pending pool.
 
         Raises:
             SpecRejectionError: VALIDATOR_NOT_IN_STATE if a participant is not in the state.
-            AssertionError: If aggregate signature verification fails.
+            SpecRejectionError: INVALID_SIGNATURE if aggregate verification fails.
         """
+        # Unpack the aggregated vote: the vote, and the single proof covering its signers.
         attestation_data = signed_attestation.data
         aggregated_proof = signed_attestation.proof
 
+        # Validate the attestation data before verifying.
+        #
+        # It checks that:
+        # - the source, target, and head blocks are all known in the store,
+        # - their slots are ordered source <= target <= head,
+        # - each checkpoint slot matches its block's actual slot from the store,
+        # - source, target, and head lie on one parent chain,
+        # - the vote's slot has already started locally with a small margin.
         self.validate_attestation(store, attestation_data)
 
-        # Get validator IDs who participated in this aggregation
+        # The proof names every validator that contributed to it.
         validator_indices = aggregated_proof.participants.to_validator_indices()
 
-        # Retrieve the relevant state to look up public keys for verification.
+        # Resolve each participant's public key from the target block's post-state:
+        #
+        #     target root -> post-state -> validators[participant index] -> public key
+        #
+        # The state always exists.
+        #
+        # Validation proved:
+        # - the block is known,
+        # - blocks are stored together with their post-state.
         key_state = store.states.get(attestation_data.target.root)
         assert key_state is not None, (
             f"No state available to verify committee aggregation for target "
             f"{attestation_data.target.root.hex()}"
         )
 
-        # Ensure all participants exist in the active set
+        # Every participant must fall inside that registry.
+        # An out-of-range index names a validator the target state never knew.
         validators = key_state.validators
         for validator_index in validator_indices:
             if not validator_index.is_within_registry(Uint64(len(validators))):
@@ -388,13 +460,16 @@ class ForkChoiceMixin(LstarSpecBase):
                     f"{attestation_data.target.root.hex()}",
                 )
 
-        # Prepare public keys for verification
+        # Collect the participants' keys, in the order the proof expects them.
         public_keys = [
-            PublicKey.decode_bytes(bytes(validators[validator_index].attestation_public_key))
+            PublicKey.decode_bytes(validators[validator_index].attestation_public_key)
             for validator_index in validator_indices
         ]
 
-        # Verify the single-message aggregate proof.
+        # Verify the aggregate proof.
+        #
+        # The proof binds every participant key, the slot, and the vote hash together.
+        # A failure rejects the whole aggregate, not one signer.
         try:
             aggregated_proof.verify(
                 public_keys=public_keys,
@@ -402,16 +477,29 @@ class ForkChoiceMixin(LstarSpecBase):
                 slot=attestation_data.slot,
             )
         except AggregationError as exception:
-            raise AssertionError(
-                f"Committee aggregation signature verification failed: {exception}"
+            raise SpecRejectionError(
+                RejectionReason.INVALID_SIGNATURE,
+                f"Committee aggregation signature verification failed: {exception}",
             ) from exception
 
-        # Copy the inner sets so the caller's store is left untouched.
-        new_aggregated_payloads = {
-            pooled_data: set(pooled_proofs)
-            for pooled_data, pooled_proofs in store.latest_new_aggregated_payloads.items()
+        # Record the proof in the pending pool.
+        #
+        # The pool groups proofs by the exact vote they cover:
+        #
+        #     vote A  ->  { proof P, proof Q }
+        #     vote B  ->  { proof P }
+        #
+        # Add the proof to a fresh copy of this vote's set.
+        # The union builds a new set, so the caller's set is never touched.
+        proofs_for_vote = store.latest_new_aggregated_payloads.get(attestation_data, set()) | {
+            aggregated_proof
         }
-        new_aggregated_payloads.setdefault(attestation_data, set()).add(aggregated_proof)
+
+        # Merge that one set back into a new map, sharing the other votes' sets.
+        # Only the changed vote allocates; everything else stays immutable.
+        new_aggregated_payloads = store.latest_new_aggregated_payloads | {
+            attestation_data: proofs_for_vote
+        }
 
         return store.model_copy(update={"latest_new_aggregated_payloads": new_aggregated_payloads})
 
@@ -439,18 +527,18 @@ class ForkChoiceMixin(LstarSpecBase):
             block = signed_block.block
             block_root = hash_tree_root(block)
 
-            # Skip duplicate blocks (idempotent operation)
+            # Skip a block already in the store; re-importing it would change nothing.
             if block_root in store.blocks:
                 return store
 
-            # Capture the finalized slot before any updates so we can decide
-            # at the end whether finalization advanced and pruning is needed.
+            # Snapshot the finalized slot before any update.
+            # Comparing against it at the end tells us whether pruning is needed.
             previous_finalized_slot = store.latest_finalized.slot
 
-            # Verify parent chain is available
+            # Resolve the parent's post-state, where the state transition starts from.
             #
-            # The parent state must exist before processing this block.
-            # If missing, the node must sync the parent chain first.
+            # A missing parent state means a gap in the chain.
+            # The node must sync the parent chain before this block can apply.
             parent_state = store.states.get(block.parent_root)
             if parent_state is None:
                 raise SpecRejectionError(
@@ -459,8 +547,14 @@ class ForkChoiceMixin(LstarSpecBase):
                     f"Sync parent chain before processing block at slot {block.slot}.",
                 )
 
-            # The block body constrains how many distinct AttestationData
-            # entries it may carry.
+            # Bound the distinct votes the block may carry.
+            #
+            # Collapsing the votes to their distinct data exposes any repeat:
+            #
+            #     votes  ->  { vote A, vote B, vote B }  ->  distinct { vote A, vote B }
+            #
+            # A repeat (fewer distinct than total) is rejected as duplicate data.
+            # More distinct votes than the cap is rejected to bound import work.
             aggregated_attestations = block.body.attestations
             attestation_data_set = {attestation.data for attestation in aggregated_attestations}
             if len(attestation_data_set) != len(aggregated_attestations):
@@ -481,41 +575,32 @@ class ForkChoiceMixin(LstarSpecBase):
             # This raises on any invalid signature, aborting the import.
             self.verify_signatures(signed_block, parent_state.validators)
 
-            # Execute state transition function to compute post-block state
+            # Run the state transition from the parent state to this block's post-state.
             post_state = self.state_transition(parent_state, block)
 
-            # Propagate checkpoint advances from the post-state.
+            # Advance the justified and finalized checkpoints from the post-state.
             #
-            # A candidate replaces the store's checkpoint only when its slot is strictly higher.
-            # On slot ties the store's view stays authoritative.
+            # A candidate wins only when its slot is strictly higher than the store's.
+            # On a slot tie the store keeps its checkpoint, avoiding a silent root swap:
             #
-            # Why: the store's checkpoint is pinned at init.
-            # It advances only on real justification or finalization events.
-            # An incoming tie must not silently swap roots.
+            #     store slot 5, candidate slot 7  ->  take candidate
+            #     store slot 5, candidate slot 5  ->  keep store
             latest_justified = store.latest_justified.advance_to(post_state.latest_justified)
             latest_finalized = store.latest_finalized.advance_to(post_state.latest_finalized)
 
-            # Register each block attestation's data in the known pool.
+            # Seed each block-carried vote into the known pool with an empty proof set.
             #
-            # Only the data key is recorded here, with an empty proof set.
-            # The block carries one merged proof for all attestations.
-            # That proof is verified as a whole and not decomposed at import.
-            # Per-attestation proofs reach the pools through the
-            # deconstruction and gossip path instead.
+            # A block's merged proof is never split here.
+            # Per-vote proofs arrive later through the gossip path.
+            # Until then a block's own votes add zero head weight, deferred by up to one slot.
             #
-            # Consequence: a block's own attestations contribute zero weight
-            # to the head computation triggered by this import.
-            # Recovered single-message aggregate proofs land in the new pool and migrate to
-            # the known pool at the next acceptance tick.
-            # Head weight from block-imported votes is therefore deferred
-            # by up to one slot.
-            # Copy the inner sets so the caller's store is left untouched.
+            # Existing entries win on collision, keeping their proofs:
+            #
+            #     pool { vote A -> {p} }  +  block votes A, B  ->  { vote A -> {p}, vote B -> {} }
             new_known_aggregated_payloads = {
-                attestation_data: set(proofs)
-                for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
-            }
-            for aggregated_attestation in aggregated_attestations:
-                new_known_aggregated_payloads.setdefault(aggregated_attestation.data, set())
+                aggregated_attestation.data: set()
+                for aggregated_attestation in aggregated_attestations
+            } | store.latest_known_aggregated_payloads
 
             store = store.model_copy(
                 update={
@@ -527,10 +612,10 @@ class ForkChoiceMixin(LstarSpecBase):
                 }
             )
 
-            # Update forkchoice head based on new block and attestations.
+            # Recompute the head now that the block and its votes are in the store.
             store = self.update_head(store)
 
-            # Prune stale attestation data when finalization advances
+            # Prune stale vote data, but only when finalization advanced past the snapshot.
             if store.latest_finalized.slot > previous_finalized_slot:
                 store = self.prune_stale_attestation_data(store)
 
@@ -538,27 +623,32 @@ class ForkChoiceMixin(LstarSpecBase):
 
     def extract_attestations_from_aggregated_payloads(
         self,
-        store: LstarStore,
         aggregated_payloads: dict[AttestationData, set[SingleMessageAggregate]],
     ) -> dict[ValidatorIndex, AttestationData]:
         """
-        Extract attestations from aggregated payloads.
+        Map each participating validator to the latest vote it cast.
 
-        Given a mapping of aggregated signature proofs, extract the attestation data
-        for each validator that participated in the aggregation.
+        This is the LMD view fork choice runs on.
+        On equal slots the first vote seen wins, since the slot comparison is strict.
+
+        Args:
+            aggregated_payloads: Proof sets keyed by the vote they cover.
+
+        Returns:
+            Each validator mapped to its highest-slot vote.
         """
-        attestations: dict[ValidatorIndex, AttestationData] = {}
+        latest_vote_by_validator: dict[ValidatorIndex, AttestationData] = {}
 
+        # Walk every vote, every proof for it, and every validator the proof covers.
         for attestation_data, proofs in aggregated_payloads.items():
             for proof in proofs:
                 for validator_index in proof.participants.to_validator_indices():
-                    current_attestation_data = attestations.get(validator_index)
-                    if (
-                        current_attestation_data is None
-                        or current_attestation_data.slot < attestation_data.slot
-                    ):
-                        attestations[validator_index] = attestation_data
-        return attestations
+                    # Keep this vote only when it is newer than the one already stored.
+                    previous_vote = latest_vote_by_validator.get(validator_index)
+                    if previous_vote is None or previous_vote.slot < attestation_data.slot:
+                        latest_vote_by_validator[validator_index] = attestation_data
+
+        return latest_vote_by_validator
 
     def _accumulate_ancestor_weights(
         self,
@@ -567,44 +657,62 @@ class ForkChoiceMixin(LstarSpecBase):
         start_slot: Slot,
     ) -> dict[Bytes32, int]:
         """
-        Accumulate one unit of voting weight per ancestor of each head vote.
+        Tally how many latest votes credit each block.
 
-        For every vote, follow the chosen head upward through its ancestors.
-        Each visited block above the start slot accumulates one unit of weight
-        from that validator.
+        A vote credits its head block and every ancestor above the start slot.
+        Climbing stops at the start slot, or where the chain leaves the known tree.
 
-        Climbing stops at the start slot or as soon as the chain leaves the
-        known tree, so partial views and ongoing sync are handled naturally.
+        Args:
+            store: Fork-choice store holding the known block tree.
+            attestations: Each validator mapped to its latest vote.
+            start_slot: Anchor slot; ancestors at or below it are not counted.
+
+        Returns:
+            Each block root mapped to the number of votes crediting it.
         """
         weights: dict[Bytes32, int] = defaultdict(int)
 
         for attestation_data in attestations.values():
+            # Climb from this vote's head toward genesis, crediting each block.
             current_root = attestation_data.head.root
+            while current_root in store.blocks:
+                current_block = store.blocks[current_root]
 
-            while current_root in store.blocks and store.blocks[current_root].slot > start_slot:
+                # Stop at the anchor: the start slot and below are out of scope.
+                if current_block.slot <= start_slot:
+                    break
+
                 weights[current_root] += 1
-                current_root = store.blocks[current_root].parent_root
+                current_root = current_block.parent_root
 
         return weights
 
     def compute_block_weights(self, store: LstarStore) -> dict[Bytes32, int]:
         """
-        Compute attestation-based weight for each block above the finalized slot.
+        Weigh each block by the latest votes landing on it or its descendants.
 
-        Walks backward from each validator's latest head vote, incrementing weight
-        for every ancestor above the finalized slot.
+        Only counted votes whose head outlives the finalized slot can move the head.
+
+        Args:
+            store: Fork-choice store holding the block tree and vote pools.
+
+        Returns:
+            Each block root mapped to its accumulated vote weight.
         """
-        attestations = self.extract_attestations_from_aggregated_payloads(
-            store,
+        # Reduce the counted pool to each validator's latest still-relevant vote.
+        latest_votes = self.extract_attestations_from_aggregated_payloads(
             {
                 attestation_data: proofs
                 for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
                 if attestation_data.head.slot > store.latest_finalized.slot
-            },
+            }
         )
 
+        # Credit every block on those votes' ancestor chains above finalization.
+        #
+        # Return a plain dict so callers read missing blocks as absent, not zero.
         weights = self._accumulate_ancestor_weights(
-            store, attestations, store.latest_finalized.slot
+            store, latest_votes, store.latest_finalized.slot
         )
 
         return dict(weights)
@@ -619,10 +727,10 @@ class ForkChoiceMixin(LstarSpecBase):
         """
         Walk the block tree according to the LMD GHOST rule.
 
-        The walk starts from a chosen root.
-        At each fork, the child subtree with the highest weight is taken.
-        The process stops when a leaf is reached.
-        That leaf is the chosen head.
+        1. The walk starts from a chosen root.
+        2. At each fork, the child subtree with the highest weight is taken.
+        3. The process stops when a leaf is reached.
+        4. That leaf is the chosen head.
 
         Weights are derived from votes as follows:
         - Each validator contributes its full weight to its most recent head vote.
@@ -636,7 +744,6 @@ class ForkChoiceMixin(LstarSpecBase):
         larger hash is chosen to break ties.
         """
         # Invariant: the anchor must be a block the store already knows.
-        # A loud failure here beats a cryptic missing-key error deep in the weight loop.
         assert start_root in store.blocks, f"start_root {start_root.hex()} not in store.blocks"
 
         # Remember the slot of the anchor once and reuse it during the walk.
@@ -648,10 +755,6 @@ class ForkChoiceMixin(LstarSpecBase):
         weights = self._accumulate_ancestor_weights(store, attestations, start_slot)
 
         # Build the parent -> children adjacency.
-        #
-        # Genesis blocks land in the bucket keyed by the zero hash.
-        # That bucket is never consulted.
-        # The walk anchors at the latest justified root and only descends.
         children_map: dict[Bytes32, list[Bytes32]] = defaultdict(list)
 
         for root, block in store.blocks.items():
@@ -675,66 +778,62 @@ class ForkChoiceMixin(LstarSpecBase):
 
     def update_head(self, store: LstarStore) -> LstarStore:
         """
-        Compute updated store with new canonical head.
+        Recompute the canonical head and return the store updated with it.
 
-        Selects the canonical chain head using:
+        Fork choice starts at the latest justified root and applies LMD-GHOST,
+        descending to the heaviest subtree by attestation weight.
 
-        1. Latest justified checkpoint as the starting root
-        2. LMD-GHOST fork choice rule (heaviest subtree by attestation weight)
+        Args:
+            store: Fork-choice store holding the block tree and vote pools.
+
+        Returns:
+            The store with its head set to the chosen block.
         """
-        # Extract fork-choice relevant attestations from known aggregated payloads.
-        # A vote whose head is at or below finalization has no weight above the
-        # finalized boundary.
-        attestations = self.extract_attestations_from_aggregated_payloads(
-            store,
+        # Reduce the counted pool to each validator's latest still-relevant vote.
+        latest_votes = self.extract_attestations_from_aggregated_payloads(
             {
                 attestation_data: proofs
                 for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
                 if attestation_data.head.slot > store.latest_finalized.slot
-            },
+            }
         )
 
-        # Run LMD-GHOST fork choice algorithm.
+        # Descend from the justified root to the heaviest leaf.
         #
-        # Starts from the justified root and greedily descends to the heaviest
-        # leaf. The result is always a descendant of the justified root by
-        # construction: the walk only follows child edges within the subtree.
+        # The result is always a descendant of that root, since the walk only follows children.
         new_head = self._compute_lmd_ghost_head(
             store,
             start_root=store.latest_justified.root,
-            attestations=attestations,
+            attestations=latest_votes,
         )
         return store.model_copy(update={"head": new_head})
 
     def accept_new_attestations(self, store: LstarStore) -> LstarStore:
         """
-        Process pending aggregated payloads and update forkchoice head.
+        Promote pending aggregate proofs into the counted pool, then recompute the head.
 
-        Moves aggregated payloads from latest_new_aggregated_payloads to
-        latest_known_aggregated_payloads, making them eligible to contribute to
-        fork choice weights. This migration happens at specific interval ticks.
+        Proofs gathered this slot sit in the pending pool and carry no fork-choice weight.
+        This acceptance tick merges them into the counted pool, where they begin to count.
+        The pending pool is then emptied.
 
-        The Interval Tick System
-        -------------------------
-        Aggregated payloads progress through intervals:
-        - Interval 0: Block proposal
-        - Interval 1: Validators cast attestations (enter "new")
-        - Interval 2: Aggregators create proofs & broadcast
-        - Interval 3: Safe target update
-        - Interval 4: Process accumulated attestations
+        Args:
+            store: Fork-choice store holding both aggregate pools.
 
-        This staged progression ensures proper timing and prevents premature
-        influence on fork choice decisions.
+        Returns:
+            The store with proofs promoted and the head recomputed.
         """
-        # Merge new aggregated payloads into known aggregated payloads.
-        # Copy the inner sets so the caller's store is left untouched.
+        # Union each vote's pending proofs with its counted proofs.
+        #
+        # Each union builds a fresh set, so the caller's store stays untouched.
+        known_payloads = store.latest_known_aggregated_payloads
+        new_payloads = store.latest_new_aggregated_payloads
         merged_aggregated_payloads = {
-            attestation_data: set(proofs)
-            for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
+            attestation_data: known_payloads.get(attestation_data, set())
+            | new_payloads.get(attestation_data, set())
+            for attestation_data in known_payloads.keys() | new_payloads.keys()
         }
-        for attestation_data, proofs in store.latest_new_aggregated_payloads.items():
-            merged_aggregated_payloads.setdefault(attestation_data, set()).update(proofs)
 
+        # Promote into the counted pool and clear the pending one.
         store = store.model_copy(
             update={
                 "latest_known_aggregated_payloads": merged_aggregated_payloads,
@@ -742,77 +841,44 @@ class ForkChoiceMixin(LstarSpecBase):
             }
         )
 
-        # Update head with newly accepted aggregated payloads
+        # Recompute the head now that the promoted proofs count.
         return self.update_head(store)
 
     def update_safe_target(self, store: LstarStore) -> LstarStore:
         """
-        Compute the deepest block that has 2/3+ supermajority attestation weight.
+        Find the deepest block backed by two-thirds of this slot's voters.
 
-        The safe target is the furthest-from-genesis block where enough validators
-        agree. Validators use it to decide which block is safe to attest to.
-        Only blocks meeting the supermajority threshold qualify.
+        This is the block a validator is safe to attest to.
 
-        This runs at interval 3 of the slot cycle:
+        Args:
+            store: Fork-choice store holding the block tree and vote pools.
 
-        - Interval 0: Block proposal
-        - Interval 1: Validators cast attestation votes
-        - Interval 2: Aggregators create proofs, broadcast via gossip
-        - Interval 3: Safe target update (HERE)
-        - Interval 4: New attestations migrate to "known" pool
-
-        Only the "new" pool counts. Migration into "known" runs at interval 4,
-        after this step, so safe target sees only votes received this slot.
-
-        Safe target is an *availability* signal, not durable knowledge:
-
-        - A block is safe when 2/3 of currently online validators vote for a descendant.
-        - "Known" carries block-included, previously migrated, and self-attestations.
-        - Those reflect historical knowledge, not current liveness.
-        - Counting them would advance safe target on stale evidence after a participation collapse.
+        Returns:
+            The store with its safe target updated.
         """
-        # Look up the post-state of the current head block.
-        #
-        # The validator registry in this state tells us how many active
-        # validators exist. We need that count to compute the threshold.
-        head_state = store.states[store.head]
-        num_validators = Uint64(len(head_state.validators))
+        # Validator count from the head block's post-state sets the threshold.
+        num_validators = len(store.states[store.head].validators)
 
-        # Compute the 2/3 supermajority threshold.
-        #
-        # A block needs at least this many attestation votes to be "safe".
-        # The threshold is rounded UP so a strict majority is required.
-        # For example, 100 validators => threshold is 67, not 66.
-        min_target_score = math.ceil(int(num_validators) * 2 / 3)
+        # Round up for a strict supermajority: 100 validators need 67, not 66.
+        min_target_score = math.ceil(num_validators * 2 / 3)
 
-        # Unpack "new" payloads into a flat validator -> vote mapping.
-        # "Known" is excluded by design.
-        attestations = self.extract_attestations_from_aggregated_payloads(
-            store,
+        # Reduce the pending pool to each validator's latest still-relevant vote.
+        latest_votes = self.extract_attestations_from_aggregated_payloads(
             {
                 attestation_data: proofs
                 for attestation_data, proofs in store.latest_new_aggregated_payloads.items()
                 if attestation_data.head.slot > store.latest_finalized.slot
-            },
+            }
         )
 
-        # Run LMD GHOST with the supermajority threshold.
+        # Descend from the justified root, taking only children that clear the threshold.
         #
-        # The walk starts from the latest justified checkpoint and descends
-        # through the block tree. At each fork, only children with at least
-        # `min_target_score` attestation weight are considered. The result
-        # is the deepest block that clears the 2/3 bar.
-        #
-        # If no child meets the threshold at some fork, the walk stops
-        # early. The safe target is then shallower than the actual head.
+        # The walk stops where no child qualifies, so the target can sit shallower than the head.
         safe_target = self._compute_lmd_ghost_head(
             store,
             start_root=store.latest_justified.root,
-            attestations=attestations,
+            attestations=latest_votes,
             min_score=min_target_score,
         )
 
-        # Return a new Store with only the safe target updated.
-        #
-        # The head and attestation pools remain unchanged.
         return store.model_copy(update={"safe_target": safe_target})

--- a/src/lean_spec/spec/forks/lstar/signatures.py
+++ b/src/lean_spec/spec/forks/lstar/signatures.py
@@ -67,9 +67,7 @@ class SignatureMixin(LstarSpecBase):
 
             public_keys_per_message.append(
                 [
-                    PublicKey.decode_bytes(
-                        bytes(validators[validator_index].attestation_public_key)
-                    )
+                    PublicKey.decode_bytes(validators[validator_index].attestation_public_key)
                     for validator_index in validator_indices
                 ]
             )
@@ -92,7 +90,7 @@ class SignatureMixin(LstarSpecBase):
             )
 
         public_keys_per_message.append(
-            [PublicKey.decode_bytes(bytes(validators[proposer_index].proposal_public_key))]
+            [PublicKey.decode_bytes(validators[proposer_index].proposal_public_key)]
         )
         message_bindings.append((hash_tree_root(block), block.slot))
 

--- a/tests/lean_spec/helpers/builders.py
+++ b/tests/lean_spec/helpers/builders.py
@@ -464,15 +464,13 @@ def make_signed_block_from_store(
     head_state = new_store.states[new_store.head]
     public_keys_per_aggregate: list[list] = [
         [
-            PublicKey.decode_bytes(
-                bytes(head_state.validators[validator_index].attestation_public_key)
-            )
+            PublicKey.decode_bytes(head_state.validators[validator_index].attestation_public_key)
             for validator_index in attestation_proof.participants.to_validator_indices()
         ]
         for attestation_proof in attestation_proofs
     ]
     proposer_public_key = PublicKey.decode_bytes(
-        bytes(head_state.validators[proposer_index].proposal_public_key)
+        head_state.validators[proposer_index].proposal_public_key
     )
     public_keys_per_aggregate.append([proposer_public_key])
 

--- a/tests/lean_spec/spec/forks/lstar/test_aggregation.py
+++ b/tests/lean_spec/spec/forks/lstar/test_aggregation.py
@@ -500,9 +500,7 @@ def test_aggregated_signatures_prefers_full_gossip_payload(
     }
 
     public_keys = [
-        PublicKey.decode_bytes(
-            bytes(head_state.validators[ValidatorIndex(i)].attestation_public_key)
-        )
+        PublicKey.decode_bytes(head_state.validators[ValidatorIndex(i)].attestation_public_key)
         for i in range(2)
     ]
     aggregated_attestations[0].proof.verify(

--- a/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
+++ b/tests/lean_spec/spec/forks/lstar/test_fork_choice.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import NamedTuple
+
 import pytest
 from hypothesis import given, settings, strategies as st
 from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
@@ -27,6 +30,7 @@ from lean_spec.spec.forks.lstar.containers import (
     SingleMessageAggregate,
     Validators,
 )
+from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
 from lean_spec.spec.forks.lstar.spec import LstarSpec
 from lean_spec.spec.ssz import Uint64
 from lean_spec.spec.ssz.byte_arrays import ByteList512KiB, Bytes32
@@ -412,195 +416,382 @@ def test_compute_lmd_ghost_head_rejects_unknown_start_root(
         spec._compute_lmd_ghost_head(base_store, start_root=unknown_root, attestations={})
 
 
-# Slot used by every time-check case below.
-ATTESTATION_SLOT = Slot(2)
-"""Slot of the attestation under test."""
+class ValidateAttestationFixture(NamedTuple):
+    """A known-good store plus the named block roots its valid attestation references."""
 
-ATTESTATION_START_INTERVAL = Interval.from_slot(ATTESTATION_SLOT)
-"""First interval at which ATTESTATION_SLOT begins."""
-
-DISPARITY_BOUNDARY_INTERVAL = ATTESTATION_START_INTERVAL - Interval(int(GOSSIP_DISPARITY_INTERVALS))
-"""Latest local interval that still admits the attestation."""
-
-JUST_BEYOND_DISPARITY_BOUNDARY_INTERVAL = DISPARITY_BOUNDARY_INTERVAL - Interval(1)
-"""First local interval that rejects the attestation."""
-
-ONE_FULL_SLOT_BEHIND_INTERVAL = ATTESTATION_START_INTERVAL - Interval(int(INTERVALS_PER_SLOT))
-"""Local interval one full slot behind the attestation's slot start."""
+    store: Store
+    genesis_root: Bytes32
+    block_at_slot_one_root: Bytes32
+    block_at_slot_two_root: Bytes32
+    block_above_skipped_slots_root: Bytes32
+    sibling_at_slot_two_root: Bytes32
+    orphan_at_slot_two_root: Bytes32
 
 
-class TestValidateAttestationHeadChecks:
-    """Head checkpoint must be consistent and at least as recent as source and target."""
+def _build_validate_attestation_fixture(
+    spec: LstarSpec, observer_store: Store
+) -> ValidateAttestationFixture:
+    """Build a known-good store whose default attestation passes every validation stage.
 
-    def test_head_checkpoint_slot_mismatch_rejected(
-        self,
-        spec: LstarSpec,
-        observer_store: Store,
-    ) -> None:
-        """Head checkpoint slot must match the actual block slot."""
-        store = observer_store
+    Chain topology, all reusing the genesis post-state:
 
-        # Build a one-block chain on top of genesis.
-        # This gives us a real block whose actual slot is 1.
-        slot_1 = Slot(1)
-        proposer = ValidatorIndex(1)
-        store, block, _ = spec.produce_block_with_signatures(store, slot_1, proposer)
-        block_root = hash_tree_root(block)
+        genesis(0) -> block_at_slot_one(1) -> block_at_slot_two(2) -> block_above_skipped(4)
+                   -> sibling_at_slot_two(2)                       (fork off genesis)
+        unknown(99) -> orphan_at_slot_two(2)                       (parent absent from store)
+    """
+    genesis_root = observer_store.latest_justified.root
 
-        genesis_root = store.latest_justified.root
+    store, block_at_slot_one_root = _add_known_block(
+        observer_store, Slot(1), ValidatorIndex(1), genesis_root, 1
+    )
+    store, block_at_slot_two_root = _add_known_block(
+        store, Slot(2), ValidatorIndex(2), block_at_slot_one_root, 2
+    )
+    # Slot 3 is skipped: this block sits at slot 4 directly above the slot-2 block.
+    store, block_above_skipped_slots_root = _add_known_block(
+        store, Slot(4), ValidatorIndex(4), block_at_slot_two_root, 4
+    )
+    # A sibling at slot 2 forking straight off genesis, off the main chain.
+    store, sibling_at_slot_two_root = _add_known_block(
+        store, Slot(2), ValidatorIndex(3), genesis_root, 5
+    )
+    # A block at slot 2 whose parent root the store has never seen.
+    store, orphan_at_slot_two_root = _add_known_block(
+        store, Slot(2), ValidatorIndex(2), make_bytes32(99), 6
+    )
 
-        # Craft an attestation where the head checkpoint claims slot 999.
-        # The block actually lives at slot 1.
-        # This violates the consistency check: checkpoint slot must match block slot.
-        attestation = Attestation(
-            validator_index=ValidatorIndex(0),
-            data=AttestationData(
-                slot=slot_1,
-                head=Checkpoint(root=block_root, slot=Slot(999)),
-                target=Checkpoint(root=block_root, slot=slot_1),
-                source=Checkpoint(root=genesis_root, slot=Slot(0)),
-            ),
-        )
+    # Pin the local clock to the start of the attestation's slot.
+    # This isolates topology and ancestry cases from the time check.
+    store = store.model_copy(update={"time": Interval.from_slot(Slot(2))})
 
-        with pytest.raises(AssertionError, match="Head checkpoint slot mismatch"):
-            spec.validate_attestation(store, attestation.data)
+    return ValidateAttestationFixture(
+        store=store,
+        genesis_root=genesis_root,
+        block_at_slot_one_root=block_at_slot_one_root,
+        block_at_slot_two_root=block_at_slot_two_root,
+        block_above_skipped_slots_root=block_above_skipped_slots_root,
+        sibling_at_slot_two_root=sibling_at_slot_two_root,
+        orphan_at_slot_two_root=orphan_at_slot_two_root,
+    )
 
-    def test_head_slot_less_than_source_rejected(
-        self,
-        spec: LstarSpec,
-        observer_store: Store,
-    ) -> None:
-        """Head cannot be older than the justified source."""
-        store = observer_store
 
-        # Build two blocks so we have three known slots: genesis (0), slot 1, slot 2.
-        slot_1 = Slot(1)
-        slot_2 = Slot(2)
-        proposer = ValidatorIndex(1)
-        store, block_1, _ = spec.produce_block_with_signatures(store, slot_1, proposer)
-        block_1_root = hash_tree_root(block_1)
+def _valid_attestation_data(fixture: ValidateAttestationFixture) -> AttestationData:
+    """The default attestation that passes every stage: source genesis, target slot 1, head slot 2.
 
-        store, block_2, _ = spec.produce_block_with_signatures(store, slot_2, ValidatorIndex(2))
-        block_2_root = hash_tree_root(block_2)
+    slot=2, source=genesis@0, target=block_at_slot_one@1, head=block_at_slot_two@2.
+    All checkpoints lie on one parent chain and all slots match their blocks.
+    """
+    return AttestationData(
+        slot=Slot(2),
+        source=Checkpoint(root=fixture.genesis_root, slot=Slot(0)),
+        target=Checkpoint(root=fixture.block_at_slot_one_root, slot=Slot(1)),
+        head=Checkpoint(root=fixture.block_at_slot_two_root, slot=Slot(2)),
+    )
 
-        genesis_root = store.latest_justified.root
 
-        # Point the head back to genesis (slot 0) while source is at slot 1.
-        # Time flows forward: the chain tip cannot be older than the justified source.
-        # Since source <= target is enforced first, head < source also means head < target.
-        # The topology check catches this via the head >= target assertion.
-        attestation = Attestation(
-            validator_index=ValidatorIndex(0),
-            data=AttestationData(
-                slot=slot_2,
-                head=Checkpoint(root=genesis_root, slot=Slot(0)),
-                target=Checkpoint(root=block_2_root, slot=slot_2),
-                source=Checkpoint(root=block_1_root, slot=slot_1),
-            ),
-        )
+class ValidateAttestationCase(NamedTuple):
+    """One isolated scenario: a single mutation of the valid base and its expected outcome."""
 
-        with pytest.raises(AssertionError, match="Head checkpoint must not be older than target"):
-            spec.validate_attestation(store, attestation.data)
+    case_id: str
+    mutate: Callable[[ValidateAttestationFixture, AttestationData], tuple[Store, AttestationData]]
+    expected_reason: RejectionReason | None
+    expected_message_substring: str | None
 
-    def test_head_slot_less_than_target_rejected(
-        self,
-        spec: LstarSpec,
-        observer_store: Store,
-    ) -> None:
-        """Head cannot be older than the target."""
-        store = observer_store
 
-        # Two blocks again: slot 1 and slot 2.
-        slot_1 = Slot(1)
-        slot_2 = Slot(2)
-        proposer = ValidatorIndex(1)
-        store, block_1, _ = spec.produce_block_with_signatures(store, slot_1, proposer)
-        block_1_root = hash_tree_root(block_1)
-
-        store, block_2, _ = spec.produce_block_with_signatures(store, slot_2, ValidatorIndex(2))
-        block_2_root = hash_tree_root(block_2)
-
-        genesis_root = store.latest_justified.root
-
-        # Head at slot 1, target at slot 2.
-        # The head is the chain tip a validator votes for.
-        # It must be at least as recent as the target checkpoint.
-        # Slot 1 < slot 2 violates this ordering.
-        attestation = Attestation(
-            validator_index=ValidatorIndex(0),
-            data=AttestationData(
-                slot=slot_2,
-                head=Checkpoint(root=block_1_root, slot=slot_1),
-                target=Checkpoint(root=block_2_root, slot=slot_2),
-                source=Checkpoint(root=genesis_root, slot=Slot(0)),
-            ),
-        )
-
-        with pytest.raises(AssertionError, match="Head checkpoint must not be older than target"):
-            spec.validate_attestation(store, attestation.data)
-
-    def test_valid_attestation_with_correct_head_passes(
-        self,
-        spec: LstarSpec,
-        observer_store: Store,
-    ) -> None:
-        """An attestation with all checkpoints consistent should pass."""
-        store = observer_store
-
-        # Produce a single block at slot 1.
-        slot_1 = Slot(1)
-        proposer = ValidatorIndex(1)
-        store, block, _ = spec.produce_block_with_signatures(store, slot_1, proposer)
-        block_root = hash_tree_root(block)
-
-        genesis_root = store.latest_justified.root
-
-        # All checkpoints are well-ordered and consistent:
-        #
-        # - Source: genesis at slot 0 (justified ancestor)
-        # - Target: block at slot 1 (finalization target)
-        # - Head: same block at slot 1 (chain tip)
-        #
-        # Source <= target <= head, and all slots match their blocks.
-        # This should pass every validation stage.
-        attestation = Attestation(
-            validator_index=ValidatorIndex(0),
-            data=AttestationData(
-                slot=slot_1,
-                head=Checkpoint(root=block_root, slot=slot_1),
-                target=Checkpoint(root=block_root, slot=slot_1),
-                source=Checkpoint(root=genesis_root, slot=Slot(0)),
-            ),
-        )
-
-        spec.validate_attestation(store, attestation.data)
-
-    def test_head_equal_to_source_and_target_passes(
-        self,
-        spec: LstarSpec,
-        observer_store: Store,
-    ) -> None:
-        """All three checkpoints pointing to genesis (slot 0) is valid."""
-        store = observer_store
-
-        genesis_root = store.latest_justified.root
-
-        # All three checkpoints reference the same genesis block at slot 0.
-        # This is the degenerate case: no chain progress yet.
-        # The ordering source <= target <= head holds trivially (0 <= 0 <= 0).
-        genesis_checkpoint = Checkpoint(root=genesis_root, slot=Slot(0))
-
-        attestation = Attestation(
-            validator_index=ValidatorIndex(0),
-            data=AttestationData(
+VALIDATE_ATTESTATION_CASES: list[ValidateAttestationCase] = [
+    ValidateAttestationCase(
+        case_id="valid_three_slot_chain_passes",
+        mutate=lambda fixture, attestation_data: (fixture.store, attestation_data),
+        expected_reason=None,
+        expected_message_substring=None,
+    ),
+    ValidateAttestationCase(
+        case_id="all_checkpoints_at_genesis_passes",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            AttestationData(
                 slot=Slot(0),
-                head=genesis_checkpoint,
-                target=genesis_checkpoint,
-                source=genesis_checkpoint,
+                source=Checkpoint(root=fixture.genesis_root, slot=Slot(0)),
+                target=Checkpoint(root=fixture.genesis_root, slot=Slot(0)),
+                head=Checkpoint(root=fixture.genesis_root, slot=Slot(0)),
             ),
-        )
+        ),
+        expected_reason=None,
+        expected_message_substring=None,
+    ),
+    ValidateAttestationCase(
+        case_id="at_disparity_boundary_passes",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store.model_copy(
+                update={
+                    "time": Interval.from_slot(Slot(2)) - Interval(int(GOSSIP_DISPARITY_INTERVALS))
+                }
+            ),
+            attestation_data,
+        ),
+        expected_reason=None,
+        expected_message_substring=None,
+    ),
+    ValidateAttestationCase(
+        case_id="attestation_in_past_passes",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store.model_copy(
+                update={
+                    "time": Interval.from_slot(Slot(2)) + Interval(int(INTERVALS_PER_SLOT) * 10)
+                }
+            ),
+            attestation_data,
+        ),
+        expected_reason=None,
+        expected_message_substring=None,
+    ),
+    ValidateAttestationCase(
+        case_id="head_above_skipped_slots_passes",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store.model_copy(update={"time": Interval.from_slot(Slot(4))}),
+            attestation_data.model_copy(
+                update={
+                    "slot": Slot(4),
+                    "head": Checkpoint(root=fixture.block_above_skipped_slots_root, slot=Slot(4)),
+                }
+            ),
+        ),
+        expected_reason=None,
+        expected_message_substring=None,
+    ),
+    ValidateAttestationCase(
+        case_id="unknown_source_block_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={"source": Checkpoint(root=make_bytes32(200), slot=Slot(0))}
+            ),
+        ),
+        expected_reason=RejectionReason.UNKNOWN_SOURCE_BLOCK,
+        expected_message_substring="Unknown source block",
+    ),
+    ValidateAttestationCase(
+        case_id="unknown_target_block_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={"target": Checkpoint(root=make_bytes32(201), slot=Slot(1))}
+            ),
+        ),
+        expected_reason=RejectionReason.UNKNOWN_TARGET_BLOCK,
+        expected_message_substring="Unknown target block",
+    ),
+    ValidateAttestationCase(
+        case_id="unknown_head_block_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={"head": Checkpoint(root=make_bytes32(202), slot=Slot(2))}
+            ),
+        ),
+        expected_reason=RejectionReason.UNKNOWN_HEAD_BLOCK,
+        expected_message_substring="Unknown head block",
+    ),
+    ValidateAttestationCase(
+        case_id="source_after_target_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={
+                    "source": Checkpoint(root=fixture.block_at_slot_two_root, slot=Slot(2)),
+                    "target": Checkpoint(root=fixture.block_at_slot_one_root, slot=Slot(1)),
+                }
+            ),
+        ),
+        expected_reason=RejectionReason.SOURCE_AFTER_TARGET,
+        expected_message_substring="Source checkpoint slot must not exceed target",
+    ),
+    ValidateAttestationCase(
+        case_id="head_older_than_target_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={
+                    "target": Checkpoint(root=fixture.block_at_slot_two_root, slot=Slot(2)),
+                    "head": Checkpoint(root=fixture.block_at_slot_one_root, slot=Slot(1)),
+                }
+            ),
+        ),
+        expected_reason=RejectionReason.HEAD_OLDER_THAN_TARGET,
+        expected_message_substring="Head checkpoint must not be older than target",
+    ),
+    ValidateAttestationCase(
+        case_id="source_slot_mismatch_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={"source": Checkpoint(root=fixture.genesis_root, slot=Slot(1))}
+            ),
+        ),
+        expected_reason=RejectionReason.SOURCE_SLOT_MISMATCH,
+        expected_message_substring="Source checkpoint slot mismatch",
+    ),
+    ValidateAttestationCase(
+        case_id="target_slot_mismatch_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={"target": Checkpoint(root=fixture.block_at_slot_one_root, slot=Slot(2))}
+            ),
+        ),
+        expected_reason=RejectionReason.TARGET_SLOT_MISMATCH,
+        expected_message_substring="Target checkpoint slot mismatch",
+    ),
+    ValidateAttestationCase(
+        case_id="head_slot_mismatch_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={"head": Checkpoint(root=fixture.block_at_slot_two_root, slot=Slot(3))}
+            ),
+        ),
+        expected_reason=RejectionReason.HEAD_SLOT_MISMATCH,
+        expected_message_substring="Head checkpoint slot mismatch",
+    ),
+    ValidateAttestationCase(
+        case_id="source_not_ancestor_of_target_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={
+                    "source": Checkpoint(root=fixture.sibling_at_slot_two_root, slot=Slot(2)),
+                    "target": Checkpoint(root=fixture.block_at_slot_two_root, slot=Slot(2)),
+                }
+            ),
+        ),
+        expected_reason=RejectionReason.SOURCE_NOT_ANCESTOR_OF_TARGET,
+        expected_message_substring="Source checkpoint must be ancestor of target",
+    ),
+    ValidateAttestationCase(
+        case_id="target_not_ancestor_of_head_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={
+                    "target": Checkpoint(root=fixture.sibling_at_slot_two_root, slot=Slot(2)),
+                    "head": Checkpoint(root=fixture.block_at_slot_two_root, slot=Slot(2)),
+                }
+            ),
+        ),
+        expected_reason=RejectionReason.TARGET_NOT_ANCESTOR_OF_HEAD,
+        expected_message_substring="Target checkpoint must be ancestor of head",
+    ),
+    ValidateAttestationCase(
+        case_id="head_with_unknown_parent_chain_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={"head": Checkpoint(root=fixture.orphan_at_slot_two_root, slot=Slot(2))}
+            ),
+        ),
+        expected_reason=RejectionReason.TARGET_NOT_ANCESTOR_OF_HEAD,
+        expected_message_substring="Target checkpoint must be ancestor of head",
+    ),
+    ValidateAttestationCase(
+        case_id="just_beyond_disparity_boundary_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store.model_copy(
+                update={
+                    "time": Interval.from_slot(Slot(2))
+                    - Interval(int(GOSSIP_DISPARITY_INTERVALS))
+                    - Interval(1)
+                }
+            ),
+            attestation_data,
+        ),
+        expected_reason=RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE,
+        expected_message_substring="Attestation too far in future",
+    ),
+    ValidateAttestationCase(
+        case_id="one_full_slot_in_future_rejected",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store.model_copy(
+                update={"time": Interval.from_slot(Slot(2)) - Interval(int(INTERVALS_PER_SLOT))}
+            ),
+            attestation_data,
+        ),
+        expected_reason=RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE,
+        expected_message_substring="Attestation too far in future",
+    ),
+    ValidateAttestationCase(
+        case_id="ordering_unknown_source_beats_source_after_target",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={
+                    "source": Checkpoint(root=make_bytes32(200), slot=Slot(2)),
+                    "target": Checkpoint(root=fixture.block_at_slot_one_root, slot=Slot(1)),
+                }
+            ),
+        ),
+        expected_reason=RejectionReason.UNKNOWN_SOURCE_BLOCK,
+        expected_message_substring="Unknown source block",
+    ),
+    ValidateAttestationCase(
+        case_id="ordering_source_slot_mismatch_beats_ancestry",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store,
+            attestation_data.model_copy(
+                update={
+                    "source": Checkpoint(root=fixture.sibling_at_slot_two_root, slot=Slot(1)),
+                    "target": Checkpoint(root=fixture.block_at_slot_two_root, slot=Slot(2)),
+                }
+            ),
+        ),
+        expected_reason=RejectionReason.SOURCE_SLOT_MISMATCH,
+        expected_message_substring="Source checkpoint slot mismatch",
+    ),
+    ValidateAttestationCase(
+        case_id="ordering_topology_beats_time_check",
+        mutate=lambda fixture, attestation_data: (
+            fixture.store.model_copy(
+                update={"time": Interval.from_slot(Slot(2)) - Interval(int(INTERVALS_PER_SLOT))}
+            ),
+            attestation_data.model_copy(
+                update={
+                    "source": Checkpoint(root=fixture.block_at_slot_two_root, slot=Slot(2)),
+                    "target": Checkpoint(root=fixture.block_at_slot_one_root, slot=Slot(1)),
+                }
+            ),
+        ),
+        expected_reason=RejectionReason.SOURCE_AFTER_TARGET,
+        expected_message_substring="Source checkpoint slot must not exceed target",
+    ),
+]
+"""Every isolated scenario exercising validate_attestation, one mutation per case."""
 
-        spec.validate_attestation(store, attestation.data)
+
+class TestValidateAttestation:
+    """validate_attestation enforces availability, topology, consistency, ancestry, and timing."""
+
+    @pytest.mark.parametrize(
+        "case",
+        VALIDATE_ATTESTATION_CASES,
+        ids=[case.case_id for case in VALIDATE_ATTESTATION_CASES],
+    )
+    def test_validate_attestation(
+        self,
+        spec: LstarSpec,
+        observer_store: Store,
+        case: ValidateAttestationCase,
+    ) -> None:
+        """Each case mutates one thing from the valid base and asserts the exact outcome."""
+        fixture = _build_validate_attestation_fixture(spec, observer_store)
+        store, attestation_data = case.mutate(fixture, _valid_attestation_data(fixture))
+
+        if case.expected_reason is None:
+            assert spec.validate_attestation(store, attestation_data) is None
+            return
+
+        assert case.expected_message_substring is not None
+        with pytest.raises(SpecRejectionError, match=case.expected_message_substring) as rejection:
+            spec.validate_attestation(store, attestation_data)
+        assert rejection.value.reason == case.expected_reason
 
 
 def _add_known_block(
@@ -625,190 +816,6 @@ def _add_known_block(
         }
     )
     return updated_store, block_root
-
-
-class TestValidateAttestationAncestryChecks:
-    """Source, target, and head must lie on one parent chain."""
-
-    def test_proper_ancestor_chain_passes(
-        self,
-        spec: LstarSpec,
-        observer_store: Store,
-    ) -> None:
-        """A vote whose checkpoints form one chain across three slots validates."""
-        store = observer_store
-        genesis_root = store.latest_justified.root
-        store, target_root = _add_known_block(store, Slot(1), ValidatorIndex(1), genesis_root, 1)
-        store, head_root = _add_known_block(store, Slot(2), ValidatorIndex(2), target_root, 2)
-        store = store.model_copy(update={"time": Interval.from_slot(Slot(2))})
-
-        attestation_data = AttestationData(
-            slot=Slot(2),
-            source=Checkpoint(root=genesis_root, slot=Slot(0)),
-            target=Checkpoint(root=target_root, slot=Slot(1)),
-            head=Checkpoint(root=head_root, slot=Slot(2)),
-        )
-
-        spec.validate_attestation(store, attestation_data)
-
-    def test_target_must_be_ancestor_of_head(
-        self,
-        spec: LstarSpec,
-        observer_store: Store,
-    ) -> None:
-        """A head on a sibling fork must not validate against this target."""
-        store = observer_store
-        genesis_root = store.latest_justified.root
-        store, target_root = _add_known_block(store, Slot(1), ValidatorIndex(1), genesis_root, 1)
-        store, sibling_head_root = _add_known_block(
-            store, Slot(2), ValidatorIndex(2), genesis_root, 2
-        )
-        store = store.model_copy(update={"time": Interval.from_slot(Slot(2))})
-
-        attestation_data = AttestationData(
-            slot=Slot(2),
-            source=Checkpoint(root=genesis_root, slot=Slot(0)),
-            target=Checkpoint(root=target_root, slot=Slot(1)),
-            head=Checkpoint(root=sibling_head_root, slot=Slot(2)),
-        )
-
-        with pytest.raises(AssertionError, match="Target checkpoint must be ancestor of head"):
-            spec.validate_attestation(store, attestation_data)
-
-    def test_source_must_be_ancestor_of_target(
-        self,
-        spec: LstarSpec,
-        observer_store: Store,
-    ) -> None:
-        """A source on a sibling fork must not validate against this target."""
-        store = observer_store
-        genesis_root = store.latest_justified.root
-        store, source_root = _add_known_block(store, Slot(1), ValidatorIndex(1), genesis_root, 1)
-        store, target_parent_root = _add_known_block(
-            store, Slot(1), ValidatorIndex(2), genesis_root, 2
-        )
-        store, target_root = _add_known_block(
-            store, Slot(2), ValidatorIndex(2), target_parent_root, 3
-        )
-        store = store.model_copy(update={"time": Interval.from_slot(Slot(2))})
-
-        attestation_data = AttestationData(
-            slot=Slot(2),
-            source=Checkpoint(root=source_root, slot=Slot(1)),
-            target=Checkpoint(root=target_root, slot=Slot(2)),
-            head=Checkpoint(root=target_root, slot=Slot(2)),
-        )
-
-        with pytest.raises(AssertionError, match="Source checkpoint must be ancestor of target"):
-            spec.validate_attestation(store, attestation_data)
-
-    def test_head_with_unknown_parent_chain_rejected(
-        self,
-        spec: LstarSpec,
-        observer_store: Store,
-    ) -> None:
-        """A head whose parent chain leaves the store cannot prove ancestry."""
-        store = observer_store
-        genesis_root = store.latest_justified.root
-        store, target_root = _add_known_block(store, Slot(1), ValidatorIndex(1), genesis_root, 1)
-        store, orphan_head_root = _add_known_block(
-            store, Slot(2), ValidatorIndex(2), make_bytes32(99), 2
-        )
-        store = store.model_copy(update={"time": Interval.from_slot(Slot(2))})
-
-        attestation_data = AttestationData(
-            slot=Slot(2),
-            source=Checkpoint(root=genesis_root, slot=Slot(0)),
-            target=Checkpoint(root=target_root, slot=Slot(1)),
-            head=Checkpoint(root=orphan_head_root, slot=Slot(2)),
-        )
-
-        with pytest.raises(AssertionError, match="Target checkpoint must be ancestor of head"):
-            spec.validate_attestation(store, attestation_data)
-
-
-class TestValidateAttestationTimeCheck:
-    """
-    Time check boundaries.
-
-    Each case sets `store.time` explicitly to isolate the time check from
-    on_tick side effects (aggregation, safe-target update, acceptance).
-    """
-
-    @staticmethod
-    def _build_two_block_chain(spec: LstarSpec, store: Store) -> tuple[Store, AttestationData]:
-        """Produce blocks at slots 1 and ATTESTATION_SLOT; return ATTESTATION_SLOT data."""
-        store, _, _ = spec.produce_block_with_signatures(store, Slot(1), ValidatorIndex(1))
-        store, block_2, _ = spec.produce_block_with_signatures(
-            store, ATTESTATION_SLOT, ValidatorIndex(int(ATTESTATION_SLOT))
-        )
-        block_2_root = hash_tree_root(block_2)
-        genesis_root = store.latest_justified.root
-
-        attestation_data = AttestationData(
-            slot=ATTESTATION_SLOT,
-            head=Checkpoint(root=block_2_root, slot=ATTESTATION_SLOT),
-            target=Checkpoint(root=block_2_root, slot=ATTESTATION_SLOT),
-            source=Checkpoint(root=genesis_root, slot=Slot(0)),
-        )
-        return store, attestation_data
-
-    def test_attestation_at_current_slot_passes(
-        self, spec: LstarSpec, observer_store: Store
-    ) -> None:
-        """A vote at the current slot is always accepted, every interval."""
-        store, attestation_data = self._build_two_block_chain(spec, observer_store)
-
-        # Sweep every interval in the attestation's slot.
-        for offset in range(int(INTERVALS_PER_SLOT)):
-            local = store.model_copy(update={"time": ATTESTATION_START_INTERVAL + Interval(offset)})
-            spec.validate_attestation(local, attestation_data)
-
-    def test_attestation_in_past_passes(self, spec: LstarSpec, observer_store: Store) -> None:
-        """A vote from a past slot is always accepted."""
-        store, attestation_data = self._build_two_block_chain(spec, observer_store)
-
-        # Place the local clock several slots ahead.
-        far_future = ATTESTATION_START_INTERVAL + Interval(int(INTERVALS_PER_SLOT) * 10)
-        store = store.model_copy(update={"time": far_future})
-        spec.validate_attestation(store, attestation_data)
-
-    def test_attestation_at_disparity_boundary_passes(
-        self, spec: LstarSpec, observer_store: Store
-    ) -> None:
-        """At the disparity boundary the attestation is still accepted."""
-        store, attestation_data = self._build_two_block_chain(spec, observer_store)
-
-        store = store.model_copy(update={"time": DISPARITY_BOUNDARY_INTERVAL})
-        spec.validate_attestation(store, attestation_data)
-
-    def test_attestation_just_beyond_disparity_boundary_rejected(
-        self, spec: LstarSpec, observer_store: Store
-    ) -> None:
-        """One interval past the disparity boundary the attestation is rejected."""
-        store, attestation_data = self._build_two_block_chain(spec, observer_store)
-
-        store = store.model_copy(update={"time": JUST_BEYOND_DISPARITY_BOUNDARY_INTERVAL})
-
-        with pytest.raises(AssertionError, match="Attestation too far in future"):
-            spec.validate_attestation(store, attestation_data)
-
-    def test_attestation_one_full_slot_in_future_rejected(
-        self, spec: LstarSpec, observer_store: Store
-    ) -> None:
-        """
-        Regression: a full-slot future window must be rejected.
-
-        An earlier rule admitted votes up to a full slot ahead.
-        That window let an adversary pre-publish next-slot aggregates
-        before any honest validator could produce them.
-        """
-        store, attestation_data = self._build_two_block_chain(spec, observer_store)
-
-        store = store.model_copy(update={"time": ONE_FULL_SLOT_BEHIND_INTERVAL})
-
-        with pytest.raises(AssertionError, match="Attestation too far in future"):
-            spec.validate_attestation(store, attestation_data)
 
 
 def test_prunes_entries_with_head_at_finalized(spec: LstarSpec, pruning_store: Store) -> None:
@@ -1575,7 +1582,7 @@ class TestIntegrationScenarios:
         public_keys_per_aggregate: list[list] = [
             [
                 PublicKey.decode_bytes(
-                    bytes(head_state.validators[validator_index].attestation_public_key)
+                    head_state.validators[validator_index].attestation_public_key
                 )
                 for validator_index in proof.participants.to_validator_indices()
             ]
@@ -1635,7 +1642,7 @@ def test_on_block_processes_multi_validator_aggregations(
 
     # Verify attestations can be extracted from aggregated payloads
     extracted_attestations = spec.extract_attestations_from_aggregated_payloads(
-        updated_store, updated_store.latest_known_aggregated_payloads
+        updated_store.latest_known_aggregated_payloads
     )
     assert ValidatorIndex(1) in extracted_attestations
     assert ValidatorIndex(2) in extracted_attestations
@@ -1938,7 +1945,7 @@ class TestOnGossipAggregatedAttestation:
 
     def test_invalid_proof_rejected(self, key_manager: XmssKeyManager, spec: LstarSpec) -> None:
         """
-        Corrupted aggregated proof is rejected with AssertionError.
+        Corrupted aggregated proof is rejected as an invalid signature.
 
         A proof with tampered bytes should fail verification.
         """


### PR DESCRIPTION
## Summary

Documentation and small code cleanups across the lstar fork-choice mixin (`fork_choice.py`), plus a comprehensive parametrized rewrite of the attestation-validation tests. No behavior changes to the spec — pool updates are refactored to equivalent functional forms, and one dead parameter is dropped.

## Source changes (`fork_choice.py` and friends)

- **Docs**: rewrote docstrings and inline comments to the project doc rules — one sentence per line, tight blocks, concrete worked examples (e.g. the interval-margin and ancestor-walk examples), and no `Why ...` section headers.
- **Pool updates**: replaced the copy-then-mutate idiom (`{k: set(v)}` + `setdefault().add()/.update()`) in `on_gossip_attestation`, `on_gossip_aggregated_attestation`, `on_block`, and `accept_new_attestations` with functional copy-on-write dict/set unions; bound repeated `store.blocks[...]` lookups once in `_accumulate_ancestor_weights`.
- **Dead parameter**: dropped the unused `store` argument from `extract_attestations_from_aggregated_payloads` and updated all call sites.
- **Redundant coercions**: removed `bytes(...)` wraps around `Bytes52` public keys (already a `bytes` subclass, and `decode_bytes` takes `bytes`) across fork choice, aggregation, block production, signatures, and the node sync/validator services. Left the ENR `Bytes33` case (different type, external crypto lib) untouched.

## Test changes (`test_fork_choice.py`)

- Replaced the three scattered `validate_attestation` test classes with **one parametrized `TestValidateAttestation` suite** (21 cases): all 11 rejection reasons, five happy paths, and short-circuit ordering cases (earliest check wins). Each rejection asserts **both** the exact `RejectionReason` (the language-neutral contract) **and** the message substring — the old tests asserted only a bare `AssertionError` message. This closes real blind spots: `UNKNOWN_TARGET_BLOCK`, `UNKNOWN_HEAD_BLOCK`, `SOURCE_AFTER_TARGET`, `SOURCE_SLOT_MISMATCH`, and `TARGET_SLOT_MISMATCH` had no prior coverage.

## Tooling

- Documented the no-`Why ...`-header / no-AI-marketing-tone rule in `.claude/rules/documentation.md` and the doc skill, and fixed the gold-standard exemplar to match.

## Verification

- `just check` passes (ruff lint + format, ty, codespell, mdformat).
- `uv run pytest tests/lean_spec/spec/forks/lstar/test_fork_choice.py` → 64 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)