### PR TITLE
fix(testing): make consensus vector generation deterministic across hash seeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Fill test fixtures
         run: just fill-ci
 
+      - name: Check fixture determinism (order-sensitive vectors)
+        run: just fill-determinism
+
   interop-tests:
     name: Interop tests - Multi-node consensus
     runs-on: macos-latest

--- a/Justfile
+++ b/Justfile
@@ -85,6 +85,31 @@ test-consensus *args:
 fill-ci *args:
     uv run --group test fill --fork=Lstar --clean -n auto --dist=worksteal "$@"
 
+# Generate the order-sensitive vectors twice under different hash seeds and diff.
+# Only the vectors marked order_sensitive run, so this stays cheap.
+# A difference means an emitted vector depends on set or dict iteration order,
+# which is hash-seeded and would break cross-client reproducibility.
+# Pass a path to widen the scope (for example the whole tests/consensus tree).
+[group('tests')]
+fill-determinism *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target="{{args}}"
+    [ -z "$target" ] && target="tests/consensus -m order_sensitive"
+    first="$(mktemp -d)"
+    second="$(mktemp -d)"
+    trap 'rm -rf "$first" "$second"' EXIT
+    # Single process: the marked subset is small, so xdist worker startup would
+    # cost more than it saves, and one process pins the hash seed cleanly.
+    PYTHONHASHSEED=1 uv run --group test fill --fork=Lstar --clean -n 0 -o "$first" $target -q
+    PYTHONHASHSEED=2 uv run --group test fill --fork=Lstar --clean -n 0 -o "$second" $target -q
+    if diff -rq "$first" "$second"; then
+        echo "Determinism check passed: fixtures are byte-identical across hash seeds."
+    else
+        echo "Determinism check FAILED: emitted vectors differ across PYTHONHASHSEED." >&2
+        exit 1
+    fi
+
 # Run API conformance tests against an external client
 [group('tests')]
 apitest server_url *args:

--- a/packages/testing/src/consensus_testing/pytest_plugins/filler.py
+++ b/packages/testing/src/consensus_testing/pytest_plugins/filler.py
@@ -194,6 +194,11 @@ def pytest_configure(config: pytest.Config) -> None:
         "real_crypto(smoke=False): build and verify with the real prover, never the mock; "
         "smoke=True also keeps it in the fast mocked lane",
     )
+    config.addinivalue_line(
+        "markers",
+        "order_sensitive: emission could depend on set or dict iteration order; "
+        "the determinism check generates this vector twice and diffs the output",
+    )
 
     # Crypto mode is chosen explicitly and applies to either scheme.
     AggregationProver.set_mode(CryptoMode(config.getoption("--crypto")))

--- a/packages/testing/src/consensus_testing/test_fixtures/gossipsub_handler.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/gossipsub_handler.py
@@ -476,8 +476,14 @@ class GossipsubHandlerTest(BaseTestSpec):
         # Each entry represents one RPC sent to a peer.
         # The structure mirrors the gossipsub RPC wire format.
         # Fixture consumers use this to assert exact outbound behavior.
+        # Emit outbound RPCs in canonical recipient order.
+        # The send order to mesh peers is set-driven.
+        # It is not consensus-relevant.
+        # Sorting by recipient keeps the emitted vector reproducible across runs.
         sent_rpcs = []
-        for recipient_peer_id, rpc in capture.sent:
+        for recipient_peer_id, rpc in sorted(
+            capture.sent, key=lambda entry: peer_names.get(entry[0], str(entry[0]))
+        ):
             subscriptions = (
                 [
                     SentSubscription(

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -178,7 +178,7 @@ class BlockSpec(CamelModel):
     ) -> tuple[
         list[Attestation],
         dict[AttestationData, dict[ValidatorIndex, Signature]],
-        set[Attestation],
+        list[Attestation],
     ]:
         """
         Build attestations and signatures from this block's attestation specs.
@@ -195,11 +195,14 @@ class BlockSpec(CamelModel):
                 - Subset of attestations that have valid (non-dummy) signatures
         """
         if self.attestations is None:
-            return [], {}, set()
+            return [], {}, []
 
         attestations: list[Attestation] = []
         signature_lookup: dict[AttestationData, dict[ValidatorIndex, Signature]] = {}
-        valid_attestations: set[Attestation] = set()
+        # A list, not a set.
+        # Build order is the canonical order consumers gossip in.
+        # That keeps the emitted block body reproducible across runs.
+        valid_attestations: list[Attestation] = []
 
         for aggregated_spec in self.attestations:
             # Build attestation data once.
@@ -224,7 +227,7 @@ class BlockSpec(CamelModel):
                         validator_index,
                         attestation_data,
                     )
-                    valid_attestations.add(attestation)
+                    valid_attestations.append(attestation)
                 else:
                     signature = create_dummy_signature()
 

--- a/src/lean_spec/spec/forks/lstar/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/aggregation.py
@@ -113,9 +113,11 @@ class AggregationMixin(LstarSpecBase):
         #
         # Known payloads cannot start a round alone, since re-aggregating them adds nothing.
         # They serve only as fallback building blocks once fresh evidence exists.
-        for attestation_data in (
-            store.latest_new_aggregated_payloads.keys() | store.attestation_signatures.keys()
-        ):
+        # Iterate in insertion order, in order to have a deterministic pool order.
+        for attestation_data in {
+            **store.latest_new_aggregated_payloads,
+            **store.attestation_signatures,
+        }:
             # Phase 1: Select.
             #
             # Reuse existing proofs first to keep the proof tree shallow.

--- a/tests/consensus/lstar/fork_choice/test_block_attestation_limits.py
+++ b/tests/consensus/lstar/fork_choice/test_block_attestation_limits.py
@@ -14,7 +14,7 @@ from consensus_testing import (
 from lean_spec.spec.forks import RejectionReason, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import MAX_ATTESTATIONS_DATA
 
-pytestmark = pytest.mark.valid_until("Lstar")
+pytestmark = [pytest.mark.valid_until("Lstar"), pytest.mark.order_sensitive]
 
 
 def _justifiable_slots(n: int) -> list[Slot]:

--- a/tests/consensus/lstar/networking/test_gossipsub_handlers.py
+++ b/tests/consensus/lstar/networking/test_gossipsub_handlers.py
@@ -16,7 +16,7 @@ from consensus_testing import (
     PeerConfiguration,
 )
 
-pytestmark = pytest.mark.valid_until("Lstar")
+pytestmark = [pytest.mark.valid_until("Lstar"), pytest.mark.order_sensitive]
 
 TOPIC = "test_topic"
 PARAMS = GossipsubMeshParameters(d=4, d_low=3, d_high=6, d_lazy=3)


### PR DESCRIPTION
## Problem

Some emitted consensus vectors depended on **set / dict iteration order**, which Python seeds per process (`PYTHONHASHSEED`). Two fills of identical input could therefore produce different bytes — and a client matching one ordering would fail a vector generated under the other. This is the same class as the fork-choice pool-merge bug fixed earlier; this PR closes the remaining sources and adds a guard.

Confirmed empirically: generating the suite under two hash seeds and diffing surfaced real divergence (fork-choice block weights, and gossipsub forward order).

## Fix

- **`aggregation.py`** — build the new aggregate pool by iterating an insertion-ordered dict merge instead of a hash-seeded `keys() | keys()` set union (mirrors the fork-choice `accept_new_attestations` merge), so fork-choice weights are reproducible.
- **`block_spec.py`** — collect a block's valid attestations in a list (build order) rather than a `set`, so block bodies are stable.
- **`gossipsub_handler.py`** — emit outbound RPCs in recipient order rather than send (set-iteration) order; only the recipient *set* is meaningful, not the order.

## Guard

- A new `order_sensitive` marker tags the vectors that exercise these orderings (the multi-attestation block-limit vector and the gossipsub mesh-forward vector).
- `just fill-determinism` regenerates **only** the marked subset under two hash seeds and diffs them — cheap (~25s, single-process), not a full second suite run. Wired into CI alongside the normal single fill.

## Proof it guards the bug

- Revert the `aggregation.py` fix → `just fill-determinism` **fails** (marked vectors differ across seeds).
- Fix in place → **passes**. Full mocked suite green and reproducible across hash seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)