### PR TITLE
docs(sync): document order-invariance of block-deconstruction proof folding

### DIFF
--- a/src/lean_spec/node/sync/service.py
+++ b/src/lean_spec/node/sync/service.py
@@ -615,6 +615,16 @@ class SyncService:
                 )
 
                 if local_proofs:
+                    # The local proofs arrive in set-iteration order.
+                    # That order is not stable across nodes.
+                    # Folding them stays order-invariant for consensus.
+                    #
+                    # The merged participant bitfield is positional and ascending.
+                    # It names the same validators regardless of child order.
+                    #
+                    # Folding may emit byte-distinct proofs across orderings.
+                    # Every ordering verifies against that same canonical key set.
+                    # No consensus rule compares these re-merged proofs by bytes.
                     combined = SingleMessageAggregate.aggregate(
                         children=[
                             (


### PR DESCRIPTION
## Finding investigated

Audit finding SEC-12 (Minor, safety, LOW confidence): the local single-message proofs folded after block deconstruction are extended from set-valued pools, so set-iteration order flows into the aggregation call. The concern was that if the fold were order-sensitive, two honest nodes could diverge on the merged proof.

## Order-sensitivity conclusion: order-INVARIANT (for consensus)

I inspected the call site, the aggregate primitive, and the underlying Rust binding, then verified behaviorally with the test prover.

- The Rust binding sorts public keys internally (it returns `(sorted_pks_ssz, proof_bytes)`), and the participant bitfield is built positionally in ascending order, so the merged participant set is identical regardless of child order. This is the consensus-relevant output that drives fork-choice weight and block production.
- Empirically folding the same children in different orders yields the same participants and a proof that always verifies against the same canonical key set.
- The merged proof BYTES are not byte-deterministic across orderings. This is harmless: no consensus rule compares these locally re-merged proofs by bytes. A merged proof is either re-verified by peers (any byte form verifies) or carried in a block authored by a single proposer (its hash-tree-root is that proposer's alone, never re-derived by importers).

Because the fold is order-invariant in the only sense that matters for consensus, no behavior change is warranted. Per the audit instructions, the resolution is a documenting comment making the order-invariance assumption explicit at the call site, so a future reader does not mistake the set-iteration ordering for a latent divergence bug.

## Change

A comment-only clarification at the fold call site. No behavior change. All sync service unit tests pass and `just check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)