### PR TITLE
test(networking): move ConnectionState/Direction tests to mirrored test_types.py

### DIFF
--- a/tests/node/networking/test_peer.py
+++ b/tests/node/networking/test_peer.py
@@ -13,26 +13,6 @@ def peer(name: str) -> PeerId:
     return PeerId.from_base58(name)
 
 
-class TestConnectionState:
-    """Tests for ConnectionState enum."""
-
-    def test_state_values(self) -> None:
-        """ConnectionState has the 4 expected states."""
-        assert ConnectionState.DISCONNECTED == 1
-        assert ConnectionState.CONNECTING == 2
-        assert ConnectionState.CONNECTED == 3
-        assert ConnectionState.DISCONNECTING == 4
-
-
-class TestDirection:
-    """Tests for Direction enum."""
-
-    def test_direction_values(self) -> None:
-        """Direction has inbound and outbound."""
-        assert Direction.INBOUND == 1
-        assert Direction.OUTBOUND == 2
-
-
 class TestPeerInfo:
     """Tests for PeerInfo dataclass."""
 

--- a/tests/node/networking/test_types.py
+++ b/tests/node/networking/test_types.py
@@ -1,0 +1,23 @@
+"""Tests for networking shared types."""
+
+from lean_spec.node.networking.types import ConnectionState, Direction
+
+
+class TestConnectionState:
+    """Tests for ConnectionState enum."""
+
+    def test_state_values(self) -> None:
+        """ConnectionState has the 4 expected states."""
+        assert ConnectionState.DISCONNECTED == 1
+        assert ConnectionState.CONNECTING == 2
+        assert ConnectionState.CONNECTED == 3
+        assert ConnectionState.DISCONNECTING == 4
+
+
+class TestDirection:
+    """Tests for Direction enum."""
+
+    def test_direction_values(self) -> None:
+        """Direction has inbound and outbound."""
+        assert Direction.INBOUND == 1
+        assert Direction.OUTBOUND == 2


### PR DESCRIPTION
## Summary

`TestConnectionState` and `TestDirection` lived in `tests/node/networking/test_peer.py`, but the `ConnectionState` and `Direction` enums they test are defined in `src/lean_spec/node/networking/types.py`, not `peer.py`. This violates the strict test-mirroring law that a test file only tests the single source module it mirrors.

This change moves those two test classes into a new `tests/node/networking/test_types.py` and leaves the `PeerInfo` tests in `test_peer.py`.

## Details

- New `tests/node/networking/test_types.py` holds `TestConnectionState` and `TestDirection`, importing both enums from `node/networking/types.py`.
- `test_peer.py` keeps `TestPeerInfo`, which still legitimately uses `ConnectionState`, `Direction`, and `Multiaddr`, so its import line is unchanged.
- Scoped to the two enum tests only; other parts of `types.py` are out of scope.

## Verification

- `uv run pytest tests/node/networking/test_types.py tests/node/networking/test_peer.py -q` — 7 passed.
- `just check` — all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)