### PR TITLE
refactor(lstar): rename except-as-e to exception in state.py

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/state.py
+++ b/src/lean_spec/spec/forks/lstar/containers/state.py
@@ -61,11 +61,11 @@ class JustifiedSlots(BaseBitlist):
         # If the caller asks for a slot too far in the future, it indicates a logic error.
         try:
             return self[relative_index]
-        except IndexError as e:
+        except IndexError as exception:
             raise IndexError(
                 f"Slot {target_slot} is outside the tracked range "
                 f"(finalized_boundary={finalized_slot}, tracked_length={len(self)})"
-            ) from e
+            ) from exception
 
     def extend_to_slot(self, finalized_slot: Slot, target_slot: Slot) -> Self:
         """


### PR DESCRIPTION
## Summary

Rename the caught exception variable from the single-letter `e` to the fully spelled-out `exception` in the justified-slots range lookup.

This follows the no-abbreviations convention for the reference spec: `except ... as e` becomes `except ... as exception`, and the `raise ... from e` chain is updated to match.

Pure rename. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)