### PR TITLE
refactor(testing): inline single-use _serialize_ssz_value

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -13,22 +13,6 @@ from lean_spec.spec.ssz.boolean import Boolean
 from lean_spec.spec.ssz.ssz_base import SSZType
 
 
-def _serialize_ssz_value(ssz_value: SSZType) -> Any:
-    """Convert an SSZ value to a JSON-safe representation."""
-    if isinstance(ssz_value, CamelModel):
-        return ssz_value.to_json()
-    # Boolean before int — Boolean subclasses int.
-    if isinstance(ssz_value, Boolean):
-        return bool(ssz_value)
-    if isinstance(ssz_value, bytes):
-        return to_hex(ssz_value)
-    if isinstance(ssz_value, int):
-        return str(ssz_value)
-    if isinstance(ssz_value, Fp):
-        return str(ssz_value.value)
-    return str(ssz_value)
-
-
 class SSZFixture(BaseConsensusFixture):
     """
     Emitted vector for SSZ conformance.
@@ -55,7 +39,18 @@ class SSZFixture(BaseConsensusFixture):
     @field_serializer("value", when_used="json")
     def serialize_value(self, ssz_value: SSZType) -> Any:
         """Convert an SSZ value to a JSON-safe representation."""
-        return _serialize_ssz_value(ssz_value)
+        if isinstance(ssz_value, CamelModel):
+            return ssz_value.to_json()
+        # Boolean before int — Boolean subclasses int.
+        if isinstance(ssz_value, Boolean):
+            return bool(ssz_value)
+        if isinstance(ssz_value, bytes):
+            return to_hex(ssz_value)
+        if isinstance(ssz_value, int):
+            return str(ssz_value)
+        if isinstance(ssz_value, Fp):
+            return str(ssz_value.value)
+        return str(ssz_value)
 
 
 class SSZTest(BaseTestSpec):


### PR DESCRIPTION
## Summary

The SSZ-to-JSON conversion helper had exactly one caller, the field serializer on the emitted SSZ fixture. Per the repository preference to inline single-use helpers, its body now lives directly in the serializer.

The helper's docstring was identical to the method's existing docstring, so the method keeps that docstring, and the Boolean-before-int ordering comment moves inline with the body.

## Testing

`just check` passes (lint, format, type check, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)