### PR TITLE
refactor(testing): remove unread _MockBlock.parent_root field

### DIFF
--- a/packages/testing/src/consensus_testing/mocks.py
+++ b/packages/testing/src/consensus_testing/mocks.py
@@ -116,10 +116,9 @@ class MockEventSource:
 
 @dataclass
 class _MockBlock:
-    """Block stub carrying only the slot and parent root used in lookups."""
+    """Terminal genesis block stub carrying only the slot used in lookups."""
 
     slot: Slot = field(default_factory=lambda: Slot(0))
-    parent_root: Bytes32 = field(default_factory=Bytes32.zero)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Removes the unread `parent_root` field from the `_MockBlock` genesis stub in the consensus-testing forkchoice double.

The double seeds a single terminal genesis block stub at its head root. The sync path reads `parent_root` only off real incoming blocks; it uses the stub purely for a dict-membership check on its key (`parent_root in store.blocks`) and never reads the `parent_root` attribute back off the stored stub. The reorg-depth ancestor walker that does read `parent_root` operates on the real consensus `Store`, not this mock.

The field was therefore dead. It is removed and the class docstring updated to name the stub terminal.

## Verification

- `uv run pytest tests/node/sync/test_head_sync.py tests/node/sync/test_service.py` — 46 passed
- `just check` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)