### PR TITLE
refactor(testing): rename signer_ids to signer_indices

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -103,7 +103,10 @@ class StateTransitionTest(BaseTestSpec):
         """Reject signature-flavored attestation fields at construction."""
         for block_spec in self.blocks:
             for attestation_spec in block_spec.attestations or []:
-                if not attestation_spec.valid_signature or attestation_spec.signer_ids is not None:
+                if (
+                    not attestation_spec.valid_signature
+                    or attestation_spec.signer_indices is not None
+                ):
                     raise ValueError(
                         "state transition assumes signatures were verified upstream; "
                         "author invalid-signature scenarios through the fork choice "

--- a/packages/testing/src/consensus_testing/test_types/attestation_specs.py
+++ b/packages/testing/src/consensus_testing/test_types/attestation_specs.py
@@ -145,7 +145,7 @@ class AggregatedAttestationSpec(AttestationSpec):
     validator_indices: list[ValidatorIndex]
     """The indices of validators making the attestation (required)."""
 
-    signer_ids: list[ValidatorIndex] | None = None
+    signer_indices: list[ValidatorIndex] | None = None
     """
     Override which validators actually sign the attestation.
 
@@ -187,7 +187,7 @@ class AggregatedAttestationSpec(AttestationSpec):
         # - Actual signers produce the cryptographic material.
         # They default to the same set for honest attestations.
         validator_indices = self.validator_indices
-        signer_ids = self.signer_ids or self.validator_indices
+        signer_indices = self.signer_indices or self.validator_indices
 
         # Path 1: Invalid signature.
         #
@@ -202,7 +202,7 @@ class AggregatedAttestationSpec(AttestationSpec):
             return SignedAggregatedAttestation(data=attestation_data, proof=proof)
 
         # Path 2: Valid signature.
-        proof = key_manager.sign_and_aggregate(signer_ids, attestation_data)
+        proof = key_manager.sign_and_aggregate(signer_indices, attestation_data)
 
         # Path 3: Participant mismatch.
         #
@@ -211,7 +211,7 @@ class AggregatedAttestationSpec(AttestationSpec):
         # The proof is cryptographically valid for the actual signers,
         # but the claimed participants no longer match.
         # The store must detect and reject this inconsistency.
-        if self.signer_ids and self.signer_ids != self.validator_indices:
+        if self.signer_indices and self.signer_indices != self.validator_indices:
             proof = SingleMessageAggregate(
                 participants=AggregationBits.from_indices(validator_indices),
                 proof=proof.proof,
@@ -257,9 +257,9 @@ class AggregatedAttestationSpec(AttestationSpec):
 
         if not self.valid_signature:
             invalid_proof = SingleMessageAggregate(participants=aggregation_bits, proof=placeholder)
-        elif self.signer_ids is not None:
+        elif self.signer_indices is not None:
             # Valid proof from wrong validators (participant mismatch).
-            valid_proof = key_manager.sign_and_aggregate(self.signer_ids, attestation_data)
+            valid_proof = key_manager.sign_and_aggregate(self.signer_indices, attestation_data)
             invalid_proof = SingleMessageAggregate(
                 participants=aggregation_bits, proof=valid_proof.proof
             )

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -365,8 +365,8 @@ class BlockSpec(CamelModel):
             for attestation_spec in (self.attestations or [])
             if not attestation_spec.valid_signature
             or (
-                attestation_spec.signer_ids is not None
-                and attestation_spec.signer_ids != attestation_spec.validator_indices
+                attestation_spec.signer_indices is not None
+                and attestation_spec.signer_indices != attestation_spec.validator_indices
             )
         ]
 

--- a/tests/consensus/lstar/fork_choice/test_gossip_aggregated_registry_and_signature.py
+++ b/tests/consensus/lstar/fork_choice/test_gossip_aggregated_registry_and_signature.py
@@ -103,7 +103,7 @@ def test_aggregated_attestation_proof_verification_failure_rejected(
             GossipAggregatedAttestationStep(
                 attestation=AggregatedAttestationSpec(
                     validator_indices=[ValidatorIndex(1)],
-                    signer_ids=[ValidatorIndex(2)],
+                    signer_indices=[ValidatorIndex(2)],
                     slot=Slot(2),
                     target_slot=Slot(2),
                     target_root_label="block_2",


### PR DESCRIPTION
## Summary

Renames the `signer_ids` field on `AggregatedAttestationSpec` to `signer_indices` (audit finding **DOC-01**).

A validator is referenced by its **index**, never an "id" — a project naming rule. The field even described "these validator indices" in its own docstring, so the name contradicted itself.

## Change

- Rename the field `signer_ids` → `signer_indices` and every reference across the testing framework:
  - `test_types/attestation_specs.py` (field declaration, local variable, and all accesses)
  - `test_types/block_spec.py`
  - `test_fixtures/state_transition.py`
  - `tests/consensus/lstar/fork_choice/test_gossip_aggregated_registry_and_signature.py` (the one consuming consensus test)

The field has **no explicit pydantic alias** and is referenced by **no emitted JSON/YAML fixture** (verified), so the inherited camelCase serialization simply changes from `signerIds` to `signerIndices` — there is no on-the-wire compatibility concern. `validator_indices` was already correct and is untouched.

## Verification

- `grep` for `signer_ids` / `signerIds` across the source tree (excluding the gitignored `build/`): zero remaining matches.
- `just check` passes: ruff check, ruff format, `ty`, codespell, mdformat all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)