### PR TITLE
refactor(metrics): drop never-passed get_metrics_output registry param

### DIFF
--- a/src/lean_spec/node/metrics/registry.py
+++ b/src/lean_spec/node/metrics/registry.py
@@ -374,19 +374,14 @@ throughout the codebase.
 """
 
 
-def get_metrics_output(registry: CollectorRegistry | None = None) -> bytes:
+def get_metrics_output() -> bytes:
     """
     Serialize all registered metrics into Prometheus text exposition format.
 
     Typically called by an HTTP handler to serve the `/metrics` endpoint.
     The output is ready to return as a response body.
 
-    Args:
-        registry: Prometheus collector registry to export. Falls back to
-            the global default registry when not provided.
-
     Returns:
         UTF-8 encoded bytes in Prometheus text exposition format.
     """
-    reg = registry or REGISTRY
-    return generate_latest(reg)
+    return generate_latest(REGISTRY)


### PR DESCRIPTION
## Summary

The Prometheus metrics output helper accepted an optional collector registry parameter that no caller ever passed. The only call site serves the `/metrics` endpoint with no arguments, so the parameter and its `value or REGISTRY` fallback were dead.

This removes the parameter and exports the module's default registry directly.

## Verification

- Confirmed no caller passes `registry=`: `grep -rn "get_metrics_output" src/ tests/ packages/`
- `uv run pytest tests/node/metrics/test_registry.py -q` passes
- `just check` clean (lint, format, typecheck, spell, mdformat, lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)