### PR TITLE
refactor(sync): drop write-only HeadSyncResult.error field

### DIFF
--- a/src/lean_spec/node/sync/head_sync.py
+++ b/src/lean_spec/node/sync/head_sync.py
@@ -63,15 +63,11 @@ class HeadSyncResult:
     """
     Result of processing a gossip block.
 
-    The SyncService only branches on the processed flag; the error string is
-    retained for incident-response logs and post-mortem inspection.
+    The SyncService only branches on the processed flag.
     """
 
     processed: bool
     """True if the block was immediately integrated into the Store."""
-
-    error: str | None = None
-    """Error message if processing failed."""
 
 
 @dataclass(slots=True)
@@ -236,7 +232,6 @@ class HeadSync:
                 )
                 return HeadSyncResult(
                     processed=False,
-                    error=str(exception),
                 ), store
 
             # Process cached descendants.

--- a/tests/node/sync/test_head_sync.py
+++ b/tests/node/sync/test_head_sync.py
@@ -270,12 +270,12 @@ class TestDescendantProcessing:
 class TestErrorHandling:
     """Tests for error handling during block processing."""
 
-    async def test_processing_error_captured_in_result(
+    async def test_processing_error_reported_as_not_processed(
         self,
         genesis_block,
         peer_id: PeerId,
     ) -> None:
-        """Processing errors are captured in the result, not raised."""
+        """Processing errors are swallowed, reported as not processed, never raised."""
         genesis_root = hash_tree_root(genesis_block)
         store = cast(Store, MockForkchoiceStore())
         store.blocks[genesis_root] = genesis_block
@@ -300,7 +300,6 @@ class TestErrorHandling:
 
         assert head_sync_result == HeadSyncResult(
             processed=False,
-            error="State transition failed",
         )
         assert returned_store is store  # Original store returned on error
 


### PR DESCRIPTION
## Summary

`HeadSyncResult.error` was a write-only field: it was assigned on the block-processing failure path but never read anywhere in `src/`, `packages/`, or `tests/`. The `SyncService` only branches on the `processed` flag.

This drops the dead field and its single assignment site, keeping `HeadSyncResult` minimal and the spec readable.

## Changes

- Remove the `error` field and its docstring from `HeadSyncResult`.
- Remove its sole assignment on the processing-failure path.
- Update the head-sync test: drop the `error=` assertion and rename the test to describe the now-accurate behavior — a processing failure is swallowed, reported as not processed, and never raised.

## Verification

- `grep` confirms `.error` is never read on a `HeadSyncResult` (only unrelated `logger.error` calls match).
- `uv run pytest tests/node/sync/test_head_sync.py` — 13 passed.
- `just check` — clean (ruff, format, ty, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)