### PR TITLE
fix(reqresp): re-check length on stream-closed decompress fallback

### DIFF
--- a/src/lean_spec/node/networking/reqresp/handler.py
+++ b/src/lean_spec/node/networking/reqresp/handler.py
@@ -481,11 +481,18 @@ class ReqRespServer:
 
             chunk = await stream.read()
             if not chunk:
-                # Stream closed, try one more decompress
+                # Stream closed, try one final decompress.
+                # The decompressed payload must still match the declared length.
+                # A short or failed decode means the request is incomplete.
+                # Return empty so the caller raises a clean INVALID_REQUEST,
+                # never the raw length-prefixed buffer as if it were SSZ.
                 try:
-                    return frame_decompress(bytes(compressed_data))
+                    decompressed = frame_decompress(bytes(compressed_data))
                 except SnappyDecompressionError:
-                    return bytes(buffer)
+                    return b""
+                if len(decompressed) == declared_length:
+                    return decompressed
+                return b""
             compressed_data.extend(chunk)
 
     async def _dispatch(

--- a/tests/node/networking/reqresp/test_handler.py
+++ b/tests/node/networking/reqresp/test_handler.py
@@ -32,6 +32,7 @@ from lean_spec.node.networking.reqresp.message import (
 )
 from lean_spec.node.networking.types import ProtocolId
 from lean_spec.node.networking.varint import encode_varint
+from lean_spec.node.snappy import frame_compress
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Checkpoint, Slot
 from lean_spec.spec.forks.lstar.containers import SignedBlock
@@ -1199,6 +1200,47 @@ class TestReadRequestBufferLimit:
 
         code, _ = ResponseCode.decode(stream.written[0])
         assert code == ResponseCode.INVALID_REQUEST
+
+
+class TestReadRequestStreamClosedFallback:
+    """Tests for the stream-closed decompress fallback in _read_request."""
+
+    async def test_stream_closed_decompress_length_mismatch_returns_empty(self) -> None:
+        """A decompressed length below the declared length yields empty bytes."""
+        server = ReqRespServer(handler=RequestHandler(our_status=make_test_status()))
+
+        # The frame decompresses to 5 bytes, but the prefix declares 9999.
+        # The in-loop check at line 474 rejects the mismatch and reads on.
+        # The stream then closes, and the fallback must reject the short payload.
+        compressed_frame = frame_compress(b"short")
+        wire_bytes = encode_varint(9999) + compressed_frame
+        stream = MockChunkedStream(chunks=[wire_bytes])
+
+        assert await server._read_request(stream) == b""
+
+    async def test_stream_closed_decompress_failure_returns_empty(self) -> None:
+        """A truncated frame that never decompresses yields empty bytes."""
+        server = ReqRespServer(handler=RequestHandler(our_status=make_test_status()))
+
+        # Drop the final byte so the frame is incomplete and always fails to decode.
+        # The in-loop decode raises, the stream closes, and the fallback decode raises again.
+        # The fallback must return empty, never the raw length-prefixed buffer.
+        compressed_frame = frame_compress(b"payload")
+        wire_bytes = encode_varint(7) + compressed_frame[:-1]
+        stream = MockChunkedStream(chunks=[wire_bytes])
+
+        assert await server._read_request(stream) == b""
+
+    async def test_full_frame_decompresses_to_declared_payload(self) -> None:
+        """A complete frame matching the declared length yields the payload."""
+        server = ReqRespServer(handler=RequestHandler(our_status=make_test_status()))
+
+        # The declared length matches the decompressed payload, so the read succeeds.
+        compressed_frame = frame_compress(b"payload")
+        wire_bytes = encode_varint(7) + compressed_frame
+        stream = MockChunkedStream(chunks=[wire_bytes])
+
+        assert await server._read_request(stream) == b"payload"
 
 
 class TestBlocksByRangeRequestRoundTrip:


### PR DESCRIPTION
## Summary

The stream-closed branch of the inbound ReqResp request reader had two defects:

- It returned the result of a final decompress without re-checking the decompressed length against the declared length prefix.
- On a decode failure it returned the raw `buffer` (length prefix + compressed bytes) as if it were the decoded SSZ payload.

Either path could hand a malformed or short payload to the request dispatcher.

## Fix

On the stream-closed fallback, verify the decompressed length equals the declared length. Return empty bytes on a length mismatch or a decode failure, so the caller raises a clean INVALID_REQUEST instead of treating partial wire bytes as SSZ.

## Tests

Three new tests against the request reader exercise the fallback:

- A decompressed length below the declared length returns empty bytes.
- A truncated frame that never decompresses returns empty bytes.
- A complete frame matching the declared length still returns the payload.

`just check` passes; the mirrored handler test file passes in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)