### PR TITLE
fix(ssz): reject non-canonical trailing zero byte in bitlist decode

### DIFF
--- a/src/lean_spec/spec/ssz/bitfields.py
+++ b/src/lean_spec/spec/ssz/bitfields.py
@@ -401,6 +401,15 @@ class BaseBitlist(SSZModel):
             raise SSZSerializationError(f"{cls.__name__}: no delimiter bit found")
         delimiter_pos = total.bit_length() - 1
 
+        # The delimiter must sit in the final byte of the input.
+        # Reading the stream as one integer silently drops trailing zero bytes.
+        # So a canonical encoding and one with extra zero bytes decode the same.
+        # Rejecting the padded form keeps a single valid encoding per value.
+        if delimiter_pos // 8 != len(data) - 1:
+            raise SSZSerializationError(
+                f"{cls.__name__}: non-canonical trailing zero bytes after delimiter"
+            )
+
         # Phase 3: extract data bits below the delimiter and enforce the size limit.
         #
         # The delimiter position equals the data bit count. For each bit index i:

--- a/tests/spec/ssz/test_bitfields.py
+++ b/tests/spec/ssz/test_bitfields.py
@@ -418,6 +418,31 @@ class TestBitfieldSSZ:
             Bitlist8.decode_bytes(b"\x00")
         assert str(exception_info.value) == "Bitlist8: no delimiter bit found"
 
+    def test_bitlist_decode_rejects_non_canonical_trailing_zero_byte(self) -> None:
+        """Bitlist.decode_bytes rejects a trailing zero byte after the delimiter byte."""
+
+        class Bitlist8(BaseBitlist):
+            LIMIT = 8
+
+        # Byte 0x0d encodes bits [1, 0, 1] with the delimiter at bit 3.
+        # Appending a zero byte leaves the delimiter in byte 0, not the final byte.
+        with pytest.raises(SSZSerializationError) as exception_info:
+            Bitlist8.decode_bytes(b"\x0d\x00")
+        assert (
+            str(exception_info.value)
+            == "Bitlist8: non-canonical trailing zero bytes after delimiter"
+        )
+
+    def test_bitlist_decode_canonical_encoding_round_trips(self) -> None:
+        """Bitlist.decode_bytes accepts the canonical single-byte encoding of bits [1, 0, 1]."""
+
+        class Bitlist8(BaseBitlist):
+            LIMIT = 8
+
+        assert Bitlist8.decode_bytes(b"\x0d") == Bitlist8(
+            data=(Boolean(True), Boolean(False), Boolean(True))
+        )
+
     def test_bitlist_decode_exceeds_limit(self) -> None:
         """Bitlist.decode_bytes rejects encodings whose recovered bit count exceeds LIMIT."""
 


### PR DESCRIPTION
## Summary

Bitlist decoding read the SSZ byte stream as one little-endian integer to locate the trailing delimiter bit. Because `int.from_bytes` discards leading zeros in the integer, trailing zero bytes in the stream were silently dropped: `b"\x0d\x00"` and `b"\x0d"` decoded to the same bitlist, then re-encoded to the canonical single-byte form. This is a non-canonical dual encoding — two distinct byte sequences map to one value.

## Fix

After computing the delimiter position, require the delimiter to live in the final input byte. If it does not, the input carries non-canonical trailing zero bytes and is rejected with `SSZSerializationError`, the same error type already used for empty input and the missing-delimiter case. This guarantees a single valid encoding per bitlist value.

## Tests

- A bitlist with an extra trailing zero byte raises `SSZSerializationError` (full message asserted).
- The canonical single-byte encoding still round-trips.

`just check` passes; `tests/spec/ssz/test_bitfields.py` is green with full coverage of the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)