### PR TITLE
fix: resolve vulture dead-code findings on main

### DIFF
--- a/tests/node/validator/test_service.py
+++ b/tests/node/validator/test_service.py
@@ -711,7 +711,7 @@ class TestValidatorServiceRun:
 
         block_slots: list[Slot] = []
 
-        async def mock_produce(self_inner, slot: Slot) -> None:
+        async def mock_produce(_self, slot: Slot) -> None:
             block_slots.append(slot)
             service.stop()
 
@@ -733,7 +733,7 @@ class TestValidatorServiceRun:
 
         attest_slots: list[Slot] = []
 
-        async def mock_attest(self_inner, slot: Slot) -> None:
+        async def mock_attest(_self, slot: Slot) -> None:
             attest_slots.append(slot)
             service.stop()
 
@@ -796,7 +796,7 @@ class TestValidatorServiceRun:
 
         attest_calls: list[Slot] = []
 
-        async def mock_attest(self_inner, slot: Slot) -> None:
+        async def mock_attest(_self, slot: Slot) -> None:
             attest_calls.append(slot)
 
         with (
@@ -824,7 +824,7 @@ class TestValidatorServiceRun:
         )
         service._attested_slots = {Slot(i) for i in range(6)}  # slots 0-5
 
-        async def mock_attest(self_inner, slot: Slot) -> None:
+        async def mock_attest(_self, slot: Slot) -> None:
             service.stop()
 
         with patch.object(ValidatorService, "_produce_attestations", mock_attest):

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -64,6 +64,8 @@ _.validate_target
 _.validate_rejection_is_declared
 _.validate_signatures_are_out_of_scope
 _._yaml_int_to_hex
+_._check_list_lengths
+_._reject_oversized_validator_set
 
 # Pydantic serializers, invoked by the model during serialization.
 _.serialize_value
@@ -169,3 +171,11 @@ y
 first_name
 slot_number
 _.slot_number
+
+# Access tier recorded on every route entry to document the route, not yet
+# read back by the registration path.
+is_admin
+
+# Attribute assignment in slotted-class tests that proves new attributes are
+# rejected; the assignment is the action under test, never read back.
+_.extra_field


### PR DESCRIPTION
## Summary

The `Dead code detection` CI job (vulture, via `just deadcode`) is failing on `main`. Several recently-merged PRs introduced symbols vulture reports, because they were verified with `just check` (which does not run vulture) rather than `just deadcode`. This PR makes the dead-code job green again.

## Findings and how each is handled

Genuinely unused — fixed in code:
- **`self_inner` (×4, 100% confidence)** in `tests/node/validator/test_service.py`: mock functions replacing `_maybe_produce_block` / `_produce_attestations` via `patch.object` receive the instance positionally but never use it. Renamed to `_self`, the idiomatic intentionally-unused marker vulture respects. The parameter cannot be dropped (the patched method is still called with the instance first).

Live code vulture cannot see — added to `vulture_whitelist.py` (its stated purpose: name the indirectly-used symbols):
- **`_check_list_lengths`** (`spec/crypto/xmss/containers.py`): a `@model_validator` invoked by pydantic. Removing it would disable the XMSS signature length validation.
- **`_reject_oversized_validator_set`** (`node/genesis/config.py`): a `@field_validator` invoked by pydantic. Removing it would disable the genesis validator-count bound.
- **`is_admin`** (`node/api/routes.py`): access-tier flag set on every route entry to document the route; not yet read by the registration path.
- **`extra_field`** (`tests/node/networking/test_types.py`): the attribute assignment is the action under test (slotted classes must reject new attributes), never read back.

Not addressed (out of scope): the `packages/testing/build/lib/*` hits are a gitignored local build artifact that CI never checks out.

## Verification

- `just deadcode` exits 0 against a tree without the local `build/` artifact (mirroring CI's fresh checkout).
- `just check` is fully green.
- `uv run pytest tests/node/validator/test_service.py` — 51 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)