### PR TITLE
refactor(sync): reconcile block-request batch ceiling onto MAX_REQUEST_BLOCKS

### DIFF
--- a/src/lean_spec/node/sync/backfill_sync.py
+++ b/src/lean_spec/node/sync/backfill_sync.py
@@ -45,7 +45,7 @@ from typing import Protocol
 from lean_spec.node.networking.config import MAX_REQUEST_BLOCKS
 from lean_spec.node.networking.transport.peer_id import PeerId
 from lean_spec.node.sync.block_cache import BlockCache
-from lean_spec.node.sync.config import MAX_BACKFILL_DEPTH, MAX_BLOCKS_PER_REQUEST
+from lean_spec.node.sync.config import MAX_BACKFILL_DEPTH
 from lean_spec.node.sync.peer_manager import PeerManager
 from lean_spec.spec.forks import SignedBlock, Slot
 from lean_spec.spec.ssz import Bytes32, Uint64
@@ -220,9 +220,13 @@ class BackfillSync:
         self._pending.update(roots_to_fetch)
 
         try:
-            # Fetch in batches to respect request limits.
-            for batch_start in range(0, len(roots_to_fetch), MAX_BLOCKS_PER_REQUEST):
-                batch = roots_to_fetch[batch_start : batch_start + MAX_BLOCKS_PER_REQUEST]
+            # Split into per-message batches bounded by the wire request limit.
+            #
+            # A by-root request carries at most MAX_REQUEST_BLOCKS roots.
+            # That is the same ceiling the responder enforces.
+            # A wider set becomes several round-trips here.
+            for batch_start in range(0, len(roots_to_fetch), MAX_REQUEST_BLOCKS):
+                batch = roots_to_fetch[batch_start : batch_start + MAX_REQUEST_BLOCKS]
                 await self._fetch_batch(batch, depth)
         finally:
             # Always clear pending status, even on error.

--- a/src/lean_spec/node/sync/config.py
+++ b/src/lean_spec/node/sync/config.py
@@ -8,9 +8,6 @@ from __future__ import annotations
 
 from typing import Final
 
-MAX_BLOCKS_PER_REQUEST: Final[int] = 10
-"""Maximum blocks to request in a single BlocksByRoot request."""
-
 MAX_CONCURRENT_REQUESTS: Final[int] = 2
 """Maximum concurrent requests to a single peer."""
 

--- a/tests/node/sync/test_backfill_sync.py
+++ b/tests/node/sync/test_backfill_sync.py
@@ -8,11 +8,12 @@ import pytest
 
 from consensus_testing import MockNetworkRequester, make_signed_block
 from lean_spec.node.networking import PeerId
+from lean_spec.node.networking.config import MAX_REQUEST_BLOCKS
 from lean_spec.node.networking.peer import PeerInfo
 from lean_spec.node.networking.types import ConnectionState
 from lean_spec.node.sync.backfill_sync import BackfillSync
 from lean_spec.node.sync.block_cache import BlockCache, PendingBlock
-from lean_spec.node.sync.config import MAX_BACKFILL_DEPTH, MAX_BLOCKS_PER_REQUEST
+from lean_spec.node.sync.config import MAX_BACKFILL_DEPTH
 from lean_spec.node.sync.peer_manager import (
     INITIAL_PEER_SCORE,
     SCORE_FAILURE_PENALTY,
@@ -228,15 +229,15 @@ class TestBatchingAndPeerManagement:
         network: MockNetworkRequester,
         peer_id: PeerId,
     ) -> None:
-        """Requests larger than MAX_BLOCKS_PER_REQUEST are split."""
-        num_roots = MAX_BLOCKS_PER_REQUEST + 5
+        """Requests larger than MAX_REQUEST_BLOCKS are split."""
+        num_roots = MAX_REQUEST_BLOCKS + 5
         roots = [Bytes32(i.to_bytes(32, "big")) for i in range(num_roots)]
 
         await backfill_system.fill_missing(roots)
 
         assert network.root_request_log == [
-            (peer_id, roots[:MAX_BLOCKS_PER_REQUEST]),
-            (peer_id, roots[MAX_BLOCKS_PER_REQUEST:]),
+            (peer_id, roots[:MAX_REQUEST_BLOCKS]),
+            (peer_id, roots[MAX_REQUEST_BLOCKS:]),
         ]
 
     async def test_no_requests_without_available_peer(


### PR DESCRIPTION
## Summary

Backfill's by-root fetch batched at 10 roots per request (`MAX_BLOCKS_PER_REQUEST`), while the by-range fetch and the wire protocol both cap a single request at 1024 blocks (`MAX_REQUEST_BLOCKS`). Two ceilings, 100x apart, for the same SSZ request — with no stated reason.

The by-root request container itself already permits up to 1024 roots (`RequestedBlockRoots.LIMIT = MAX_REQUEST_BLOCKS`), the same limit the responder enforces, so the smaller batch was an inconsistency rather than a deliberate cap.

## Change

- Route the by-root batching in `fill_missing` through the single authoritative wire limit `MAX_REQUEST_BLOCKS`.
- Delete the now-unused `MAX_BLOCKS_PER_REQUEST` from `node/sync/config.py` (no backward-compat alias).
- Update the splitting test to exercise the wire ceiling.

## Verification

- `uv run pytest tests/node/sync/test_backfill_sync.py` — 16 passed.
- `just check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)