### PR TITLE
refactor(lstar): replace interval if/elif chain with match

### DIFF
--- a/src/lean_spec/spec/forks/lstar/timeline.py
+++ b/src/lean_spec/spec/forks/lstar/timeline.py
@@ -34,14 +34,17 @@ class TimelineMixin(LstarSpecBase):
         current_interval = Interval(int(store.time) % int(INTERVALS_PER_SLOT))
         new_aggregates: list[SignedAggregatedAttestation] = []
 
-        if current_interval == Interval(0) and has_proposal:
-            store = self.accept_new_attestations(store)
-        elif current_interval == Interval(2) and is_aggregator:
-            store, new_aggregates = self.aggregate(store)
-        elif current_interval == Interval(3):
-            store = self.update_safe_target(store)
-        elif current_interval == Interval(4):
-            store = self.accept_new_attestations(store)
+        match int(current_interval):
+            case 0 if has_proposal:
+                store = self.accept_new_attestations(store)
+            case 2 if is_aggregator:
+                store, new_aggregates = self.aggregate(store)
+            case 3:
+                store = self.update_safe_target(store)
+            case 4:
+                store = self.accept_new_attestations(store)
+            case _:
+                pass
 
         return store, new_aggregates
 


### PR DESCRIPTION
## Summary

Modernizes the interval dispatch in the lstar fork's interval ticking.

The previous code compared the current interval against `Interval` literals through an if/elif chain. This converts it to a `match` on the integer interval value, which reads more clearly and is exhaustive at a glance.

## Behavior

Identical to the original:

- Interval 0 accepts new attestations only when a proposal exists (case guard).
- Interval 2 aggregates only when the node is an aggregator (case guard).
- Interval 3 updates the safe target unconditionally.
- Interval 4 accepts new attestations unconditionally.
- Interval 1, interval 0 without a proposal, interval 2 without an aggregator, and any out-of-range value fall through to the `case _` no-op.

## Verification

- `just check` passes (ruff lint, ruff format, ty, codespell, mdformat, lock).
- Smoke-tested the dispatch for every interval value 0-4 plus an out-of-range value, confirming each selects the same branch as the prior chain.

This file lives under `spec/forks/`, which is covered by consensus test vectors rather than pytest, so no unit tests were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)