### PR TITLE
fix(genesis): validate genesis validator-list size at load

### DIFF
--- a/src/lean_spec/node/genesis/config.py
+++ b/src/lean_spec/node/genesis/config.py
@@ -22,7 +22,12 @@ import yaml
 from pydantic import Field, field_validator
 
 from lean_spec.base import StrictBaseModel
-from lean_spec.spec.forks import Validator, ValidatorIndex, Validators
+from lean_spec.spec.forks import (
+    VALIDATOR_REGISTRY_LIMIT,
+    Validator,
+    ValidatorIndex,
+    Validators,
+)
 from lean_spec.spec.ssz import Bytes52, Uint64
 
 
@@ -93,6 +98,26 @@ class GenesisConfig(StrictBaseModel):
 
     Security note: 2/3+ collusion controls the chain until new validators join.
     """
+
+    @field_validator("genesis_validators")
+    @classmethod
+    def _reject_oversized_validator_set(
+        cls, genesis_validators: list[GenesisValidatorEntry]
+    ) -> list[GenesisValidatorEntry]:
+        """
+        Bound the genesis validator set against the registry limit.
+
+        The state registry holds at most this many validators.
+        A genesis list larger than the limit can never fit on chain.
+        Each entry also triggers an XMSS public-key decode, so an unbounded
+        list lets a malicious config exhaust memory during load.
+        """
+        if len(genesis_validators) > int(VALIDATOR_REGISTRY_LIMIT):
+            raise ValueError(
+                f"genesis validator count {len(genesis_validators)} "
+                f"exceeds registry limit {int(VALIDATOR_REGISTRY_LIMIT)}"
+            )
+        return genesis_validators
 
     def to_validators(self) -> Validators:
         """

--- a/tests/node/genesis/test_config.py
+++ b/tests/node/genesis/test_config.py
@@ -9,7 +9,7 @@ import yaml
 from pydantic import ValidationError
 
 from lean_spec.node.genesis import GenesisConfig
-from lean_spec.spec.forks import ValidatorIndex
+from lean_spec.spec.forks import VALIDATOR_REGISTRY_LIMIT, ValidatorIndex
 from lean_spec.spec.ssz import Bytes52, SSZValueError, Uint64
 
 
@@ -208,6 +208,44 @@ class TestGenesisConfigValidation:
         )
         with pytest.raises(ValidationError):
             _load(yaml_content)
+
+    def test_validator_count_at_registry_limit_loads(self) -> None:
+        """Accepts a genesis set whose size equals the registry limit."""
+        config = GenesisConfig.model_validate(
+            {
+                "GENESIS_TIME": 1704085200,
+                "GENESIS_VALIDATORS": [
+                    {
+                        "attestation_public_key": SAMPLE_PUBLIC_KEY_1,
+                        "proposal_public_key": SAMPLE_PUBLIC_KEY_1,
+                    }
+                ]
+                * int(VALIDATOR_REGISTRY_LIMIT),
+            }
+        )
+
+        assert len(config.genesis_validators) == int(VALIDATOR_REGISTRY_LIMIT)
+
+    def test_validator_count_over_registry_limit_raises_error(self) -> None:
+        """Rejects a genesis set larger than the registry limit."""
+        with pytest.raises(ValidationError) as exception_info:
+            GenesisConfig.model_validate(
+                {
+                    "GENESIS_TIME": 1704085200,
+                    "GENESIS_VALIDATORS": [
+                        {
+                            "attestation_public_key": SAMPLE_PUBLIC_KEY_1,
+                            "proposal_public_key": SAMPLE_PUBLIC_KEY_1,
+                        }
+                    ]
+                    * (int(VALIDATOR_REGISTRY_LIMIT) + 1),
+                }
+            )
+
+        assert exception_info.value.errors()[0]["msg"] == (
+            f"Value error, genesis validator count {int(VALIDATOR_REGISTRY_LIMIT) + 1} "
+            f"exceeds registry limit {int(VALIDATOR_REGISTRY_LIMIT)}"
+        )
 
 
 class TestCrossClientFormat:


### PR DESCRIPTION
## Summary

The genesis validator list loaded from a YAML config was unbounded.
Each entry triggers an XMSS public-key decode, so a malicious or
malformed config could pass an arbitrarily large list and exhaust
memory during load (audit finding SEC-16).

This adds a Pydantic `field_validator` on `genesis_validators` that
bounds the count against `VALIDATOR_REGISTRY_LIMIT` (4096), the same
limit the state registry enforces. An oversized set is rejected before
any key decode runs. A set larger than the registry limit can never
fit on chain anyway, so rejecting it at load is strictly correct.

## Changes

- `src/lean_spec/node/genesis/config.py`: reject genesis validator sets
  exceeding the registry limit, with a precise error message.
- `tests/node/genesis/test_config.py`: a set at exactly the limit loads;
  a set one over the limit raises (full error message asserted).

## Testing

- `uv run pytest tests/node/genesis/test_config.py -q` — all pass.
- `just check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)