### PR TITLE
refactor(ssz): annotate arithmetic stub NoReturn

### DIFF
--- a/src/lean_spec/spec/ssz/boolean.py
+++ b/src/lean_spec/spec/ssz/boolean.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import IO, Any, Self, override
+from typing import IO, Any, NoReturn, Self, override
 
 from pydantic.annotated_handlers import GetCoreSchemaHandler
 from pydantic_core import CoreSchema, core_schema
@@ -164,7 +164,7 @@ class Boolean(int, SSZType):
             raise SSZSerializationError(f"Boolean: expected scope of 1, got {scope}")
         return cls.decode_bytes(stream.read(1))
 
-    def _no_arithmetic(self, other: Any) -> Self:
+    def _no_arithmetic(self, other: Any) -> NoReturn:
         """Reject arithmetic on Boolean — use bitwise & | ^ instead."""
         raise TypeError("Arithmetic operations are not supported for Boolean.")
 


### PR DESCRIPTION
## Summary

The boolean arithmetic-rejection stub always raises, but it was annotated `-> Self`. Change it to `-> NoReturn` so the annotation states the truth: the function never returns a value.

This matches the sibling rejection stubs already using `NoReturn` in the uint type and the koalabear field type. `NoReturn` is imported from `typing`, consistent with those modules.

Annotation-only change. No behavior change. Boolean tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)