### PR TITLE
ci(prod-vectors): unpin rayon and lower xdist workers for prod fill

### DIFF
--- a/.github/workflows/prod-vectors.yml
+++ b/.github/workflows/prod-vectors.yml
@@ -94,8 +94,11 @@ jobs:
 
       - name: Fill production test fixtures
         env:
-          # RAYON_NUM_THREADS=1 keeps the runner from oversubscribing cores by giving each xdist worker one rayon thread.
-          RAYON_NUM_THREADS: "1"
+          # Only the real_crypto smoke vectors run genuine production XMSS proofs.
+          # Each proof parallelizes internally with rayon, so few heavy tasks dominate the run.
+          # Two xdist workers overlap the heavy proofs and chew through the mocked backlog.
+          # Leaving rayon unpinned lets each proof spread across cores instead of one thread.
+          FILL_WORKERS: "2"
         run: just fill-ci --scheme=prod
 
       - name: Bundle keys with fixtures

--- a/Justfile
+++ b/Justfile
@@ -86,9 +86,11 @@ test-consensus *args:
     uv run --group test pytest -n auto --maxprocesses=10 --durations=10 --dist=worksteal tests/node/networking "$@"
 
 # Canonical CI fixture run; contributors should use `uv run fill` directly.
+# FILL_WORKERS overrides the xdist worker count (defaults to one per core).
+# The prod scheme lowers it so real proofs are not starved of rayon threads.
 [group('tests'), private]
 fill-ci *args:
-    uv run --group test fill --fork=Lstar --clean -n auto --dist=worksteal "$@"
+    uv run --group test fill --fork=Lstar --clean -n "${FILL_WORKERS:-auto}" --dist=worksteal "$@"
 
 # Standalone determinism audit: regenerate vectors twice under different hash seeds and diff.
 # The fill command already gates the order_sensitive subset on every run.


### PR DESCRIPTION
## Problem

The "Fill production test fixtures" job runs ~56m on `main`, while the test-scheme fill is ~4m. After #895 mocked the aggregation prover for both schemes, the prod run is dominated almost entirely by the `real_crypto(smoke=True)` vectors — a handful of genuine production XMSS proofs that intentionally bypass the mock.

Each of those proofs parallelizes internally via rayon. But the prod job pinned `RAYON_NUM_THREADS=1` while running one xdist worker per core (`-n auto`), so every heavy proof was starved to a single thread, and idle cores were never used to speed up an individual proof.

## Change

- Add a `FILL_WORKERS` knob to the canonical `fill-ci` recipe. It defaults to `auto`, so the test-scheme job is unchanged.
- In the prod-vectors job, set `FILL_WORKERS=2` and drop the `RAYON_NUM_THREADS=1` pin.

A heavy proof can now spread across all cores via rayon instead of one thread, while two xdist workers still overlap proofs and clear the (instant) mocked backlog.

## Expected impact and caveat

The mocking from #895 is working correctly — this only retunes parallelism for the real-proof subset. The realistic win is on the tail (when fewer heavy proofs remain than cores, a single proof now uses all cores). The ~4m figure is the test-parameter floor; the prod floor is the inherent cost of real production SNARK proofs, so expect a moderate improvement rather than a return to single-digit minutes.

If this doesn't move the needle enough, the higher-leverage levers are a larger runner or trimming the `real_crypto(smoke=True)` subset for the prod scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)