### PR TITLE
test(state-transition): assert all multi-target justified slots (4, 6, 9)

### DIFF
--- a/tests/consensus/lstar/state_transition/test_justification.py
+++ b/tests/consensus/lstar/state_transition/test_justification.py
@@ -1489,7 +1489,7 @@ def test_same_block_multi_target_attestations_advance_to_highest_slot(
 
     Then
     ----
-    - slots 4, 6, and 9 are each justified.
+    - the justified-slots bitfield marks slots 4, 6, and 9 alone.
     - justified slot is 9, the highest target, not the last one processed.
     - finalized stays at slot 0.
     """
@@ -1547,5 +1547,18 @@ def test_same_block_multi_target_attestations_advance_to_highest_slot(
             slot=Slot(10),
             latest_justified_slot=Slot(9),
             latest_finalized_slot=Slot(0),
+            justified_slots=JustifiedSlots(
+                data=[
+                    Boolean(False),
+                    Boolean(False),
+                    Boolean(False),
+                    Boolean(True),
+                    Boolean(False),
+                    Boolean(True),
+                    Boolean(False),
+                    Boolean(False),
+                    Boolean(True),
+                ]
+            ),
         ),
     )


### PR DESCRIPTION
## Summary

The multi-target justification state-transition vector
(`test_same_block_multi_target_attestations_advance_to_highest_slot`) exists to
prove that slots 4, 6, and 9 each become justified within a single block.
Its expectation, however, only checked `latest_justified_slot=9`, the highest
target. A regression that justified only slot 9 (and silently dropped slots 4
and 6) would have passed unnoticed, defeating the test's entire purpose.

## Change

Assert the full `justified_slots` bitfield in the `StateExpectation`, pinning
slots 4, 6, and 9 as the only justified slots, mirroring the sibling vectors in
this file that already pin the bitfield. The Given/When/Then docstring is
updated so its Then bullet stays one-to-one with the new assertion.

## Verification

- `uv run fill --fork=Lstar --clean -k test_same_block_multi_target_attestations_advance_to_highest_slot` passes; the asserted bitfield matches the produced state exactly.
- `just check` passes (ruff, format, ty, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)