### PR TITLE
refactor(validator): narrow _sign_with_key return to Signature

### DIFF
--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -433,7 +433,7 @@ class ValidatorService:
 
         # Sign the block root with the proposal key.
         block_root = hash_tree_root(block)
-        _, proposer_signature = self._sign_with_key(
+        proposer_signature = self._sign_with_key(
             validator_entry,
             block.slot,
             block_root,
@@ -521,7 +521,7 @@ class ValidatorService:
             raise ValueError(f"No secret key for validator {validator_index}")
 
         # Sign the attestation data root with the attestation key.
-        _, signature = self._sign_with_key(
+        signature = self._sign_with_key(
             validator_entry,
             attestation_data.slot,
             hash_tree_root(attestation_data),
@@ -540,7 +540,7 @@ class ValidatorService:
         slot: Slot,
         message: Bytes32,
         key_field: Literal["attestation_secret_key", "proposal_secret_key"],
-    ) -> tuple[ValidatorEntry, Signature]:
+    ) -> Signature:
         """
         Prepare an XMSS key for the given slot, sign, and update the registry.
 
@@ -557,7 +557,7 @@ class ValidatorService:
             key_field: Which secret key field to use and advance.
 
         Returns:
-            Tuple of (updated entry, signature).
+            The signature over the message.
         """
         scheme = TARGET_SIGNATURE_SCHEME
         secret_key = getattr(validator_entry, key_field)
@@ -577,7 +577,7 @@ class ValidatorService:
             },
         )
         self.registry.add(updated_entry)
-        return updated_entry, signature
+        return signature
 
     def _is_synced_for_duties(
         self,

--- a/tests/node/validator/test_service.py
+++ b/tests/node/validator/test_service.py
@@ -381,10 +381,10 @@ class TestSignWithKey:
         assert stored.proposal_secret_key is advanced_proposal
         assert stored.attestation_secret_key is attestation_key
 
-    def test_returns_updated_entry_and_signature(
+    def test_returns_signature(
         self, sync_service: SyncService, key_manager: XmssKeyManager
     ) -> None:
-        """Return value is (updated ValidatorEntry, Signature) — both fields correct."""
+        """Return value is the signature produced by the scheme."""
         service, _, validator_entry, attestation_key, _ = self._setup(sync_service, key_manager)
         advanced = MagicMock(name="adv")
         mock_signature = MagicMock(name="ret_sig")
@@ -396,12 +396,11 @@ class TestSignWithKey:
             scheme.advance_preparation.return_value = advanced
             scheme.sign.return_value = mock_signature
 
-            returned_entry, returned_signature = service._sign_with_key(
+            returned_signature = service._sign_with_key(
                 validator_entry, Slot(2), MagicMock(), "attestation_secret_key"
             )
 
         assert returned_signature is mock_signature
-        assert returned_entry.attestation_secret_key is advanced
 
 
 class TestValidatorServiceBasic:


### PR DESCRIPTION
## Summary

The signing helper in the validator service returned a `tuple[ValidatorEntry, Signature]`, but the updated entry was never used by any caller. Both call sites discarded it with `_,`, and the registry is already updated in place inside the helper before it returns. The wider return type was dead surface area.

This narrows the return to `Signature`:

- Drop the unused tuple element from the helper; return the signature directly.
- Update both call sites to bind the signature without the discard placeholder.
- Update the docstring `Returns:` section accordingly.
- Simplify the unit test that previously unpacked the tuple — registry persistence is already covered by a dedicated test.

The type narrowing is validated by `ty`; `just check` passes clean.

## Testing

- `uv run pytest tests/node/validator/test_service.py -q` — 51 passed.
- `just check` — lint, format, typecheck, spell, mdformat all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)