### PR TITLE
test(testing): add label-pinned attestation_target_root store check

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -211,6 +211,14 @@ class StoreChecks(SelectiveCheck):
     - The checkpoint root references an actual block at that slot
     """
 
+    attestation_target_root_label: str | None = None
+    """
+    Expected attestation target checkpoint root by label reference.
+
+    The framework resolves this label to a block root and compares it to the
+    root that the spec would attest to from the current store.
+    """
+
     attestation_checks: list[AttestationCheck] | None = None
     """Optional list of attestation content checks for specific validators."""
 
@@ -346,8 +354,10 @@ class StoreChecks(SelectiveCheck):
             _check("filled_block.root", hash_tree_root(filled_block), expected_filled_block_root)
 
         # Attestation target checkpoint (slot + root consistency)
-        if "attestation_target_slot" in fields:
+        if "attestation_target_slot" in fields or "attestation_target_root_label" in fields:
             attestation_target = LstarSpec().get_attestation_target(store)
+
+        if "attestation_target_slot" in fields:
             _check("attestation_target.slot", attestation_target.slot, self.attestation_target_slot)
 
             block_found = any(
@@ -366,6 +376,16 @@ class StoreChecks(SelectiveCheck):
                     f"block at slot {self.attestation_target_slot}. "
                     f"Available blocks: {block_roots_at_target_slot}"
                 )
+
+        # Attestation target root pinned to a labeled block
+        if "attestation_target_root_label" in fields:
+            assert self.attestation_target_root_label is not None
+            expected_attestation_target_root = _resolve(self.attestation_target_root_label)
+            _check(
+                "attestation_target.root",
+                attestation_target.root,
+                expected_attestation_target_root,
+            )
 
         # Per-validator attestation content checks
         if "attestation_checks" in fields:

--- a/tests/consensus/lstar/fork_choice/test_attestation_target_selection.py
+++ b/tests/consensus/lstar/fork_choice/test_attestation_target_selection.py
@@ -535,7 +535,8 @@ def test_attestation_target_selection_after_finality_has_moved(
     - justified stays at slot 7.
     - finalized stays at slot 1.
     - the safe target settles on block_7.
-    - the target pins to block_7 as the head extends.
+    - the target slot pins to slot 7 as the head extends.
+    - the target root pins to block_7 as the head extends.
     """
     fork_choice_test(
         steps=[
@@ -630,6 +631,7 @@ def test_attestation_target_selection_after_finality_has_moved(
                     safe_target_slot=Slot(7),
                     safe_target_root_label="block_7",
                     attestation_target_slot=Slot(7),
+                    attestation_target_root_label="block_7",
                 ),
             ),
             BlockStep(


### PR DESCRIPTION
## Summary

The fork-choice store checks support pinning various store roots by label (head, justified, finalized, safe target), but there was no way to pin the *attestation target's* root by label. A vector could only assert the target slot and that the resolved root happened to sit on some block at that slot.

This adds an `attestation_target_root_label` check that resolves a labeled block root and compares it directly to the root the spec would attest to from the current store, mirroring the existing label-pinned root checks.

## Changes

- Add the `attestation_target_root_label` field to the store checks model.
- Resolve the label to a block root and compare it to the spec's attestation target root.
- Share the attestation-target computation with the existing slot check.
- Exercise the new check in the post-finality attestation-target vector by pinning the target root to `block_7` at slot 9, alongside the existing target-slot assertion.

## Verification

- `uv run fill --fork=Lstar --clean tests/consensus/lstar/fork_choice/test_attestation_target_selection.py -k test_attestation_target_selection_after_finality_has_moved` passes.
- Confirmed the check fires negatively: substituting `block_2` for the pinned label fails with an `attestation_target.root` mismatch.
- `just check` is clean (ruff, format, ty, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)