### PR TITLE
fix(sync): make peer finalized-slot tie-break deterministic

### DIFF
--- a/src/lean_spec/node/sync/peer_manager.py
+++ b/src/lean_spec/node/sync/peer_manager.py
@@ -150,17 +150,24 @@ class PeerManager:
         """
         Determine network consensus finalized slot.
 
-        Returns the mode (most common) finalized slot reported by connected peers.
+        Returns the most-reported finalized slot among connected peers.
+        Ties resolve to the higher slot, never to peer insertion order.
+        This decision is consensus-adjacent, so it stays deterministic.
         """
-        slots = (
+        reported_finalized_slots = Counter(
             peer.status.finalized.slot
             for peer in self.peers.values()
             if peer.status is not None and peer.is_connected()
         )
-        counter = Counter(slots)
-        if not counter:
+        if not reported_finalized_slots:
             return None
-        return counter.most_common(1)[0][0]
+        # Rank candidates by report count first, then by the slot itself.
+        # The higher slot wins an equal-count tie, so the result never depends
+        # on which peer connected first.
+        return max(
+            reported_finalized_slots,
+            key=lambda finalized_slot: (reported_finalized_slots[finalized_slot], finalized_slot),
+        )
 
     def on_request_success(self, peer_id: PeerId) -> None:
         """Record a successful request to a peer."""

--- a/tests/node/sync/test_peer_manager.py
+++ b/tests/node/sync/test_peer_manager.py
@@ -248,6 +248,28 @@ class TestPeerManagerNetworkConsensus:
         finalized = manager.get_network_finalized_slot()
         assert finalized == Slot(100)
 
+    def test_get_network_finalized_slot_tie_prefers_higher_slot(
+        self, peer_id: PeerId, peer_id_2: PeerId, peer_id_3: PeerId
+    ) -> None:
+        """get_network_finalized_slot breaks an equal-count tie toward the higher slot."""
+        manager = PeerManager()
+
+        # Two peers report slot 100 and two report slot 200.
+        # The lower slot is inserted first, so insertion order would pick 100.
+        for pid, finalized_slot in [
+            (peer_id, 100),
+            (peer_id_2, 100),
+            (peer_id_3, 200),
+            (peer("peerD"), 200),
+        ]:
+            sync_peer = manager.add_peer(PeerInfo(peer_id=pid, state=ConnectionState.CONNECTED))
+            sync_peer.status = Status(
+                finalized=Checkpoint(root=Bytes32.zero(), slot=Slot(finalized_slot)),
+                head=Checkpoint(root=Bytes32.zero(), slot=Slot(finalized_slot + 50)),
+            )
+
+        assert manager.get_network_finalized_slot() == Slot(200)
+
     def test_get_network_finalized_slot_none_without_status(
         self, connected_peer_info: PeerInfo
     ) -> None:


### PR DESCRIPTION
## Summary

The peer manager derives a network finalized slot by counting the finalized slots peers report, then taking the most reported one. The previous implementation used `Counter.most_common(1)`, whose tie-break among equally-reported slots falls back to peer insertion order. That made a consensus-adjacent SYNCED decision depend on which peer happened to connect first.

This change ranks candidate slots by report count first, then by the slot value itself, so an equal-count tie deterministically resolves to the higher slot regardless of connection order. The decision no longer depends on dict insertion order.

## Test

Added a mirrored unit test in `tests/node/sync/test_peer_manager.py`: two peers report slot 100 and two report slot 200, with the lower slot inserted first. The result is asserted to be slot 200, which insertion order would not have produced.

`uv run pytest tests/node/sync/test_peer_manager.py` passes (36 tests). `just check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)