### PR TITLE
test: add test vector for block production with merging aggregates

### DIFF
--- a/tests/consensus/lstar/fork_choice/test_signature_aggregation.py
+++ b/tests/consensus/lstar/fork_choice/test_signature_aggregation.py
@@ -8,19 +8,22 @@ from consensus_testing import (
     BlockSpec,
     BlockStep,
     ForkChoiceTestFiller,
+    GossipAggregatedAttestationStep,
     StoreChecks,
+    TickStep,
 )
-from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
 
 pytestmark = pytest.mark.valid_until("Lstar")
 
 
 @pytest.mark.real_crypto(smoke=True)
-def test_multiple_specs_same_target_merge_into_one(
+def test_multiple_attestations_same_target_merge_into_one(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
     """
-    Two attestations sharing one target merge into a single aggregation.
+    Two attestations in the known pool sharing one target get merged
+    into a single aggregation.
 
     Given
     -----
@@ -67,6 +70,91 @@ def test_multiple_specs_same_target_merge_into_one(
                         ),
                     ],
                 ),
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    block_attestation_count=1,
+                    block_attestations=[
+                        AggregatedAttestationCheck(
+                            participants={0, 1, 2, 3},
+                            attestation_slot=Slot(1),
+                            target_slot=Slot(1),
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
+def test_overlapping_proofs_same_target_recursively_merge_into_one(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Two overlapping proofs (enforced by 2 separate gossips) for one target
+    fold into a single in-block attestation.
+
+    Given
+    -----
+    - 4 validators.
+    - the chain:
+        genesis -> block_1(1)
+    - one proof covers V0, V1, V2 targeting block_1.
+    - one proof covers V1, V2, V3 targeting block_1.
+    - the two proofs overlap on V1, V2.
+    - both proofs carry identical attestation data.
+    - the clock ticks past slot 1's aggregate phase before they gossip.
+    - both proofs arrive by gossip.
+    - both proofs wait unmerged in the known pool.
+
+    When
+    ----
+    - block_2 is built on block_1, carrying no votes of its own.
+
+    Then
+    ----
+    - the builder takes the first proof.
+    - the builder takes the second proof for its one uncovered voter.
+    - the builder folds both proofs into one attestation.
+    - block_2 holds 1 aggregated attestation covering V0, V1, V2, V3.
+    - head is block_2 at slot 2.
+
+    Timing
+    ------
+    - the proofs are gossipped at slot 1, interval 3 (past the aggregate phase).
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            TickStep(interval=int(Interval.from_slot(Slot(1))) + 3),
+            GossipAggregatedAttestationStep(
+                attestation=AggregatedAttestationSpec(
+                    validator_indices=[
+                        ValidatorIndex(0),
+                        ValidatorIndex(1),
+                        ValidatorIndex(2),
+                    ],
+                    slot=Slot(1),
+                    target_slot=Slot(1),
+                    target_root_label="block_1",
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=AggregatedAttestationSpec(
+                    validator_indices=[
+                        ValidatorIndex(1),
+                        ValidatorIndex(2),
+                        ValidatorIndex(3),
+                    ],
+                    slot=Slot(1),
+                    target_slot=Slot(1),
+                    target_root_label="block_1",
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), label="block_2"),
                 checks=StoreChecks(
                     head_slot=Slot(2),
                     block_attestation_count=1,

--- a/tests/consensus/lstar/fork_choice/test_signature_aggregation.py
+++ b/tests/consensus/lstar/fork_choice/test_signature_aggregation.py
@@ -85,6 +85,7 @@ def test_multiple_attestations_same_target_merge_into_one(
         ],
     )
 
+
 @pytest.mark.real_crypto(smoke=True)
 def test_overlapping_proofs_same_target_recursively_merge_into_one(
     fork_choice_test: ForkChoiceTestFiller,

--- a/tests/consensus/lstar/fork_choice/test_signature_aggregation.py
+++ b/tests/consensus/lstar/fork_choice/test_signature_aggregation.py
@@ -102,7 +102,6 @@ def test_overlapping_proofs_same_target_recursively_merge_into_one(
     - one proof covers V1, V2, V3 targeting block_1.
     - the two proofs overlap on V1, V2.
     - both proofs carry identical attestation data.
-    - both proofs arrive by gossip.
     - both proofs wait unmerged in the known pool.
 
     When
@@ -113,11 +112,13 @@ def test_overlapping_proofs_same_target_recursively_merge_into_one(
     ----
     - block_2 holds 1 aggregated attestation.
     - that aggregation covers V0, V1, V2, V3.
-    - head is block_2 at slot 2.
+    - head is block_2.
+    - head is at slot 2.
 
     Timing
     ------
-    - the proofs are gossipped at slot 1, interval 3 (past the aggregate phase).
+    - the proofs are gossipped at slot 1, interval 3.
+    - interval 3 is past the aggregate phase.
     """
     fork_choice_test(
         steps=[
@@ -154,6 +155,7 @@ def test_overlapping_proofs_same_target_recursively_merge_into_one(
                 block=BlockSpec(slot=Slot(2), label="block_2"),
                 checks=StoreChecks(
                     head_slot=Slot(2),
+                    head_root_label="block_2",
                     block_attestation_count=1,
                     block_attestations=[
                         AggregatedAttestationCheck(

--- a/tests/consensus/lstar/fork_choice/test_signature_aggregation.py
+++ b/tests/consensus/lstar/fork_choice/test_signature_aggregation.py
@@ -85,13 +85,12 @@ def test_multiple_attestations_same_target_merge_into_one(
         ],
     )
 
-
+@pytest.mark.real_crypto(smoke=True)
 def test_overlapping_proofs_same_target_recursively_merge_into_one(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
     """
-    Two overlapping proofs (enforced by 2 separate gossips) for one target
-    fold into a single in-block attestation.
+    Two overlapping proofs for one target fold into a single in-block attestation.
 
     Given
     -----
@@ -102,7 +101,6 @@ def test_overlapping_proofs_same_target_recursively_merge_into_one(
     - one proof covers V1, V2, V3 targeting block_1.
     - the two proofs overlap on V1, V2.
     - both proofs carry identical attestation data.
-    - the clock ticks past slot 1's aggregate phase before they gossip.
     - both proofs arrive by gossip.
     - both proofs wait unmerged in the known pool.
 
@@ -112,10 +110,8 @@ def test_overlapping_proofs_same_target_recursively_merge_into_one(
 
     Then
     ----
-    - the builder takes the first proof.
-    - the builder takes the second proof for its one uncovered voter.
-    - the builder folds both proofs into one attestation.
-    - block_2 holds 1 aggregated attestation covering V0, V1, V2, V3.
+    - block_2 holds 1 aggregated attestation.
+    - that aggregation covers V0, V1, V2, V3.
     - head is block_2 at slot 2.
 
     Timing


### PR DESCRIPTION
## 🗒️ Description

Add a test vector that asserts if a block producer has 2 aggregates of the same message, they get merged successfully for block inclusion.

Since proof bytes are not deterministic, this vector checks that all attesters are accounted for in the produced block.

I was also trying to add split and merge but seems like it needs a leanVM commit bump so I'll defer that to later.