### PR TITLE
refactor(validator): rename loop var shadowing validator_index parameter

### DIFF
--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -476,14 +476,14 @@ class ValidatorService:
         public_keys_per_aggregate: list[list[PublicKey]] = []
         for attestation_proof in attestation_proofs:
             participant_public_keys: list[PublicKey] = []
-            for validator_index in attestation_proof.participants.to_validator_indices():
-                if not validator_index.is_within_registry(num_validators):
+            for participant_index in attestation_proof.participants.to_validator_indices():
+                if not participant_index.is_within_registry(num_validators):
                     raise ValueError(
-                        f"Attestation proof references validator {validator_index}; "
+                        f"Attestation proof references validator {participant_index}; "
                         f"active set has {num_validators} validators"
                     )
                 participant_public_keys.append(
-                    PublicKey.decode_bytes(validators[validator_index].attestation_public_key)
+                    PublicKey.decode_bytes(validators[participant_index].attestation_public_key)
                 )
             public_keys_per_aggregate.append(participant_public_keys)
         public_keys_per_aggregate.append([proposer_public_key])


### PR DESCRIPTION
## Summary

Fixes audit finding NAME-02. In the block-signing path of the validator
service, an inner loop over attestation-proof participants reused the name
`validator_index` — the same name as the enclosing method parameter that holds
the **proposer** index.

This violates the repository's strict "never reuse one name for two things"
rule and is a latent correctness trap: after the loop, the name no longer holds
the proposer; it holds the last participant.

## Correctness implication

In the current code the proposer `validator_index` is only read **before** the
loop (resolving the proposer public key and building the proposer
single-message aggregate). Nothing after the loop reads it, so this rename is
**behavior-preserving** today. The risk was latent: any future edit that read
`validator_index` after the loop would silently get the last participant
instead of the proposer. Removing the shadow eliminates that trap.

## Change

- Rename the loop variable and its in-loop uses to `participant_index`.
- The method parameter `validator_index` (the proposer) is unchanged.

## Testing

- `uv run pytest tests/node/validator/test_service.py -q` — 51 passed.
- `just check` — all checks pass.

No new test added: behavior is unchanged, so existing coverage applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)