### PR TITLE
refactor(testing): type proof_setting as an IntEnum and fix its derivation

### DIFF
--- a/packages/testing/src/consensus_testing/pytest_plugins/filler.py
+++ b/packages/testing/src/consensus_testing/pytest_plugins/filler.py
@@ -13,7 +13,12 @@ import pytest
 from consensus_testing.crypto_mode import AggregationProver, CryptoMode
 from consensus_testing.forks import FORKS_BY_NAME
 from consensus_testing.keys import DEFAULT_MAX_SLOT, XmssKeyManager
-from consensus_testing.test_fixtures import FIXTURE_FORMATS, FixtureInfo
+from consensus_testing.test_fixtures import (
+    FIXTURE_FORMATS,
+    PROOF_FAILURE_REJECTION_REASONS,
+    FixtureInfo,
+    ProofSetting,
+)
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.ssz import Bytes32
 
@@ -450,15 +455,19 @@ def base_spec_filler_parametrizer(spec_class: Any) -> Any:
             else:
                 generated_fixture = test_spec.generate()
 
-            # - 0 mocked,
-            # - 1 real and must verify,
-            # - 2 real and must fail verification.
+            # A mocked proof is never verified.
+            # A real proof must fail only when the rejection is itself a proof failure.
+            # A non-crypto rejection (such as an unknown parent) still carries a valid proof.
+            expected_rejection = test_spec.expected_rejection
             if mock_prover:
-                proof_setting = 0
-            elif test_spec.expected_rejection is not None:
-                proof_setting = 2
+                proof_setting = ProofSetting.MOCKED
+            elif (
+                expected_rejection is not None
+                and expected_rejection.reason in PROOF_FAILURE_REJECTION_REASONS
+            ):
+                proof_setting = ProofSetting.REAL_AND_INVALID
             else:
-                proof_setting = 1
+                proof_setting = ProofSetting.REAL_AND_VALID
 
             filled_fixture = generated_fixture.with_info(
                 info=FixtureInfo(

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -2,10 +2,12 @@
 
 from consensus_testing.test_fixtures.api_endpoint import ApiEndpointFixture, ApiEndpointTest
 from consensus_testing.test_fixtures.base import (
+    PROOF_FAILURE_REJECTION_REASONS,
     BaseConsensusFixture,
     BaseTestSpec,
     ExpectedRejection,
     FixtureInfo,
+    ProofSetting,
 )
 from consensus_testing.test_fixtures.fork_choice import ForkChoiceFixture, ForkChoiceTest
 from consensus_testing.test_fixtures.gossipsub_handler import (
@@ -159,6 +161,8 @@ __all__ = [
     "BaseTestSpec",
     "ExpectedRejection",
     "FixtureInfo",
+    "ProofSetting",
+    "PROOF_FAILURE_REJECTION_REASONS",
     "StateTransitionFixture",
     "StateTransitionTest",
     "ForkChoiceFixture",

--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 from abc import abstractmethod
+from enum import IntEnum
 from functools import cached_property
 from typing import Any, ClassVar, Self
 
@@ -58,6 +59,25 @@ class ExpectedRejection(StrictBaseModel):
     """
 
 
+class ProofSetting(IntEnum):
+    """Aggregation proof regime emitted with each fixture."""
+
+    MOCKED = 0
+    """The proof is mocked and must not be verified."""
+
+    REAL_AND_VALID = 1
+    """The proof is real and must verify."""
+
+    REAL_AND_INVALID = 2
+    """The proof is real and must fail verification."""
+
+
+PROOF_FAILURE_REJECTION_REASONS: frozenset[RejectionReason] = frozenset(
+    {RejectionReason.INVALID_SIGNATURE, RejectionReason.INVALID_BLOCK_PROOF}
+)
+"""Rejection reasons whose direct cause is the aggregation proof failing to verify."""
+
+
 class BaseConsensusFixture(CamelModel):
     """
     Base class for all consensus test fixtures.
@@ -93,14 +113,8 @@ class BaseConsensusFixture(CamelModel):
     This is the field clients assert against.
     """
 
-    proof_setting: int = 0
-    """
-    Aggregation proof regime, mirroring eth2's bls_setting.
-
-    - 0 means the proof is mocked and must not be verified.
-    - 1 means the proof is real and must verify.
-    - 2 means the proof is real and must fail verification.
-    """
+    proof_setting: ProofSetting = ProofSetting.MOCKED
+    """Aggregation proof regime, emitted as an integer; each value documents its own meaning."""
 
     def with_info(self, info: FixtureInfo, network: str) -> Self:
         """


### PR DESCRIPTION
## Motivation

The emitted `proof_setting` field was a bare `int` with three magic values, documented only by a re-explaining inline comment block at the single place it was assigned:

```python
# - 0 mocked,
# - 1 real and must verify,
# - 2 real and must fail verification.
if mock_prover:
    proof_setting = 0
elif test_spec.expected_rejection is not None:
    proof_setting = 2
else:
    proof_setting = 1
```

Two problems:
1. **Stringly/numerically typed** — the meaning lives in a comment, not the type.
2. **Derivation bug** — `proof_setting` was set to `2` ("real proof must fail verification") for *any* vector carrying an expected rejection, even when the rejection is non-crypto (e.g. an unknown parent, a slot mismatch) and the proof is perfectly valid. A client that verifies such a proof (and it passes) then rejects for the real reason is behaving correctly, yet contradicts `proof_setting=2`.

## What this does

**Self-documenting `IntEnum`.** Each member carries its own meaning:

```python
class ProofSetting(IntEnum):
    MOCKED = 0           # the proof is mocked and must not be verified
    REAL_AND_VALID = 1   # the proof is real and must verify
    REAL_AND_INVALID = 2 # the proof is real and must fail verification
```

The fixture field is retyped to `ProofSetting`. Because it is an `IntEnum`, it serializes to the same integer (0/1/2) — **emitted vectors are byte-identical** — and `ProofSetting.MOCKED == 0` still holds for any consumer comparing against integers.

**Fixed derivation.** `REAL_AND_INVALID` is now reserved for rejections whose direct cause is the proof failing verification:

```python
PROOF_FAILURE_REJECTION_REASONS = frozenset(
    {RejectionReason.INVALID_SIGNATURE, RejectionReason.INVALID_BLOCK_PROOF}
)
```

Every other rejection keeps its valid proof and maps to `REAL_AND_VALID`.

The default mocked lane is unaffected (every vector is `MOCKED`), so generated vectors do not churn; only the real-crypto authoritative set is corrected for non-crypto negative vectors.

## Testing

- `just check` passes (lint, format, ty, codespell, mdformat).
- Verified the field serializes to a plain `int` (0/1/2) for every member, and `ProofSetting.MOCKED == 0`.
- Verified the reason mapping: `UNKNOWN_PARENT_BLOCK` is not a proof failure; `INVALID_SIGNATURE`/`INVALID_BLOCK_PROOF` are.
- Mocked fill smoke on a rejection test runs clean and emits `proofSetting: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)