### PR TITLE
fix(chain): clamp backward wall-clock target instead of asserting

### DIFF
--- a/src/lean_spec/node/chain/service.py
+++ b/src/lean_spec/node/chain/service.py
@@ -99,8 +99,11 @@ class ChainService:
         store = self.sync_service.store
         all_new_aggregates: list[SignedAggregatedAttestation] = []
 
-        # The target comes from wall clock, so it never moves time backward.
-        assert target_interval >= store.time
+        # The target comes from the wall clock, which can step backward.
+        # NTP slew, a leap second, or a VM migration can move it before the store time.
+        # A backward target ticks nothing, so return the empty result without ticking.
+        if target_interval <= store.time:
+            return []
 
         # Skip stale intervals when falling behind.
         # Jump to the last full slot boundary before the target.

--- a/tests/node/chain/test_service.py
+++ b/tests/node/chain/test_service.py
@@ -175,14 +175,30 @@ class TestCatchUp:
         await service._tick_to(Interval(3))
         assert spec.ticks == [(1, False, True), (2, False, True), (3, False, True)]
 
-    async def test_rejects_a_target_before_the_current_time(self) -> None:
-        """Catch-up refuses a target earlier than where the store already sits."""
-        service = make_service(ProbeSpec())
+    async def test_clamps_a_backward_wall_clock_target_to_a_no_op(self) -> None:
+        """A target before the store time ticks nothing and yields no aggregates."""
+        spec = ProbeSpec()
+        service = make_service(spec)
+        # A backward wall clock can target an interval the store already passed.
         service.sync_service.store = service.sync_service.store.model_copy(
             update={"time": Interval(5)}
         )
-        with pytest.raises(AssertionError):
-            await service._tick_to(Interval(3))
+        produced_aggregates = await service._tick_to(Interval(3))
+        assert produced_aggregates == []
+        assert spec.ticks == []
+        assert int(service.sync_service.store.time) == 5
+
+    async def test_clamps_a_target_equal_to_the_current_time_to_a_no_op(self) -> None:
+        """A target equal to the store time ticks nothing and yields no aggregates."""
+        spec = ProbeSpec()
+        service = make_service(spec)
+        service.sync_service.store = service.sync_service.store.model_copy(
+            update={"time": Interval(5)}
+        )
+        produced_aggregates = await service._tick_to(Interval(5))
+        assert produced_aggregates == []
+        assert spec.ticks == []
+        assert int(service.sync_service.store.time) == 5
 
     async def test_continues_on_a_store_swapped_in_during_the_yield(self) -> None:
         """A store replaced mid-catch-up is picked up on the next tick, not the stale one."""


### PR DESCRIPTION
## Summary

The catch-up helper that walks the fork-choice store forward to a target interval guarded its precondition with a bare assert:

```python
# The target comes from wall clock, so it never moves time backward.
assert target_interval >= store.time
```

The premise is false. The target is derived from the wall clock via the total-interval count, and the wall clock can step backward: NTP slew, a leap second, or a VM migration can move it before the store time. This made the guard a real correctness hazard:

- When the assert held a backward target, it tore down the consensus tick loop.
- Under `python -O` the assert is stripped, so a backward target slipped through silently. The remaining tick loop then no-ops on it, masking the regression rather than surfacing it.

## Change

Replace the assert with an early return of the empty result whenever the target is at or before the store time. A backward (or equal) target ticks nothing, so it is now a safe no-op on every interpreter optimization level. The function returns aggregated attestations, so the no-op value is an empty list.

## Tests

`tests/node/chain/test_service.py`: the test that asserted the old raising behavior is replaced with two tests over real objects proving the clamp:

- a backward target ticks nothing, yields no aggregates, and leaves the store time unchanged
- a target equal to the store time does the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)