### PR TITLE
refactor(networking): dedup fanout top-up and clean up two nits

### DIFF
--- a/src/lean_spec/node/networking/gossipsub/mesh.py
+++ b/src/lean_spec/node/networking/gossipsub/mesh.py
@@ -308,12 +308,8 @@ class MeshState:
 
         fanout.last_published = time.time()
 
-        # Fill fanout up to D peers
-        if len(fanout.peers) < self.params.d:
-            candidates = available_peers - fanout.peers
-            needed = self.params.d - len(fanout.peers)
-            new_peers = random.sample(list(candidates), min(needed, len(candidates)))
-            fanout.peers.update(new_peers)
+        # Top up to D peers, reusing the same fill routine the heartbeat runs.
+        self.fill_fanout(topic, available_peers)
 
         return fanout.peers.copy()
 

--- a/src/lean_spec/node/networking/reqresp/handler.py
+++ b/src/lean_spec/node/networking/reqresp/handler.py
@@ -524,7 +524,7 @@ class ReqRespServer:
             # - Correct size (80 bytes for Status)
             # - Valid field offsets
             try:
-                _request = Status.decode_bytes(ssz_bytes)  # noqa: F841
+                Status.decode_bytes(ssz_bytes)
             except Exception as exception:
                 # SSZ decode failure: wrong size, malformed offsets, etc.
                 #

--- a/tests/lean_spec/node/networking/gossipsub/test_topic.py
+++ b/tests/lean_spec/node/networking/gossipsub/test_topic.py
@@ -16,37 +16,37 @@ class TestTopicForkValidation:
 
     def test_validate_fork_success(self) -> None:
         """Test validate_fork passes for matching network_name."""
-        topic = GossipTopic(kind=TopicKind.BLOCK, network_name="0x12345678")
-        topic.validate_fork("0x12345678")  # Should not raise
+        topic = GossipTopic(kind=TopicKind.BLOCK, network_name="12345678")
+        topic.validate_fork("12345678")  # Should not raise
 
     def test_validate_fork_raises_on_mismatch(self) -> None:
         """Test validate_fork raises ForkMismatchError on mismatch."""
-        topic = GossipTopic(kind=TopicKind.BLOCK, network_name="0x12345678")
+        topic = GossipTopic(kind=TopicKind.BLOCK, network_name="12345678")
         with pytest.raises(ForkMismatchError) as exc_info:
-            topic.validate_fork("0xdeadbeef")
+            topic.validate_fork("deadbeef")
 
-        assert exc_info.value.expected == "0xdeadbeef"
-        assert exc_info.value.actual == "0x12345678"
+        assert exc_info.value.expected == "deadbeef"
+        assert exc_info.value.actual == "12345678"
 
     def test_from_string_validated_success(self) -> None:
         """Test from_string_validated parses and validates successfully."""
         assert GossipTopic.from_string_validated(
-            "/leanconsensus/0x12345678/block/ssz_snappy",
-            expected_network_name="0x12345678",
-        ) == GossipTopic(kind=TopicKind.BLOCK, network_name="0x12345678")
+            "/leanconsensus/12345678/block/ssz_snappy",
+            expected_network_name="12345678",
+        ) == GossipTopic(kind=TopicKind.BLOCK, network_name="12345678")
 
     def test_from_string_validated_raises_on_mismatch(self) -> None:
         """Test from_string_validated raises ForkMismatchError on mismatch."""
         with pytest.raises(ForkMismatchError):
             GossipTopic.from_string_validated(
-                "/leanconsensus/0x12345678/block/ssz_snappy",
-                expected_network_name="0xdeadbeef",
+                "/leanconsensus/12345678/block/ssz_snappy",
+                expected_network_name="deadbeef",
             )
 
     def test_from_string_validated_raises_on_invalid_topic(self) -> None:
         """Test from_string_validated raises ValueError for invalid topics."""
         with pytest.raises(ValueError) as exception_info:
-            GossipTopic.from_string_validated("/invalid/topic", "0x12345678")
+            GossipTopic.from_string_validated("/invalid/topic", "12345678")
         assert str(exception_info.value) == "Invalid topic format: expected 4 parts, got 2"
 
 
@@ -55,31 +55,31 @@ class TestTopicFormatting:
 
     def test_gossip_topic_creation(self) -> None:
         """Test GossipTopic creation."""
-        topic = GossipTopic(kind=TopicKind.BLOCK, network_name="0x12345678")
-        assert topic == GossipTopic(kind=TopicKind.BLOCK, network_name="0x12345678")
-        assert str(topic) == "/leanconsensus/0x12345678/block/ssz_snappy"
+        topic = GossipTopic(kind=TopicKind.BLOCK, network_name="12345678")
+        assert topic == GossipTopic(kind=TopicKind.BLOCK, network_name="12345678")
+        assert str(topic) == "/leanconsensus/12345678/block/ssz_snappy"
 
     def test_gossip_topic_from_string(self) -> None:
         """Test parsing topic string."""
-        topic_str = "/leanconsensus/0x12345678/block/ssz_snappy"
+        topic_str = "/leanconsensus/12345678/block/ssz_snappy"
         assert GossipTopic.from_string(topic_str) == GossipTopic(
-            kind=TopicKind.BLOCK, network_name="0x12345678"
+            kind=TopicKind.BLOCK, network_name="12345678"
         )
 
     def test_gossip_topic_factory_methods(self) -> None:
         """Test GossipTopic factory methods."""
-        assert GossipTopic.block("0xabcd1234") == GossipTopic(
-            kind=TopicKind.BLOCK, network_name="0xabcd1234"
+        assert GossipTopic.block("abcd1234") == GossipTopic(
+            kind=TopicKind.BLOCK, network_name="abcd1234"
         )
-        assert GossipTopic.attestation_subnet("0xabcd1234", SubnetId(0)) == GossipTopic(
-            kind=TopicKind.ATTESTATION_SUBNET, network_name="0xabcd1234", subnet_id=SubnetId(0)
+        assert GossipTopic.attestation_subnet("abcd1234", SubnetId(0)) == GossipTopic(
+            kind=TopicKind.ATTESTATION_SUBNET, network_name="abcd1234", subnet_id=SubnetId(0)
         )
 
     def test_parse_topic_string(self) -> None:
         """Test topic string parsing."""
-        assert parse_topic_string("/leanconsensus/0x12345678/block/ssz_snappy") == (
+        assert parse_topic_string("/leanconsensus/12345678/block/ssz_snappy") == (
             "leanconsensus",
-            "0x12345678",
+            "12345678",
             "block",
             "ssz_snappy",
         )
@@ -91,7 +91,7 @@ class TestTopicFormatting:
         assert str(exception_info.value) == "Invalid topic format: expected 4 parts, got 2"
 
         with pytest.raises(ValueError) as exception_info:
-            GossipTopic.from_string("/wrongprefix/0x123/block/ssz_snappy")
+            GossipTopic.from_string("/wrongprefix/123/block/ssz_snappy")
         assert (
             str(exception_info.value)
             == "Invalid prefix: expected 'leanconsensus', got 'wrongprefix'"


### PR DESCRIPTION
## Summary

Three small, behavior-preserving networking cleanups.

### 1. `mesh.py` — remove duplicated fanout top-up
`update_fanout` and `fill_fanout` carried a byte-identical block that tops the fanout up to `D` peers. By the time `update_fanout` reaches it, the `FanoutEntry` always exists (it creates one), so it now delegates to `fill_fanout`, which mutates the same entry in place. The returned `fanout.peers.copy()` is unchanged. `fill_fanout` is also called from the heartbeat, so it is a genuine shared routine — not a single-use helper.

### 2. `handler.py` — drop a throwaway assignment
The Status request is decoded purely to validate the incoming bytes; the parsed value is never used (the handler replies with our own status regardless). Replaced `_request = Status.decode_bytes(...)  # noqa: F841` with a bare validating call. The surrounding comment already documents that the decode is the validation step.

### 3. `test_topic.py` — drop the misleading `0x` prefix
The canonical network name is the 4-byte fork digest as hex with **no** `0x` prefix (`GOSSIP_DIGEST = "12345678"`; `topic.py` docstrings say "hex string (no 0x prefix)"). The test data used `0x`-prefixed values that no real node produces. Dropped the prefixes so the fixtures match the wire format. The parser treats `network_name` as opaque, so the assertions are unaffected.

## Verification

- Impacted tests pass (mesh, topic, handler — 109 tests).
- `just check` passes (ruff lint + format, `ty`, codespell, mdformat).

## Note

A related audit item — the three near-identical timing context managers in `spec/observability/observer.py` — was intentionally left as-is. The duplication is a trivial 3-line stopwatch, while each function carries distinct cross-client portability documentation; collapsing them would trade clarity and docs for ~4 fewer lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)