### PR TITLE
fix(lstar): guard proposer_for_slot against zero validators

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/identifiers.py
+++ b/src/lean_spec/spec/forks/lstar/containers/identifiers.py
@@ -1,6 +1,7 @@
 """Scalar identifiers naming validators, subnets, and the registry index space."""
 
 from lean_spec.spec.forks.lstar.config import VALIDATOR_REGISTRY_LIMIT
+from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
 from lean_spec.spec.forks.lstar.slot import Slot
 from lean_spec.spec.ssz import SSZList, Uint64
 
@@ -18,7 +19,17 @@ class ValidatorIndex(Uint64):
         Return the validator index responsible for proposing at the given slot.
 
         Round-robin selection: the proposer is slot modulo registry size.
+
+        Raises:
+            SpecRejectionError: EMPTY_VALIDATOR_REGISTRY if the registry is empty.
         """
+        # An empty registry has no validator to schedule.
+        # Reject explicitly so the modulo never divides by zero.
+        if int(num_validators) == 0:
+            raise SpecRejectionError(
+                RejectionReason.EMPTY_VALIDATOR_REGISTRY,
+                "Cannot schedule a proposer for an empty validator registry",
+            )
         return cls(int(slot) % int(num_validators))
 
     def is_within_registry(self, num_validators: Uint64) -> bool:

--- a/src/lean_spec/spec/forks/lstar/errors.py
+++ b/src/lean_spec/spec/forks/lstar/errors.py
@@ -28,6 +28,9 @@ class RejectionReason(StrEnum):
     PROPOSER_INDEX_OUT_OF_RANGE = "PROPOSER_INDEX_OUT_OF_RANGE"
     """The proposer index does not address any registered validator."""
 
+    EMPTY_VALIDATOR_REGISTRY = "EMPTY_VALIDATOR_REGISTRY"
+    """The registry holds no validators, so no proposer can be scheduled for any slot."""
+
     WRONG_PROPOSER = "WRONG_PROPOSER"
     """The block proposer is not the scheduled proposer for its slot."""
 


### PR DESCRIPTION
## Summary

Round-robin proposer selection computed `int(slot) % int(num_validators)`. With an empty validator registry this divides by zero and surfaces a bare `ZeroDivisionError` instead of a typed spec rejection. Genesis enforces no minimum registry size, and the path is reachable from block header processing, so the unguarded modulo is a latent safety defect (audit finding SEC-07).

## Change

- Add an `EMPTY_VALIDATOR_REGISTRY` rejection reason to the lstar error enum.
- Raise the typed `SpecRejectionError` carrying that reason when the registry is empty, before the modulo executes.

`SpecRejectionError` subclasses `AssertionError` (not the builtin `ValueError`/`TypeError`), matching the existing rejection pattern used throughout this fork's state transition and fork choice. The guard mirrors how other consensus checks reject invalid inputs.

## Testing

`just check` passes (ruff, format, ty, codespell, mdformat). A focused smoke check confirms the empty registry raises `EMPTY_VALIDATOR_REGISTRY` with the message "Cannot schedule a proposer for an empty validator registry", and a non-empty registry still returns the round-robin index.

No consensus test vector is added: the only way to exercise this path through a `state_transition` fixture would require a well-formed signed block whose `proposer_index` matches the scheduled proposer, which is impossible to construct for an empty registry (there is no proposer to schedule or sign). The guard is a defensive precondition, and existing block-header and proposer vectors cover the non-empty paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)