### PR TITLE
fix(sync): use typed exception for unknown-target attestation buffering

### DIFF
--- a/packages/testing/src/consensus_testing/mocks.py
+++ b/packages/testing/src/consensus_testing/mocks.py
@@ -18,7 +18,13 @@ from lean_spec.node.sync.block_cache import BlockCache
 from lean_spec.node.sync.peer_manager import PeerManager
 from lean_spec.node.sync.service import SyncService
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import Checkpoint, Slot, ValidatorIndex
+from lean_spec.spec.forks import (
+    Checkpoint,
+    RejectionReason,
+    Slot,
+    SpecRejectionError,
+    ValidatorIndex,
+)
 from lean_spec.spec.forks.lstar import Store
 from lean_spec.spec.forks.lstar.containers import (
     Block,
@@ -164,10 +170,15 @@ class MockForkchoiceStore:
     """Post-state of each block, keyed by root."""
 
     reject_attestation: Callable[[SignedAttestation], bool] | None = None
-    """When it returns true for an attestation, processing raises instead."""
+    """When it returns true for an attestation, processing raises a spec rejection."""
 
     reject_aggregated_attestation: Callable[[SignedAggregatedAttestation], bool] | None = None
-    """When it returns true for an aggregate, processing raises instead."""
+    """When it returns true for an aggregate, processing raises a spec rejection."""
+
+    rejection_reason: RejectionReason = RejectionReason.UNKNOWN_TARGET_BLOCK
+    """Reason carried by a triggered rejection.
+    The default names a missing block, which the sync service buffers for replay.
+    Set a permanent reason to exercise the logged-and-dropped path."""
 
     on_block_post_state: State | None = None
     """Post-state recorded for each processed block, when set."""
@@ -214,7 +225,7 @@ class MockForkchoiceStore:
     ) -> MockForkchoiceStore:
         """Record a gossip attestation, unless the reject predicate fires."""
         if self.reject_attestation is not None and self.reject_attestation(signed_attestation):
-            raise KeyError("simulated missing block")
+            raise SpecRejectionError(self.rejection_reason, "simulated rejection")
         self.received_attestations.append(signed_attestation)
         return self
 
@@ -227,7 +238,7 @@ class MockForkchoiceStore:
         if self.reject_aggregated_attestation is not None and self.reject_aggregated_attestation(
             signed_attestation
         ):
-            raise KeyError("simulated missing block")
+            raise SpecRejectionError(self.rejection_reason, "simulated rejection")
         self.received_aggregated_attestations.append(signed_attestation)
         return self
 

--- a/src/lean_spec/node/sync/service.py
+++ b/src/lean_spec/node/sync/service.py
@@ -28,10 +28,12 @@ from lean_spec.spec.forks import (
     AttestationData,
     Block,
     LstarSpec,
+    RejectionReason,
     SignedAggregatedAttestation,
     SignedAttestation,
     SignedBlock,
     Slot,
+    SpecRejectionError,
     Store,
 )
 from lean_spec.spec.forks.lstar.containers import (
@@ -41,6 +43,26 @@ from lean_spec.spec.forks.lstar.containers import (
 from lean_spec.spec.ssz import Bytes32
 
 logger = logging.getLogger(__name__)
+
+
+class UnknownAttestationBlockError(Exception):
+    """
+    An attestation references a source, target, or head block the store has not seen.
+
+    A later block can still supply the missing block.
+    The sync service buffers the attestation and replays it after the next block.
+    This is the only attestation rejection worth retrying, so it carries its own type.
+    """
+
+
+BUFFERABLE_REJECTION_REASONS: frozenset[RejectionReason] = frozenset(
+    {
+        RejectionReason.UNKNOWN_SOURCE_BLOCK,
+        RejectionReason.UNKNOWN_TARGET_BLOCK,
+        RejectionReason.UNKNOWN_HEAD_BLOCK,
+    }
+)
+"""Rejections a later block can resolve, so the attestation is worth replaying."""
 
 
 @dataclass(slots=True)
@@ -399,13 +421,11 @@ class SyncService:
 
         # The store validates the signature and updates branch weights.
         #
-        # Failures are logged and the event loop continues.
+        # A missing block buffers for replay.
+        # Any permanent rejection is logged and dropped.
+        # A genuine bug raises some other exception and propagates uncaught.
         try:
-            self.store = self.spec.on_gossip_attestation(
-                self.store,
-                signed_attestation=attestation,
-                is_aggregator=is_aggregator_role,
-            )
+            self.store = self._integrate_gossip_attestation(attestation, is_aggregator_role)
             metrics.lean_attestations_valid_total.labels(source="gossip").inc()
             logger.info(
                 "Attestation from peer %s slot=%s validator=%s: validation and signature ok",
@@ -413,19 +433,26 @@ class SyncService:
                 slot,
                 validator_index,
             )
-        except (AssertionError, KeyError) as exception:
+        except UnknownAttestationBlockError as missing_block:
             metrics.lean_attestations_invalid_total.labels(source="gossip").inc()
             logger.warning(
-                "Attestation from peer %s slot=%s validator=%s: validation or signature failed: %s",
+                "Attestation from peer %s slot=%s validator=%s: %s",
                 peer_str,
                 slot,
                 validator_index,
-                exception,
+                missing_block,
             )
-            # Target block has not arrived yet; buffer for post-block replay.
-            #
             # Cap drops oldest on overflow: newer attestations are likelier to land soon.
             self._pending_attestations.append(attestation)
+        except SpecRejectionError as rejection:
+            metrics.lean_attestations_invalid_total.labels(source="gossip").inc()
+            logger.warning(
+                "Attestation from peer %s slot=%s validator=%s: rejected: %s",
+                peer_str,
+                slot,
+                validator_index,
+                rejection,
+            )
 
     async def on_gossip_aggregated_attestation(
         self,
@@ -449,25 +476,71 @@ class SyncService:
         # - verifies the aggregated signature,
         # - credits weight to every validator covered by the aggregate.
         #
-        # Failures are logged and the event loop continues.
+        # A missing block buffers for replay.
+        # Any permanent rejection is logged and dropped.
+        # A genuine bug raises some other exception and propagates uncaught.
         try:
-            self.store = self.spec.on_gossip_aggregated_attestation(self.store, signed_attestation)
+            self.store = self._integrate_gossip_aggregated_attestation(signed_attestation)
             logger.info(
                 "Aggregated attestation from peer %s slot=%s: validation and signature ok",
                 peer_str,
                 slot,
             )
-        except (AssertionError, KeyError) as exception:
+        except UnknownAttestationBlockError as missing_block:
             logger.warning(
-                "Aggregated attestation from peer %s slot=%s: validation or signature failed: %s",
+                "Aggregated attestation from peer %s slot=%s: %s",
                 peer_str,
                 slot,
-                exception,
+                missing_block,
             )
-            # Target block has not arrived yet; buffer for post-block replay.
-            #
             # Cap drops oldest on overflow: newer aggregates are likelier to land soon.
             self._pending_aggregated_attestations.append(signed_attestation)
+        except SpecRejectionError as rejection:
+            logger.warning(
+                "Aggregated attestation from peer %s slot=%s: rejected: %s",
+                peer_str,
+                slot,
+                rejection,
+            )
+
+    def _integrate_gossip_attestation(
+        self,
+        attestation: SignedAttestation,
+        is_aggregator_role: bool,
+    ) -> Store:
+        """
+        Process a single-validator attestation, flagging a missing block as retryable.
+
+        A rejection naming an unseen source, target, or head block becomes the retryable type.
+        Every other rejection propagates unchanged, and so does any genuine bug.
+        """
+        try:
+            return self.spec.on_gossip_attestation(
+                self.store,
+                signed_attestation=attestation,
+                is_aggregator=is_aggregator_role,
+            )
+        except SpecRejectionError as rejection:
+            if rejection.reason in BUFFERABLE_REJECTION_REASONS:
+                raise UnknownAttestationBlockError(str(rejection)) from rejection
+            raise
+
+    def _integrate_gossip_aggregated_attestation(
+        self,
+        signed_attestation: SignedAggregatedAttestation,
+    ) -> Store:
+        """
+        Process an aggregated attestation, flagging a missing block as retryable.
+
+        A rejection naming an unseen source, target, or head block becomes the retryable type.
+        Every other rejection propagates unchanged, and so does any genuine bug.
+        """
+        try:
+            return self.spec.on_gossip_aggregated_attestation(self.store, signed_attestation)
+        except SpecRejectionError as rejection:
+            if rejection.reason in BUFFERABLE_REJECTION_REASONS:
+                raise UnknownAttestationBlockError(str(rejection)) from rejection
+            raise
 
     def _replay_pending_attestations(self) -> None:
         """Retry buffered attestations after a block is processed."""
@@ -476,35 +549,35 @@ class SyncService:
 
         # Drain the queue into a local and iterate it.
         # Successful retries disappear into the store.
-        # Failed retries re-append to the now-empty field.
+        # Retries whose block is still missing re-append to the now-empty field.
         #
         # Example: queue is [A (target=T1), B (target=T2)]; a block carrying T1 just landed.
         #   - A succeeds: T1 is in the store, A is consumed.
         #   - B fails:    T2 still missing, B is re-appended.
         # Post-loop queue: [B].
+        #
+        # A retry that became permanently invalid is dropped, not re-buffered.
+        # A genuine bug raises some other exception and propagates uncaught.
         pending = self._pending_attestations
         self._pending_attestations = deque(maxlen=MAX_PENDING_ATTESTATIONS)
         for attestation in pending:
             try:
-                self.store = self.spec.on_gossip_attestation(
-                    self.store,
-                    signed_attestation=attestation,
-                    is_aggregator=is_aggregator_role,
-                )
-            except (AssertionError, KeyError):
-                # Block still missing; preserve for the next replay cycle.
+                self.store = self._integrate_gossip_attestation(attestation, is_aggregator_role)
+            except UnknownAttestationBlockError:
                 self._pending_attestations.append(attestation)
+            except SpecRejectionError:
+                pass
 
         # Same mechanism for aggregated attestations.
         pending_aggregate = self._pending_aggregated_attestations
         self._pending_aggregated_attestations = deque(maxlen=MAX_PENDING_ATTESTATIONS)
         for signed_attestation in pending_aggregate:
             try:
-                self.store = self.spec.on_gossip_aggregated_attestation(
-                    self.store, signed_attestation
-                )
-            except (AssertionError, KeyError):
+                self.store = self._integrate_gossip_aggregated_attestation(signed_attestation)
+            except UnknownAttestationBlockError:
                 self._pending_aggregated_attestations.append(signed_attestation)
+            except SpecRejectionError:
+                pass
 
     def _deconstruct_block_into_store(
         self,

--- a/tests/node/sync/test_service.py
+++ b/tests/node/sync/test_service.py
@@ -26,12 +26,19 @@ from lean_spec.node.sync.service import SyncService
 from lean_spec.node.sync.states import SyncState
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.crypto.xmss.containers import PublicKey
-from lean_spec.spec.forks import Checkpoint, Interval, Slot, ValidatorIndex
+from lean_spec.spec.forks import (
+    Checkpoint,
+    Interval,
+    RejectionReason,
+    Slot,
+    ValidatorIndex,
+)
 from lean_spec.spec.forks.lstar import Store
 from lean_spec.spec.forks.lstar.containers import (
     AttestationData,
     MultiMessageAggregate,
     SignedAggregatedAttestation,
+    SignedAttestation,
     SignedBlock,
     SingleMessageAggregate,
 )
@@ -377,6 +384,46 @@ class TestAttestationGossipHandling:
         await sync_service.on_gossip_attestation(attestation)
 
         assert list(sync_service._pending_attestations) == [attestation]
+
+    async def test_attestation_dropped_when_permanently_rejected(
+        self,
+        sync_service: SyncService,
+    ) -> None:
+        """Attestation rejected for a non-block reason is dropped, not buffered."""
+        sync_service.state = SyncState.SYNCING
+
+        # A bad signature can never be fixed by a later block.
+        mock_store = cast(MockForkchoiceStore, sync_service.store)
+        mock_store.rejection_reason = RejectionReason.INVALID_SIGNATURE
+        mock_store.reject_attestation = lambda _attestation: True
+
+        target = Checkpoint(root=sync_service.store.head, slot=Slot(0))
+        attestation = make_signed_attestation(validator=ValidatorIndex(0), target=target)
+
+        await sync_service.on_gossip_attestation(attestation)
+
+        assert list(sync_service._pending_attestations) == []
+
+    async def test_attestation_genuine_error_propagates(
+        self,
+        sync_service: SyncService,
+    ) -> None:
+        """A non-rejection error from processing propagates instead of being buffered."""
+        sync_service.state = SyncState.SYNCING
+
+        def raise_indexing_bug(_attestation: SignedAttestation) -> bool:
+            raise RuntimeError("indexing bug")
+
+        mock_store = cast(MockForkchoiceStore, sync_service.store)
+        mock_store.reject_attestation = raise_indexing_bug
+
+        target = Checkpoint(root=sync_service.store.head, slot=Slot(0))
+        attestation = make_signed_attestation(validator=ValidatorIndex(0), target=target)
+
+        with pytest.raises(RuntimeError) as exception_info:
+            await sync_service.on_gossip_attestation(attestation)
+        assert str(exception_info.value) == "indexing bug"
+        assert list(sync_service._pending_attestations) == []
 
     async def test_buffered_attestation_replayed_after_block(
         self,
@@ -735,11 +782,12 @@ class TestAggregatedAttestationGossip:
         mock_store = cast(MockForkchoiceStore, sync_service.store)
         assert mock_store.received_aggregated_attestations == [signed]
 
-    async def test_aggregated_buffered_on_key_error(
+    async def test_aggregated_buffered_when_block_unknown(
         self,
         sync_service: SyncService,
         key_manager: XmssKeyManager,
     ) -> None:
+        """Aggregated attestation naming an unseen block is buffered for replay."""
         sync_service.state = SyncState.SYNCING
         signed = _signed_aggregated_attestation(key_manager)
 


### PR DESCRIPTION
## Summary

The gossip attestation and replay paths in the sync service caught `(AssertionError, KeyError)` to mean "the referenced block has not arrived yet, buffer it for post-block replay." That net was too wide and had two safety defects:

- `SpecRejectionError` subclasses `AssertionError`, so **every** permanent rejection (bad signature, slot mismatch, attestation too far in future) was buffered and replayed indefinitely even though no later block could ever make it valid.
- A genuine `KeyError` from an indexing bug was silently re-buffered as "block missing" instead of surfacing, masking the bug. `AssertionError`-based validation is also stripped under `python -O`.

## Change

- Add a typed domain exception `UnknownAttestationBlockError` that does **not** subclass `ValueError`, `TypeError`, or `AssertionError`.
- A thin wrapper around each spec call translates **only** the unknown source/target/head block rejection reasons into that typed exception. Every other `SpecRejectionError` propagates unchanged, and any non-rejection exception propagates as a genuine bug.
- The live gossip handlers and the replay loop now buffer **only** on the typed exception, log-and-drop other rejections, and let genuine bugs surface uncaught.

## Tests

- Mirrored unit tests in `tests/node/sync/test_service.py`:
  - An unknown-block attestation is buffered via the typed exception path (existing coverage, renamed the mis-named aggregated case).
  - A permanently-rejected attestation (invalid signature) is dropped, not buffered.
  - A non-rejection error from processing propagates and is asserted with the full message, never swallowed.
- The forkchoice store test double now raises the real `SpecRejectionError` with a configurable reason instead of a bare `KeyError`, so tests exercise the production exception path.

`just check` is clean; `tests/node/sync/` passes (144 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)