### PR TITLE
fix(xmss): pin signature list lengths on deserialization

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/containers.py
+++ b/src/lean_spec/spec/crypto/xmss/containers.py
@@ -1,8 +1,8 @@
 """Generalized XMSS containers."""
 
-from typing import override
+from typing import Self, override
 
-from pydantic import model_serializer
+from pydantic import model_serializer, model_validator
 
 from lean_spec.base import StrictBaseModel
 from lean_spec.spec.crypto.xmss.constants import TARGET_CONFIG
@@ -18,6 +18,7 @@ from lean_spec.spec.crypto.xmss.types import (
 from lean_spec.spec.forks.lstar.slot import Slot
 from lean_spec.spec.ssz import Uint64
 from lean_spec.spec.ssz.container import Container
+from lean_spec.spec.ssz.exceptions import SSZSerializationError
 
 
 class HexSerializedContainer(Container):
@@ -40,7 +41,29 @@ class PublicKey(HexSerializedContainer):
 
 
 class Signature(HexSerializedContainer):
-    """A single XMSS signature for one slot and message under one public key."""
+    """
+    A single XMSS signature for one slot and message under one public key.
+
+    # Fixed size on the wire
+
+    Two fields hold variable-length lists at the type level:
+
+    - the authentication path siblings,
+    - the released Winternitz chain hashes.
+
+    Yet every valid signature pins both lengths to scheme constants:
+
+    - one sibling per tree level, so exactly LOG_LIFETIME siblings,
+    - one released hash per chain, so exactly DIMENSION hashes.
+
+    The encoded byte length is therefore the same constant for every signature.
+
+    Inherited container decoding reads each list through an attacker-controlled
+    offset, so distinct byte strings of equal length could otherwise decode to
+    signatures whose lists hold the wrong number of digests.
+    A post-construction check rejects any signature off these two lengths,
+    so the fixed-size declaration holds and the SSZ root pins one encoding.
+    """
 
     path: HashTreeOpening
     """Authentication path from the one-time key up to the Merkle root."""
@@ -51,10 +74,29 @@ class Signature(HexSerializedContainer):
     hashes: HashDigestList
     """Released Winternitz chain hashes that form the one-time signature."""
 
+    @model_validator(mode="after")
+    def _check_list_lengths(self) -> Self:
+        """Pin the two variable-length lists to their scheme-constant counts."""
+        sibling_count = len(self.path.siblings)
+        if sibling_count != TARGET_CONFIG.LOG_LIFETIME:
+            raise SSZSerializationError(
+                f"Signature.path.siblings requires exactly {TARGET_CONFIG.LOG_LIFETIME} "
+                f"siblings, got {sibling_count}"
+            )
+
+        hash_count = len(self.hashes)
+        if hash_count != TARGET_CONFIG.DIMENSION:
+            raise SSZSerializationError(
+                f"Signature.hashes requires exactly {TARGET_CONFIG.DIMENSION} hashes, "
+                f"got {hash_count}"
+            )
+
+        return self
+
     @classmethod
     @override
     def is_fixed_size(cls) -> bool:
-        """Always fixed-size on the wire (see class docstring for why)."""
+        """Always fixed-size on the wire (see class docstring)."""
         return True
 
     @classmethod

--- a/tests/spec/crypto/xmss/test_containers.py
+++ b/tests/spec/crypto/xmss/test_containers.py
@@ -1,5 +1,6 @@
 """Behaviour tests for the XMSS containers."""
 
+import io
 import json
 
 import pytest
@@ -16,8 +17,12 @@ from lean_spec.spec.crypto.xmss.containers import (
     ValidatorKeyPair,
 )
 from lean_spec.spec.crypto.xmss.interface import TEST_SIGNATURE_SCHEME
+from lean_spec.spec.crypto.xmss.types import HashDigestList, HashTreeOpening
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.ssz import Bytes32, Uint64
+from lean_spec.spec.ssz.exceptions import SSZSerializationError
+from lean_spec.spec.ssz.ssz_base import BYTES_PER_LENGTH_OFFSET
+from lean_spec.spec.ssz.uint import Uint32
 
 
 @pytest.fixture(scope="module")
@@ -345,3 +350,39 @@ def test_signature_decodes_from_json(sample_signature: Signature) -> None:
     """A signature decodes back from its JSON hex form."""
     encoded = "0x" + sample_signature.encode_bytes().hex()
     assert Signature.from_hex(encoded) == sample_signature
+
+
+def test_signature_rejects_too_few_hashes(sample_signature: Signature) -> None:
+    """Bytes whose released-hash list is one digest short fail to decode."""
+    # The hash list is the final field, so dropping the trailing digest leaves a
+    # well-formed payload that decodes to one fewer hash than the scheme dimension.
+    one_digest_bytes = TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS * P_BYTES
+    truncated = sample_signature.encode_bytes()[:-one_digest_bytes]
+    with pytest.raises(SSZSerializationError) as exception_info:
+        Signature.decode_bytes(truncated)
+    assert str(exception_info.value) == "Signature.hashes requires exactly 4 hashes, got 3"
+
+
+def test_signature_rejects_too_many_siblings(sample_signature: Signature) -> None:
+    """Bytes whose authentication path carries one extra sibling fail to decode."""
+    # Rebuild the path with one duplicated sibling, then reassemble the container
+    # bytes around it so the field offsets still point at the right payloads.
+    oversized_opening = HashTreeOpening(
+        siblings=HashDigestList(
+            data=tuple(sample_signature.path.siblings.data)
+            + (sample_signature.path.siblings.data[0],)
+        )
+    )
+    path_bytes = oversized_opening.encode_bytes()
+    randomness_bytes = sample_signature.rho.encode_bytes()
+    hashes_bytes = sample_signature.hashes.encode_bytes()
+    fixed_part_length = BYTES_PER_LENGTH_OFFSET + len(randomness_bytes) + BYTES_PER_LENGTH_OFFSET
+    stream = io.BytesIO()
+    Uint32(fixed_part_length).serialize(stream)
+    stream.write(randomness_bytes)
+    Uint32(fixed_part_length + len(path_bytes)).serialize(stream)
+    stream.write(path_bytes)
+    stream.write(hashes_bytes)
+    with pytest.raises(SSZSerializationError) as exception_info:
+        Signature.decode_bytes(stream.getvalue())
+    assert str(exception_info.value) == "Signature.path.siblings requires exactly 8 siblings, got 9"


### PR DESCRIPTION
## SEC-05 — XMSS signature fixed-size declaration was not enforced

### Finding

`Signature.is_fixed_size()` returned `True` with a constant `get_byte_length()`, yet `path.siblings` and `hashes` are variable-length lists decoded through attacker-controlled offsets. Distinct byte strings of equal length could decode to signatures whose lists held the wrong number of digests, so the fixed-size declaration was dishonest and the SSZ root was not pinned to one canonical encoding. The docstring referenced a "see class docstring for why" rationale that did not exist.

### Length-invariance finding

A valid XMSS signature **always** carries exactly `DIMENSION` released chain hashes and exactly `LOG_LIFETIME` path siblings:

- Signing rejects any codeword whose length is not `config.DIMENSION`, then appends one released hash per chain — exactly `DIMENSION` hashes.
- The combined opening is a bottom-tree path (`depth/2` siblings) joined with a top-tree path (`depth/2` siblings), where `depth == LOG_LIFETIME` — exactly `LOG_LIFETIME` siblings.
- `SIGNATURE_LENGTH_BYTES` itself is computed from these two counts, so the constant byte length and the fixed-size override already assume them.

Because the lengths are genuinely invariant, validating them on deserialization is correct and complements SEC-01 (the verify-side fix). The recommended strict check applies.

### Change

- Add a post-construction validator on `Signature` that rejects any signature whose sibling count is not `LOG_LIFETIME` or whose hash count is not `DIMENSION`, raising a precise `SSZSerializationError`. It runs after deserialization, which reconstructs through the model constructor.
- Document the rationale in the class docstring and fix the dangling reference.
- Add two mirrored unit tests: bytes that decode to one fewer hash and bytes that decode to one extra sibling each raise the exact SSZ error (full-message assertion). Valid round-trip remains covered by the existing roundtrip test.

`just check` passes; `tests/spec/crypto/xmss/test_containers.py` and `test_interface.py` pass (56 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)