### PR TITLE
chore: add vulture dead-code detection and remove findings

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -37,6 +37,11 @@ fix:
 typecheck *args:
     uv run --group lint ty check "$@"
 
+# Detect dead code with vulture (paths and ignores configured in pyproject.toml)
+[group('quality')]
+deadcode *args:
+    uv run --group lint vulture "$@"
+
 # Spell check source, tests, packages, and docs
 [group('quality')]
 spellcheck *args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ packages = ["src/lean_spec"]
 
 [tool.ruff]
 line-length = 100
+# The vulture whitelist is data for dead-code detection, not executable code.
+# It references symbols by bare name, which is not valid standalone Python.
+extend-exclude = ["vulture_whitelist.py"]
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -89,7 +92,7 @@ known-first-party = ["lean_spec", "consensus_testing"]
 python-version = "3.12"
 
 [tool.ty.src]
-exclude = [".claude/"]
+exclude = [".claude/", "vulture_whitelist.py"]
 
 [tool.ty.rules]
 # Flag any suppression comment that no longer matches a real diagnostic.
@@ -136,6 +139,16 @@ branch = true
 [tool.coverage.report]
 fail_under = 90
 
+[tool.vulture]
+# Scan source, the testing framework, the test tree, and the whitelist together.
+# Most spec code is exercised only through the test suite, so the tests must be
+# in scope or every test-only-used symbol shows up as a false positive.
+# The whitelist names the indirectly-used symbols vulture cannot see; listing
+# them explicitly keeps the ignores tight instead of relying on wide globs.
+paths = ["src", "packages", "tests", "vulture_whitelist.py"]
+# Show the largest unused blocks first; they are the highest-value removals.
+sort_by_size = true
+
 [tool.mdformat]
 number = true
 wrap = 80
@@ -166,6 +179,7 @@ lint = [
     "ty>=0.0.1a34",
     "ruff>=0.13.2,<1",
     "codespell>=2.4.1,<3",
+    "vulture>=2.14,<3",
 ]
 docs = [
     "mkdocs>=1.6.1,<2",

--- a/src/lean_spec/node/networking/gossipsub/behavior.py
+++ b/src/lean_spec/node/networking/gossipsub/behavior.py
@@ -169,9 +169,6 @@ class PeerState:
     receive_task: asyncio.Task[None] | None = None
     """Task running the receive loop for this peer."""
 
-    last_rpc_time: float = 0.0
-    """Timestamp of last RPC exchange."""
-
     backoff: dict[TopicId, float] = field(default_factory=dict)
     """Per-topic backoff expiry times (from PRUNE)."""
 
@@ -919,8 +916,6 @@ class GossipsubBehavior:
             )
             peer_state.outbound_stream.write(frame)
             await peer_state.outbound_stream.drain()
-
-            peer_state.last_rpc_time = time.time()
         except Exception as exception:
             logger.warning("Failed to send RPC to %s: %s", peer_id, exception)
 

--- a/tests/interop/helpers/node_runner.py
+++ b/tests/interop/helpers/node_runner.py
@@ -528,43 +528,6 @@ class NodeCluster:
         self.nodes.clear()
         logger.info("All nodes stopped")
 
-    async def wait_for_finalization(
-        self,
-        target_slot: int,
-        timeout: float = 120.0,
-        poll_interval: float = 1.0,
-    ) -> bool:
-        """
-        Wait until all nodes finalize to at least target_slot.
-
-        Args:
-            target_slot: Minimum finalized slot to wait for.
-            timeout: Maximum wait time in seconds.
-            poll_interval: Time between checks.
-
-        Returns:
-            True if all nodes reached target, False on timeout.
-        """
-        start = time.monotonic()
-
-        while time.monotonic() - start < timeout:
-            all_finalized = all(node.finalized_slot >= target_slot for node in self.nodes)
-
-            if all_finalized:
-                logger.info("All %d nodes finalized to slot %d", len(self.nodes), target_slot)
-                return True
-
-            slots = [node.finalized_slot for node in self.nodes]
-            logger.debug("Finalized slots: %s (target: %d)", slots, target_slot)
-
-            await asyncio.sleep(poll_interval)
-
-        slots = [node.finalized_slot for node in self.nodes]
-        logger.warning(
-            "Timeout waiting for finalization. Slots: %s (target: %d)", slots, target_slot
-        )
-        return False
-
     async def wait_for_slot(
         self,
         target_slot: int,

--- a/tests/node/networking/gossipsub/conftest.py
+++ b/tests/node/networking/gossipsub/conftest.py
@@ -38,9 +38,6 @@ class MockOutboundStream:
     def close(self) -> None:
         pass
 
-    async def wait_closed(self) -> None:
-        pass
-
 
 def make_behavior(
     d: int = 8, d_low: int = 6, d_high: int = 12, d_lazy: int = 6

--- a/tests/node/networking/reqresp/test_handler.py
+++ b/tests/node/networking/reqresp/test_handler.py
@@ -106,9 +106,6 @@ class MockResponseStream:
     errors: list[tuple[ResponseCode, str]] = field(default_factory=list)
     """Errors sent via send_error as (code, message) tuples."""
 
-    finished: bool = False
-    """Whether finish() was called."""
-
     async def send_success(self, ssz_data: bytes) -> None:
         """Record a success response."""
         self.successes.append(ssz_data)
@@ -118,8 +115,7 @@ class MockResponseStream:
         self.errors.append((code, message))
 
     async def finish(self) -> None:
-        """Mark stream as finished."""
-        self.finished = True
+        """Accept the finish call."""
 
 
 class TestStreamResponseAdapter:

--- a/tests/node/validator/test_registry.py
+++ b/tests/node/validator/test_registry.py
@@ -346,13 +346,6 @@ def _write_manifest(path: Path, validators: list[dict[str, object]]) -> None:
     )
 
 
-def _write_key_files(directory: Path, indices: list[int]) -> None:
-    """Write dummy SSZ key file stubs for the given validator indices."""
-    for i in indices:
-        (directory / f"att_key_{i}.ssz").write_bytes(b"att" + bytes([i]))
-        (directory / f"prop_key_{i}.ssz").write_bytes(b"prop" + bytes([i]))
-
-
 class TestValidatorRegistryFromYaml:
     """Integration tests for the full YAML loading pipeline (files on disk -> registry)."""
 

--- a/tests/spec/crypto/test_merkleization.py
+++ b/tests/spec/crypto/test_merkleization.py
@@ -86,19 +86,17 @@ def test_merkleize_empty_no_limit() -> None:
 
 
 @pytest.mark.parametrize(
-    "limit, expected_width, expected_zero_root",
+    "limit, expected_zero_root",
     [
-        (0, 1, Z[0]),  # limit=0 -> width=1 -> root is Z[0]
-        (1, 1, Z[0]),  # limit=1 -> width=1 -> root is Z[0]
-        (2, 2, Z[1]),  # limit=2 -> width=2 -> root is Z[1]
-        (3, 4, Z[2]),  # limit=3 -> width=4 -> root is Z[2]
-        (7, 8, Z[3]),  # limit=7 -> width=8 -> root is Z[3]
-        (8, 8, Z[3]),
+        (0, Z[0]),  # limit=0 -> width=1 -> root is Z[0]
+        (1, Z[0]),  # limit=1 -> width=1 -> root is Z[0]
+        (2, Z[1]),  # limit=2 -> width=2 -> root is Z[1]
+        (3, Z[2]),  # limit=3 -> width=4 -> root is Z[2]
+        (7, Z[3]),  # limit=7 -> width=8 -> root is Z[3]
+        (8, Z[3]),
     ],
 )
-def test_merkleize_empty_with_limit(
-    limit: int, expected_width: int, expected_zero_root: Bytes32
-) -> None:
+def test_merkleize_empty_with_limit(limit: int, expected_zero_root: Bytes32) -> None:
     """Empty input with a limit yields the zero-subtree root at the rounded-up width."""
     assert merkleize([], limit=limit) == expected_zero_root
 

--- a/uv.lock
+++ b/uv.lock
@@ -910,6 +910,7 @@ dev = [
     { name = "tomli-w" },
     { name = "twine" },
     { name = "ty" },
+    { name = "vulture" },
 ]
 docs = [
     { name = "mdformat" },
@@ -921,6 +922,7 @@ lint = [
     { name = "codespell" },
     { name = "ruff" },
     { name = "ty" },
+    { name = "vulture" },
 ]
 test = [
     { name = "hypothesis" },
@@ -972,6 +974,7 @@ dev = [
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "twine", specifier = ">=5.1.0,<6" },
     { name = "ty", specifier = ">=0.0.1a34" },
+    { name = "vulture", specifier = ">=2.14,<3" },
 ]
 docs = [
     { name = "mdformat", specifier = "==0.7.22" },
@@ -983,6 +986,7 @@ lint = [
     { name = "codespell", specifier = ">=2.4.1,<3" },
     { name = "ruff", specifier = ">=0.13.2,<1" },
     { name = "ty", specifier = ">=0.0.1a34" },
+    { name = "vulture", specifier = ">=2.14,<3" },
 ]
 test = [
     { name = "hypothesis", specifier = ">=6.138.14" },
@@ -2281,6 +2285,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,0 +1,169 @@
+# Whitelist for vulture dead-code detection.
+#
+# Each line names a symbol whose use is real but invisible to static analysis:
+# framework dispatch, serialization, reflection, or an interpreter protocol.
+# Vulture parses every reference here as a use, so the symbol stops being
+# reported. A bare name covers a function or variable; the "_." prefix covers a
+# method or an attribute.
+#
+# This file is data for vulture, not executable code, so it is excluded from
+# ruff and ty.
+#
+# Keep it tight. Add a symbol only after confirming its use is genuine but
+# unseen by vulture. Genuinely dead code must stay out of this file so vulture
+# keeps reporting it. Prefer fixing the dead code over silencing it here.
+
+# Single-dispatch handlers for the hash_tree_root generic function.
+# Dispatched by argument type, so they have no direct call site.
+_htr_uint
+_htr_boolean
+_htr_fp
+_htr_bytes
+_htr_bytearray
+_htr_memoryview
+_htr_bytevector
+_htr_bytelist
+_htr_bitvector_base
+_htr_bitlist_base
+_htr_vector
+_htr_list
+_htr_container
+
+# Magic methods invoked by the interpreter.
+# Flagged only because they are defined as overloaded functions or as an
+# attribute rather than a plain method, which the built-in dunder filter misses.
+__pow__
+__repr__
+_.__len__
+
+# pytest hooks, discovered by name from the plugin and conftest modules.
+pytest_addoption
+pytest_ignore_collect
+pytest_configure
+pytest_collection_modifyitems
+pytest_sessionstart
+pytest_sessionfinish
+pytest_runtest_makereport
+pytest_generate_tests
+
+# pytest autouse fixtures and module markers, applied implicitly.
+reset_xmss_signing_state
+_reset_registry
+_reset_metrics
+_reset_observer
+pytestmark
+
+# Pydantic validators, invoked by the model during validation.
+_.check_lengths
+_._coerce_and_validate
+_._accept_hex_string
+_._validate_byte_list_data
+_._validate_decomposition
+_.validate_state_length
+_.validate_target
+_.validate_rejection_is_declared
+_.validate_signatures_are_out_of_scope
+_._yaml_int_to_hex
+
+# Pydantic serializers, invoked by the model during serialization.
+_.serialize_value
+_.serialize_block
+_._serialize_data
+_._serialize_as_hex
+
+# Fork-upgrade protocol method, invoked polymorphically on a fork transition.
+# A single-fork tree has no transition yet, so there is no call site.
+_.upgrade_state
+
+# Signature parameters mandated by external protocols we cannot rename.
+# The pydantic core-schema hook, the pytest session-finish hook, and the
+# prometheus metric stub interface.
+source_type
+exitstatus
+amount
+
+# logging.Formatter.format override, invoked by the logging framework.
+_.format
+
+# httpx transport hook, invoked by the httpx client through its test doubles.
+_.handle_async_request
+
+# unittest.mock attributes, read by the mock library.
+_.return_value
+_.side_effect
+
+# sqlite3 connection attribute, read by the sqlite3 driver.
+_.row_factory
+
+# Enum member resolved from a command-line string through the enum constructor.
+# The mode is selected by value, so the member name has no direct reference.
+REAL
+
+# XMSS protocol parameter documented in the configuration model.
+# The byte length of a signed message, kept for spec fidelity even though the
+# computation works from the field-element count.
+MESSAGE_LENGTH
+
+# Dataclass field on a peer-subscription event.
+# Set from the subscribe flag at construction and compared through dataclass
+# equality in tests, neither of which vulture counts as a read.
+subscribed
+
+# Validator manifest fields, mirroring an external YAML schema.
+# Deserialized and validated by pydantic, not all read back by attribute.
+attestation_public_key_hex
+proposal_public_key_hex
+key_scheme
+hash_function
+log_num_active_epochs
+num_active_epochs
+
+# Field names on test-vector and fixture models.
+# Populated from constructor keywords and consumed by serialization or
+# comparison, never read by attribute in Python.
+description
+comment
+expected_status_code
+expected_content_type
+expected_body
+to_peer
+signature_valid
+protobuf_encoded
+compressed_length
+framed_length
+seconds_per_slot
+intervals_per_slot
+milliseconds_per_interval
+state_bytes
+step_type
+latest_justified_slot
+latest_justified_root
+latest_finalized_slot
+latest_finalized_root
+config_genesis_time
+latest_block_header_slot
+latest_block_header_proposer_index
+latest_block_header_parent_root
+latest_block_header_state_root
+latest_block_header_body_root
+historical_block_hashes_count
+justifications_roots_count
+justifications_validators_count
+safe_target_root
+safe_target_root_label
+attestation_signature_target_slots
+latest_new_aggregated_target_slots
+latest_known_aggregated_target_slots
+participant_sets
+block_weights
+known_aggregated_payloads
+
+# SSZ container and model field names declared inside unit tests.
+# Serialized by the SSZ codec or set through pydantic, never read by attribute.
+A
+B
+C
+y
+first_name
+slot_number
+_.slot_number


### PR DESCRIPTION
## What

Adds [vulture](https://github.com/jendrikseipp/vulture) for dead-code detection, then removes the dead code it found. Split into two commits so the tooling and the removals can be reviewed independently.

### Commit 1 — add vulture dead-code detection
- Adds `vulture` to the `lint` dependency group and a `just deadcode` recipe.
- Configures vulture in `pyproject.toml` to scan `src`, `packages`, `tests`, and the whitelist together (most spec code is exercised only through the test suite, so the tests must be in scope or every test-only-used symbol reads as a false positive).
- Adds a tight `vulture_whitelist.py` that names each indirectly-used symbol explicitly (framework dispatch, serialization, interpreter protocols) instead of relying on wide glob ignores. Excluded from ruff and ty since it is data, not executable code.
- `just deadcode` is intentionally **not** wired into `just check`: vulture has unavoidable false positives on a Pydantic-heavy codebase, so gating CI on it would be noisy.

### Commit 2 — remove dead code flagged by vulture
Removes the six symbols `just deadcode` reported and that were confirmed unused:
- a write-only last-RPC timestamp on the gossipsub peer state
- a mock response-stream flag that was set but never asserted
- an unused parametrize column in the merkleization tests
- an uncalled mock outbound-stream method
- two uncalled test helpers (a key-file stub writer and an interop finalization waiter)

Three reported symbols were **kept** as confirmed false positives and recorded in the whitelist instead of removed:
- `subscribed` — essential event field, compared via dataclass equality in tests
- `REAL` — constructed via `CryptoMode("real")` from the `--crypto` CLI option
- `MESSAGE_LENGTH` — documented XMSS protocol parameter

## Verification
- `just deadcode` → clean (exit 0)
- `just check` → passes (lint, format, ty, codespell, mdformat, lock)
- affected unit tests pass

## Notes
Draft: the whitelist makes ignores explicit, which means a newly-added Pydantic validator/serializer or fixture will trip vulture until added to `vulture_whitelist.py`. That is the intended trade-off for tight, greppable ignores.