### PR TITLE
docs(validator): remove banned # Why: labels

### DIFF
--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -609,18 +609,15 @@ class ValidatorService:
 
         # Saturate at zero lag when the head is ahead of wall clock.
         #
-        # Why:
-        #     Local clock drift is normal. Unconditional trust would let
-        #     a chain 100 slots in the future bypass every check.
+        # Local clock drift is normal.
+        # Unconditional trust would let a chain 100 slots in the future bypass every check.
         lag = 0 if head_slot >= slot else int(slot - head_slot)
 
         # Local stall evidence from the block map.
         #
-        # Why:
-        #     Only blocks with valid signatures enter the map, so the
-        #     freshest entry is an authenticated lower bound on the
-        #     network tip. A stale max here means the network is not
-        #     producing.
+        # Only blocks with valid signatures enter the map.
+        # So the freshest entry is an authenticated lower bound on the network tip.
+        # A stale max here means the network is not producing.
         max_seen_slot = max(
             (b.slot for b in store.blocks.values()),
             default=head_slot,


### PR DESCRIPTION
Removes two banned `# Why:` comment labels in the validator duty-gating helper.

The documentation rules ban the `# Why:` label: a comment exists only when the reason is non-obvious, so the label is redundant noise. The rationale is preserved as plain-prose comment lines, one sentence per line per the documentation rules.

Pure comment change. No behavior change. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)