### PR TITLE
refactor(testing): hoist codec dispatch tables out of run()

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -1,6 +1,7 @@
 """Networking codec test fixture for wire-format conformance testing."""
 
-from typing import Annotated, ClassVar, Literal, Union
+from collections.abc import Callable
+from typing import Annotated, ClassVar, Final, Literal, Union
 
 from pydantic import Field
 
@@ -558,14 +559,9 @@ class PeerIdentifierDerivation(StrictBaseModel):
 
     def run(self) -> PeerIdentifierOutput:
         """Derive the identifier and assert the Base58 roundtrip."""
-        key_type_map = {
-            "ed25519": KeyType.ED25519,
-            "secp256k1": KeyType.SECP256K1,
-            "ecdsa": KeyType.ECDSA,
-            "rsa": KeyType.RSA,
-        }
+        # The literal values match the enum member names once upper-cased.
         protobuf = PublicKeyProtobuf(
-            key_type=key_type_map[self.key_type], key_data=from_hex(self.public_key)
+            key_type=KeyType[self.key_type.upper()], key_data=from_hex(self.public_key)
         )
         peer_id = PeerId.from_public_key(protobuf)
         peer_id_string = str(peer_id)
@@ -661,6 +657,18 @@ class DecodeFailureOutput(StrictBaseModel):
     """Name of the decoder that must reject the input."""
 
 
+_DECODERS_BY_NAME: Final[dict[str, Callable[[bytes], object]]] = {
+    "varint": decode_varint,
+    "snappy_frame": frame_decompress,
+    "snappy_block": decompress,
+    "gossipsub_rpc": RPC.decode,
+    "reqresp_request": decode_request,
+    "reqresp_response": ResponseCode.decode,
+    "enr": ENR.from_rlp,
+}
+"""Wire-format decoders keyed by the name a rejection vector targets."""
+
+
 class DecodeFailure(StrictBaseModel):
     """Assert that a wire-format decoder rejects malformed input."""
 
@@ -683,17 +691,8 @@ class DecodeFailure(StrictBaseModel):
 
     def attempt_decode(self) -> Exception | None:
         """Run the decoder on the malformed input and return what it raised."""
-        decoders = {
-            "varint": decode_varint,
-            "snappy_frame": frame_decompress,
-            "snappy_block": decompress,
-            "gossipsub_rpc": RPC.decode,
-            "reqresp_request": decode_request,
-            "reqresp_response": ResponseCode.decode,
-            "enr": ENR.from_rlp,
-        }
         try:
-            decoders[self.decoder](from_hex(self.raw_bytes))
+            _DECODERS_BY_NAME[self.decoder](from_hex(self.raw_bytes))
         except Exception as exception:
             return exception
         return None


### PR DESCRIPTION
## Motivation

Two networking-codec fixtures rebuilt a constant lookup table on every `run()` / `attempt_decode()` call:

- **`PeerIdentifierDerivation`** rebuilt a `{str: KeyType}` map each call — doubly redundant, since the `key_type` literal values already match the `KeyType` enum member names once upper-cased.
- **`DecodeFailure`** rebuilt its `{str: decoder}` table each call.

## What this does

- Drops the peer-id map entirely: `KeyType[self.key_type.upper()]` looks the member up by name (`"ed25519"` → `KeyType.ED25519`, etc.).
- Hoists the decoder table to a module-level `Final` constant (`_DECODERS_BY_NAME`), built once at import.

## Byte-equivalence

The `KeyType` enum lookup yields the same members as the old map, and the decoder table holds the same callables. Verified by filling the networking suite before and after:

```
141 passed
diff -rq <golden> <new>  ->  IDENTICAL: no vector churn
```

## Testing

- `just check` passes (lint, format, ty, codespell, mdformat).
- All 141 `tests/consensus/lstar/networking` vectors are byte-identical to the pre-change output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)