### PR TITLE
refactor(testing): resolve_checkpoint delegates to resolve_block_root

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/utils.py
+++ b/packages/testing/src/consensus_testing/test_types/utils.py
@@ -49,9 +49,8 @@ def resolve_checkpoint(
     Raises:
         ValueError: If label not found in registry.
     """
-    if (block := block_registry.get(label)) is None:
-        raise ValueError(f"label '{label}' not found - available: {list(block_registry.keys())}")
-    return Checkpoint(
-        root=hash_tree_root(block),
-        slot=block.slot if slot_override is None else slot_override,
-    )
+    root = resolve_block_root(label, block_registry)
+    # An explicit override wins; otherwise fall back to the labeled block's own slot.
+    if slot_override is not None:
+        return Checkpoint(root=root, slot=slot_override)
+    return Checkpoint(root=root, slot=block_registry[label].slot)


### PR DESCRIPTION
## Summary

`resolve_checkpoint` re-implemented the same registry lookup and `hash_tree_root` call that `resolve_block_root` already performs. This routes root resolution through the existing function, removing the duplication.

The behavior is identical:

- The root is computed via the existing block-root resolver, which performs the same not-found check and `hash_tree_root` of the labeled block.
- The slot still falls back to the labeled block's own slot when no override is given, and the not-found error raises before the slot lookup, so the registry access stays safe.

## Testing

`just check` passes (lint, format, type check, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)