### PR TITLE
refactor(testing): route genesis-block constructors through one helper

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -6,10 +6,10 @@ from consensus_testing import forks
 from consensus_testing.genesis import (
     build_anchor,
     generate_pre_state,
-    make_genesis_block,
     make_genesis_state,
     make_genesis_store,
     make_validators,
+    reconstruct_block_from_header,
 )
 from consensus_testing.mocks import (
     MockEventSource,
@@ -192,7 +192,7 @@ __all__ = [
     "build_anchor",
     "generate_pre_state",
     # Unit-test builders and value constructors
-    "make_genesis_block",
+    "reconstruct_block_from_header",
     "make_genesis_state",
     "make_genesis_store",
     "make_validators",

--- a/packages/testing/src/consensus_testing/genesis.py
+++ b/packages/testing/src/consensus_testing/genesis.py
@@ -16,7 +16,7 @@ from lean_spec.spec.forks.lstar.containers import (
     Validators,
 )
 from lean_spec.spec.forks.lstar.spec import LstarSpec
-from lean_spec.spec.ssz import Bytes32, Bytes52, Uint64
+from lean_spec.spec.ssz import Bytes52, Uint64
 
 _DEFAULT_GENESIS_TIME = Uint64(0)
 
@@ -114,14 +114,7 @@ def build_anchor(
 
     # Reconstruct the genesis block from the state's latest header.
     # The genesis block is fully determined by the genesis state.
-    genesis_block = Block(
-        slot=state.latest_block_header.slot,
-        proposer_index=state.latest_block_header.proposer_index,
-        parent_root=state.latest_block_header.parent_root,
-        state_root=hash_tree_root(state),
-        body=BlockBody(attestations=AggregatedAttestations(data=[])),
-    )
-    current_block = genesis_block
+    current_block = reconstruct_block_from_header(state)
     parent_root = hash_tree_root(current_block)
 
     num_validators_u64 = Uint64(num_validators)
@@ -201,12 +194,20 @@ def make_genesis_state(num_validators: int = 3, genesis_time: int = 0) -> State:
     )
 
 
-def make_genesis_block(state: State) -> Block:
-    """Build the genesis block matching a genesis state."""
+def reconstruct_block_from_header(state: State) -> Block:
+    """
+    Rebuild the block matching a state's latest header.
+
+    The header pins the slot, proposer index, and parent root.
+    The state root is the hash of the state itself.
+    The body is the empty body of the genesis and empty-block convention.
+
+    For a genesis state this is the genesis block.
+    """
     return Block(
-        slot=Slot(0),
-        proposer_index=ValidatorIndex(0),
-        parent_root=Bytes32.zero(),
+        slot=state.latest_block_header.slot,
+        proposer_index=state.latest_block_header.proposer_index,
+        parent_root=state.latest_block_header.parent_root,
         state_root=hash_tree_root(state),
         body=BlockBody(attestations=AggregatedAttestations(data=[])),
     )
@@ -234,7 +235,7 @@ def make_genesis_store(
     )
     store = LstarSpec().create_store(
         state,
-        make_genesis_block(state),
+        reconstruct_block_from_header(state),
         validator_index=None if observer else validator_index,
     )
     return store if time is None else store.model_copy(update={"time": time})

--- a/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
@@ -3,7 +3,11 @@
 from collections.abc import Callable
 from typing import Any, ClassVar
 
-from consensus_testing.genesis import build_anchor, generate_pre_state, make_genesis_block
+from consensus_testing.genesis import (
+    build_anchor,
+    generate_pre_state,
+    reconstruct_block_from_header,
+)
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
 from lean_spec.base import StrictBaseModel
 from lean_spec.spec.forks import Slot
@@ -50,7 +54,7 @@ def _build_store(num_validators: int, genesis_time: int, anchor_slot: int = 0) -
         state = generate_pre_state(
             fork=fork, genesis_time=Uint64(genesis_time), num_validators=num_validators
         )
-        block = make_genesis_block(state)
+        block = reconstruct_block_from_header(state)
         # No validator identity — fixture only reads store data, never signs.
         return fork.create_store(state, block, validator_index=None)
 

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -6,7 +6,7 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from consensus_testing.genesis import generate_pre_state
+from consensus_testing.genesis import generate_pre_state, reconstruct_block_from_header
 from consensus_testing.keys import XmssKeyManager
 from consensus_testing.rejection import classify_rejection
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
@@ -34,10 +34,8 @@ from lean_spec.spec.forks import (
     ValidatorIndex,
 )
 from lean_spec.spec.forks.lstar.containers import (
-    AggregatedAttestations,
     AggregationError,
     Block,
-    BlockBody,
     SignedAggregatedAttestation,
     SignedAttestation,
     State,
@@ -144,13 +142,7 @@ class ForkChoiceTest(BaseTestSpec):
         #
         # The state already contains the block header.
         # We extract its fields to create a matching Block.
-        return Block(
-            slot=self.anchor_state.latest_block_header.slot,
-            proposer_index=self.anchor_state.latest_block_header.proposer_index,
-            parent_root=self.anchor_state.latest_block_header.parent_root,
-            state_root=hash_tree_root(self.anchor_state),
-            body=BlockBody(attestations=AggregatedAttestations(data=[])),
-        )
+        return reconstruct_block_from_header(self.anchor_state)
 
     def _resolved_max_slot(self) -> Slot:
         """

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 from collections import defaultdict
 
+from consensus_testing.genesis import reconstruct_block_from_header
 from consensus_testing.keys import XmssKeyManager, create_dummy_signature
 from consensus_testing.test_types.attestation_specs import AggregatedAttestationSpec
 from lean_spec.base import CamelModel
@@ -344,13 +345,7 @@ class BlockSpec(CamelModel):
         proposer_index = self.resolve_proposer_index(len(state.validators))
 
         # Build a genesis block registry so attestation specs can resolve labels.
-        anchor_block = Block(
-            slot=state.latest_block_header.slot,
-            proposer_index=state.latest_block_header.proposer_index,
-            parent_root=state.latest_block_header.parent_root,
-            state_root=hash_tree_root(state),
-            body=BlockBody(attestations=AggregatedAttestations(data=[])),
-        )
+        anchor_block = reconstruct_block_from_header(state)
         block_registry: dict[str, Block] = {"genesis": anchor_block}
 
         # Resolve the parent root.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,9 @@ if "LEAN_ENV" not in os.environ:
     os.environ["LEAN_ENV"] = "test"
 
 from consensus_testing import (  # noqa: E402
-    make_genesis_block,
     make_genesis_state,
     make_genesis_store,
+    reconstruct_block_from_header,
 )
 from consensus_testing.keys import XmssKeyManager  # noqa: E402
 from lean_spec.spec.forks import Slot  # noqa: E402
@@ -47,7 +47,7 @@ def genesis_state() -> State:
 @pytest.fixture
 def genesis_block(genesis_state: State) -> Block:
     """Genesis block matching the null-key genesis state."""
-    return make_genesis_block(genesis_state)
+    return reconstruct_block_from_header(genesis_state)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Four sites in the consensus testing package reconstructed an essentially identical block from a state's latest header:

- the genesis-block builder used by the genesis store and conftest
- the non-genesis anchor builder
- the fork-choice anchor resolver
- the store-less signed-block builder

Each independently read the slot, proposer index, and parent root from the state's latest header, set the state root to the hash of the state, and attached an empty body.

This routes all four through a single header-based reconstruction helper. The old hardcoded genesis-block builder (slot 0, proposer 0, zero parent root) is replaced by the same header-derived form. For a genesis state the header already holds those exact values, so the produced block is unchanged and behavior is preserved.

Per the no-backward-compatibility rule, the old builder is removed entirely and every call site and the package export are updated to the new helper.

## Verification

- `just check` clean (lint, format, type check, codespell, mdformat)
- node unit tests pass (1687 passed) — exercises the conftest genesis-block fixture
- fork-choice fill vectors pass (113), including the cross-seed determinism check
- signature-verification, api-endpoint, and block-production fill vectors pass (19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)