### PR TITLE
refactor(node): rename single-letter checkpoint locals

### DIFF
--- a/src/lean_spec/node/node.py
+++ b/src/lean_spec/node/node.py
@@ -537,18 +537,18 @@ class Node:
                 len(self.validator_service.registry) if self.validator_service is not None else 0
             )
             metrics.lean_validators_count.set(count)
-            j = store.latest_justified
-            f = store.latest_finalized
-            j_root = j.root.hex()
-            f_root = f.root.hex()
+            justified_checkpoint = store.latest_justified
+            finalized_checkpoint = store.latest_finalized
+            justified_root = justified_checkpoint.root.hex()
+            finalized_root = finalized_checkpoint.root.hex()
             logger.info("=" * 64)
             logger.info(
                 "Peers=%s | Justified slot=%s root=%s | Finalized slot=%s root=%s",
                 peers_connected,
-                j.slot,
-                j_root,
-                f.slot,
-                f_root,
+                justified_checkpoint.slot,
+                justified_root,
+                finalized_checkpoint.slot,
+                finalized_root,
             )
             logger.info("=" * 64)
 


### PR DESCRIPTION
## Summary

Renames single-letter checkpoint locals in the node status-log block to descriptive names, per the repository no-single-letter and no-abbreviation naming laws.

- `j` -> `justified_checkpoint`
- `f` -> `finalized_checkpoint`
- `j_root` -> `justified_root`
- `f_root` -> `finalized_root`

These held `Checkpoint` values and their hex roots, so the names now state what each value is when read in isolation.

## Scope

Pure local-variable rename within a single logging scope. No behavior change, no public API change, no new test required.

## Verification

- `uv run pytest tests/node/test_node.py -q` passes
- `just check` passes (lint, format, typecheck, spell, mdformat, lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)