### PR TITLE
refactor(quic): remove never-set shutdown_event and no-op cert try/except

### DIFF
--- a/src/lean_spec/node/networking/transport/quic/connection.py
+++ b/src/lean_spec/node/networking/transport/quic/connection.py
@@ -207,26 +207,15 @@ class LibP2PQuicProtocol(QuicConnectionProtocol):
         """Initialize the libp2p QUIC protocol handler."""
         super().__init__(*args, **kwargs)
         self.connection: QuicConnection | None = None
-        self.peer_identity: PeerId | None = None
         self.handshake_complete = asyncio.Event()
         self._buffered_events: list[QuicEvent] = []
 
     def quic_event_received(self, event: QuicEvent) -> None:
         """Handle QUIC events."""
         if isinstance(event, HandshakeCompleted):
-            # Extract peer identity from certificate.
-            #
-            # aioquic stores the peer certificate in _quic.tls.
-            # We verify the libp2p extension and extract the identity.
-            try:
-                # Get peer certificate from TLS session.
-                # aioquic may not expose this directly, need to check.
-                # For now, mark handshake complete.
-                # TODO: Extract and verify peer certificate
-                self.peer_identity = None  # Will be set if we can extract certificate
-            except Exception:
-                self.peer_identity = None
-
+            # TODO: extract and verify the peer certificate from the TLS session.
+            # aioquic stores it in the underlying QUIC connection, but does not
+            # expose it directly, so the libp2p identity is not yet recovered.
             self.handshake_complete.set()
 
             # For server-side connections, invoke the handshake callback.
@@ -521,14 +510,12 @@ class QuicConnectionManager:
             protocol._on_handshake = handle_handshake
             return protocol
 
-        # Create a shutdown event to allow graceful termination.
-        shutdown_event = asyncio.Event()
-
         await quic_serve(
             host,
             port,
             configuration=server_config,
             create_protocol=create_protocol,
         )
-        # Keep running until shutdown is requested.
-        await shutdown_event.wait()
+        # Park until cancelled.
+        # The caller stops the server by cancelling this coroutine.
+        await asyncio.Event().wait()

--- a/tests/node/networking/transport/quic/test_connection.py
+++ b/tests/node/networking/transport/quic/test_connection.py
@@ -532,7 +532,6 @@ class TestLibP2PQuicProtocol:
         """A protocol with mocked parent internals (bypasses aioquic constructor)."""
         protobuf = LibP2PQuicProtocol.__new__(LibP2PQuicProtocol)
         protobuf.connection = None
-        protobuf.peer_identity = None
         protobuf.handshake_complete = asyncio.Event()
         protobuf._buffered_events = []
         protobuf._on_handshake = None
@@ -665,42 +664,6 @@ class TestLibP2PQuicProtocol:
         )
         protocol._replay_buffered_events()
         assert protocol._buffered_events == []
-
-    def test_handshake_exception_sets_peer_identity_none(
-        self, protocol: LibP2PQuicProtocol
-    ) -> None:
-        """
-        Handshake completes even if certificate extraction raises.
-
-        The except branch is defensive — if the try block inside the
-        handshake handler raises, the handshake must still complete
-        so the connection can proceed.
-        """
-        # Trigger a standard handshake event.
-        event = HandshakeCompleted(
-            alpn_protocol="libp2p", early_data_accepted=False, session_resumed=False
-        )
-
-        # Force the first assignment to peer_identity to raise.
-        #
-        # This simulates a failure during certificate extraction.
-        # The except branch catches it and sets peer_identity = None.
-        original_setattr = object.__setattr__
-        call_count = 0
-
-        def raising_setattr(self_inner: object, name: str, value: object) -> None:
-            nonlocal call_count
-            if name == "peer_identity" and call_count == 0:
-                call_count += 1
-                raise RuntimeError("cert extraction failed")
-            original_setattr(self_inner, name, value)
-
-        with patch.object(type(protocol), "__setattr__", raising_setattr):
-            protocol.quic_event_received(event)
-
-        # Despite the exception, handshake completed and identity is set.
-        assert protocol.peer_identity is None
-        assert protocol.handshake_complete.is_set()
 
 
 class TestQuicStreamProtocolId:
@@ -929,7 +892,7 @@ class TestLibP2PQuicProtocolInit:
         """
         All custom attributes start in their expected initial state.
 
-        Connection and peer identity are None until handshake completes.
+        Connection is None until handshake completes.
         The handshake event is unset. No events are buffered yet.
         """
 
@@ -938,7 +901,6 @@ class TestLibP2PQuicProtocolInit:
             protocol = LibP2PQuicProtocol()
 
         assert protocol.connection is None
-        assert protocol.peer_identity is None
         assert not protocol.handshake_complete.is_set()
         assert protocol._buffered_events == []
 


### PR DESCRIPTION
## Summary

Two related dead-code cleanups in the QUIC transport connection module, both in `src/lean_spec/node/networking/transport/quic/connection.py`.

### DEAD-07 — never-set shutdown event
The server loop created an `asyncio.Event`, never set it anywhere, then awaited it. The comment promised graceful shutdown, but the await blocked forever and there was no way to signal it. Replaced with `await asyncio.Event().wait()`, documented as parking until the coroutine is cancelled — which is how the caller actually stops the server.

### DEAD-08 — no-op peer-certificate try/except
The handshake handler wrapped a single `self.peer_identity = None` assignment in a `try`/`except`. That assignment cannot raise, so the `except` branch was unreachable. The `peer_identity` field it set was never read anywhere in `src/`. Dropped the field and the dead wrapper, keeping the certificate-extraction TODO as prose. The random-peer-id fallback (SEC-17) is intentionally untouched.

## Tests
- Removed the test that existed only to exercise the unreachable except branch.
- Dropped the `peer_identity` references from the protocol fixture and the init test.
- `uv run pytest tests/node/networking/transport/quic/test_connection.py` — 73 passed.
- `just check` — clean (lint, format, typecheck, spell, mdformat, vulture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)