### PR TITLE
fix(quic): reject missing peer-id instead of fabricating a random one

### DIFF
--- a/src/lean_spec/node/networking/transport/quic/connection.py
+++ b/src/lean_spec/node/networking/transport/quic/connection.py
@@ -393,12 +393,26 @@ class QuicConnectionManager:
             Established connection.
 
         Raises:
-            QuicTransportError: If connection fails.
+            QuicTransportError: If the multiaddr is not a QUIC address.
+            QuicTransportError: If the multiaddr carries no peer identity.
+            QuicTransportError: If the connection fails.
         """
         host, port, transport, expected_peer_id = parse_multiaddr(multiaddr)
 
         if transport != "quic":
             raise QuicTransportError(f"Not a QUIC multiaddr: {multiaddr}")
+
+        # The remote peer identity must come from the dialed multiaddr.
+        #
+        # We do not yet extract identity from the verified libp2p
+        # certificate extension, so the multiaddr is the only trustworthy
+        # source of the remote peer identity.
+        # A missing identity means the connection cannot be keyed, so we
+        # fail cleanly rather than invent a fabricated one.
+        # This is checked before dialing so it is not re-wrapped as a
+        # connection failure below.
+        if expected_peer_id is None:
+            raise QuicTransportError(f"Multiaddr is missing a peer identity: {multiaddr}")
 
         try:
             # Create QUIC connection using aioquic.
@@ -423,32 +437,15 @@ class QuicConnectionManager:
             # Wait for handshake to complete.
             await protocol.handshake_complete.wait()
 
-            # For now, we don't verify peer certificate (requires deeper aioquic integration).
-            # In production, we would extract and verify the libp2p certificate extension.
-            #
-            # Without peer ID verification, we trust the connection based on:
-            # - QUIC encryption (TLS 1.3)
-            # - The peer being at the expected address
-
-            # Create a placeholder peer_id if we couldn't verify.
-            # In a real implementation, we'd extract this from the certificate.
-            if expected_peer_id:
-                peer_id = expected_peer_id
-            else:
-                # Generate a random peer ID for now.
-                # This is NOT correct for production but allows testing.
-                temp_key = IdentityKeypair.generate()
-                peer_id = temp_key.to_peer_id()
-
             connection = QuicConnection(
                 _protocol=protocol,
-                _peer_id=peer_id,
+                _peer_id=expected_peer_id,
                 _remote_address=multiaddr,
             )
             protocol.connection = connection
             protocol._replay_buffered_events()
 
-            self._connections[peer_id] = connection
+            self._connections[expected_peer_id] = connection
             return connection
 
         except Exception as exception:
@@ -465,18 +462,19 @@ class QuicConnectionManager:
         Creates a server using aioquic with libp2p-tls authentication.
         Runs until shutdown is requested.
 
-        For each accepted connection:
-
-        1. Complete QUIC/TLS handshake
-        2. Create QuicConnection wrapper
-        3. Invoke the callback
+        Inbound connections are rejected until peer identity verification
+        from the libp2p certificate extension is implemented.
+        Without it the remote peer identity is unknown, and keying a
+        connection by a fabricated identity is unsafe.
 
         Args:
             multiaddr: Address to listen on (e.g., "/ip4/0.0.0.0/udp/9000/quic-v1").
-            on_connection: Async callback invoked for each accepted connection.
+            on_connection: Async callback to invoke once inbound connections are supported.
 
         Raises:
-            QuicTransportError: If multiaddr is not a QUIC address.
+            QuicTransportError: If the multiaddr is not a QUIC address.
+            QuicTransportError: When an inbound connection completes its handshake,
+                because the remote peer identity cannot yet be verified.
         """
         host, port, transport, _ = parse_multiaddr(multiaddr)
 
@@ -496,24 +494,18 @@ class QuicConnectionManager:
             key_path = self._temp_directory / "key.pem"
             server_config.load_cert_chain(str(certificate_path), str(key_path))
 
-        # Callback to set up connection when handshake completes.
-        # Captures this manager's state (self, on_connection, host, port).
+        # Callback invoked when an inbound TLS handshake completes.
         def handle_handshake(protocol_instance: LibP2PQuicProtocol) -> None:
-            temp_key = IdentityKeypair.generate()
-            remote_peer_id = temp_key.to_peer_id()
-
-            remote_address = f"/ip4/{host}/udp/{port}/quic-v1/p2p/{remote_peer_id}"
-            connection = QuicConnection(
-                _protocol=protocol_instance,
-                _peer_id=remote_peer_id,
-                _remote_address=remote_address,
+            # An inbound connection has no multiaddr to carry the peer identity.
+            #
+            # The only trustworthy source is the libp2p certificate extension,
+            # whose verification is not yet implemented on this side.
+            # Until that exists we cannot key the connection by a real identity,
+            # so we fail cleanly rather than invent a fabricated one.
+            raise QuicTransportError(
+                "Cannot accept inbound connection: "
+                "peer identity verification from the libp2p certificate is not implemented"
             )
-            protocol_instance.connection = connection
-            protocol_instance._replay_buffered_events()
-            self._connections[remote_peer_id] = connection
-
-            # Invoke callback asynchronously so it doesn't block event processing.
-            asyncio.ensure_future(on_connection(connection))
 
         # Protocol factory that attaches our callback to each new instance.
         def create_protocol(*args, **kwargs) -> LibP2PQuicProtocol:

--- a/tests/node/networking/transport/quic/test_connection.py
+++ b/tests/node/networking/transport/quic/test_connection.py
@@ -1061,45 +1061,27 @@ class TestQuicConnectionManagerConnect:
         # Buffered events from the handshake window are replayed.
         mock_protocol._replay_buffered_events.assert_called_once()
 
-    @patch("lean_spec.node.networking.transport.quic.connection.IdentityKeypair")
     @patch("lean_spec.node.networking.transport.quic.connection.quic_connect")
-    async def test_connect_happy_path_without_peer_id(
+    async def test_connect_without_peer_id_raises(
         self,
         mock_quic_connect: MagicMock,
-        mock_identity_cls: MagicMock,
         manager: QuicConnectionManager,
     ) -> None:
         """
-        Without a p2p component, a temporary peer ID is generated.
+        A multiaddr with no p2p component is rejected, not fabricated.
 
-        Full peer certificate verification is not yet implemented.
-        This fallback allows connections to proceed during development.
+        The remote peer identity is unknown without it, so keying a
+        connection by a fabricated identity would be unsafe.
+        The check happens before dialing, so quic_connect is never called.
         """
+        with pytest.raises(QuicTransportError) as exception_info:
+            await manager.connect("/ip4/127.0.0.1/udp/9000/quic-v1")
+        assert str(exception_info.value) == (
+            "Multiaddr is missing a peer identity: /ip4/127.0.0.1/udp/9000/quic-v1"
+        )
 
-        # Simulate a protocol whose TLS handshake already completed.
-        mock_protocol = MagicMock(spec=LibP2PQuicProtocol)
-        mock_protocol.handshake_complete = asyncio.Event()
-        mock_protocol.handshake_complete.set()
-        mock_protocol.connection = None
-        mock_protocol._buffered_events = []
-        mock_protocol._replay_buffered_events = MagicMock()
-
-        # Wire quic_connect to return our pre-configured protocol.
-        mock_cm = AsyncMock()
-        mock_cm.__aenter__ = AsyncMock(return_value=mock_protocol)
-        mock_quic_connect.return_value = mock_cm
-
-        # Simulate generation of a temporary identity keypair.
-        temp_peer = PeerId.from_base58("tempPeer")
-        mock_temp_key = MagicMock()
-        mock_temp_key.to_peer_id.return_value = temp_peer
-        mock_identity_cls.generate.return_value = mock_temp_key
-
-        # Connect without a peer ID in the multiaddr.
-        connection = await manager.connect("/ip4/127.0.0.1/udp/9000/quic-v1")
-
-        # A temporary peer ID was generated and used.
-        assert connection.peer_id == temp_peer
+        # The rejection precedes any network work.
+        mock_quic_connect.assert_not_called()
 
     @patch("lean_spec.node.networking.transport.quic.connection.quic_connect")
     async def test_connect_wraps_exception(
@@ -1117,7 +1099,7 @@ class TestQuicConnectionManagerConnect:
         mock_quic_connect.return_value = mock_cm
 
         with pytest.raises(QuicTransportError) as exception_info:
-            await manager.connect("/ip4/127.0.0.1/udp/9000/quic-v1")
+            await manager.connect("/ip4/127.0.0.1/udp/9000/quic-v1/p2p/peerB")
         assert str(exception_info.value) == "Failed to connect: connection refused"
 
 
@@ -1207,28 +1189,21 @@ class TestQuicConnectionManagerListen:
 
     @patch("lean_spec.node.networking.transport.quic.connection.QuicConfiguration")
     @patch("lean_spec.node.networking.transport.quic.connection.quic_serve")
-    @patch("lean_spec.node.networking.transport.quic.connection.IdentityKeypair")
-    async def test_listen_handle_handshake_creates_connection(
+    async def test_listen_handle_handshake_rejects_inbound_connection(
         self,
-        mock_identity_cls: MagicMock,
         mock_quic_serve: MagicMock,
         mock_config_cls: MagicMock,
         manager_with_temp_directory: QuicConnectionManager,
     ) -> None:
         """
-        The handshake callback creates and registers a QuicConnection.
+        The handshake callback rejects inbound connections, never fabricating one.
 
-        This test captures the protocol factory that listen() passes to
-        quic_serve, then invokes the handshake callback to verify that
-        a connection is correctly wired up and registered.
+        Peer identity verification from the libp2p certificate is not
+        implemented, so the remote identity is unknown.
+        The callback raises rather than register a connection under a
+        fabricated identity.
         """
         mock_config_cls.return_value = MagicMock()
-
-        # Simulate generation of a remote peer identity.
-        temp_peer = PeerId.from_base58("remotePeer")
-        mock_temp_key = MagicMock()
-        mock_temp_key.to_peer_id.return_value = temp_peer
-        mock_identity_cls.generate.return_value = mock_temp_key
 
         # Capture the protocol factory that listen() passes to quic_serve.
         captured_create_protocol = None
@@ -1262,23 +1237,30 @@ class TestQuicConnectionManagerListen:
         #
         # The parent constructor is patched to avoid aioquic dependencies.
         with patch.object(LibP2PQuicProtocol.__bases__[0], "__init__", return_value=None):
-            protobuf_instance = captured_create_protocol()
+            protocol_instance = captured_create_protocol()
 
         # The factory must have attached a handshake callback.
-        assert protobuf_instance._on_handshake is not None
+        assert protocol_instance._on_handshake is not None
 
         # Simulate the handshake callback being invoked by aioquic.
-        protobuf_instance._quic = MagicMock()
-        protobuf_instance.transmit = MagicMock()
-        protobuf_instance.connection = None
-        protobuf_instance._buffered_events = []
+        protocol_instance._quic = MagicMock()
+        protocol_instance.transmit = MagicMock()
+        protocol_instance.connection = None
+        protocol_instance._buffered_events = []
 
-        protobuf_instance._on_handshake(protobuf_instance)
+        with pytest.raises(QuicTransportError) as exception_info:
+            protocol_instance._on_handshake(protocol_instance)
+        assert str(exception_info.value) == (
+            "Cannot accept inbound connection: "
+            "peer identity verification from the libp2p certificate is not implemented"
+        )
 
-        # The callback creates a connection and registers it in the manager.
-        assert protobuf_instance.connection is not None
-        assert protobuf_instance.connection.peer_id == temp_peer
-        assert temp_peer in manager_with_temp_directory._connections
+        # No connection is wired up and none is registered under a fabricated identity.
+        assert protocol_instance.connection is None
+        assert manager_with_temp_directory._connections == {}
+
+        # The inbound callback is never invoked.
+        callback.assert_not_called()
 
     @patch("lean_spec.node.networking.transport.quic.connection.QuicConfiguration")
     @patch("lean_spec.node.networking.transport.quic.connection.quic_serve")

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -82,6 +82,12 @@ source_type
 exitstatus
 amount
 
+# Inbound-connection callback on the QUIC listener.
+# Callers pass it across modules, so the use is real but invisible here.
+# It stays reserved until inbound peer-identity verification is implemented,
+# at which point the handshake stops rejecting and invokes it.
+on_connection
+
 # logging.Formatter.format override, invoked by the logging framework.
 _.format
 


### PR DESCRIPTION
## Summary

The QUIC transport keyed connections by a freshly generated random identity (`IdentityKeypair.generate()`) whenever no verified peer identity was available — once in the outbound dialer and again, verbatim, in the inbound listener's handshake callback. A fabricated identity then propagated to every id-keyed structure (the connection map, the remote multiaddr), silently mislabeling the remote peer (audit finding SEC-17).

There is no verified source for the remote identity today: the libp2p certificate extension is generated but never parsed/verified on the receiving side, so extracting the identity from the TLS cert is not available. Following the audit recommendation, both sites now fail cleanly instead of fabricating.

## Changes

- **Outbound `connect`**: requires the peer identity in the dialed multiaddr. Raises `QuicTransportError` when it is absent. The check runs before any network work, so it is not re-wrapped as a generic "Failed to connect" error.
- **Inbound `listen` handshake**: raises `QuicTransportError` on completion, because peer-identity verification from the libp2p certificate extension is not yet implemented. Keying a connection by a fabricated identity is unsafe.
- Updated the affected docstrings (`Raises` sections, the listener overview) to describe the new behavior.
- Reworked the two unit tests that relied on the random fallback to assert the full rejection messages, and adjusted the connection-failure test to dial with a peer id so it still exercises the network-error path.
- Whitelisted the `on_connection` listener callback for vulture: callers across modules pass it, so the use is real but invisible to static analysis, and it stays reserved until inbound identity verification lands.

## Testing

- `uv run pytest tests/node/networking/transport/quic/test_connection.py` (74 passed)
- `uv run pytest tests/node/networking/client/event_source/` (84 passed)
- `just check` and `just deadcode` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)