### PR TITLE
refactor(api): inline import-time _routes global into start()

### DIFF
--- a/src/lean_spec/node/api/server.py
+++ b/src/lean_spec/node/api/server.py
@@ -21,10 +21,6 @@ from lean_spec.spec.forks import LstarSpec, Store
 logger = logging.getLogger(__name__)
 
 
-_routes = [web.get(path, handler) for path, handler in ROUTES.items()]
-_routes += [web.route(method, path, handler) for method, path, handler in ADMIN_ROUTES]
-"""aiohttp route definitions generated from ROUTES and ADMIN_ROUTES."""
-
 # The following classes are implementation details.
 # Other implementations may structure their code differently.
 
@@ -103,8 +99,10 @@ class ApiServer:
         # Absence is fine; endpoints return 503 when unset.
         app["aggregator_controller"] = self.aggregator_controller
 
-        # Add all routes
-        app.add_routes(_routes)
+        # Add all routes, generated from ROUTES and ADMIN_ROUTES.
+        routes = [web.get(path, handler) for path, handler in ROUTES.items()]
+        routes += [web.route(method, path, handler) for method, path, handler in ADMIN_ROUTES]
+        app.add_routes(routes)
 
         self._runner = web.AppRunner(app)
         await self._runner.setup()


### PR DESCRIPTION
## Summary

The API server module built its aiohttp route list in a module-level `_routes` global at import time.
This created an import-time side effect, and the value was only ever read once, inside `start()`.

This change moves the route-list construction into `start()` as a local variable and removes the global.
Behavior is unchanged: the same routes are registered on the application before the server starts.

## Testing

- `uv run pytest tests/node/api/test_server.py -q` (19 passed)
- `just check` (lint, format, typecheck, spell, mdformat, lock) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)