### PR TITLE
docs(testing): remove banned Why: labels

### DIFF
--- a/packages/testing/src/consensus_testing/cli/fill.py
+++ b/packages/testing/src/consensus_testing/cli/fill.py
@@ -75,7 +75,7 @@ def fill(
         # Use specific XMSS scheme (overrides LEAN_ENV env var)
         fill --fork=Lstar --scheme=prod --clean -v
     """
-    # Why: the spec config reads this flag once, at import time.
+    # The spec config reads this flag once, at import time.
     # The current process froze the old value when the package imported.
     # Only the pytest subprocess below starts fresh and sees this export.
     os.environ["LEAN_ENV"] = scheme.lower()
@@ -91,7 +91,7 @@ def fill(
     if not (keys_directory.exists() and any(keys_directory.glob("*.json"))):
         click.echo(f"Test keys for '{scheme}' scheme not found. Downloading...")
         download_keys(scheme.lower())
-    # Why: stale or modified local keys would silently change every vector.
+    # Stale or modified local keys would silently change every vector.
     elif compute_key_set_digest(keys_directory) != PINNED_KEY_SET_DIGESTS[scheme.lower()]:
         click.echo(f"Local '{scheme}' keys do not match the pinned key set. Re-downloading...")
         download_keys(scheme.lower())

--- a/packages/testing/src/consensus_testing/pytest_plugins/filler.py
+++ b/packages/testing/src/consensus_testing/pytest_plugins/filler.py
@@ -346,7 +346,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     A signature must depend only on the key, the slot, and the message.
     Prior signing activity must never influence the bytes.
 
-    Why: a scheme change breaking this invariant must abort the fill.
+    A scheme change breaking this invariant must abort the fill.
     Emitting order-dependent vectors would be worse than failing.
 
     Under sharded runs every worker process probes its own key state.

--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -34,7 +34,7 @@ class FixtureInfo(StrictBaseModel):
     """
     Digest of the XMSS key set used during generation.
 
-    Why: consumers can detect vectors generated from a different key set.
+    Consumers can detect vectors generated from a different key set.
     """
 
 

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -490,7 +490,7 @@ class ForkChoiceTest(BaseTestSpec):
             "steps must be empty when anchor_valid is False: "
             "Store.from_anchor is expected to fail before any step can run"
         )
-        # Why: a vector saying only "reject this anchor" lets a client
+        # A vector saying only "reject this anchor" lets a client
         # reject for the wrong reason and still pass.
         assert self.expected_rejection is not None, (
             "anchor_valid=False requires expected_rejection to be set"

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -58,7 +58,7 @@ class BaseForkChoiceStep(CamelModel):
         """
         Require a declared rejection on every step expected to fail.
 
-        Why: a vector saying only "reject this" lets a client reject
+        A vector saying only "reject this" lets a client reject
         for the wrong reason and still pass.
         """
         if not self.valid and self.expected_rejection is None:

--- a/packages/testing/src/consensus_testing/test_types/store_snapshot.py
+++ b/packages/testing/src/consensus_testing/test_types/store_snapshot.py
@@ -84,7 +84,7 @@ class StoreSnapshot(StrictBaseModel):
     """
     Every block root the store retains, ascending.
 
-    Why: pruning behavior stays invisible without the full membership.
+    Pruning behavior stays invisible without the full membership.
     An over- or under-pruning client must fail here.
     """
 
@@ -93,9 +93,9 @@ class StoreSnapshot(StrictBaseModel):
     Fork-choice weight per block above the finalized slot, ascending by root.
 
     Zero-weight blocks are included.
-    Why: two clients can agree on the head while holding divergent
-    weights, then split on the next attestation. The weights drive
-    head selection and must match exactly.
+    Two clients can agree on the head while holding divergent weights.
+    They then split on the next attestation.
+    The weights drive head selection and must match exactly.
     """
 
     attestation_signatures: list[AttestationPoolEntry]


### PR DESCRIPTION
Removes the banned `Why:` labels from the consensus testing package (9 sites across 6 files).

The documentation rules ban the `Why:` label: a comment or docstring exists only when the reason is non-obvious, so the label is redundant noise. Every rationale is preserved as plain prose, one sentence per line.

Files touched:
- test_types/store_snapshot.py (2 sites)
- test_types/step_types.py
- test_fixtures/fork_choice.py
- test_fixtures/base.py
- cli/fill.py (2 sites)
- pytest_plugins/filler.py

Pure comment/docstring change. No behavior change. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)