### PR TITLE
docs(fork-choice): document attestation signature pool growth bound

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/store.py
+++ b/src/lean_spec/spec/forks/lstar/containers/store.py
@@ -61,7 +61,25 @@ class Store[StateT: Container, BlockT: Container](StrictBaseModel):
     attestation_signatures: dict[AttestationData, set[AttestationSignatureEntry]] = Field(
         default_factory=dict
     )
-    """Per-validator signatures observed, grouped by the vote they sign."""
+    """
+    Per-validator signatures observed, grouped by the vote they sign.
+
+    This pool only shrinks when finalization advances.
+    Pruning drops every vote whose head sits at or below the finalized slot.
+    Between two finalizations the set of distinct vote keys can keep growing.
+
+    A staked validator holds one key entry per distinct vote it signs.
+    The vote's head may be any block descending from the finalized block.
+    During a long non-finalizing window the number of such blocks is unbounded.
+    Each new head a validator signs adds a fresh key here.
+    The signature is verified before insertion, so the writer pays that cost first.
+    The growth is a resource bound, not a safety break.
+
+    The spec sets no cap on this pool.
+    A hard cap would change attestation acceptance and could diverge from the reference.
+    Bounding memory during a non-finalizing window is a node-implementation responsibility.
+    A node may cap retained keys, evict by age, or apply its own admission policy.
+    """
 
     latest_new_aggregated_payloads: dict[AttestationData, set[SingleMessageAggregate]] = Field(
         default_factory=dict


### PR DESCRIPTION
## Summary

Resolves audit finding SEC-08 (Minor, security, medium confidence).

The per-validator attestation signature pool in the fork-choice store is keyed by attestation data and pruned only when finalization advances. During a non-finalizing window, a staked validator can vary the vote head across every block descending from the finalized block, growing the map by one distinct key per head. The signature is verified before insertion, so the writer pays that cost first, but the pool is unbounded until the next finalization.

## Resolution

This is a resource bound, not a safety break. The safest spec-level fix is to document the bound rather than introduce a consensus-affecting cap.

A hard cap on distinct keys would change attestation acceptance and risk diverging from the reference, so none is added. Instead, the pool field now documents:

- the growth is unbounded until finalization advances,
- the signature is verified before insertion,
- this is a resource bound, not a safety break,
- bounding memory during a non-finalizing window is a node-implementation responsibility.

## Testing

Documentation-only change with no effect on acceptance behavior, so no consensus vector is required. `just check` passes (lint, format, type check, spell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)