### PR TITLE
refactor(validator): replace dict-key-collision field set with explicit if

### DIFF
--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -568,14 +568,19 @@ class ValidatorService:
 
         signature = scheme.sign(secret_key, slot, message)
 
-        updated_entry = ValidatorEntry(
-            index=validator_entry.index,
-            **{
-                "attestation_secret_key": validator_entry.attestation_secret_key,
-                "proposal_secret_key": validator_entry.proposal_secret_key,
-                key_field: secret_key,
-            },
-        )
+        # Carry over both secret keys, replacing only the one that was advanced.
+        if key_field == "attestation_secret_key":
+            updated_entry = ValidatorEntry(
+                index=validator_entry.index,
+                attestation_secret_key=secret_key,
+                proposal_secret_key=validator_entry.proposal_secret_key,
+            )
+        else:
+            updated_entry = ValidatorEntry(
+                index=validator_entry.index,
+                attestation_secret_key=validator_entry.attestation_secret_key,
+                proposal_secret_key=secret_key,
+            )
         self.registry.add(updated_entry)
         return updated_entry, signature
 


### PR DESCRIPTION
## Summary

While preparing an XMSS key for a slot, the validator service rebuilds the registry entry with the advanced secret key. It did this by spreading a dict whose `key_field` key collided with one of the literal secret-key keys, relying on dict-key-collision ordering to pick the advanced key:

```python
updated_entry = ValidatorEntry(
    index=validator_entry.index,
    **{
        "attestation_secret_key": validator_entry.attestation_secret_key,
        "proposal_secret_key": validator_entry.proposal_secret_key,
        key_field: secret_key,
    },
)
```

This is implicit and hard to read. The intent — "keep both keys, replace the one that was advanced" — is hidden behind dict-key collision semantics.

## Change

Replace it with an explicit conditional that names which secret key was advanced and carries the other over unchanged. Behavior is identical; the two `key_field` literal values map one-to-one to the two branches.

## Testing

- `uv run pytest tests/node/validator/test_service.py -q` — 51 passed
- `just check` — all checks pass (lint, format, typecheck, spell, mdformat, lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)