### PR TITLE
docs(lstar): collapse slot module docstring to one line

### DIFF
--- a/src/lean_spec/spec/forks/lstar/slot.py
+++ b/src/lean_spec/spec/forks/lstar/slot.py
@@ -1,10 +1,4 @@
-"""
-Slot primitive shared by the consensus and crypto layers.
-
-The crypto signing scheme binds each signature to a specific slot.
-Hosting the type here lets the crypto layer name the slot without
-importing the rest of the consensus container module.
-"""
+"""Slot primitive shared by the consensus and crypto layers."""
 
 import math
 from typing import Final


### PR DESCRIPTION
## Summary

The slot module header carried a multi-paragraph rationale for a simple primitive type. Reduce it to a single summary line, per the one-line-header documentation rule.

## Testing

Documentation-only change. No behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)