### PR TITLE
docs(node): remove orphaned bare # and reposition comment

### DIFF
--- a/src/lean_spec/node/node.py
+++ b/src/lean_spec/node/node.py
@@ -211,9 +211,6 @@ class Node:
                 block_class=config.fork.block_class,
             )
 
-        #
-        # If database contains valid state, resume from there.
-        # Otherwise, fall through to genesis initialization.
         validator_index = (
             config.validator_registry.primary_index() if config.validator_registry else None
         )
@@ -225,6 +222,9 @@ class Node:
             f"Only LstarSpec is supported at the composition root, got {type(config.fork).__name__}"
         )
         fork = config.fork
+
+        # If the database contains valid state, resume from there.
+        # Otherwise, fall through to genesis initialization.
         store = cls._try_load_store_from_database(
             database, validator_index, config.genesis_time, config.time_fn, fork
         )


### PR DESCRIPTION
Removes an orphaned bare `#` line and moves the comment to sit with the code it describes.

The "resume from database" comment was separated from the store-load call by the validator-index computation and the composition-root assertion, with a stray bare `#` opening the block. The comment now sits directly above the store-load call it explains.

Pure comment change. No behavior change. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)