### PR TITLE
fix(ssz): reject non-zero padding bits in bitvector decode

### DIFF
--- a/src/lean_spec/spec/ssz/bitfields.py
+++ b/src/lean_spec/spec/ssz/bitfields.py
@@ -146,6 +146,7 @@ class BaseBitvector(SSZModel):
 
         Raises:
             SSZValueError: If the input length does not match the expected byte count.
+            SSZValueError: If any padding bit above the last data bit is set.
         """
         # Reject inputs whose byte count does not match the expected size.
         expected_byte_count = cls.get_byte_length()
@@ -153,6 +154,17 @@ class BaseBitvector(SSZModel):
             raise SSZValueError(
                 f"{cls.__name__}: expected {expected_byte_count} bytes, got {len(data)}"
             )
+
+        # When the bit count is not a multiple of 8, the last byte holds padding
+        # bits above the highest data bit.
+        # SSZ requires those padding bits to be zero so the encoding is canonical.
+        # Without this check, 0b00011111 and 0b11111111 both decode to a 5-bit
+        # vector of all ones.
+        if trailing_bit_count := cls.LENGTH % 8:
+            if data[-1] >> trailing_bit_count:
+                raise SSZValueError(
+                    f"{cls.__name__}: non-zero padding bits in final byte {data[-1]:#04x}"
+                )
 
         # Read every bit position out of the byte stream.
         #

--- a/tests/spec/ssz/test_bitfields.py
+++ b/tests/spec/ssz/test_bitfields.py
@@ -376,6 +376,27 @@ class TestBitfieldSSZ:
             Bitvector8.decode_bytes(b"\x01\x02")
         assert str(exception_info.value) == "Bitvector8: expected 1 bytes, got 2"
 
+    def test_bitvector_decode_rejects_non_zero_padding_bits(self) -> None:
+        """Bitvector.decode_bytes rejects a final byte with set bits above the data bits."""
+
+        class Bitvector5(BaseBitvector):
+            LENGTH = 5
+
+        # Bits 5, 6, 7 are padding above the 5 data bits and must be zero.
+        # 0b11111111 sets them, so it is a non-canonical encoding of [1] * 5.
+        with pytest.raises(SSZValueError) as exception_info:
+            Bitvector5.decode_bytes(b"\xff")
+        assert str(exception_info.value) == "Bitvector5: non-zero padding bits in final byte 0xff"
+
+    def test_bitvector_decode_canonical_with_zero_padding_bits(self) -> None:
+        """Bitvector.decode_bytes accepts the canonical encoding with zero padding bits."""
+
+        class Bitvector5(BaseBitvector):
+            LENGTH = 5
+
+        # 0b00011111 holds 5 data bits all set with zero padding above them.
+        assert Bitvector5.decode_bytes(b"\x1f") == Bitvector5(data=[Boolean(True)] * 5)
+
     def test_bitvector_deserialize_invalid_scope(self) -> None:
         """Bitvector.deserialize rejects a scope mismatching the type's byte length."""
 


### PR DESCRIPTION
## Summary

When a bitvector `LENGTH` is not a multiple of 8, the final byte carries padding bits above the highest data bit. The decoder read only the low `LENGTH` bits and silently ignored any set padding bit, so `0b00011111` and `0b11111111` both decoded to a 5-bit vector of all ones. SSZ requires the canonical encoding where those padding bits are zero, so two distinct byte sequences must not decode to the same value.

## Change

- Bitvector decode now rejects a final byte whose bits above the data region are set, raising `SSZValueError` with a precise message naming the offending byte.
- Added two mirrored unit tests: a 5-bit vector with set padding bits is rejected (full-message equality), and the canonical encoding still decodes.

## Validation

- `uv run pytest tests/spec/ssz/test_bitfields.py` passes (56 tests).
- `just check` passes (lint, format, type check, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)