### PR TITLE
refactor(sync): remove unused BlockCache.get_processable

### DIFF
--- a/src/lean_spec/node/sync/block_cache.py
+++ b/src/lean_spec/node/sync/block_cache.py
@@ -45,7 +45,7 @@ from dataclasses import dataclass, field
 from lean_spec.node.networking.transport.peer_id import PeerId
 from lean_spec.node.sync.config import MAX_CACHED_BLOCKS
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import SignedBlock, Slot, Store
+from lean_spec.spec.forks import SignedBlock, Slot
 from lean_spec.spec.ssz import Bytes32
 
 
@@ -307,35 +307,6 @@ class BlockCache:
         # If block A at slot 100 and block B at slot 101 both waited for
         # parent P, we must process A before B.
         return sorted(children, key=lambda p: p.slot)
-
-    def get_processable(self, store: Store) -> list[PendingBlock]:
-        """
-        Get blocks whose parents exist in the Store.
-
-        This method scans the cache for blocks that can be immediately processed.
-        A block is processable if its parent is already in the Store (not just
-        in the cache - it must be fully validated and integrated).
-
-        Use this after processing new blocks to find newly-unblocked descendants.
-
-        Args:
-            store: The Store to check for parent existence.
-
-        Returns:
-            List of processable pending blocks, sorted by slot (earliest first).
-        """
-        processable: list[PendingBlock] = []
-
-        for pending in self._blocks.values():
-            # A block is processable if its parent is in the Store.
-            #
-            # Note: we check store.blocks, not the cache. The parent must be
-            # fully processed, not just received.
-            if pending.parent_root in store.blocks:
-                processable.append(pending)
-
-        # Sort ensures parent-before-child processing order.
-        return sorted(processable, key=lambda p: p.slot)
 
     @property
     def orphan_count(self) -> int:

--- a/tests/lean_spec/node/sync/test_block_cache.py
+++ b/tests/lean_spec/node/sync/test_block_cache.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-from typing import cast
-
 from lean_spec.node.networking import PeerId
 from lean_spec.node.sync.block_cache import BlockCache, PendingBlock
 from lean_spec.node.sync.config import MAX_CACHED_BLOCKS
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Slot, ValidatorIndex
-from lean_spec.spec.forks.lstar import Store
 from lean_spec.spec.ssz import Bytes32
-from tests.lean_spec.helpers import MockForkchoiceStore, make_signed_block
+from tests.lean_spec.helpers import make_signed_block
 
 
 class TestPendingBlock:
@@ -507,94 +504,6 @@ class TestBlockCacheCapacityManagement:
 
         # The original orphan should be evicted
         assert pending.root not in cache
-
-
-class TestBlockCacheProcessable:
-    """Tests for get_processable with Store integration."""
-
-    def test_get_processable_empty_cache(self) -> None:
-        """get_processable returns empty list for empty cache."""
-        cache = BlockCache()
-        store = MockForkchoiceStore()
-        store.blocks.clear()
-
-        processable = cache.get_processable(cast(Store, store))
-
-        assert processable == []
-
-    def test_get_processable_no_parents_in_store(self, peer_id: PeerId) -> None:
-        """get_processable returns empty when no parents are in Store."""
-        cache = BlockCache()
-        store = MockForkchoiceStore()
-        store.blocks.clear()
-
-        block = make_signed_block(
-            slot=Slot(1),
-            proposer_index=ValidatorIndex(0),
-            parent_root=Bytes32(b"\x01" * 32),
-            state_root=Bytes32.zero(),
-        )
-        cache.add(block, peer_id)
-
-        processable = cache.get_processable(cast(Store, store))
-
-        assert processable == []
-
-    def test_get_processable_finds_block_with_parent_in_store(self, peer_id: PeerId) -> None:
-        """get_processable finds blocks whose parents are in Store."""
-        cache = BlockCache()
-        parent_root = Bytes32(b"\x01" * 32)
-
-        store = MockForkchoiceStore()
-        store.blocks[parent_root] = object()
-
-        block = make_signed_block(
-            slot=Slot(1),
-            proposer_index=ValidatorIndex(0),
-            parent_root=parent_root,
-            state_root=Bytes32.zero(),
-        )
-        pending = cache.add(block, peer_id)
-
-        processable = cache.get_processable(cast(Store, store))
-
-        assert processable == [pending]
-
-    def test_get_processable_sorted_by_slot(self, peer_id: PeerId) -> None:
-        """get_processable returns blocks sorted by slot."""
-        cache = BlockCache()
-        parent_root = Bytes32(b"\x01" * 32)
-
-        store = MockForkchoiceStore()
-        store.blocks[parent_root] = object()
-
-        # Add blocks out of order
-        block3 = make_signed_block(
-            slot=Slot(3),
-            proposer_index=ValidatorIndex(0),
-            parent_root=parent_root,
-            state_root=Bytes32(b"\x03" * 32),
-        )
-        block1 = make_signed_block(
-            slot=Slot(1),
-            proposer_index=ValidatorIndex(0),
-            parent_root=parent_root,
-            state_root=Bytes32(b"\x01" * 32),
-        )
-        block2 = make_signed_block(
-            slot=Slot(2),
-            proposer_index=ValidatorIndex(0),
-            parent_root=parent_root,
-            state_root=Bytes32(b"\x02" * 32),
-        )
-
-        pending3 = cache.add(block3, peer_id)
-        pending1 = cache.add(block1, peer_id)
-        pending2 = cache.add(block2, peer_id)
-
-        processable = cache.get_processable(cast(Store, store))
-
-        assert processable == [pending1, pending2, pending3]
 
 
 class TestBlockCacheBackfillDepth:


### PR DESCRIPTION
## Summary

Removes `BlockCache.get_processable`, which has no production caller.

Sync drives descendant processing through `get_children(parent_root)` after each block is integrated into the `Store` (`head_sync.py`). The full-cache scan in `get_processable` — checking every cached block's parent against `store.blocks` — is a parallel strategy that nothing in production reaches; it was only exercised by its own unit tests.

## Changes

- Remove `BlockCache.get_processable` and its now-orphaned `Store` import in `block_cache.py`.
- Remove the dedicated `TestBlockCacheProcessable` test class and its now-orphaned `cast` / `Store` / `MockForkchoiceStore` imports.

## Verification

- `just check` passes (ruff lint + format, ty, codespell, mdformat).
- `uv run pytest tests/lean_spec/node/sync/test_block_cache.py` — 28 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)