### PR TITLE
fix(gossipsub): drop non-subscribed topics and clamp payload size before caching

### DIFF
--- a/src/lean_spec/node/networking/gossipsub/behavior.py
+++ b/src/lean_spec/node/networking/gossipsub/behavior.py
@@ -65,6 +65,7 @@ from itertools import count
 from typing import ClassVar, Final, cast
 
 from lean_spec.node.networking.config import (
+    MAX_PAYLOAD_SIZE,
     MESSAGE_DOMAIN_INVALID_SNAPPY,
     MESSAGE_DOMAIN_VALID_SNAPPY,
     PRUNE_BACKOFF,
@@ -576,6 +577,12 @@ class GossipsubBehavior:
         if not message.topic:
             return
 
+        # Drop messages on topics this node does not participate in.
+        # A peer could otherwise flood arbitrary topics to fill the
+        # message cache and the event queue without ever joining our mesh.
+        if message.topic not in self.mesh.subscriptions:
+            return
+
         topic_bytes = message.topic.encode("utf-8")
 
         # Decompress once for message ID computation and event delivery.
@@ -584,6 +591,12 @@ class GossipsubBehavior:
         # The decompressed data is also passed to the event consumer,
         # eliminating a second decompression there.
         decompressed, domain = _try_decompress(message.data)
+
+        # Snappy decompression is pure Python and otherwise unbounded.
+        # Reject payloads that expand past the wire limit before caching.
+        if len(decompressed) > MAX_PAYLOAD_SIZE:
+            return
+
         message_id = GossipsubMessage.compute_id(topic_bytes, decompressed, domain=domain)
 
         # Deduplicate: each message is processed at most once.

--- a/tests/node/networking/gossipsub/test_behavior.py
+++ b/tests/node/networking/gossipsub/test_behavior.py
@@ -11,7 +11,7 @@ import time
 
 import pytest
 
-from lean_spec.node.networking.config import PRUNE_BACKOFF
+from lean_spec.node.networking.config import MAX_PAYLOAD_SIZE, PRUNE_BACKOFF
 from lean_spec.node.networking.gossipsub.behavior import (
     IDONTWANT_SIZE_THRESHOLD,
     GossipsubMessageEvent,
@@ -31,6 +31,7 @@ from lean_spec.node.networking.gossipsub.rpc import (
     SubOpts,
 )
 from lean_spec.node.networking.gossipsub.types import MessageId, Timestamp, TopicId
+from lean_spec.node.snappy import compress as snappy_compress
 from tests.node.networking.gossipsub.conftest import add_peer, make_behavior, make_peer
 
 
@@ -393,8 +394,9 @@ class TestHandleMessage:
 
     @pytest.mark.asyncio
     async def test_message_event_emitted(self) -> None:
-        """Received message emits GossipsubMessageEvent."""
+        """Received message on a subscribed topic emits GossipsubMessageEvent."""
         behavior, _ = make_behavior()
+        behavior.subscribe(TopicId("topic"))
         peer_id = add_peer(behavior, "peer1")
 
         message = Message(topic=TopicId("topic"), data=b"payload")
@@ -420,22 +422,19 @@ class TestHandleMessage:
         assert behavior._event_queue.empty()
 
     @pytest.mark.asyncio
-    async def test_not_forwarded_when_not_subscribed(self) -> None:
-        """Message is not forwarded when we're not subscribed to the topic."""
+    async def test_dropped_when_not_subscribed(self) -> None:
+        """Message on a topic we don't subscribe to is dropped, not cached or enqueued."""
         behavior, capture = make_behavior()
         peer_id = add_peer(behavior, "peer1")
 
-        # Not subscribed to "topic"
         message = Message(topic=TopicId("topic"), data=b"data")
+        message_id = GossipsubMessage.compute_id(b"topic", b"data")
         await behavior._handle_message(peer_id, message)
 
         assert capture.sent == []
-        assert behavior._event_queue.get_nowait() == GossipsubMessageEvent(
-            peer_id=peer_id,
-            topic=TopicId("topic"),
-            data=b"data",
-            message_id=GossipsubMessage.compute_id(b"topic", b"data"),
-        )
+        assert behavior._event_queue.empty()
+        assert behavior.seen_cache.has(message_id) is False
+        assert behavior.message_cache.get(message_id) is None
 
     @pytest.mark.asyncio
     async def test_idontwant_sent_for_large_messages(self) -> None:
@@ -465,6 +464,26 @@ class TestHandleMessage:
                 ),
             ),
         ]
+
+    @pytest.mark.asyncio
+    async def test_oversized_decompressed_payload_rejected(self) -> None:
+        """A payload that decompresses past the wire limit is dropped before caching."""
+        behavior, capture = make_behavior()
+        topic = TopicId("test_topic")
+        behavior.subscribe(topic)
+        peer_id = add_peer(behavior, "peer1", {topic})
+
+        # Highly compressible bytes that expand one byte past the 10 MiB cap.
+        oversized_payload = b"\x00" * (MAX_PAYLOAD_SIZE + 1)
+        compressed_payload = snappy_compress(oversized_payload)
+        message = Message(topic=topic, data=compressed_payload)
+        message_id = GossipsubMessage.compute_id(topic.encode("utf-8"), oversized_payload)
+        await behavior._handle_message(peer_id, message)
+
+        assert capture.sent == []
+        assert behavior._event_queue.empty()
+        assert behavior.seen_cache.has(message_id) is False
+        assert behavior.message_cache.get(message_id) is None
 
     @pytest.mark.asyncio
     async def test_idontwant_not_sent_for_small_messages(self) -> None:


### PR DESCRIPTION
## Summary

Audit finding SEC-15 (Minor, security). The gossipsub message handler decompressed, cached in the message cache, and enqueued an event for every incoming publish — including on topics the node does not subscribe to. The subscription check only gated forwarding, so a peer could flood distinct messages on arbitrary topics to fill the message cache and the event queue without ever joining our mesh.

Separately, Snappy decompression here is pure Python and unbounded, unlike the reqresp codec which clamps to the wire limit. A peer could ship a small compressed payload that expands far past that limit.

## Changes

- Return early in the message handler when the topic is not in our subscriptions, before any caching or enqueuing.
- Reject payloads whose decompressed size exceeds the wire limit (`MAX_PAYLOAD_SIZE`, 10 MiB), before caching.

## Tests

- `test_dropped_when_not_subscribed`: a message on a non-subscribed topic is not forwarded, not enqueued, not in the seen cache, and not in the message cache.
- `test_oversized_decompressed_payload_rejected`: a small compressed payload that decompresses one byte past the wire limit is dropped before caching.
- `test_message_event_emitted` now subscribes to the topic, matching the new model where only subscribed topics are processed.

`uv run pytest tests/node/networking/gossipsub/test_behavior.py` (56 passed) and `just check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)