### PR TITLE
fix(fork-choice): merge aggregate pools in deterministic order

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -825,12 +825,17 @@ class ForkChoiceMixin(LstarSpecBase):
         # Union each vote's pending proofs with its counted proofs.
         #
         # Each union builds a fresh set, so the caller's store stays untouched.
+        #
+        # Iterate in insertion order: counted votes first, then pending-only votes.
+        # A plain key-set union would order by hash, and the equal-slot tie-break in
+        # the LMD walk keeps the first-seen vote, so a nondeterministic order would
+        # make the head depend on hash seeding and diverge across clients.
         known_payloads = store.latest_known_aggregated_payloads
         new_payloads = store.latest_new_aggregated_payloads
         merged_aggregated_payloads = {
             attestation_data: known_payloads.get(attestation_data, set())
             | new_payloads.get(attestation_data, set())
-            for attestation_data in known_payloads.keys() | new_payloads.keys()
+            for attestation_data in {**known_payloads, **new_payloads}
         }
 
         # Promote into the counted pool and clear the pending one.

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -825,11 +825,6 @@ class ForkChoiceMixin(LstarSpecBase):
         # Union each vote's pending proofs with its counted proofs.
         #
         # Each union builds a fresh set, so the caller's store stays untouched.
-        #
-        # Iterate in insertion order: counted votes first, then pending-only votes.
-        # A plain key-set union would order by hash, and the equal-slot tie-break in
-        # the LMD walk keeps the first-seen vote, so a nondeterministic order would
-        # make the head depend on hash seeding and diverge across clients.
         known_payloads = store.latest_known_aggregated_payloads
         new_payloads = store.latest_new_aggregated_payloads
         merged_aggregated_payloads = {


### PR DESCRIPTION
## Summary

`accept_new_attestations` merged the pending and counted aggregate pools by iterating:

```python
for attestation_data in known_payloads.keys() | new_payloads.keys()
```

A union of two `dict_keys` views returns a plain `set`, whose iteration order follows object hashing, **not** insertion order. The LMD-GHOST walk keeps the **first-seen** vote when two votes share an attestation slot (the equal-slot tie-break), so the order of the merged pool decides which fork an equivocating validator's weight lands on. With a hash-ordered merge, the resulting head depended on the process hash seed — non-deterministic, and divergent across clients for a consensus spec.

This regressed in #888 (which rewrote the pool-merge). It surfaced in CI as `test_same_slot_equivocating_attesters_count_once` flipping the head from slot 2 to slot 3.

## Fix

Iterate `{**known_payloads, **new_payloads}` instead. A dict unpack preserves insertion order — counted votes first, then pending-only votes — restoring the deterministic pre-#888 ordering. Values are still unioned per vote, so no proofs are lost.

## Verification

- `test_same_slot_equivocating_attesters_count_once` now passes under `PYTHONHASHSEED` 0, 1, 7, 42, 123 (previously hash-seed dependent).
- `just check` passes (ruff lint + format, `ty`, codespell, mdformat).

Root-cause confirmation:
```
type(a.keys() | b.keys()).__name__  -> 'set'      # unordered
list({**a, **b})                    -> insertion-ordered
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)