### PR TITLE
refactor(xmss): drop never-read MESSAGE_LENGTH config field

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/constants.py
+++ b/src/lean_spec/spec/crypto/xmss/constants.py
@@ -15,9 +15,6 @@ from lean_spec.spec.ssz.ssz_base import BYTES_PER_LENGTH_OFFSET
 class XmssConfig(StrictBaseModel):
     """A model holding the configuration constants for an XMSS preset."""
 
-    MESSAGE_LENGTH: int
-    """The length in bytes for all messages to be signed."""
-
     LOG_LIFETIME: int
     """The base-2 logarithm of the scheme's maximum lifetime."""
 
@@ -115,7 +112,6 @@ class XmssConfig(StrictBaseModel):
 
 
 PROD_CONFIG: Final = XmssConfig(
-    MESSAGE_LENGTH=32,
     LOG_LIFETIME=32,
     DIMENSION=46,
     BASE=8,
@@ -134,7 +130,6 @@ PROD_CONFIG: Final = XmssConfig(
 
 
 TEST_CONFIG: Final = XmssConfig(
-    MESSAGE_LENGTH=32,
     LOG_LIFETIME=8,
     DIMENSION=4,
     BASE=8,

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -99,11 +99,6 @@ _.row_factory
 # The mode is selected by value, so the member name has no direct reference.
 REAL
 
-# XMSS protocol parameter documented in the configuration model.
-# The byte length of a signed message, kept for spec fidelity even though the
-# computation works from the field-element count.
-MESSAGE_LENGTH
-
 # Dataclass field on a peer-subscription event.
 # Set from the subscribe flag at construction and compared through dataclass
 # equality in tests, neither of which vulture counts as a read.


### PR DESCRIPTION
## Summary

Removes the `MESSAGE_LENGTH` field from the XMSS configuration model. It was
declared on the config and set in both the production and test presets, but
nothing ever reads it: the signing and encoding paths work entirely from
`MESSAGE_LENGTH_FIELD_ELEMENTS`.

The maintainer decided to delete it rather than keep it for spec fidelity.

## Changes

- Drop the `MESSAGE_LENGTH` field (and its docstring) from the config model.
- Drop the two preset assignments (production and test).
- Drop the now-orphaned `vulture_whitelist.py` entry, so the dead-code gate
  passes without it.

`MESSAGE_LENGTH_FIELD_ELEMENTS` and every other config field are untouched.

## Verification

- Confirmed via repository-wide grep that the bare `MESSAGE_LENGTH` field has
  no readers (all reads target `MESSAGE_LENGTH_FIELD_ELEMENTS`).
- `uv run pytest tests/spec/crypto/xmss/` — 179 passed.
- `just check` — clean.
- `just deadcode` (vulture) — clean without the whitelist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)