### PR TITLE
refactor(sync): align __all__ with the package public surface

### DIFF
--- a/src/lean_spec/node/sync/__init__.py
+++ b/src/lean_spec/node/sync/__init__.py
@@ -23,16 +23,14 @@ How It Works
 - When parents arrive, process waiting children
 """
 
-from __future__ import annotations
-
-__all__ = [
-    "SyncService",
-    "BlockCache",
-    "NetworkRequester",
-    "PeerManager",
-]
-
 from lean_spec.node.sync.backfill_sync import NetworkRequester
 from lean_spec.node.sync.block_cache import BlockCache
 from lean_spec.node.sync.peer_manager import PeerManager
 from lean_spec.node.sync.service import SyncService
+
+__all__ = [
+    "BlockCache",
+    "NetworkRequester",
+    "PeerManager",
+    "SyncService",
+]


### PR DESCRIPTION
## What

Reconcile the `__all__` export block in the sync package init so it follows the same policy as every sibling `node` package.

## The inconsistency

Every sibling package init (chain, storage, validator, genesis, metrics) follows one convention:

- imports first, then `__all__`
- entries sorted alphabetically

The sync init diverged on both points:

- `__all__` sat **before** the imports
- entries were listed in import order (`SyncService`, `BlockCache`, `NetworkRequester`, `PeerManager`), not alphabetically

It also carried a `from __future__ import annotations` that no sibling init uses and that this module does not need — there are no annotations in the file.

## The fix

- Move `__all__` below the imports.
- Sort entries alphabetically: `BlockCache`, `NetworkRequester`, `PeerManager`, `SyncService`.
- Drop the unused future-annotations import.

The public surface is unchanged — all four names are imported by real external callers (`node.py`, `validator/service.py`, `networking/service/service.py`, `chain/service.py`, `api/aggregator_controller.py`), so this is purely a policy alignment with no behavioral change. No backward-compat shims added.

## Verification

- `uv run pytest tests/node/sync/` — 142 passed
- `just check` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)