### PR TITLE
test(testing): add validator-registry contents expectation

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/state_expectation.py
+++ b/packages/testing/src/consensus_testing/test_types/state_expectation.py
@@ -13,6 +13,7 @@ from lean_spec.spec.forks.lstar.containers import (
     JustificationValidators,
     JustifiedSlots,
     State,
+    Validators,
 )
 from lean_spec.spec.ssz import Bytes32
 
@@ -42,6 +43,7 @@ class StateExpectation(SelectiveCheck):
         "latest_finalized_slot": lambda s: s.latest_finalized.slot,
         "latest_finalized_root": lambda s: s.latest_finalized.root,
         "validator_count": lambda s: len(s.validators),
+        "validators": lambda s: s.validators,
         "config_genesis_time": lambda s: int(s.config.genesis_time),
         "latest_block_header_slot": lambda s: s.latest_block_header.slot,
         "latest_block_header_proposer_index": lambda s: int(s.latest_block_header.proposer_index),
@@ -91,6 +93,9 @@ class StateExpectation(SelectiveCheck):
 
     validator_count: int | None = None
     """Expected number of validators."""
+
+    validators: Validators | None = None
+    """Expected validator registry contents, entry for entry."""
 
     config_genesis_time: int | None = None
     """Expected genesis time in the config."""

--- a/tests/consensus/lstar/state_transition/test_genesis.py
+++ b/tests/consensus/lstar/state_transition/test_genesis.py
@@ -198,6 +198,47 @@ def test_genesis_custom_validator_set(
     )
 
 
+def test_genesis_registry_holds_exact_validator_entries(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Genesis carries the exact validator registry it was seeded with.
+
+    Given
+    -----
+    - 3 validators with zeroed public keys.
+    - V0, V1, V2 carry indices 0, 1, 2 in registry order.
+
+    When
+    ----
+    - genesis is generated and no blocks are processed.
+
+    Then
+    ----
+    - the registry holds those three entries in that order.
+    """
+    zero_public_key = Bytes52(b"\x00" * 52)
+    seeded_validators = Validators(
+        data=[
+            Validator(
+                attestation_public_key=zero_public_key,
+                proposal_public_key=zero_public_key,
+                index=ValidatorIndex(validator_position),
+            )
+            for validator_position in range(3)
+        ]
+    )
+
+    state_transition_test(
+        pre=LstarSpec().generate_genesis(
+            genesis_time=Uint64(0),
+            validators=seeded_validators,
+        ),
+        blocks=[],
+        post=StateExpectation(validators=seeded_validators),
+    )
+
+
 def test_genesis_maximum_validators_with_forced_threshold_attestation(
     state_transition_test: StateTransitionTestFiller,
 ) -> None:


### PR DESCRIPTION
## Summary

`StateExpectation` previously exposed only a validator-registry **count** accessor (`validator_count`). A consensus vector could assert *how many* validators a post-state held, but not *which ones* or their fields.

This adds an optional `validators` expectation that, when set, checks the actual registry entries against the expected ones, mirroring the existing collection fields (`historical_block_hashes`, `justified_slots`, etc.). It is wired in through the same `_SCALAR_ACCESSORS` table, so the check runs in the existing selective-validation path with a full-equality comparison.

## Changes

- `packages/testing/src/consensus_testing/test_types/state_expectation.py`: add an optional `validators` field and its accessor.
- `tests/consensus/lstar/state_transition/test_genesis.py`: a genesis vector seeds three known zero-key validators and asserts the registry holds exactly those entries in order.

## Verification

- `uv run fill --fork=Lstar --clean` on the new vector: passes (determinism check passes).
- Confirmed the check is meaningful: a matching registry passes; a wrong entry count and wrong key bytes each raise an `AssertionError`.
- `just check`: clean (ruff, format, ty, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)