### PR TITLE
fix(gossipsub): rate-limit IWANT responses to prevent amplification

### DIFF
--- a/src/lean_spec/node/networking/gossipsub/behavior.py
+++ b/src/lean_spec/node/networking/gossipsub/behavior.py
@@ -150,6 +150,24 @@ warrant the overhead of IDONTWANT control messages.
 """
 
 
+GOSSIP_RETRANSMISSION: Final = 3
+"""Maximum times one message is re-served to a peer per heartbeat window.
+
+A peer can repeatedly ask for the same message via IWANT to amplify our
+outbound traffic.
+Past this count the message is skipped until the window resets.
+Matches the gossipsub-v1.1 default.
+"""
+
+
+MAX_IWANT_MESSAGE_IDS_PER_REQUEST: Final = 5000
+"""Maximum message IDs processed from a single IWANT request.
+
+One RPC frame can list an unbounded number of IDs.
+This caps the per-call work and reply size to bound amplification.
+"""
+
+
 @dataclass(slots=True)
 class PeerState:
     """State tracked for each connected peer."""
@@ -176,6 +194,13 @@ class PeerState:
     """Message IDs this peer does not want.
 
     Populated from incoming IDONTWANT control messages.
+    Cleared each heartbeat.
+    """
+
+    iwant_served_counts: dict[MessageId, int] = field(default_factory=dict)
+    """Times each message was served to this peer via IWANT in the current window.
+
+    Bounds gossip amplification from repeated IWANT requests.
     Cleared each heartbeat.
     """
 
@@ -726,17 +751,35 @@ class GossipsubBehavior:
         logger.debug("Sent IWANT for %d messages from %s", len(wanted), peer_id)
 
     async def _handle_iwant(self, peer_id: PeerId, iwant: ControlIWant) -> None:
-        """Handle an IWANT request from a peer."""
+        """
+        Handle an IWANT request from a peer.
+
+        Per-peer retransmission counts and a per-call ID cap bound the
+        amplification an attacker can extract from a single oversized request.
+        """
+        state = self._peers.get(peer_id)
+        if state is None:
+            return
+
         messages = []
 
-        for message_id in iwant.message_ids:
+        # Bound the per-call work and reply size against an oversized request.
+        for message_id in iwant.message_ids[:MAX_IWANT_MESSAGE_IDS_PER_REQUEST]:
             if len(message_id) != 20:
                 continue
             message_id_typed = MessageId(message_id)
+
+            # Skip a message already served the maximum times this window.
+            if state.iwant_served_counts.get(message_id_typed, 0) >= GOSSIP_RETRANSMISSION:
+                continue
+
             cached = self.message_cache.get(message_id_typed)
             if cached:
                 topic_id = TopicId(cached.topic.decode("utf-8"))
                 messages.append(Message(topic=topic_id, data=cached.raw_data))
+                state.iwant_served_counts[message_id_typed] = (
+                    state.iwant_served_counts.get(message_id_typed, 0) + 1
+                )
 
         if messages:
             rpc = RPC(publish=messages)
@@ -808,8 +851,11 @@ class GossipsubBehavior:
 
         # IDONTWANT is only valid within a single heartbeat window;
         # stale entries would suppress legitimate new forwards.
+        # IWANT retransmission budgets reset on the same window so a fresh
+        # heartbeat allows legitimate re-requests again.
         for state in self._peers.values():
             state.dont_want_ids.clear()
+            state.iwant_served_counts.clear()
 
     async def _maintain_mesh(self, topic: TopicId, now: float) -> None:
         """Maintain mesh size for a topic."""

--- a/tests/node/networking/gossipsub/test_behavior.py
+++ b/tests/node/networking/gossipsub/test_behavior.py
@@ -13,7 +13,9 @@ import pytest
 
 from lean_spec.node.networking.config import PRUNE_BACKOFF
 from lean_spec.node.networking.gossipsub.behavior import (
+    GOSSIP_RETRANSMISSION,
     IDONTWANT_SIZE_THRESHOLD,
+    MAX_IWANT_MESSAGE_IDS_PER_REQUEST,
     GossipsubMessageEvent,
     GossipsubPeerEvent,
 )
@@ -305,6 +307,53 @@ class TestHandleIWant:
         peer_id = add_peer(behavior, "peer1")
 
         iwant = ControlIWant(message_ids=[b"short"])
+        await behavior._handle_iwant(peer_id, iwant)
+
+        assert capture.sent == []
+
+    @pytest.mark.asyncio
+    async def test_iwant_unknown_peer_sends_nothing(self) -> None:
+        """IWANT from an untracked peer is silently ignored."""
+        behavior, capture = make_behavior()
+        message = GossipsubMessage(topic=b"topic", raw_data=b"payload")
+        behavior.message_cache.put(TopicId("topic"), message)
+
+        iwant = ControlIWant(message_ids=[bytes(message.id)])
+        await behavior._handle_iwant(make_peer("stranger"), iwant)
+
+        assert capture.sent == []
+
+    @pytest.mark.asyncio
+    async def test_iwant_serves_up_to_retransmission_limit_then_skips(self) -> None:
+        """One message is served GOSSIP_RETRANSMISSION times then skipped."""
+        behavior, capture = make_behavior()
+        peer_id = add_peer(behavior, "peer1")
+        message = GossipsubMessage(topic=b"topic", raw_data=b"payload")
+        behavior.message_cache.put(TopicId("topic"), message)
+
+        iwant = ControlIWant(message_ids=[bytes(message.id)])
+        for _ in range(GOSSIP_RETRANSMISSION + 2):
+            await behavior._handle_iwant(peer_id, iwant)
+
+        served_reply = (peer_id, RPC(publish=[Message(topic=TopicId("topic"), data=b"payload")]))
+        assert capture.sent == [served_reply] * GOSSIP_RETRANSMISSION
+
+    @pytest.mark.asyncio
+    async def test_iwant_caps_message_ids_per_request(self) -> None:
+        """Only the first MAX_IWANT_MESSAGE_IDS_PER_REQUEST IDs are processed."""
+        behavior, capture = make_behavior()
+        peer_id = add_peer(behavior, "peer1")
+
+        served_message = GossipsubMessage(topic=b"topic", raw_data=b"payload")
+        behavior.message_cache.put(TopicId("topic"), served_message)
+
+        # Pad the request past the cap with junk IDs, then place the cached ID
+        # one slot beyond the cap so the cap must drop it.
+        junk_ids = [bytes([byte_value] * 20) for byte_value in range(1, 5)]
+        padding_ids = junk_ids * (MAX_IWANT_MESSAGE_IDS_PER_REQUEST // len(junk_ids) + 1)
+        message_ids = padding_ids[:MAX_IWANT_MESSAGE_IDS_PER_REQUEST] + [bytes(served_message.id)]
+
+        iwant = ControlIWant(message_ids=message_ids)
         await behavior._handle_iwant(peer_id, iwant)
 
         assert capture.sent == []
@@ -872,6 +921,19 @@ class TestHeartbeatIntegration:
         await behavior._heartbeat()
 
         assert len(behavior._peers[pid].dont_want_ids) == 0
+
+    @pytest.mark.asyncio
+    async def test_clears_iwant_served_counts(self) -> None:
+        """Heartbeat resets per-peer IWANT retransmission budgets."""
+        behavior, _ = make_behavior()
+        pid = add_peer(behavior, "peer1")
+        behavior._peers[pid].iwant_served_counts[MessageId(b"12345678901234567890")] = 3
+
+        assert len(behavior._peers[pid].iwant_served_counts) == 1
+
+        await behavior._heartbeat()
+
+        assert len(behavior._peers[pid].iwant_served_counts) == 0
 
     @pytest.mark.asyncio
     async def test_gossip_includes_fanout_topics(self) -> None:


### PR DESCRIPTION
## Summary

Closes audit finding SEC-04 (Major, security).

The IWANT handler previously served the full cached payload for every matching message ID in a request, with no per-peer or per-heartbeat budget. A single RPC frame could list an unbounded number of message IDs, and a peer could re-request the same message repeatedly, turning one request into a large volume of outbound traffic (gossip amplification).

## Changes

- Add a per-peer `iwant_served_counts` map tracking how many times each message was served via IWANT in the current heartbeat window. It is cleared each heartbeat, mirroring how the IDONTWANT set is cleared.
- Skip any message already served `GOSSIP_RETRANSMISSION` times (gossipsub-v1.1 default of 3) within the window.
- Cap the number of message IDs processed per request at `MAX_IWANT_MESSAGE_IDS_PER_REQUEST` to bound per-call work and reply size.
- Ignore IWANT from untracked peers (no peer state).

## Tests

Added unit tests in the mirrored `tests/node/networking/gossipsub/test_behavior.py`:

- a message is served up to the retransmission limit, then skipped
- the per-call message-ID cap drops IDs beyond the bound
- IWANT from an unknown peer sends nothing
- the heartbeat resets the per-peer served counts

`just check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)