### PR TITLE
refactor(sync): remove unused BlockCache.get and BlockCache.clear

### DIFF
--- a/src/lean_spec/node/sync/block_cache.py
+++ b/src/lean_spec/node/sync/block_cache.py
@@ -205,18 +205,6 @@ class BlockCache:
 
         return pending
 
-    def get(self, root: Bytes32) -> PendingBlock | None:
-        """
-        Get a cached block by root.
-
-        Args:
-            root: The block root to look up.
-
-        Returns:
-            The PendingBlock if found, None otherwise.
-        """
-        return self._blocks.get(root)
-
     def remove(self, root: Bytes32) -> PendingBlock | None:
         """
         Remove a block from the cache.
@@ -312,12 +300,6 @@ class BlockCache:
     def orphan_count(self) -> int:
         """Number of orphan blocks in the cache."""
         return len(self._orphans)
-
-    def clear(self) -> None:
-        """Remove all blocks from the cache."""
-        self._blocks.clear()
-        self._orphans.clear()
-        self._by_parent.clear()
 
     def _evict_oldest(self) -> None:
         """

--- a/tests/node/sync/test_backfill_sync.py
+++ b/tests/node/sync/test_backfill_sync.py
@@ -92,16 +92,18 @@ class TestBackfillChainResolution:
 
         await backfill_system.fill_missing([block_root])
 
-        cached = backfill_system.block_cache.get(block_root)
-        assert cached is not None
-        assert cached == PendingBlock(
-            block=block,
-            root=block_root,
-            parent_root=Bytes32.zero(),
-            slot=Slot(10),
-            received_from=peer_id,
-            backfill_depth=1,
-        )
+        # The fetched block is the sole child of the zero parent root.
+        # Look it up through the parent index.
+        assert backfill_system.block_cache.get_children(Bytes32.zero()) == [
+            PendingBlock(
+                block=block,
+                root=block_root,
+                parent_root=Bytes32.zero(),
+                slot=Slot(10),
+                received_from=peer_id,
+                backfill_depth=1,
+            )
+        ]
 
     async def test_recursive_parent_chain_resolution(
         self,
@@ -148,39 +150,40 @@ class TestBackfillChainResolution:
 
         await backfill.fill_missing([child_root])
 
-        child_cached = backfill.block_cache.get(child_root)
-        parent_cached = backfill.block_cache.get(parent_root)
-        grandparent_cached = backfill.block_cache.get(grandparent_root)
+        # Each cached block is the sole child of its parent root.
+        # Look each one up through the parent index.
+        assert backfill.block_cache.get_children(parent_root) == [
+            PendingBlock(
+                block=child,
+                root=child_root,
+                parent_root=parent_root,
+                slot=Slot(3),
+                received_from=peer_id,
+                backfill_depth=1,
+            )
+        ]
 
-        assert child_cached is not None
-        assert child_cached == PendingBlock(
-            block=child,
-            root=child_root,
-            parent_root=parent_root,
-            slot=Slot(3),
-            received_from=peer_id,
-            backfill_depth=1,
-        )
+        assert backfill.block_cache.get_children(grandparent_root) == [
+            PendingBlock(
+                block=parent,
+                root=parent_root,
+                parent_root=grandparent_root,
+                slot=Slot(2),
+                received_from=peer_id,
+                backfill_depth=2,
+            )
+        ]
 
-        assert parent_cached is not None
-        assert parent_cached == PendingBlock(
-            block=parent,
-            root=parent_root,
-            parent_root=grandparent_root,
-            slot=Slot(2),
-            received_from=peer_id,
-            backfill_depth=2,
-        )
-
-        assert grandparent_cached is not None
-        assert grandparent_cached == PendingBlock(
-            block=grandparent,
-            root=grandparent_root,
-            parent_root=Bytes32.zero(),
-            slot=Slot(1),
-            received_from=peer_id,
-            backfill_depth=3,
-        )
+        assert backfill.block_cache.get_children(Bytes32.zero()) == [
+            PendingBlock(
+                block=grandparent,
+                root=grandparent_root,
+                parent_root=Bytes32.zero(),
+                slot=Slot(1),
+                received_from=peer_id,
+                backfill_depth=3,
+            )
+        ]
 
     async def test_depth_limit_stops_infinite_recursion(
         self,

--- a/tests/node/sync/test_block_cache.py
+++ b/tests/node/sync/test_block_cache.py
@@ -118,29 +118,6 @@ class TestBlockCacheBasicOperations:
         assert pending.root in cache
         assert Bytes32(b"\xff" * 32) not in cache
 
-    def test_get_block(self, peer_id: PeerId) -> None:
-        """Getting a block by root returns the PendingBlock."""
-        cache = BlockCache()
-        block = make_signed_block(
-            slot=Slot(1),
-            proposer_index=ValidatorIndex(0),
-            parent_root=Bytes32.zero(),
-            state_root=Bytes32.zero(),
-        )
-
-        pending = cache.add(block, peer_id)
-        retrieved = cache.get(pending.root)
-
-        assert retrieved == pending
-
-    def test_get_nonexistent_block(self) -> None:
-        """Getting a nonexistent block returns None."""
-        cache = BlockCache()
-
-        cached_block = cache.get(Bytes32.zero())
-
-        assert cached_block is None
-
     def test_remove_block(self, peer_id: PeerId) -> None:
         """Removing a block returns it and removes from cache."""
         cache = BlockCache()
@@ -165,25 +142,6 @@ class TestBlockCacheBasicOperations:
         removed_block = cache.remove(Bytes32.zero())
 
         assert removed_block is None
-
-    def test_clear_cache(self, peer_id: PeerId) -> None:
-        """Clear removes all blocks from the cache."""
-        cache = BlockCache()
-        for i in range(5):
-            block = make_signed_block(
-                slot=Slot(i + 1),
-                proposer_index=ValidatorIndex(0),
-                parent_root=Bytes32(i.to_bytes(32, "big")),
-                state_root=Bytes32.zero(),
-            )
-            cache.add(block, peer_id)
-
-        assert len(cache) == 5
-
-        cache.clear()
-
-        assert len(cache) == 0
-        assert cache.orphan_count == 0
 
 
 class TestBlockCacheDeduplication:


### PR DESCRIPTION
## Summary

Removes two dead methods from the sync block cache. Neither has a production caller.

- `BlockCache.get` — no production caller; the cache is consulted through the parent-to-children index, never by direct root lookup.
- `BlockCache.clear` — no production caller; no service teardown resets the cache wholesale, and entries are removed one at a time as blocks are processed or evicted.

## Verification

Confirmed by grepping every `block_cache.*` and `BlockCache` reference across `src/` and `packages/`. Production code uses only `add`, `mark_orphan`, `unmark_orphan`, `remove`, `get_children`, and `orphan_count`.

## Tests

- Deleted the dedicated get/clear unit tests in the mirrored block-cache test module.
- The backfill tests that inspected the cache via the lookup method now read cached blocks back through the parent index, preserving full-object equality assertions.

`just check` passes and the affected sync tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)