### PR TITLE
ci: gate dead-code detection with vulture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,32 @@ jobs:
       - name: Run all quality checks
         run: just check
 
+  dead-code:
+    name: Dead code detection
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout leanSpec
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Detect dead code with vulture
+        run: just deadcode
+
   test:
     name: Tests - Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -157,6 +157,7 @@ latest_known_aggregated_target_slots
 participant_sets
 block_weights
 known_aggregated_payloads
+is_justifiable
 
 # SSZ container and model field names declared inside unit tests.
 # Serialized by the SSZ codec or set through pydantic, never read by attribute.


### PR DESCRIPTION
## What

Follow-up to #915 (which added vulture and a curated whitelist). This wires vulture into CI so a regression that introduces dead code fails the build.

- Adds a **`dead-code`** job to `.github/workflows/ci.yml` that runs `just deadcode`.
  - Kept as a separate job rather than folded into `just check`, so local `just check` stays fast and a contributor working on an unrelated change is not surprise-failed mid-work; CI is where the gate is enforced.
  - Pins a single Python version: vulture's AST analysis is version-independent, so the lint job's 3-version matrix is unnecessary here.
  - Runs on `ubuntu-latest` (lightweight; the macOS runners are reserved for the SNARK-heavy filler).
- Whitelists one fixture field, `is_justifiable`, that landed on `main` after #915 merged. It is a `JustifiabilityOutput` Pydantic field set through a constructor keyword and serialized to the fixture JSON, never read by attribute, so vulture cannot see the use. Adding it keeps the new gate green and demonstrates the intended maintenance flow for the tight whitelist.

## Verification
- `just deadcode` → clean (exit 0)
- `just check` → passes (whitelist stays excluded from ruff and ty)