### PR TITLE
refactor(quic): finish_write delegates to drain

### DIFF
--- a/src/lean_spec/node/networking/transport/quic/stream_adapter.py
+++ b/src/lean_spec/node/networking/transport/quic/stream_adapter.py
@@ -145,9 +145,7 @@ class QuicStreamAdapter:
 
         Flushes any buffered data before sending FIN.
         """
-        if self._write_buffer:
-            await self._stream.write(self._write_buffer)
-            self._write_buffer = b""
+        await self.drain()
         await self._stream.finish_write()
 
     async def negotiate_server(


### PR DESCRIPTION
## Summary

The QUIC stream adapter's half-close path duplicated the buffer-flush logic already implemented by the drain method. This routes the flush through drain so both paths share a single implementation and cannot drift apart.

## Change

`finish_write` now calls `await self.drain()` to flush the write buffer, then sends FIN via the underlying stream. The extra finalization (sending FIN) is preserved; only the duplicated flush logic is consolidated.

Behavior is unchanged: drain performs the exact same buffer flush that was previously inlined.

## Verification

- `uv run pytest tests/node/networking/transport/quic/test_stream_adapter.py` — 52 passed
- `just check` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)