### PR TITLE
refactor(sync): converge duplicated gap-fetch arithmetic in head sync

### DIFF
--- a/src/lean_spec/node/sync/backfill_sync.py
+++ b/src/lean_spec/node/sync/backfill_sync.py
@@ -281,6 +281,51 @@ class BackfillSync:
             current_slot = current_slot + Slot(batch_count)
             remaining -= batch_count
 
+    async def fill_gap_above_head(
+        self,
+        target_slot: Slot,
+        head_slot: Slot,
+        depth: int = 0,
+    ) -> bool:
+        """
+        Range-fetch the contiguous gap between the head and a target slot.
+
+        When a target block sits several slots above the current head, fetching
+        the gap as one contiguous range is cheaper than recursing parent-by-parent.
+
+        The floor is the head slot, not the finalized slot.
+        Slots above finalized but at or below head are already in the Store.
+        Re-downloading them would be wasted work.
+
+        Args:
+            target_slot: Slot of the block whose parent chain is being filled.
+            head_slot: Highest known canonical slot.
+            depth: Current backfill depth.
+
+        Returns:
+            True if a range fetch was issued, False if the gap was empty.
+        """
+        if target_slot <= head_slot:
+            return False
+
+        gap_floor = head_slot + Slot(1)
+        gap_size = int(target_slot - gap_floor)
+        if gap_size <= 0:
+            return False
+
+        logger.debug(
+            "Backfill gap (%d slots) above head %s; range-fetching from %s.",
+            gap_size,
+            head_slot,
+            gap_floor,
+        )
+        await self.fill_range(
+            start_slot=gap_floor,
+            count=Uint64(gap_size),
+            depth=depth,
+        )
+        return True
+
     async def _fetch_range(
         self,
         start_slot: Slot,
@@ -416,28 +461,13 @@ class BackfillSync:
         # When the earliest received block still has a missing parent far above
         # the highest slot we already know, fetching the gap as a contiguous
         # range is cheaper than recursing parent-by-parent.
-        #
-        # Floor the range at the head slot (highest known canonical slot), not
-        # at the finalized slot. Slots above finalized but at or below head are
-        # already in the Store and should not be re-downloaded.
         if self.store_view is not None and blocks:
             earliest_block = min(blocks, key=lambda b: b.block.slot)
-            head_slot = self.store_view.head_slot()
-            if earliest_block.block.slot > head_slot:
-                gap_floor = head_slot + Slot(1)
-                gap_size = int(earliest_block.block.slot - gap_floor)
-                if gap_size > 0:
-                    logger.debug(
-                        "Backfill gap (%d slots) at slot %s; range-fetching from %s.",
-                        gap_size,
-                        earliest_block.block.slot,
-                        gap_floor,
-                    )
-                    await self.fill_range(
-                        start_slot=gap_floor,
-                        count=Uint64(gap_size),
-                        depth=depth + 1,
-                    )
+            await self.fill_gap_above_head(
+                target_slot=earliest_block.block.slot,
+                head_slot=self.store_view.head_slot(),
+                depth=depth + 1,
+            )
 
         await self.fill_missing(new_orphan_parents, depth=depth + 1)
 

--- a/src/lean_spec/node/sync/head_sync.py
+++ b/src/lean_spec/node/sync/head_sync.py
@@ -52,8 +52,8 @@ from lean_spec.node.networking.transport.peer_id import PeerId
 from lean_spec.node.sync.backfill_sync import BackfillSync
 from lean_spec.node.sync.block_cache import BlockCache
 from lean_spec.spec.crypto.merkleization import hash_tree_root
-from lean_spec.spec.forks import SignedBlock, Slot, Store
-from lean_spec.spec.ssz import Bytes32, Uint64
+from lean_spec.spec.forks import SignedBlock, Store
+from lean_spec.spec.ssz import Bytes32
 
 logger = logging.getLogger(__name__)
 
@@ -365,32 +365,17 @@ class HeadSync:
         #
         # When the new block sits several slots above the current head, fetch
         # the gap as a contiguous range rather than recursing parent-by-parent.
-        # The floor is the head slot; slots above finalized but at or below
-        # head are already in the Store.
         #
-        # Alt-fork gossip at a slot at or below head still goes through plain
-        # parent-by-root recursion: those blocks share an ancestor with the
-        # canonical chain and a range request would just refetch known slots.
+        # An empty gap means either a single-slot gap above head (direct parent
+        # missing) or alt-fork gossip at a slot at or below head.
+        # Both share an ancestor with the canonical chain, so recurse by parent
+        # root only; a range request would just refetch known slots.
         head_slot = store.blocks[store.head].slot
-        if block_inner.slot > head_slot:
-            gap_floor = head_slot + Slot(1)
-            gap_size = int(block_inner.slot - gap_floor)
-            if gap_size > 0:
-                logger.debug(
-                    "Backfill gap (%d slots) above head %s; range-fetching from %s.",
-                    gap_size,
-                    head_slot,
-                    gap_floor,
-                )
-                await self.backfill.fill_range(
-                    start_slot=gap_floor,
-                    count=Uint64(gap_size),
-                )
-            else:
-                # Direct parent missing (single-slot gap above head).
-                await self.backfill.fill_missing([parent_root])
-        else:
-            # Alt-fork gossip at or below head: recurse by parent root only.
+        range_fetched = await self.backfill.fill_gap_above_head(
+            target_slot=block_inner.slot,
+            head_slot=head_slot,
+        )
+        if not range_fetched:
             await self.backfill.fill_missing([parent_root])
 
         return HeadSyncResult(

--- a/tests/node/sync/test_head_sync.py
+++ b/tests/node/sync/test_head_sync.py
@@ -29,6 +29,10 @@ class NullBackfillSync:
         """Record the call without performing any backfill."""
         self.fill_missing_calls.append(roots)
 
+    async def fill_gap_above_head(self, target_slot: Slot, head_slot: Slot) -> bool:
+        """Report no range fetch so routing falls back to root recursion."""
+        return target_slot > head_slot + Slot(1)
+
 
 def _null_backfill() -> BackfillSync:
     """Create a NullBackfillSync cast to BackfillSync for type safety."""
@@ -447,6 +451,17 @@ class _RecordingBackfill:
     async def fill_missing(self, roots: list[Bytes32]) -> None:
         """Record a root recursion request."""
         self.missing_calls.append(roots)
+
+    async def fill_gap_above_head(self, target_slot: Slot, head_slot: Slot) -> bool:
+        """Run the real gap arithmetic, recording the range fetch it would issue."""
+        if target_slot <= head_slot:
+            return False
+        gap_floor = head_slot + Slot(1)
+        gap_size = int(target_slot - gap_floor)
+        if gap_size <= 0:
+            return False
+        await self.fill_range(start_slot=gap_floor, count=Uint64(gap_size))
+        return True
 
 
 def _backfill() -> tuple[_RecordingBackfill, BackfillSync]:


### PR DESCRIPTION
## Summary

The same start/floor/size computation for range-fetching a contiguous gap of blocks above the chain head was duplicated in two places under `src/lean_spec/node/sync/`:

- Head sync, when caching an orphan gossip block whose parent is missing.
- Backfill sync, when received blocks still have a missing parent far above the highest known slot.

Both computed the gap floor as `head + 1`, derived the gap size, logged, and dispatched to a range fetch when the size was positive.

This change factors that logic into a single `fill_gap_above_head` method on the backfill syncer that returns whether a range fetch was issued. Both call sites route through it:

- Head sync falls back to parent-by-root recursion when the gap is empty (single-slot gap above head, or alt-fork gossip at or below head).
- Backfill keeps its unconditional root recursion afterward.

Behavior and bounds are preserved exactly. The now-unused `Slot` and `Uint64` imports were dropped from the head sync module.

## Testing

- `uv run pytest tests/node/sync/test_head_sync.py tests/node/sync/test_backfill_sync.py` — all pass.
- `just check` — clean (lint, format, typecheck, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)