### PR TITLE
refactor(storage): dedup blocks/states keep-roots pruning branch

### DIFF
--- a/src/lean_spec/node/storage/sqlite.py
+++ b/src/lean_spec/node/storage/sqlite.py
@@ -555,36 +555,27 @@ class SQLiteDatabase:
             total_pruned = 0
 
             # Build the exclusion set for parameterized queries.
-            keep_bytes = [bytes(r) for r in keep_roots]
-            placeholders = ",".join("?" for _ in keep_bytes)
+            keep_root_bytes = [bytes(root) for root in keep_roots]
+            placeholders = ",".join("?" for _ in keep_root_bytes)
 
-            # Prune blocks below the threshold, preserving kept roots.
-            if keep_bytes:
-                cursor.execute(
-                    f"DELETE FROM {BLOCKS_TABLE_NAME} "
-                    f"WHERE slot < ? AND root NOT IN ({placeholders})",
-                    [int(slot), *keep_bytes],
-                )
-            else:
-                cursor.execute(
-                    f"DELETE FROM {BLOCKS_TABLE_NAME} WHERE slot < ?",
-                    (int(slot),),
-                )
-            total_pruned += cursor.rowcount
+            def prune_table_below_slot(table_name: str) -> int:
+                # Delete rows below the threshold, preserving kept roots.
+                # An empty keep set omits the NOT IN clause to avoid invalid empty parentheses.
+                if keep_root_bytes:
+                    cursor.execute(
+                        f"DELETE FROM {table_name} WHERE slot < ? AND root NOT IN ({placeholders})",
+                        [int(slot), *keep_root_bytes],
+                    )
+                else:
+                    cursor.execute(
+                        f"DELETE FROM {table_name} WHERE slot < ?",
+                        (int(slot),),
+                    )
+                return cursor.rowcount
 
-            # Prune states below the threshold, preserving kept roots.
-            if keep_bytes:
-                cursor.execute(
-                    f"DELETE FROM {STATES_TABLE_NAME} "
-                    f"WHERE slot < ? AND root NOT IN ({placeholders})",
-                    [int(slot), *keep_bytes],
-                )
-            else:
-                cursor.execute(
-                    f"DELETE FROM {STATES_TABLE_NAME} WHERE slot < ?",
-                    (int(slot),),
-                )
-            total_pruned += cursor.rowcount
+            # Blocks and states share the same root and slot columns, so prune both identically.
+            total_pruned += prune_table_below_slot(BLOCKS_TABLE_NAME)
+            total_pruned += prune_table_below_slot(STATES_TABLE_NAME)
 
             # Prune slot index entries below the threshold.
             cursor.execute(


### PR DESCRIPTION
## Summary

The pruning routine in the SQLite storage backend repeated identical keep-roots delete logic for the blocks and states tables, differing only in the table name. Since both tables share the same `root` and `slot` columns, this collapses the two branches into a single nested helper parameterized by table name.

- Extracts the slot-threshold delete (with the kept-roots exclusion) into one helper, routing both the blocks and states branches through it.
- Preserves exact SQL semantics: the same `NOT IN` exclusion is built when roots are kept, and the clause is omitted for an empty keep set to avoid invalid empty parentheses.
- The trailing slot-index prune is unchanged.

## Testing

- `uv run pytest tests/node/storage/test_sqlite.py` — 36 passed.
- `just check` — clean (lint, format, typecheck, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)