### PR TITLE
refactor(testing): base tamper specs on StrictBaseModel

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from pydantic import BaseModel
-
 from consensus_testing.keys import XmssKeyManager
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
+from lean_spec.base import StrictBaseModel
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.crypto.xmss.containers import PublicKey
 from lean_spec.spec.forks import (
@@ -28,7 +27,7 @@ ALTERNATE_HEAD_ROOT: Bytes32 = Bytes32(b"\xee" * 32)
 """Sentinel head root used by the rebind tamper to bind one component off-target."""
 
 
-class RebindToAlternateHeadRoot(BaseModel):
+class RebindToAlternateHeadRoot(StrictBaseModel):
     """
     Rebind one component's proof to an alternate head root.
 
@@ -40,14 +39,14 @@ class RebindToAlternateHeadRoot(BaseModel):
     """Index of the component whose proof is rebound (0 for single-message vectors)."""
 
 
-class IncrementEmittedSlot(BaseModel):
+class IncrementEmittedSlot(StrictBaseModel):
     """Bump one component's emitted slot while its proof stays bound to the original slot."""
 
     component_index: int = 0
     """Index of the component whose emitted slot is bumped (0 for single-message vectors)."""
 
 
-class SwapParticipantPublicKey(BaseModel):
+class SwapParticipantPublicKey(StrictBaseModel):
     """
     Replace one participant's public key with another validator's attestation key.
 
@@ -65,7 +64,7 @@ class SwapParticipantPublicKey(BaseModel):
     """Validator whose attestation key replaces the original."""
 
 
-class SwapMessageBindings(BaseModel):
+class SwapMessageBindings(StrictBaseModel):
     """
     Swap the emitted message-slot bindings of two components.
 
@@ -81,7 +80,7 @@ class SwapMessageBindings(BaseModel):
     """Index of the other component whose emitted message-slot binding is swapped."""
 
 
-class DropMessageBinding(BaseModel):
+class DropMessageBinding(StrictBaseModel):
     """
     Drop one component's emitted message-slot binding while keeping its keys.
 

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from consensus_testing.genesis import generate_pre_state
 from consensus_testing.keys import XmssKeyManager
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
 from consensus_testing.test_types import BlockSpec
+from lean_spec.base import StrictBaseModel
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import (
     AggregationBits,
@@ -30,7 +31,7 @@ from lean_spec.spec.forks.lstar.spec import LstarSpec
 from lean_spec.spec.ssz import Boolean, ByteList512KiB, Bytes32
 
 
-class SetProposerIndex(BaseModel):
+class SetProposerIndex(StrictBaseModel):
     """
     Rewrite the block's proposer index.
 
@@ -43,7 +44,7 @@ class SetProposerIndex(BaseModel):
     """Replacement proposer index written into the block."""
 
 
-class ClearFirstAttestationBits(BaseModel):
+class ClearFirstAttestationBits(StrictBaseModel):
     """
     Replace the first body attestation with one whose participation bits carry no set bit.
 
@@ -51,7 +52,7 @@ class ClearFirstAttestationBits(BaseModel):
     """
 
 
-class CorruptProof(BaseModel):
+class CorruptProof(StrictBaseModel):
     """
     Replace the merged proof with a short non-decodable blob.
 
@@ -59,7 +60,7 @@ class CorruptProof(BaseModel):
     """
 
 
-class AppendPhantomAttestation(BaseModel):
+class AppendPhantomAttestation(StrictBaseModel):
     """
     Add a body attestation with no matching proof component.
 
@@ -67,7 +68,7 @@ class AppendPhantomAttestation(BaseModel):
     """
 
 
-class MutateStateRoot(BaseModel):
+class MutateStateRoot(StrictBaseModel):
     """
     Change a block field after signing so the block root differs.
 
@@ -76,7 +77,7 @@ class MutateStateRoot(BaseModel):
     """
 
 
-class SwapFirstTwoAttestations(BaseModel):
+class SwapFirstTwoAttestations(StrictBaseModel):
     """
     Swap the first two body attestations and re-sign only the proposer.
 


### PR DESCRIPTION
## Motivation

The proof and signature tamper specs in `verify_proofs.py` (5 classes) and `verify_signatures.py` (6 classes) inherited raw `pydantic.BaseModel` — the only models in the package to do so. Every other spec and fixture model inherits `StrictBaseModel` / `CamelModel`, which adds:

- `frozen=True` — no mutation after construction
- `strict=True` — no implicit type coercion
- `extra="forbid"` — unknown fields rejected
- camelCase aliasing with `populate_by_name=True`

A latent inconsistency in a reference codebase.

## What this does

Bases all eleven tamper specs on `StrictBaseModel`. These are immutable value tags applied during generation and consumed by `match` dispatch — never mutated — so freezing is safe, and all construction sites already pass correctly typed values (`ValidatorIndex(...)` for typed fields, plain `int` for `int` fields), so strict validation accepts them unchanged.

## Why it's behavior-preserving

The `SignedBlockTamper` / `SingleMessageTamper` / `MultiMessageTamper` unions include several structurally identical empty models, so the concern was whether validation might coerce one empty tamper into a sibling and break the `match` dispatch. Verified it does not:

```
SetProposerIndex           -> SetProposerIndex           preserved=True
ClearFirstAttestationBits  -> ClearFirstAttestationBits  preserved=True
CorruptProof               -> CorruptProof               preserved=True
AppendPhantomAttestation   -> AppendPhantomAttestation   preserved=True
MutateStateRoot            -> MutateStateRoot            preserved=True
SwapFirstTwoAttestations   -> SwapFirstTwoAttestations   preserved=True
```

Pydantic v2 keeps an exact union-member instance as-is (`revalidate_instances` defaults to never), so dispatch is unchanged.

## Testing

- `just check` passes (lint, format, ty, codespell, mdformat).
- Fill smoke on `verify_proofs` + `verify_signatures` passes; tamper paths emit their distinct rejection reasons (`INVALID_BLOCK_PROOF`, `INVALID_SIGNATURE`).
- Confirmed each tamper preserves its exact type through union validation, and `frozen` rejects post-construction mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)