### PR TITLE
refactor(metrics): make PrometheusObserver inherit SpecObserver protocol

### DIFF
--- a/src/lean_spec/node/metrics/spec_observer.py
+++ b/src/lean_spec/node/metrics/spec_observer.py
@@ -11,9 +11,10 @@ The spec itself never imports this module.
 from __future__ import annotations
 
 from lean_spec.node.metrics.registry import registry as metrics
+from lean_spec.spec.observability.observer import SpecObserver
 
 
-class PrometheusObserver:
+class PrometheusObserver(SpecObserver):
     """Forward SpecObserver callbacks to Prometheus metrics."""
 
     def state_transition_timed(self, seconds: float) -> None:


### PR DESCRIPTION
## Summary

The Prometheus-backed observer matched the spec observer protocol only by structural typing, so a drift between the two (a renamed or removed hook) would go unnoticed until runtime.

This makes the class explicitly inherit the protocol, turning conformance into a type-checked contract: the type checker now verifies every protocol member is implemented.

## Changes

- `PrometheusObserver` now inherits `SpecObserver`.
- Added the import of the protocol.

All three protocol members were already implemented, so no behavior changes.

## Verification

- `uv run pytest tests/node/metrics/test_spec_observer.py` — 9 passed.
- `just check` — ruff, ruff format, ty (validates protocol conformance), codespell, mdformat all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)