### PR TITLE
test(exceptions): add mirrored test modules for ssz and storage exceptions

### DIFF
--- a/tests/node/storage/test_exceptions.py
+++ b/tests/node/storage/test_exceptions.py
@@ -1,0 +1,55 @@
+"""Tests for the storage exception hierarchy."""
+
+from __future__ import annotations
+
+from lean_spec.node.storage.exceptions import (
+    StorageCorruptionError,
+    StorageError,
+    StorageReadError,
+    StorageWriteError,
+)
+
+
+class TestStorageExceptionHierarchy:
+    """Tests for the inheritance structure of storage exceptions."""
+
+    def test_base_error_subclasses_only_exception(self) -> None:
+        """The base storage error derives from the builtin Exception and nothing else."""
+        assert StorageError.__bases__ == (Exception,)
+
+    def test_read_error_subclasses_base_error(self) -> None:
+        """The read error derives directly from the storage base error."""
+        assert StorageReadError.__bases__ == (StorageError,)
+
+    def test_write_error_subclasses_base_error(self) -> None:
+        """The write error derives directly from the storage base error."""
+        assert StorageWriteError.__bases__ == (StorageError,)
+
+    def test_corruption_error_subclasses_base_error(self) -> None:
+        """The corruption error derives directly from the storage base error."""
+        assert StorageCorruptionError.__bases__ == (StorageError,)
+
+    def test_every_specific_error_is_catchable_as_base_error(self) -> None:
+        """Each specific storage error is reachable through the common base type."""
+        assert issubclass(StorageReadError, StorageError)
+        assert issubclass(StorageWriteError, StorageError)
+        assert issubclass(StorageCorruptionError, StorageError)
+
+
+class TestStorageExceptionMessages:
+    """Tests for message handling on storage exceptions."""
+
+    def test_read_error_reports_its_message(self) -> None:
+        """The read error reports the exact message it was raised with."""
+        raised = StorageReadError("block 0x1234 not found")
+        assert str(raised) == "block 0x1234 not found"
+
+    def test_write_error_reports_its_message(self) -> None:
+        """The write error reports the exact message it was raised with."""
+        raised = StorageWriteError("database is locked")
+        assert str(raised) == "database is locked"
+
+    def test_corruption_error_reports_its_message(self) -> None:
+        """The corruption error reports the exact message it was raised with."""
+        raised = StorageCorruptionError("stored block failed SSZ deserialization")
+        assert str(raised) == "stored block failed SSZ deserialization"

--- a/tests/spec/ssz/test_exceptions.py
+++ b/tests/spec/ssz/test_exceptions.py
@@ -1,0 +1,76 @@
+"""Tests for the SSZ exception hierarchy."""
+
+from __future__ import annotations
+
+from lean_spec.spec.ssz.exceptions import (
+    SSZError,
+    SSZSerializationError,
+    SSZTypeError,
+    SSZValueError,
+)
+
+
+class TestSSZExceptionHierarchy:
+    """Tests for the inheritance structure of SSZ exceptions."""
+
+    def test_base_error_subclasses_only_exception(self) -> None:
+        """The base SSZ error derives from the builtin Exception and nothing else."""
+        assert SSZError.__bases__ == (Exception,)
+
+    def test_type_error_subclasses_base_error(self) -> None:
+        """The type error derives directly from the SSZ base error."""
+        assert SSZTypeError.__bases__ == (SSZError,)
+
+    def test_value_error_subclasses_base_error(self) -> None:
+        """The value error derives directly from the SSZ base error."""
+        assert SSZValueError.__bases__ == (SSZError,)
+
+    def test_serialization_error_subclasses_base_error(self) -> None:
+        """The serialization error derives directly from the SSZ base error."""
+        assert SSZSerializationError.__bases__ == (SSZError,)
+
+    def test_every_specific_error_is_catchable_as_base_error(self) -> None:
+        """Each specific SSZ error is reachable through the common base type."""
+        assert issubclass(SSZTypeError, SSZError)
+        assert issubclass(SSZValueError, SSZError)
+        assert issubclass(SSZSerializationError, SSZError)
+
+
+class TestSSZExceptionPydanticCompatibility:
+    """Tests guarding the deliberate non-inheritance from builtin error types."""
+
+    def test_base_error_is_not_a_builtin_value_or_type_error(self) -> None:
+        """The SSZ base error must not derive from the builtin ValueError or TypeError."""
+        assert not issubclass(SSZError, ValueError)
+        assert not issubclass(SSZError, TypeError)
+
+    def test_type_error_is_not_a_builtin_type_error(self) -> None:
+        """The SSZ type error must not derive from the builtin TypeError."""
+        assert not issubclass(SSZTypeError, TypeError)
+
+    def test_value_error_is_not_a_builtin_value_error(self) -> None:
+        """The SSZ value error must not derive from the builtin ValueError."""
+        assert not issubclass(SSZValueError, ValueError)
+
+    def test_serialization_error_is_not_a_builtin_value_error(self) -> None:
+        """The SSZ serialization error must not derive from the builtin ValueError."""
+        assert not issubclass(SSZSerializationError, ValueError)
+
+
+class TestSSZExceptionMessages:
+    """Tests for message handling on SSZ exceptions."""
+
+    def test_type_error_reports_its_message(self) -> None:
+        """The type error reports the exact message it was raised with."""
+        raised = SSZTypeError("cannot coerce list into Uint64")
+        assert str(raised) == "cannot coerce list into Uint64"
+
+    def test_value_error_reports_its_message(self) -> None:
+        """The value error reports the exact message it was raised with."""
+        raised = SSZValueError("value 256 overflows Uint8")
+        assert str(raised) == "value 256 overflows Uint8"
+
+    def test_serialization_error_reports_its_message(self) -> None:
+        """The serialization error reports the exact message it was raised with."""
+        raised = SSZSerializationError("unexpected end of stream")
+        assert str(raised) == "unexpected end of stream"


### PR DESCRIPTION
## Summary

Adds the missing mirrored unit-test modules for two exception hierarchies that previously had no dedicated test coverage:

- `tests/spec/ssz/test_exceptions.py` mirrors `src/lean_spec/spec/ssz/exceptions.py`
- `tests/node/storage/test_exceptions.py` mirrors `src/lean_spec/node/storage/exceptions.py`

This closes finding TEST-10 from the audit report: both source modules existed without their mirrored test modules.

## What is tested

For each exception class the tests verify:

- The exact inheritance chain (`__bases__`), confirming the hierarchy matches the intended design.
- That every specific error is catchable through its common base type.
- Full-message round-tripping with string equality.

The SSZ tests additionally guard a deliberate design choice: these domain exceptions must NOT subclass the builtin `ValueError` or `TypeError`. Pydantic catches those builtins inside field validators and wraps them in `ValidationError`, which would break `except SSZValueError:` catches at construction sites. The tests pin that non-inheritance so a future refactor cannot silently reintroduce it.

These assertions do not duplicate coverage made elsewhere; they target the exception classes themselves.

## Verification

- `uv run pytest tests/spec/ssz/test_exceptions.py tests/node/storage/test_exceptions.py` — 20 passed, both source modules at 100% coverage.
- `just check` — all checks pass (lint, format, typecheck, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)