### PR TITLE
refactor(testing): use A | B syntax in discriminated unions

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -1,6 +1,6 @@
 """Networking codec test fixture for wire-format conformance testing."""
 
-from typing import Annotated, ClassVar, Literal, Union
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -700,20 +700,18 @@ class DecodeFailure(StrictBaseModel):
 
 
 NetworkingCodec = Annotated[
-    Union[
-        VarintRoundtrip,
-        GossipTopicRoundtrip,
-        GossipMessageIdentifier,
-        GossipsubRpcRoundtrip,
-        ReqRespRequestRoundtrip,
-        ReqRespResponseRoundtrip,
-        ReqRespResponseStream,
-        EnrRoundtrip,
-        PeerIdentifierDerivation,
-        SnappyBlockRoundtrip,
-        SnappyFrameRoundtrip,
-        DecodeFailure,
-    ],
+    VarintRoundtrip
+    | GossipTopicRoundtrip
+    | GossipMessageIdentifier
+    | GossipsubRpcRoundtrip
+    | ReqRespRequestRoundtrip
+    | ReqRespResponseRoundtrip
+    | ReqRespResponseStream
+    | EnrRoundtrip
+    | PeerIdentifierDerivation
+    | SnappyBlockRoundtrip
+    | SnappyFrameRoundtrip
+    | DecodeFailure,
     Field(discriminator="kind"),
 ]
 """Discriminated union of every networking codec case under test."""

--- a/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
@@ -1,6 +1,6 @@
 """Slot clock test fixture for timing conformance testing."""
 
-from typing import Annotated, ClassVar, Literal, Union
+from typing import Annotated, ClassVar, Literal
 
 from pydantic import Field
 
@@ -146,7 +146,7 @@ class TotalIntervals(StrictBaseModel):
 
 
 SlotClockOperation = Annotated[
-    Union[FromUnixTime, FromSlot, CurrentSlot, CurrentInterval, TotalIntervals],
+    FromUnixTime | FromSlot | CurrentSlot | CurrentInterval | TotalIntervals,
     Field(discriminator="kind"),
 ]
 """Discriminated union of every slot clock conversion under test."""

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -1,6 +1,6 @@
 """Step types for fork choice tests: author-facing inputs and emitted results."""
 
-from typing import Annotated, Any, Literal, Union
+from typing import Annotated, Any, Literal
 
 from pydantic import Field, field_serializer, model_validator
 
@@ -173,7 +173,7 @@ class GossipAggregatedAttestationStep(BaseForkChoiceStep):
 
 # Discriminated union type for all fork choice steps
 ForkChoiceStep = Annotated[
-    Union[TickStep, BlockStep, AttestationStep, GossipAggregatedAttestationStep],
+    TickStep | BlockStep | AttestationStep | GossipAggregatedAttestationStep,
     Field(discriminator="step_type"),
 ]
 
@@ -281,11 +281,9 @@ class FilledGossipAggregatedAttestationStep(BaseFilledStep):
 
 # Discriminated union type for all emitted fork choice steps
 FilledForkChoiceStep = Annotated[
-    Union[
-        FilledTickStep,
-        FilledBlockStep,
-        FilledAttestationStep,
-        FilledGossipAggregatedAttestationStep,
-    ],
+    FilledTickStep
+    | FilledBlockStep
+    | FilledAttestationStep
+    | FilledGossipAggregatedAttestationStep,
     Field(discriminator="step_type"),
 ]


### PR DESCRIPTION
## Motivation

Three discriminated unions still used `typing.Union` inside `Annotated`, while the rest of the package uses the PEP 604 `A | B | C` syntax (e.g. `SlotClockOutput = IntervalOutput | SlotOutput | TotalIntervalsOutput`). A small consistency gap.

- `test_types/step_types.py` — `ForkChoiceStep`, `FilledForkChoiceStep`
- `test_fixtures/slot_clock.py` — `SlotClockOperation`
- `test_fixtures/networking_codec.py` — `NetworkingCodec`

## What this does

Switches all three to `Annotated[A | B | C, Field(discriminator=...)]` and drops the now-unused `Union` import from each file. Pydantic v2 treats `Annotated[A | B, Field(discriminator=...)]` identically to the `Union` form.

## Byte-equivalence

Filled the affected suites (fork_choice, networking, slot clock) before and after:

```
275 passed
diff -rq <golden> <new>  ->  IDENTICAL: no vector churn
```

## Testing

- `just check` passes (lint, format, ty, codespell, mdformat); no `Union[` remains in the package.
- All 275 affected vectors are byte-identical to the pre-change output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)