### PR TITLE
refactor(api): merge duplicated _async_stop and aclose teardown

### DIFF
--- a/src/lean_spec/node/api/server.py
+++ b/src/lean_spec/node/api/server.py
@@ -126,14 +126,10 @@ class ApiServer:
     def stop(self) -> None:
         """Request graceful shutdown (fire-and-forget). Prefer aclose() in async code."""
         if self._runner is not None:
-            asyncio.create_task(self._async_stop())
+            asyncio.create_task(self.aclose())
 
     async def aclose(self) -> None:
         """Gracefully stop the server. Await this in async code for clean shutdown."""
-        await self._async_stop()
-
-    async def _async_stop(self) -> None:
-        """Gracefully stop the server."""
         if self._runner:
             await self._runner.cleanup()
             self._runner = None

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -76,7 +76,7 @@ class _ServerThread(threading.Thread):
         )
 
     def stop(self) -> None:
-        """Stop the server and event loop, awaiting cleanup so _async_stop is run."""
+        """Stop the server and event loop, awaiting the graceful shutdown coroutine."""
         if self.server and self.loop:
 
             async def shutdown() -> None:


### PR DESCRIPTION
## Summary

The API server had three shutdown methods where two coroutines duplicated the
same teardown sequence:

- `stop()` — sync fire-and-forget, scheduled the private coroutine
- `aclose()` — public awaitable, delegated to the private coroutine
- `_async_stop()` — private, held the actual cleanup logic

`aclose()` is the public name every caller uses. This collapses the teardown
into `aclose()` and routes both entry points through it:

- `aclose()` now contains the runner cleanup, state reset, and stop-event signal directly.
- `stop()` schedules `aclose()` as a background task.
- `_async_stop()` is deleted.

Behavior is preserved: idempotency (guarded on the runner being present),
ordering of cleanup then stop-event signal, and the fire-and-forget vs.
awaitable distinction between the two public entry points.

## Testing

- `uv run pytest tests/node/api/test_server.py -q` — 19 passed
- `just check` — clean (ruff, format, ty, codespell, mdformat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)