### PR TITLE
fix(reqresp): bound declared request length before sizing read buffer

### DIFF
--- a/src/lean_spec/node/networking/reqresp/handler.py
+++ b/src/lean_spec/node/networking/reqresp/handler.py
@@ -66,6 +66,7 @@ from typing import Final
 
 from lean_spec.node.networking.config import (
     MAX_ERROR_MESSAGE_SIZE,
+    MAX_PAYLOAD_SIZE,
     MAX_REQUEST_BLOCKS,
     MIN_SLOTS_FOR_BLOCK_REQUESTS,
 )
@@ -458,6 +459,16 @@ class ReqRespServer:
             except VarintError:
                 # Need more data for varint
                 continue
+
+        # Reject an oversized declared length before sizing any buffer.
+        #
+        # The declared length is attacker-controlled.
+        # A 10-byte varint can claim a value up to 2^70.
+        # Without this bound the worst-case expansion below grows astronomically.
+        # The size guard never trips, so the node buffers attacker bytes.
+        # This mirrors the guard in the non-streaming request decoder.
+        if declared_length > MAX_PAYLOAD_SIZE:
+            return b""
 
         # Guard against unbounded compressed data.
         # Snappy's worst-case expansion is ~(n + n/6 + 1024).

--- a/tests/node/networking/reqresp/test_handler.py
+++ b/tests/node/networking/reqresp/test_handler.py
@@ -9,7 +9,11 @@ from typing import Final
 import pytest
 
 from consensus_testing import make_test_block, make_test_status
-from lean_spec.node.networking.config import MAX_ERROR_MESSAGE_SIZE, MAX_REQUEST_BLOCKS
+from lean_spec.node.networking.config import (
+    MAX_ERROR_MESSAGE_SIZE,
+    MAX_PAYLOAD_SIZE,
+    MAX_REQUEST_BLOCKS,
+)
 from lean_spec.node.networking.reqresp.codec import (
     ResponseCode,
     encode_request,
@@ -1199,6 +1203,31 @@ class TestReadRequestBufferLimit:
 
         code, _ = ResponseCode.decode(stream.written[0])
         assert code == ResponseCode.INVALID_REQUEST
+
+    async def test_read_request_rejects_oversized_declared_length_without_buffering(
+        self,
+    ) -> None:
+        """Oversized declared length is rejected on the varint alone, before any payload read."""
+        # A 10-byte varint can claim a length far above the payload cap.
+        # The reader must reject on the length prefix, before reading the body.
+        oversized_declared_length = MAX_PAYLOAD_SIZE + 1
+        varint_bytes = encode_varint(oversized_declared_length)
+
+        # Track every read so a post-varint read would fail the no-buffering claim.
+        @dataclass
+        class CountingStream(MockStream):
+            read_count: int = 0
+
+            async def read(self) -> bytes:
+                self.read_count += 1
+                assert self.read_count == 1, "reader must not buffer after the oversized varint"
+                return self.request_data
+
+        server = ReqRespServer(handler=RequestHandler(our_status=make_test_status()))
+        stream = CountingStream(request_data=varint_bytes)
+
+        assert await server._read_request(stream) == b""
+        assert stream.read_count == 1
 
 
 class TestBlocksByRangeRequestRoundTrip:


### PR DESCRIPTION
## Summary

The inbound ReqResp streaming reader sized its compressed-data buffer from a peer-declared varint length without bounding that length first.

The non-streaming decoders (`decode_request` and `ResponseCode.decode`) reject `declared_length > MAX_PAYLOAD_SIZE`, but the streaming reader `_read_request` did not. A peer could declare an enormous varint length (up to 2^70 with a 10-byte varint). The Snappy worst-case expansion `declared_length + declared_length // 6 + 1024` then became astronomically large, so the per-iteration size guard never tripped. The node would accumulate attacker bytes and re-run frame decompression on each read, a denial-of-service vector.

## Fix

Reject an oversized declared length immediately after the varint decode in the streaming reader, returning empty bytes. This mirrors the existing guard in the non-streaming request decoder.

## Test

Adds a unit test in the mirrored handler test module proving an oversized declared length returns empty bytes after consuming only the varint, with no further reads of the stream body (no buffering, no loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)