### PR TITLE
refactor(sync): remove orphaned BackfillSync.reset and HeadSync.reset

### DIFF
--- a/src/lean_spec/node/sync/backfill_sync.py
+++ b/src/lean_spec/node/sync/backfill_sync.py
@@ -440,8 +440,3 @@ class BackfillSync:
                     )
 
         await self.fill_missing(new_orphan_parents, depth=depth + 1)
-
-    def reset(self) -> None:
-        """Clear all pending state."""
-        self._pending.clear()
-        self._max_range_slot = Slot(0)

--- a/src/lean_spec/node/sync/head_sync.py
+++ b/src/lean_spec/node/sync/head_sync.py
@@ -396,7 +396,3 @@ class HeadSync:
         return HeadSyncResult(
             processed=False,
         ), store
-
-    def reset(self) -> None:
-        """Clear processing state."""
-        self._processing.clear()

--- a/tests/node/sync/test_backfill_sync.py
+++ b/tests/node/sync/test_backfill_sync.py
@@ -489,17 +489,3 @@ class TestBackfillOptimizations:
         network.should_fail = False
         await backfill_system.fill_range(start_slot=Slot(1), count=Uint64(10))
         assert backfill_system._max_range_slot == Slot(10)
-
-    async def test_reset_clears_watermark(
-        self,
-        backfill_system: BackfillSync,
-        network: MockNetworkRequester,
-    ) -> None:
-        """reset() restores the watermark so post-reset range fetches are honored."""
-        await backfill_system.fill_range(start_slot=Slot(1), count=Uint64(10))
-        assert backfill_system._max_range_slot == Slot(10)
-
-        backfill_system.reset()
-
-        assert backfill_system._max_range_slot == Slot(0)
-        assert backfill_system._pending == set()


### PR DESCRIPTION
## Summary

Removes two dead methods from the sync layer.

- `BackfillSync.reset` was exercised only by a single unit test, never by production code.
- `HeadSync.reset` had zero callers anywhere.
- The sync service never cascades a reset to either component, so neither method is reachable in practice.

This deletes both methods and the lone unit test that drove the backfill reset.

## Verification

- `grep` over `src/` and `packages/` confirms no production caller of either method.
- `uv run pytest tests/node/sync/test_backfill_sync.py tests/node/sync/test_head_sync.py` passes (28 tests).
- `just check` is clean (lint, format, type check, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)