### PR TITLE
test: assert full exception messages at bare pytest.raises sites

### DIFF
--- a/tests/node/chain/test_clock.py
+++ b/tests/node/chain/test_clock.py
@@ -264,8 +264,9 @@ class TestSlotClockImmutability:
     def test_is_frozen(self) -> None:
         """The clock is immutable, so reassigning a field raises."""
         clock = SlotClock(genesis_time=Uint64(1_700_000_000))
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError) as exception_info:
             clock.genesis_time = Uint64(1_700_000_001)  # type: ignore[misc]
+        assert str(exception_info.value) == "cannot assign to field 'genesis_time'"
 
 
 class TestReturnTypes:

--- a/tests/node/chain/test_service.py
+++ b/tests/node/chain/test_service.py
@@ -181,8 +181,9 @@ class TestCatchUp:
         service.sync_service.store = service.sync_service.store.model_copy(
             update={"time": Interval(5)}
         )
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError) as exception_info:
             await service._tick_to(Interval(3))
+        assert str(exception_info.value) == ""
 
     async def test_continues_on_a_store_swapped_in_during_the_yield(self) -> None:
         """A store replaced mid-catch-up is picked up on the next tick, not the stale one."""

--- a/tests/node/genesis/test_config.py
+++ b/tests/node/genesis/test_config.py
@@ -154,7 +154,9 @@ class TestGenesisConfigValidation:
                 ],
             }
         )
-        with pytest.raises(ValidationError):
+        # Anchor the stable pydantic summary line; the per-error body carries a
+        # version-pinned docs URL that drifts across pydantic releases.
+        with pytest.raises(ValidationError, match=r"^6 validation errors for GenesisConfig\n"):
             _load(yaml_content)
 
     def test_wrong_length_public_key_raises_error(self) -> None:
@@ -170,8 +172,9 @@ class TestGenesisConfigValidation:
                 ],
             }
         )
-        with pytest.raises(SSZValueError):
+        with pytest.raises(SSZValueError) as exception_info:
             _load(yaml_content)
+        assert str(exception_info.value) == "Bytes52 requires exactly 52 bytes, got 5"
 
     def test_missing_genesis_time_raises_error(self) -> None:
         """Requires GENESIS_TIME field."""
@@ -185,7 +188,12 @@ class TestGenesisConfigValidation:
                 ],
             }
         )
-        with pytest.raises(ValidationError):
+        # Anchor the stable pydantic summary and the missing-field tag; the per-error
+        # body carries a version-pinned docs URL that drifts across pydantic releases.
+        with pytest.raises(
+            ValidationError,
+            match=r"^1 validation error for GenesisConfig\nGENESIS_TIME\n  Field required",
+        ):
             _load(yaml_content)
 
     def test_missing_validators_raises_error(self) -> None:
@@ -195,7 +203,12 @@ class TestGenesisConfigValidation:
                 "GENESIS_TIME": 1704085200,
             }
         )
-        with pytest.raises(ValidationError):
+        # Anchor the stable pydantic summary and the missing-field tag; the per-error
+        # body carries a version-pinned docs URL that drifts across pydantic releases.
+        with pytest.raises(
+            ValidationError,
+            match=r"^1 validation error for GenesisConfig\nGENESIS_VALIDATORS\n  Field required",
+        ):
             _load(yaml_content)
 
     def test_validators_not_a_list_raises_error(self) -> None:
@@ -206,7 +219,15 @@ class TestGenesisConfigValidation:
                 "GENESIS_VALIDATORS": "not_a_list",
             }
         )
-        with pytest.raises(ValidationError):
+        # Anchor the stable pydantic summary and the list-type tag; the per-error
+        # body carries a version-pinned docs URL that drifts across pydantic releases.
+        with pytest.raises(
+            ValidationError,
+            match=(
+                r"^1 validation error for GenesisConfig\n"
+                r"GENESIS_VALIDATORS\n  Input should be a valid list"
+            ),
+        ):
             _load(yaml_content)
 
 

--- a/tests/node/networking/client/event_source/test_gossip.py
+++ b/tests/node/networking/client/event_source/test_gossip.py
@@ -682,8 +682,9 @@ class TestGossipReceptionEdgeCases:
         """Handles various malformed varint patterns."""
         stream = MockStream(invalid_data)
 
-        with pytest.raises(GossipMessageError):
+        with pytest.raises(GossipMessageError) as exception_info:
             await read_gossip_message(stream)
+        assert str(exception_info.value) == "Truncated gossip message"
 
     async def test_topic_only_message_missing_data(self) -> None:
         """Raises error when message has topic but no data section."""
@@ -745,8 +746,11 @@ class TestGossipHandlerForkMismatch:
         handler = GossipHandler(network_name=FORK_DIGEST)
         compressed = compress(b"\x00" * 32)
 
-        with pytest.raises(ForkMismatchError):
+        with pytest.raises(ForkMismatchError) as exception_info:
             handler.decode_message(_block_topic(WRONG_FORK_DIGEST), compressed)
+        assert str(exception_info.value) == (
+            f"Fork mismatch: expected {FORK_DIGEST}, got {WRONG_FORK_DIGEST}"
+        )
 
         # Verify it does NOT raise GossipMessageError
         try:

--- a/tests/node/networking/client/event_source/test_live.py
+++ b/tests/node/networking/client/event_source/test_live.py
@@ -185,8 +185,9 @@ class TestLiveNetworkEventSourceAsyncIteration:
         """Raises StopAsyncIteration immediately when not running."""
         es = _make_event_source()
 
-        with pytest.raises(StopAsyncIteration):
+        with pytest.raises(StopAsyncIteration) as exception_info:
             await es.__anext__()
+        assert str(exception_info.value) == ""
 
 
 class TestLiveNetworkEventSourceDisconnect:

--- a/tests/node/networking/enr/test_enr.py
+++ b/tests/node/networking/enr/test_enr.py
@@ -176,8 +176,9 @@ class TestTextFormatValidation:
 
     def test_prefix_only_rejected(self) -> None:
         """Prefix only without data is rejected."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as exception_info:
             ENR.from_string("enr:")
+        assert str(exception_info.value) == "Invalid RLP encoding: Empty RLP data"
 
     def test_invalid_base64_rejected(self) -> None:
         """Invalid base64 encoding is rejected."""

--- a/tests/node/networking/enr/test_eth2.py
+++ b/tests/node/networking/enr/test_eth2.py
@@ -33,7 +33,16 @@ class TestEth2Data:
             next_fork_version=Version(b"\x02\x00\x00\x00"),
             next_fork_epoch=Uint64(0),
         )
-        with pytest.raises(ValidationError):
+        # Pydantic emits a multi-line frozen-instance report ending in a version-pinned URL.
+        # Anchor the stable header and the frozen-instance reason line, not the URL.
+        with pytest.raises(
+            ValidationError,
+            match=(
+                r"(?s)^1 validation error for Eth2Data\n"
+                r"fork_digest\n"
+                r"  Instance is frozen \[type=frozen_instance,"
+            ),
+        ):
             eth2_data.fork_digest = ForkDigest(b"\x00\x00\x00\x00")
 
     def test_far_future_epoch_value(self) -> None:
@@ -76,21 +85,25 @@ class TestAttestationSubnets:
 
     def test_invalid_subnet_id_in_from_subnet_ids(self) -> None:
         """from_subnet_ids() raises for invalid subnet IDs."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as above_range_exception_info:
             AttestationSubnets.from_subnet_ids([64])
+        assert str(above_range_exception_info.value) == "Subnet ID must be 0-63, got 64"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as negative_exception_info:
             AttestationSubnets.from_subnet_ids([-1])
+        assert str(negative_exception_info.value) == "Subnet ID must be 0-63, got -1"
 
     def test_invalid_subnet_id_in_is_subscribed(self) -> None:
         """is_subscribed() raises for invalid subnet IDs."""
         subnets = AttestationSubnets.none()
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as above_range_exception_info:
             subnets.is_subscribed(64)
+        assert str(above_range_exception_info.value) == "Subnet ID must be 0-63, got 64"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as negative_exception_info:
             subnets.is_subscribed(-1)
+        assert str(negative_exception_info.value) == "Subnet ID must be 0-63, got -1"
 
     def test_from_subnet_ids_empty_list(self) -> None:
         """from_subnet_ids with empty list creates no subscriptions."""

--- a/tests/node/networking/gossipsub/test_topic.py
+++ b/tests/node/networking/gossipsub/test_topic.py
@@ -37,11 +37,12 @@ class TestTopicForkValidation:
 
     def test_from_string_validated_raises_on_mismatch(self) -> None:
         """Test from_string_validated raises ForkMismatchError on mismatch."""
-        with pytest.raises(ForkMismatchError):
+        with pytest.raises(ForkMismatchError) as exception_info:
             GossipTopic.from_string_validated(
                 "/leanconsensus/12345678/block/ssz_snappy",
                 expected_network_name="deadbeef",
             )
+        assert str(exception_info.value) == "Fork mismatch: expected deadbeef, got 12345678"
 
     def test_from_string_validated_raises_on_invalid_topic(self) -> None:
         """Test from_string_validated raises ValueError for invalid topics."""

--- a/tests/node/networking/reqresp/test_handler.py
+++ b/tests/node/networking/reqresp/test_handler.py
@@ -1322,24 +1322,28 @@ class TestBlocksByRangeRequestMalformedPayloads:
     def test_truncated_payload_rejected(self) -> None:
         """Payload shorter than 16 bytes is rejected."""
         truncated = b"\x01" * 15  # 15 bytes, need 16
-        with pytest.raises(SSZSerializationError):
+        with pytest.raises(SSZSerializationError) as exception_info:
             BlocksByRangeRequest.decode_bytes(truncated)
+        assert str(exception_info.value) == "Uint64: expected 8 bytes, got 7"
 
     def test_empty_payload_rejected(self) -> None:
         """Zero-length payload is rejected."""
-        with pytest.raises(SSZSerializationError):
+        with pytest.raises(SSZSerializationError) as exception_info:
             BlocksByRangeRequest.decode_bytes(b"")
+        assert str(exception_info.value) == "Slot: expected 8 bytes, got 0"
 
     def test_single_byte_rejected(self) -> None:
         """Single byte payload is rejected."""
-        with pytest.raises(SSZSerializationError):
+        with pytest.raises(SSZSerializationError) as exception_info:
             BlocksByRangeRequest.decode_bytes(b"\x00")
+        assert str(exception_info.value) == "Slot: expected 8 bytes, got 1"
 
     def test_eight_byte_payload_rejected(self) -> None:
         """8 bytes (half-payload, single field) is rejected."""
         partial = (100).to_bytes(8, "little")
-        with pytest.raises(SSZSerializationError):
+        with pytest.raises(SSZSerializationError) as exception_info:
             BlocksByRangeRequest.decode_bytes(partial)
+        assert str(exception_info.value) == "Uint64: expected 8 bytes, got 0"
 
 
 class TestBlocksByRangeProtocolId:

--- a/tests/node/networking/transport/quic/test_connection.py
+++ b/tests/node/networking/transport/quic/test_connection.py
@@ -261,10 +261,12 @@ class TestQuicStreamReset:
     async def test_repeated_reads_after_reset_raise(self, quic_stream: QuicStream) -> None:
         """Subsequent reads after reset continue to raise."""
         quic_stream._receive_reset(error_code=0)
-        with pytest.raises(QuicStreamResetError):
+        with pytest.raises(QuicStreamResetError) as first_read_exception_info:
             await quic_stream.read()
-        with pytest.raises(QuicStreamResetError):
+        assert str(first_read_exception_info.value) == "Stream 0 reset by peer (error_code=0)"
+        with pytest.raises(QuicStreamResetError) as second_read_exception_info:
             await quic_stream.read()
+        assert str(second_read_exception_info.value) == "Stream 0 reset by peer (error_code=0)"
 
     def test_reset_error_is_subclass_of_transport_error(self) -> None:
         """Reset error inherits from the base transport error."""

--- a/tests/node/networking/transport/quic/test_stream_adapter.py
+++ b/tests/node/networking/transport/quic/test_stream_adapter.py
@@ -301,8 +301,9 @@ class TestMessageFormat:
         peer.write(b"ABC")
         await peer.finish_write()
         await peer.drain()
-        with pytest.raises(EOFError):
+        with pytest.raises(EOFError) as exception_info:
             await stream.readexactly(6)
+        assert str(exception_info.value) == "Stream closed before enough data received"
 
     async def test_write_drain_buffers(self) -> None:
         """Write accumulates, drain flushes to stream"""

--- a/tests/node/snappy/test_decompress.py
+++ b/tests/node/snappy/test_decompress.py
@@ -114,8 +114,9 @@ class TestCorruptedData:
         corrupted[3] += 1
 
         # The important thing is that decompression fails gracefully.
-        with pytest.raises(SnappyDecompressionError):
+        with pytest.raises(SnappyDecompressionError) as exception_info:
             decompress(bytes(corrupted))
+        assert str(exception_info.value) == "Copy offset 1768645229 exceeds output buffer size 0"
 
     def test_zero_length_header(self) -> None:
         """Test data with zeroed length header."""
@@ -143,8 +144,9 @@ class TestCorruptedData:
         corrupted[3] = 0x00
 
         # Decompression should fail because we can't produce that many bytes.
-        with pytest.raises(SnappyDecompressionError):
+        with pytest.raises(SnappyDecompressionError) as exception_info:
             decompress(bytes(corrupted))
+        assert str(exception_info.value) == "Copy offset 766 exceeds output buffer size 0"
 
     @pytest.mark.parametrize("bad_file", ["baddata1.snappy", "baddata2.snappy", "baddata3.snappy"])
     def test_bad_data_files(self, bad_file: str) -> None:
@@ -164,8 +166,11 @@ class TestCorruptedData:
 
         # Truncate to remove some literal data
         truncated = compressed[:-3]
-        with pytest.raises(SnappyDecompressionError):
+        with pytest.raises(SnappyDecompressionError) as exception_info:
             decompress(truncated)
+        assert str(exception_info.value) == (
+            "Literal at position 1 extends past end of input: needs 13 bytes but only 10 available"
+        )
 
     def test_invalid_copy_offset(self) -> None:
         """Test copy referencing beyond available data."""

--- a/tests/node/storage/test_sqlite.py
+++ b/tests/node/storage/test_sqlite.py
@@ -273,10 +273,11 @@ class TestBatchWrite:
         with db.batch_write():
             db.put_head_root(root)
 
-        with pytest.raises(StorageWriteError):
+        with pytest.raises(StorageWriteError) as exception_info:
             with db.batch_write():
                 db.put_head_root(Bytes32(b"\x16" * 32))
                 raise StorageWriteError("simulated failure")
+        assert str(exception_info.value) == "simulated failure"
 
         assert db.get_head_root() == root
 
@@ -372,7 +373,8 @@ class TestErrorPaths:
         """Operations on a closed database raise StorageReadError."""
         db.close()
 
-        with pytest.raises(StorageReadError):
+        # Anchor only the stable prefix; the trailing sqlite3 internal text varies by version.
+        with pytest.raises(StorageReadError, match=r"^Failed to read head root: "):
             db.get_head_root()
 
 

--- a/tests/node/sync/test_checkpoint_sync.py
+++ b/tests/node/sync/test_checkpoint_sync.py
@@ -204,10 +204,11 @@ class TestFetchFinalizedState:
                 "lean_spec.node.sync.checkpoint_sync.httpx.AsyncClient",
                 return_value=httpx.AsyncClient(transport=_CapturingTransport()),
             ),
-            pytest.raises(CheckpointSyncError),
+            pytest.raises(CheckpointSyncError) as exception_info,
         ):
             await fetch_finalized_state("http://example.com/", State)
 
+        assert str(exception_info.value) == "Failed to fetch state: Slot: expected 8 bytes, got 1"
         assert captured == [f"http://example.com{FINALIZED_STATE_ENDPOINT}"]
 
 

--- a/tests/node/validator/test_registry.py
+++ b/tests/node/validator/test_registry.py
@@ -113,7 +113,11 @@ class TestValidatorManifestEntry:
 
     def test_integer_public_key_rejected(self) -> None:
         """Integer public_keys are rejected — only valid 52-byte hex strings accepted."""
-        with pytest.raises((TypeError, ValidationError)):
+        # Pydantic's multi-line report embeds the rejected integer and its type.
+        # Anchor only the stable type-mismatch line naming the expected key type.
+        with pytest.raises(
+            (TypeError, ValidationError), match=r"Input should be an instance of Bytes52"
+        ):
             ValidatorManifestEntry(
                 index=ValidatorIndex(0),
                 attestation_public_key_hex=0x123,  # type: ignore[arg-type]
@@ -124,7 +128,7 @@ class TestValidatorManifestEntry:
 
     def test_wrong_length_public_key_rejected(self) -> None:
         """Hex strings that don't decode to exactly 52 bytes are rejected."""
-        with pytest.raises((SSZValueError, ValidationError)):
+        with pytest.raises((SSZValueError, ValidationError)) as exception_info:
             ValidatorManifestEntry(
                 index=ValidatorIndex(0),
                 attestation_public_key_hex=Bytes52("0x" + "aa" * 10),
@@ -132,6 +136,7 @@ class TestValidatorManifestEntry:
                 attestation_private_key_file="att.ssz",
                 proposal_private_key_file="prop.ssz",
             )
+        assert str(exception_info.value) == "Bytes52 requires exactly 52 bytes, got 10"
 
 
 class TestValidatorManifest:

--- a/tests/spec/crypto/test_koalabear.py
+++ b/tests/spec/crypto/test_koalabear.py
@@ -348,7 +348,13 @@ def test_pydantic_schema_passes_through_existing_fp_instance() -> None:
 @pytest.mark.parametrize("bad", [P, P + 1, -1])
 def test_pydantic_schema_rejects_out_of_range_ints(bad: int) -> None:
     """Raw integers outside the canonical range are rejected by Pydantic validation."""
-    with pytest.raises(ValidationError):
+    # The union schema reports two errors whose tail differs per bound, and the URL is
+    # version-pinned, so anchor the stable count line and instance-check leg only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^2 validation errors for _PydanticModelWithFp\nx\.is-instance\[Fp\]\n"
+        r"  Input should be an instance of Fp \[type=is_instance_of,",
+    ):
         _PydanticModelWithFp(x=bad)  # ty: ignore[invalid-argument-type]
 
 

--- a/tests/spec/crypto/test_merkleization.py
+++ b/tests/spec/crypto/test_merkleization.py
@@ -169,8 +169,9 @@ def test_mix_in_length_zero() -> None:
 
 def test_mix_in_length_error_on_negative() -> None:
     """Rejects negative lengths."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exception_info:
         mix_in_length(sample_chunks[0], -1)
+    assert str(exception_info.value) == "length must be non-negative"
 
 
 def test_zero_tree_root_internal() -> None:

--- a/tests/spec/crypto/xmss/test_containers.py
+++ b/tests/spec/crypto/xmss/test_containers.py
@@ -123,7 +123,12 @@ def test_json_roundtrip_preserves_equality(keypair_a: KeyPair, keypair_b: KeyPai
 def test_frozen_blocks_field_assignment(keypair_a: KeyPair, keypair_b: KeyPair) -> None:
     """Reassigning a field after construction raises (frozen model)."""
     validator_keypair = ValidatorKeyPair(attestation_keypair=keypair_a, proposal_keypair=keypair_b)
-    with pytest.raises(ValidationError):
+    # The reported input value embeds key material, so anchor the stable core only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^1 validation error for ValidatorKeyPair\nattestation_keypair\n"
+        r"  Instance is frozen \[type=frozen_instance,",
+    ):
         validator_keypair.attestation_keypair = keypair_b
 
 
@@ -133,7 +138,12 @@ def test_extra_fields_rejected(
     """Unknown top-level keys raise so JSON typos fail loud."""
     # A misspelled role name must not silently produce defaults.
     polluted = {**hex_dict, "spurious": "ignored"}
-    with pytest.raises(ValidationError):
+    # Pydantic's report carries a version-pinned URL, so anchor the stable core only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^1 validation error for ValidatorKeyPair\nspurious\n"
+        r"  Extra inputs are not permitted \[type=extra_forbidden,",
+    ):
         ValidatorKeyPair.model_validate(polluted)
 
 
@@ -150,7 +160,12 @@ def test_rejects_non_keypair_non_mapping(
         "attestation_keypair": bad_value,
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
-    with pytest.raises(ValidationError):
+    # The reported input value varies per parametrized bad value, so anchor the core only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^1 validation error for ValidatorKeyPair\nattestation_keypair\n"
+        r"  Input should be a valid dictionary or instance of KeyPair \[type=model_type,",
+    ):
         ValidatorKeyPair.model_validate(keypair_mapping)
 
 
@@ -163,7 +178,12 @@ def test_rejects_missing_public_key(
         "attestation_keypair": {"secret_key": keypair_a.secret_key.encode_bytes().hex()},
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
-    with pytest.raises(ValidationError):
+    # The reported input value embeds key material, so anchor the stable core only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^1 validation error for ValidatorKeyPair\nattestation_keypair\.publicKey\n"
+        r"  Field required \[type=missing,",
+    ):
         ValidatorKeyPair.model_validate(keypair_mapping)
 
 
@@ -176,7 +196,12 @@ def test_rejects_missing_secret_key(
         "attestation_keypair": {"public_key": keypair_a.public_key.encode_bytes().hex()},
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
-    with pytest.raises(ValidationError):
+    # The reported input value embeds key material, so anchor the stable core only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^1 validation error for ValidatorKeyPair\nattestation_keypair\.secretKey\n"
+        r"  Field required \[type=missing,",
+    ):
         ValidatorKeyPair.model_validate(keypair_mapping)
 
 
@@ -192,7 +217,12 @@ def test_rejects_non_string_hex_value(
         },
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
-    with pytest.raises(ValidationError):
+    # Pydantic's report carries a version-pinned URL, so anchor the stable core only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^1 validation error for ValidatorKeyPair\nattestation_keypair\.public_key\n"
+        r"  Input should be a valid dictionary or instance of PublicKey \[type=model_type,",
+    ):
         ValidatorKeyPair.model_validate(keypair_mapping)
 
 
@@ -208,7 +238,13 @@ def test_rejects_invalid_hex_characters(
         },
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
-    with pytest.raises(ValidationError):
+    # The reported input value embeds the long bad hex blob, so anchor the stable core only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^1 validation error for ValidatorKeyPair\nattestation_keypair\.public_key\n"
+        r"  Value error, non-hexadecimal number found in fromhex\(\) arg at position 0 "
+        r"\[type=value_error,",
+    ):
         ValidatorKeyPair.model_validate(keypair_mapping)
 
 
@@ -222,19 +258,35 @@ def test_rejects_wrong_length_hex(keypair_a: KeyPair, hex_dict: dict[str, dict[s
         },
         "proposal_keypair": hex_dict["proposal_keypair"],
     }
-    with pytest.raises(ValidationError):
+    # Pydantic's report carries a version-pinned URL, so anchor the stable core only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^1 validation error for ValidatorKeyPair\nattestation_keypair\.public_key\n"
+        r"  Value error, invalid PublicKey hex: Value 4022250974 exceeds field modulus "
+        r"2130706433 \[type=value_error,",
+    ):
         ValidatorKeyPair.model_validate(keypair_mapping)
 
 
 def test_rejects_missing_role(hex_dict: dict[str, dict[str, str]]) -> None:
     """Both attestation and proposal roles are required."""
-    with pytest.raises(ValidationError):
+    # The reported input value embeds key material, so anchor the stable core only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^1 validation error for ValidatorKeyPair\nproposalKeypair\n"
+        r"  Field required \[type=missing,",
+    ):
         ValidatorKeyPair.model_validate({"attestation_keypair": hex_dict["attestation_keypair"]})
 
 
 def test_keypair_frozen(keypair_a: KeyPair) -> None:
     """KeyPair fields cannot be reassigned (StrictBaseModel is frozen)."""
-    with pytest.raises(ValidationError):
+    # The reported input value embeds key material, so anchor the stable core only.
+    with pytest.raises(
+        ValidationError,
+        match=r"(?s)^1 validation error for KeyPair\npublic_key\n"
+        r"  Instance is frozen \[type=frozen_instance,",
+    ):
         keypair_a.public_key = keypair_a.public_key
 
 

--- a/tests/spec/crypto/xmss/test_merkle.py
+++ b/tests/spec/crypto/xmss/test_merkle.py
@@ -361,8 +361,9 @@ def test_verify_path_rejects_excessive_depth_at_ssz_level() -> None:
     The defensive depth guard inside verification cannot be reached through a
     well-formed opening, since the digest list rejects more than its limit.
     """
-    with pytest.raises(SSZValueError):
+    with pytest.raises(SSZValueError) as exception_info:
         HashDigestList(data=[random_domain(PROD_CONFIG) for _ in range(33)])
+    assert str(exception_info.value) == "HashDigestList exceeds limit of 32, got 33"
 
 
 @pytest.mark.parametrize("position", [16, 100])

--- a/tests/spec/crypto/xmss/test_types.py
+++ b/tests/spec/crypto/xmss/test_types.py
@@ -47,8 +47,9 @@ def test_hash_digest_vector_accepts_exact_length() -> None:
 
 def test_hash_digest_vector_rejects_wrong_length() -> None:
     """A digest vector of the wrong length fails validation."""
-    with pytest.raises(SSZValueError):
+    with pytest.raises(SSZValueError) as exception_info:
         HashDigestVector(data=[Fp(value=0)] * (TEST_CONFIG.HASH_LENGTH_FIELD_ELEMENTS + 1))
+    assert str(exception_info.value) == "HashDigestVector requires exactly 8 elements, got 9"
 
 
 def test_parameter_length_is_parameter_length() -> None:
@@ -75,8 +76,9 @@ def test_hash_digest_list_accepts_limit_entries() -> None:
 def test_hash_digest_list_rejects_over_limit() -> None:
     """A digest list one entry past the cap fails validation."""
     nodes = [random_domain(TEST_CONFIG) for _ in range(NODE_LIST_LIMIT + 1)]
-    with pytest.raises(SSZValueError):
+    with pytest.raises(SSZValueError) as exception_info:
         HashDigestList(data=nodes)
+    assert str(exception_info.value) == "HashDigestList exceeds limit of 32, got 33"
 
 
 def test_hash_tree_opening_roundtrips_through_ssz() -> None:

--- a/tests/spec/observability/test_observer.py
+++ b/tests/spec/observability/test_observer.py
@@ -108,7 +108,8 @@ class TestObserveContextManagers:
         observer = _RecordingObserver()
         set_observer(observer)
 
-        with pytest.raises(RuntimeError), cm():
+        with pytest.raises(RuntimeError) as exception_info, cm():
             raise RuntimeError("boom")
+        assert str(exception_info.value) == "boom"
 
         assert observer.samples[method_name] == []

--- a/tests/spec/ssz/test_bitfields.py
+++ b/tests/spec/ssz/test_bitfields.py
@@ -112,8 +112,13 @@ class TestBitvector:
     )
     def test_pydantic_validation_rejects_wrong_length(self, invalid_value: Any) -> None:
         """Pydantic validation rejects lists of the wrong length."""
-        with pytest.raises(ValueOrValidationError):
+        provided_bit_count = len(invalid_value["data"])
+        with pytest.raises(ValueOrValidationError) as exception_info:
             Bitvector4Model(value=invalid_value)
+        assert (
+            str(exception_info.value)
+            == f"Bitvector4 requires exactly 4 elements, got {provided_bit_count}"
+        )
 
     def test_bitvector_is_immutable(self) -> None:
         """Item assignment on a Bitvector raises TypeError — Pydantic models are immutable."""
@@ -122,8 +127,9 @@ class TestBitvector:
             LENGTH = 2
 
         vec = Bitvector2(data=[Boolean(True), Boolean(False)])
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError) as exception_info:
             vec[0] = False  # type: ignore[index]
+        assert str(exception_info.value) == "'Bitvector2' object does not support item assignment"
 
 
 class TestBitlist:
@@ -207,8 +213,9 @@ class TestBitlist:
     def test_pydantic_validation_rejects_oversized_list(self) -> None:
         """Pydantic validation rejects lists exceeding the limit."""
         invalid_value = {"data": [Boolean(True)] * 9}
-        with pytest.raises(ValueOrValidationError):
+        with pytest.raises(ValueOrValidationError) as exception_info:
             Bitlist8Model(value=invalid_value)  # type: ignore[arg-type]
+        assert str(exception_info.value) == "Bitlist8 exceeds limit of 8, got 9"
 
     def test_get_item_int(self) -> None:
         """Indexing by int returns the Boolean at that position."""
@@ -255,8 +262,11 @@ class TestBitlist:
     def test_add_with_unsupported_type_raises(self) -> None:
         """Adding an unsupported type returns NotImplemented and Python raises TypeError."""
         bitlist = Bitlist8(data=[Boolean(True)])
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError) as exception_info:
             _ = bitlist + 42
+        assert (
+            str(exception_info.value) == "unsupported operand type(s) for +: 'Bitlist8' and 'int'"
+        )
 
     def test_add_exceeding_limit_raises_error(self) -> None:
         """Concatenation beyond LIMIT raises with the exact size in the message."""

--- a/tests/spec/ssz/test_boolean.py
+++ b/tests/spec/ssz/test_boolean.py
@@ -28,7 +28,9 @@ def test_pydantic_validation_accepts_valid_bool(valid_value: bool) -> None:
 @pytest.mark.parametrize("invalid_value", [1, 0, 1.0, "True"])
 def test_pydantic_strict_mode_rejects_invalid_types(invalid_value: Any) -> None:
     """Tests that Pydantic's strict mode rejects types that are not `bool`."""
-    with pytest.raises(ValidationError):
+    # Pydantic's multi-line report embeds the rejected input value and type.
+    # Anchor only the stable type-mismatch line shared across all inputs.
+    with pytest.raises(ValidationError, match=r"Input should be an instance of Boolean"):
         BooleanModel(value=invalid_value)
 
 

--- a/tests/spec/ssz/test_byte_arrays.py
+++ b/tests/spec/ssz/test_byte_arrays.py
@@ -474,8 +474,9 @@ class TestBaseByteListPydantic:
 
     def test_rejects_oversized_input(self) -> None:
         """Pydantic rejects data exceeding LIMIT via SSZValueError."""
-        with pytest.raises(SSZValueError):
+        with pytest.raises(SSZValueError) as exception_info:
             ModelLists(payload=ByteList16(data=bytes(range(17))))
+        assert str(exception_info.value) == "ByteList16 exceeds limit of 16, got 17"
 
     def test_json_serialization_to_hex(self) -> None:
         """JSON-mode serialization renders the data field as a 0x-prefixed hex string."""

--- a/tests/spec/ssz/test_collections.py
+++ b/tests/spec/ssz/test_collections.py
@@ -377,8 +377,9 @@ class TestSSZVectorAccessors:
         """Item assignment raises because the underlying model is frozen."""
         instance = Uint8Vector2(data=[Uint8(1), Uint8(2)])
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError) as exception_info:
             instance[0] = 3  # type: ignore[index]
+        assert str(exception_info.value) == "'Uint8Vector2' object does not support item assignment"
 
     def test_pydantic_dict_input_coerces_to_vector(self) -> None:
         """Pydantic coerces a dict payload into an SSZVector with typed elements."""

--- a/tests/spec/ssz/test_uint.py
+++ b/tests/spec/ssz/test_uint.py
@@ -2,6 +2,7 @@
 
 import io
 import operator
+import re
 from itertools import permutations
 from typing import Any, Type
 
@@ -63,7 +64,10 @@ def test_pydantic_strict_mode_rejects_invalid_types(
 ) -> None:
     """Tests that Pydantic's strict mode rejects types that could be coerced to an int."""
     model = UINT_MODELS[uint_class]
-    with pytest.raises(ValidationError):
+    # Pydantic's multi-line report embeds the rejected input value and type.
+    # Anchor only the stable type-mismatch line naming the expected uint class.
+    expected_type_mismatch_line = f"Input should be an instance of {uint_class.__name__}"
+    with pytest.raises(ValidationError, match=re.escape(expected_type_mismatch_line)):
         model(value=invalid_value)
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -79,7 +79,12 @@ class TestStrictBaseModel:
         """
         model = SampleStrictModel(slot_number=5, block_root="0xabc")
 
-        with pytest.raises(ValidationError):
+        # Pydantic's report carries a version-pinned URL, so anchor the stable core only.
+        with pytest.raises(
+            ValidationError,
+            match=r"(?s)^1 validation error for SampleStrictModel\nslot_number\n"
+            r"  Instance is frozen \[type=frozen_instance,",
+        ):
             model.slot_number = 10
 
     def test_extra_fields_forbidden(self) -> None:
@@ -88,7 +93,12 @@ class TestStrictBaseModel:
 
         This catches typos and schema mismatches early.
         """
-        with pytest.raises(ValidationError):
+        # Pydantic's report carries a version-pinned URL, so anchor the stable core only.
+        with pytest.raises(
+            ValidationError,
+            match=r"(?s)^1 validation error for SampleStrictModel\nunknown_field\n"
+            r"  Extra inputs are not permitted \[type=extra_forbidden,",
+        ):
             SampleStrictModel(
                 slot_number=5,
                 block_root="0xabc",
@@ -102,7 +112,12 @@ class TestStrictBaseModel:
         Without strict mode, Pydantic would silently convert "5" to 5.
         In spec code, this kind of silent coercion hides bugs.
         """
-        with pytest.raises(ValidationError):
+        # Pydantic's report carries a version-pinned URL, so anchor the stable core only.
+        with pytest.raises(
+            ValidationError,
+            match=r"(?s)^1 validation error for SampleStrictModel\nslot_number\n"
+            r"  Input should be a valid integer \[type=int_type,",
+        ):
             SampleStrictModel(slot_number="5", block_root="0xabc")  # type: ignore[arg-type]
 
     def test_inherits_camel_serialization(self) -> None:


### PR DESCRIPTION
## TEST-07 (Minor): assert full exception messages at bare `pytest.raises` sites

Many `with pytest.raises(SomeError):` blocks across the test tree asserted only the exception **type**, not the message — so a message can drift or regress unnoticed. This PR sweeps those sites and, per the repo's "assert the complete error message" rule, captures the exception and asserts the full message via string equality:

```python
with pytest.raises(SomeError) as exception_info:
    ...
assert str(exception_info.value) == "the entire expected message"
```

### Scope

- 66 candidate sites inspected across `tests/` (`grep "pytest.raises(" | grep -v "match="`, then each manually verified).
- **59 converted** to assert the full message (or anchored stable core — see below).
- **7 left** as type-only checks, each for a documented reason where pinning the message would be fragile or impossible.

### Conversion detail

Most sites now use exact full-equality on `str(exception_info.value)` (SSZ length/limit errors, fork-mismatch, snappy decompression errors, frozen-dataclass `FrozenInstanceError`, in-test raises, etc.).

Where the raised text is a **brittle third-party report**, the stable header and reason line are anchored with an anchored `match=r"(?s)^...$"`-style pattern (escaping regex metacharacters) rather than forcing a fragile exact match, with a one-line comment noting why:

- pydantic `ValidationError` multi-line reports embed the rejected input value/type and a **version-pinned docs URL** (`test_base.py`, `test_koalabear.py`, `xmss/test_containers.py`, `ssz/test_boolean.py`, `ssz/test_uint.py`, `validator/test_registry.py`, `genesis/test_config.py`, `enr/test_eth2.py`).
- `sqlite3` internal error text is version-brittle, so only the leanSpec-controlled prefix is anchored (`storage/test_sqlite.py`).

### Intentionally left as type-only (7)

| Site | Reason |
| --- | --- |
| `cli/test_args.py:110` | argparse `SystemExit` carries no message (`str(value)` is the exit code; usage text goes to stderr). |
| `quic/test_stream_adapter.py:313, 322` | `asyncio.TimeoutError` from `asyncio.wait_for` — library-raised, empty message. |
| `quic/test_connection.py:1194, 1253, 1319` | `asyncio.CancelledError` injected as a mock `side_effect` — no leanSpec-controlled message. |
| `xmss/test_merkle.py:104` | false positive — already asserted the full message. |

### Verification

- `uv run pytest tests/node tests/spec tests/cli tests/test_base.py` — 2818 passed.
- `just check` — all checks pass (ruff check, ruff format, ty, codespell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
