### PR TITLE
refactor(lstar): fold triplicated staleness filter into the extractor

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -378,9 +378,18 @@ class StoreChecks(SelectiveCheck):
                     payloads = store.latest_known_aggregated_payloads
                     label = "in latest_known"
 
-                extracted_attestations = LstarSpec().extract_attestations_from_aggregated_payloads(
-                    payloads
-                )
+                # Map each validator to its highest-slot vote across the raw pool.
+                #
+                # The checker inspects pool content before pruning, so no finality cutoff applies.
+                # On equal slots the first vote seen wins, matching the fork-choice rule.
+                extracted_attestations: dict[ValidatorIndex, AttestationData] = {}
+                for attestation_data, proofs in payloads.items():
+                    for proof in proofs:
+                        for participant_index in proof.participants.to_validator_indices():
+                            previous_vote = extracted_attestations.get(participant_index)
+                            if previous_vote is None or previous_vote.slot < attestation_data.slot:
+                                extracted_attestations[participant_index] = attestation_data
+
                 if attestation_check.validator not in extracted_attestations:
                     raise AssertionError(
                         f"Step {step_index}: validator {attestation_check.validator} not found "

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -624,6 +624,7 @@ class ForkChoiceMixin(LstarSpecBase):
     def extract_attestations_from_aggregated_payloads(
         self,
         aggregated_payloads: dict[AttestationData, set[SingleMessageAggregate]],
+        latest_finalized_slot: Slot,
     ) -> dict[ValidatorIndex, AttestationData]:
         """
         Map each participating validator to the latest vote it cast.
@@ -631,8 +632,12 @@ class ForkChoiceMixin(LstarSpecBase):
         This is the LMD view fork choice runs on.
         On equal slots the first vote seen wins, since the slot comparison is strict.
 
+        A vote whose head sits at or below the finalized slot carries no fork-choice weight.
+        Such stale votes are skipped here, so callers pass their pool without pre-filtering.
+
         Args:
             aggregated_payloads: Proof sets keyed by the vote they cover.
+            latest_finalized_slot: Finalized cutoff; votes at or below it are skipped.
 
         Returns:
             Each validator mapped to its highest-slot vote.
@@ -641,6 +646,10 @@ class ForkChoiceMixin(LstarSpecBase):
 
         # Walk every vote, every proof for it, and every validator the proof covers.
         for attestation_data, proofs in aggregated_payloads.items():
+            # Skip votes whose head no longer outlives the finalized slot.
+            if attestation_data.head.slot <= latest_finalized_slot:
+                continue
+
             for proof in proofs:
                 for validator_index in proof.participants.to_validator_indices():
                     # Keep this vote only when it is newer than the one already stored.
@@ -701,11 +710,8 @@ class ForkChoiceMixin(LstarSpecBase):
         """
         # Reduce the counted pool to each validator's latest still-relevant vote.
         latest_votes = self.extract_attestations_from_aggregated_payloads(
-            {
-                attestation_data: proofs
-                for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
-                if attestation_data.head.slot > store.latest_finalized.slot
-            }
+            store.latest_known_aggregated_payloads,
+            store.latest_finalized.slot,
         )
 
         # Credit every block on those votes' ancestor chains above finalization.
@@ -791,11 +797,8 @@ class ForkChoiceMixin(LstarSpecBase):
         """
         # Reduce the counted pool to each validator's latest still-relevant vote.
         latest_votes = self.extract_attestations_from_aggregated_payloads(
-            {
-                attestation_data: proofs
-                for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
-                if attestation_data.head.slot > store.latest_finalized.slot
-            }
+            store.latest_known_aggregated_payloads,
+            store.latest_finalized.slot,
         )
 
         # Descend from the justified root to the heaviest leaf.
@@ -864,11 +867,8 @@ class ForkChoiceMixin(LstarSpecBase):
 
         # Reduce the pending pool to each validator's latest still-relevant vote.
         latest_votes = self.extract_attestations_from_aggregated_payloads(
-            {
-                attestation_data: proofs
-                for attestation_data, proofs in store.latest_new_aggregated_payloads.items()
-                if attestation_data.head.slot > store.latest_finalized.slot
-            }
+            store.latest_new_aggregated_payloads,
+            store.latest_finalized.slot,
         )
 
         # Descend from the justified root, taking only children that clear the threshold.


### PR DESCRIPTION
## What

The fork-choice staleness predicate `head.slot > latest_finalized.slot` was applied at three separate call sites, each pre-filtering a payload pool with an identical dict comprehension before handing it to the latest-vote extractor:

- block weight computation (counted pool)
- head recomputation (counted pool)
- safe-target computation (pending pool)

This fold moves the predicate inside the extractor, so the cutoff exists in exactly one place. Each call site now passes its pool directly plus the finalized slot.

## Why it is behavior-preserving

The extractor walks `aggregated_payloads.items()` in dict insertion order. Pre-filtering with a comprehension preserves the insertion order of the surviving keys; skipping inside the loop visits the same keys in the same order and `continue`s on the filtered-out ones. The set of `(attestation_data, proofs)` pairs processed, and their order, is identical. The "first vote seen wins on equal slots" LMD tie-break therefore resolves identically.

## Test-framework checker

The fork-choice test-store checker (`store_checks.py`) deliberately inspects raw pool content *before* pruning, so it must remain unfiltered. Routing it through the now-filtered extractor changed its semantics (it dropped a validator whose head sits at the finalized slot, breaking `test_finalization_prunes_stale_aggregated_payloads`). It now uses an inlined unfiltered latest-vote loop, preserving its original behavior with no dependency on the filtered extractor.

## Equivalence verification

- Regenerated the full `tests/consensus/lstar/fork_choice` suite (110 cases) before and after the change into separate output directories.
- `diff -rq` of the two fixture trees reports **no differences** (byte-identical).
- The built-in two-seed determinism check (`--check-determinism`) passes in both runs, confirming LMD ordering is unaffected.
- `just check` passes (ruff, format, ty, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)