### PR TITLE
docs(testing): remove banned Example: block from state_expectation docstring

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/state_expectation.py
+++ b/packages/testing/src/consensus_testing/test_types/state_expectation.py
@@ -26,13 +26,6 @@ class StateExpectation(SelectiveCheck):
 
     This allows test writers to specify only the fields they care about,
     making tests more focused and maintainable.
-
-    Example:
-        # Only validate slot and justified checkpoint
-        StateExpectation(
-            slot=Slot(10),
-            latest_justified_slot=Slot(8),
-        )
     """
 
     _SCALAR_ACCESSORS: ClassVar[dict[str, Callable[["State"], Any]]] = {


### PR DESCRIPTION
Removes the banned `Example:` code block from the state expectation docstring.

The documentation and code-style rules ban `Example:` code blocks in docstrings: unit tests serve as usage examples. The concise prose description of selective validation is preserved.

Pure docstring change. No behavior change. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)