### PR TITLE
docs(networking): remove banned # Why: label in live.py

### DIFF
--- a/src/lean_spec/node/networking/client/event_source/live.py
+++ b/src/lean_spec/node/networking/client/event_source/live.py
@@ -730,7 +730,6 @@ class LiveNetworkEventSource:
             peer_id: Peer identifier.
             connection: QuicConnection to use.
         """
-        # Why:
         # The dialing path and the inbound-stream handler can both reach this
         # method concurrently for the same peer.
         # The lock serialises the check-and-open so only one stream is opened.


### PR DESCRIPTION
Removes the banned `# Why:` comment label from the gossipsub outbound-stream setup path.

The documentation rules ban the `# Why:` label: a comment exists only when the reason is non-obvious, so the label is redundant noise. The rationale is preserved verbatim as plain-prose comment lines directly above the lock setup.

Pure comment change. No behavior change. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)