### PR TITLE
refactor(node): remove unused Node.is_running property

### DIFF
--- a/src/lean_spec/node/node.py
+++ b/src/lean_spec/node/node.py
@@ -578,8 +578,3 @@ class Node:
         Signals the node to stop all services and exit.
         """
         self._shutdown.set()
-
-    @property
-    def is_running(self) -> bool:
-        """Check if node is currently running."""
-        return not self._shutdown.is_set()

--- a/tests/node/test_node.py
+++ b/tests/node/test_node.py
@@ -308,14 +308,6 @@ class TestNodeShutdown:
         node.stop()
         assert node._shutdown.is_set()
 
-    def test_is_running_reflects_shutdown_state(self, node_config: NodeConfig) -> None:
-        """is_running property reflects shutdown event state."""
-        node = Node.from_genesis(node_config)
-
-        assert node.is_running is True
-        node.stop()
-        assert node.is_running is False
-
     async def test_wait_shutdown_stops_chain_service(self, node_config: NodeConfig) -> None:
         """Shutdown stops the chain service."""
         node = Node.from_genesis(node_config)


### PR DESCRIPTION
## Summary

Removes the dead `Node.is_running` property.

The property had zero readers across `src/`, `tests/`, and `packages/`.
Every remaining `.is_running` reference belongs to a service class
(chain, network, validator, networking service), not to a `Node` instance.

## Changes

- Delete the `is_running` property from `src/lean_spec/node/node.py`.
- Remove `test_is_running_reflects_shutdown_state` from `tests/node/test_node.py`, which tested only that property.

## Verification

- `uv run pytest tests/node/test_node.py` passes.
- `just check` passes (lint, format, typecheck, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)