### PR TITLE
refactor(testing): delete never-called request_block_by_root mock

### DIFF
--- a/packages/testing/src/consensus_testing/mocks.py
+++ b/packages/testing/src/consensus_testing/mocks.py
@@ -85,14 +85,6 @@ class MockNetworkRequester:
             raise ConnectionError("Network failed")
         return [self.blocks_by_root[root] for root in roots if root in self.blocks_by_root]
 
-    async def request_block_by_root(
-        self,
-        peer_id: PeerId,
-        root: Bytes32,
-    ) -> SignedBlock | None:
-        """Return a single block by root, or none if absent."""
-        return self.blocks_by_root.get(root)
-
     async def request_blocks_by_range(
         self,
         peer_id: PeerId,


### PR DESCRIPTION
## Summary

Deletes a dead method on the `MockNetworkRequester` test double (audit finding **CORE-01**).

The mock exposed a singular `request_block_by_root` method, but the real network/protocol surface only defines the plural `request_blocks_by_root`. A repo-wide search confirms the singular form has **zero callers** — it modeled a method that does not exist on the type it doubles, so it was pure dead code.

## Change

- Remove the 7-line `request_block_by_root` method from `packages/testing/src/consensus_testing/mocks.py`.

The plural `request_blocks_by_root` and `request_blocks_by_range` methods are untouched, and no imports were orphaned (`SignedBlock` and `Bytes32` remain used throughout the file).

## Verification

- `grep` for `request_block_by_root` (singular) across the repo: zero remaining code references.
- `just check` passes: ruff check, ruff format, `ty`, codespell, mdformat all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)