### PR TITLE
fix(xmss): guard signature.hashes length in verify before indexing

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/interface.py
+++ b/src/lean_spec/spec/crypto/xmss/interface.py
@@ -315,6 +315,12 @@ class GeneralizedXmssScheme(StrictBaseModel):
         if codeword is None:
             return False
 
+        # The released chain count is recovered from the wire with only an upper bound.
+        # An attacker can send fewer than one hash per chain.
+        # Reject the malformed length here so the per-chain loop never indexes out of range.
+        if len(signature.hashes) != config.DIMENSION:
+            return False
+
         # Phase 3: finish each chain from the released hash to its endpoint.
         chain_ends: list[HashDigestVector] = []
         for chain_index, digit in enumerate(codeword):

--- a/tests/spec/crypto/xmss/test_interface.py
+++ b/tests/spec/crypto/xmss/test_interface.py
@@ -9,6 +9,7 @@ from lean_spec.spec.crypto.xmss.interface import (
     GeneralizedXmssScheme,
     _expand_activation_time,
 )
+from lean_spec.spec.crypto.xmss.types import HashDigestList
 from lean_spec.spec.forks import Slot
 from lean_spec.spec.ssz import Bytes32, Uint64
 
@@ -336,4 +337,23 @@ class TestVerifySecurityBounds:
 
         # Must return False, not raise.
         is_valid = scheme.verify(public_key, huge_epoch, message, signature)
+        assert is_valid is False
+
+    def test_rejects_signature_with_too_few_hashes(self) -> None:
+        """verify returns False when the released chain count is below DIMENSION."""
+        scheme = TEST_SIGNATURE_SCHEME
+        key_pair = scheme.key_gen(Slot(0), Uint64(int(scheme.config.LIFETIME)))
+        public_key, secret_key = key_pair.public_key, key_pair.secret_key
+
+        valid_epoch = Slot(4)
+        message = Bytes32(b"\x42" * 32)
+        signature = scheme.sign(secret_key, valid_epoch, message)
+
+        # The wire only bounds the count from above, so an attacker can drop chains.
+        # One short hash list would make the per-chain loop index out of range.
+        truncated_hashes = HashDigestList(data=list(signature.hashes)[:-1])
+        truncated_signature = signature.model_copy(update={"hashes": truncated_hashes})
+
+        # Must return False, not raise IndexError.
+        is_valid = scheme.verify(public_key, valid_epoch, message, truncated_signature)
         assert is_valid is False


### PR DESCRIPTION
## Summary

The XMSS verify path runs on attacker-controlled gossip signatures and is documented to return False rather than panic on malformed input. The released Winternitz chain hashes are recovered from the wire with only an upper bound on their count, while the per-chain verification loop always iterates DIMENSION (prod 46) times. A signature carrying fewer than DIMENSION hashes therefore made the per-chain index raise IndexError instead of returning False, a network-triggerable crash.

## Fix

Reject a hashes list whose length is not DIMENSION up front, immediately after the existing codeword guard and mirroring the existing slot bound check. This restores the return-False-rather-than-panic contract for all malformed-length signatures.

## Test

Added a unit test in the mirrored module that truncates a valid signature's released hashes by one element and asserts verify returns False rather than raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)