### PR TITLE
fix(forkchoice): derive finalized from canonical head, not an independent max

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -805,19 +805,23 @@ class ForkChoiceMixin(LstarSpecBase):
             attestations=latest_votes,
         )
         # Invariant: the finalized checkpoint stays on the head's chain.
-        # Its root is the head's own ancestor at the finalized slot.
-        # A checkpoint-sync anchor state holds a placeholder for its own block.
-        # The ancestor walk recovers the real block.
+        # Climb from the head to its ancestor at the finalized slot.
         finalized_slot = store.states[new_head].latest_finalized.slot
         finalized_root = new_head
-        while store.blocks[finalized_root].slot > finalized_slot:
-            finalized_root = store.blocks[finalized_root].parent_root
-        return store.model_copy(
-            update={
-                "head": new_head,
-                "latest_finalized": Checkpoint(root=finalized_root, slot=finalized_slot),
-            }
-        )
+        while finalized_root in store.blocks and store.blocks[finalized_root].slot > finalized_slot:
+            parent_root = store.blocks[finalized_root].parent_root
+            if parent_root not in store.blocks:
+                break
+            finalized_root = parent_root
+
+        # A fresh checkpoint-sync anchor stores no block at that slot.
+        # Keep the trusted anchor there rather than emit an unresolved root.
+        if store.blocks[finalized_root].slot == finalized_slot:
+            latest_finalized = Checkpoint(root=finalized_root, slot=finalized_slot)
+        else:
+            latest_finalized = store.latest_finalized
+
+        return store.model_copy(update={"head": new_head, "latest_finalized": latest_finalized})
 
     def accept_new_attestations(self, store: LstarStore) -> LstarStore:
         """

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -633,11 +633,6 @@ class ForkChoiceMixin(LstarSpecBase):
             )
 
             # Recompute the head now that the block and its votes are in the store.
-            # update_head derives the finalized checkpoint from the new head's chain,
-            # never an independent max over every imported block, so latest_finalized
-            # always names a block on the canonical chain and the slot a validator
-            # attests against matches the slot the state transition validates against
-            # -- finalization cannot freeze.
             store = self.update_head(store)
 
             # Prune stale vote data, but only when finalization advanced past the snapshot.

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -84,28 +84,6 @@ class ForkChoiceMixin(LstarSpecBase):
         # The chain left the known tree before reaching the ancestor's slot.
         return False
 
-    def _finalized_on_head_chain(self, store: LstarStore) -> Checkpoint:
-        """
-        Return the finalized checkpoint that lies on the canonical head's chain.
-
-        The head state names the finalized slot. Its root is taken as the head's
-        own ancestor at that slot, so the checkpoint always lies on the head chain
-        and names a block the store holds -- even when the state carries a
-        placeholder root it cannot resolve to its own block, as a checkpoint-sync
-        anchor state does.
-
-        Args:
-            store: Fork-choice store holding the head and the block tree.
-
-        Returns:
-            The finalized checkpoint on the head's chain.
-        """
-        finalized_slot = store.states[store.head].latest_finalized.slot
-        finalized_root = store.head
-        while store.blocks[finalized_root].slot > finalized_slot:
-            finalized_root = store.blocks[finalized_root].parent_root
-        return Checkpoint(root=finalized_root, slot=finalized_slot)
-
     def create_store(
         self,
         state: SpecStateType,
@@ -826,12 +804,20 @@ class ForkChoiceMixin(LstarSpecBase):
             start_root=store.latest_justified.root,
             attestations=latest_votes,
         )
-        store = store.model_copy(update={"head": new_head})
-
-        # The finalized checkpoint travels with the head. Deriving it from the new
-        # head's chain on every recompute keeps it on the canonical chain, so it
-        # never lags a head that moved nor pins a fork that lost head selection.
-        return store.model_copy(update={"latest_finalized": self._finalized_on_head_chain(store)})
+        # Invariant: the finalized checkpoint stays on the head's chain.
+        # Its root is the head's own ancestor at the finalized slot.
+        # A checkpoint-sync anchor state holds a placeholder for its own block.
+        # The ancestor walk recovers the real block.
+        finalized_slot = store.states[new_head].latest_finalized.slot
+        finalized_root = new_head
+        while store.blocks[finalized_root].slot > finalized_slot:
+            finalized_root = store.blocks[finalized_root].parent_root
+        return store.model_copy(
+            update={
+                "head": new_head,
+                "latest_finalized": Checkpoint(root=finalized_root, slot=finalized_slot),
+            }
+        )
 
     def accept_new_attestations(self, store: LstarStore) -> LstarStore:
         """

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -607,9 +607,6 @@ class ForkChoiceMixin(LstarSpecBase):
             #
             #     store slot 5, candidate slot 7  ->  take candidate
             #     store slot 5, candidate slot 5  ->  keep store
-            #
-            # The finalized checkpoint is NOT taken as an independent max here; it is
-            # derived from the canonical head's state after head selection (below).
             latest_justified = store.latest_justified.advance_to(post_state.latest_justified)
 
             # Seed each block-carried vote into the known pool with an empty proof set.

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -84,6 +84,28 @@ class ForkChoiceMixin(LstarSpecBase):
         # The chain left the known tree before reaching the ancestor's slot.
         return False
 
+    def _finalized_on_head_chain(self, store: LstarStore) -> Checkpoint:
+        """
+        Return the finalized checkpoint that lies on the canonical head's chain.
+
+        The head state names the finalized slot. Its root is taken as the head's
+        own ancestor at that slot, so the checkpoint always lies on the head chain
+        and names a block the store holds -- even when the state carries a
+        placeholder root it cannot resolve to its own block, as a checkpoint-sync
+        anchor state does.
+
+        Args:
+            store: Fork-choice store holding the head and the block tree.
+
+        Returns:
+            The finalized checkpoint on the head's chain.
+        """
+        finalized_slot = store.states[store.head].latest_finalized.slot
+        finalized_root = store.head
+        while store.blocks[finalized_root].slot > finalized_slot:
+            finalized_root = store.blocks[finalized_root].parent_root
+        return Checkpoint(root=finalized_root, slot=finalized_slot)
+
     def create_store(
         self,
         state: SpecStateType,
@@ -578,15 +600,17 @@ class ForkChoiceMixin(LstarSpecBase):
             # Run the state transition from the parent state to this block's post-state.
             post_state = self.state_transition(parent_state, block)
 
-            # Advance the justified and finalized checkpoints from the post-state.
+            # Advance the justified checkpoint from the post-state.
             #
             # A candidate wins only when its slot is strictly higher than the store's.
             # On a slot tie the store keeps its checkpoint, avoiding a silent root swap:
             #
             #     store slot 5, candidate slot 7  ->  take candidate
             #     store slot 5, candidate slot 5  ->  keep store
+            #
+            # The finalized checkpoint is NOT taken as an independent max here; it is
+            # derived from the canonical head's state after head selection (below).
             latest_justified = store.latest_justified.advance_to(post_state.latest_justified)
-            latest_finalized = store.latest_finalized.advance_to(post_state.latest_finalized)
 
             # Seed each block-carried vote into the known pool with an empty proof set.
             #
@@ -607,12 +631,16 @@ class ForkChoiceMixin(LstarSpecBase):
                     "blocks": store.blocks | {block_root: block},
                     "states": store.states | {block_root: post_state},
                     "latest_justified": latest_justified,
-                    "latest_finalized": latest_finalized,
                     "latest_known_aggregated_payloads": new_known_aggregated_payloads,
                 }
             )
 
             # Recompute the head now that the block and its votes are in the store.
+            # update_head derives the finalized checkpoint from the new head's chain,
+            # never an independent max over every imported block, so latest_finalized
+            # always names a block on the canonical chain and the slot a validator
+            # attests against matches the slot the state transition validates against
+            # -- finalization cannot freeze.
             store = self.update_head(store)
 
             # Prune stale vote data, but only when finalization advanced past the snapshot.
@@ -806,7 +834,12 @@ class ForkChoiceMixin(LstarSpecBase):
             start_root=store.latest_justified.root,
             attestations=latest_votes,
         )
-        return store.model_copy(update={"head": new_head})
+        store = store.model_copy(update={"head": new_head})
+
+        # The finalized checkpoint travels with the head. Deriving it from the new
+        # head's chain on every recompute keeps it on the canonical chain, so it
+        # never lags a head that moved nor pins a fork that lost head selection.
+        return store.model_copy(update={"latest_finalized": self._finalized_on_head_chain(store)})
 
     def accept_new_attestations(self, store: LstarStore) -> LstarStore:
         """

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -199,29 +199,21 @@ class ValidatorDutiesMixin(LstarSpecBase):
         # Compute block hash for storage.
         block_hash = hash_tree_root(final_block)
 
-        # Update checkpoints from post-state.
+        # Persist the produced block and advance the justified checkpoint.
         #
-        # Locally produced blocks bypass normal block processing.
-        # Checkpoint advances must be propagated manually here.
-        #
-        # Tie semantics mirror the block-import path.
-        # A candidate needs a strictly higher slot to replace the store's view.
+        # Locally produced blocks bypass normal block processing, so the justified
+        # checkpoint is advanced manually. The finalized checkpoint is not written
+        # here: update_head derives it from the canonical head, and get_proposal_head
+        # ran update_head just above, so the store's finalized already sits on the head
+        # this block extends. Pinning it here from the produced block's own state would
+        # strand it -- and prune against it -- if the proposal later lost head selection.
         latest_justified = store.latest_justified.advance_to(final_post_state.latest_justified)
-        latest_finalized = store.latest_finalized.advance_to(final_post_state.latest_finalized)
-
-        # Persist block and state.
-        previous_finalized_slot = store.latest_finalized.slot
         store = store.model_copy(
             update={
                 "blocks": store.blocks | {block_hash: final_block},
                 "states": store.states | {block_hash: final_post_state},
                 "latest_justified": latest_justified,
-                "latest_finalized": latest_finalized,
             }
         )
-
-        # Prune stale attestation data when finalization advances
-        if store.latest_finalized.slot > previous_finalized_slot:
-            store = self.prune_stale_attestation_data(store)
 
         return store, final_block, signatures

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -199,14 +199,10 @@ class ValidatorDutiesMixin(LstarSpecBase):
         # Compute block hash for storage.
         block_hash = hash_tree_root(final_block)
 
-        # Persist the produced block and advance the justified checkpoint.
-        #
-        # Locally produced blocks bypass normal block processing, so the justified
-        # checkpoint is advanced manually. The finalized checkpoint is not written
-        # here: update_head derives it from the canonical head, and get_proposal_head
-        # ran update_head just above, so the store's finalized already sits on the head
-        # this block extends. Pinning it here from the produced block's own state would
-        # strand it -- and prune against it -- if the proposal later lost head selection.
+        # A locally produced block skips the import path.
+        # Advance the justified checkpoint manually here.
+        # Leave the finalized checkpoint to head recomputation.
+        # Pinning it from this block's own state would strand it on a later reorg.
         latest_justified = store.latest_justified.advance_to(final_post_state.latest_justified)
         store = store.model_copy(
             update={

--- a/tests/consensus/lstar/fork_choice/test_checkpoint_sync.py
+++ b/tests/consensus/lstar/fork_choice/test_checkpoint_sync.py
@@ -82,6 +82,55 @@ def test_store_init_from_non_genesis_anchor(
     )
 
 
+def test_head_recompute_on_anchor_below_its_finalized_slot(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Appending a block above a mid-chain anchor whose finalized sits below it does not crash.
+
+    Given
+    -----
+    - 4 validators.
+    - a mid-chain anchor at slot 10 built without rebasing its checkpoints.
+    - the anchor state's finalized stays at the genesis boundary, slot 0.
+    - slot 0 sits below the anchor block slot.
+    - the store holds only the anchor block.
+
+    When
+    ----
+    - one block is appended above the anchor, recomputing the head over the anchor chain.
+
+    Then
+    ----
+    - head advances to the appended block at slot 11.
+    - finalized stays at the trusted anchor at slot 10.
+    - the parent walk stops at the anchor, so head recomputation does not raise.
+    """
+    anchor_state, anchor_block = build_anchor(
+        synced=False, num_validators=NUM_VALIDATORS, anchor_slot=ANCHOR_SLOT
+    )
+
+    fork_choice_test(
+        anchor_state=anchor_state,
+        anchor_block=anchor_block,
+        steps=[
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(11),
+                    parent_label="genesis",
+                    label="block_11",
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(11),
+                    head_root_label="block_11",
+                    latest_finalized_slot=ANCHOR_SLOT,
+                    latest_finalized_root_label="genesis",
+                ),
+            ),
+        ],
+    )
+
+
 def test_extend_chain_from_non_genesis_anchor(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:

--- a/tests/consensus/lstar/fork_choice/test_finalized_safety.py
+++ b/tests/consensus/lstar/fork_choice/test_finalized_safety.py
@@ -387,3 +387,192 @@ def test_fork_above_finalized_wins_at_or_below_loses(
             ),
         ],
     )
+
+
+def test_losing_fork_higher_finalized_does_not_latch(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    A fork that finalizes a higher slot but loses head selection must not leave its
+    finalized checkpoint latched in the store.
+
+    Given
+    -----
+    - 8 validators; a slot needs 6 votes (2/3) to be justified.
+    - the chain:
+        genesis
+        - block_1(1) -> block_2(2) -> block_3(3)
+          - dead_4(4) -> dead_5(5) -> dead_6(6)
+          - heavy_7(7) -> heavy_8(8)
+    - block_2 includes V0..V5's votes for block_1.
+    - block_3 includes V0..V5's votes for block_2.
+    - the chain through block_3 justifies slot 2 and finalizes slot 1.
+    - the dead fork branches off block_3:
+        - dead_4 includes V0..V5's votes for block_3, finalizing slot 2.
+        - dead_5 includes V0..V5's votes for dead_4, finalizing slot 3.
+        - dead_6 includes V0..V5's votes for dead_5, finalizing slot 4.
+      so the dead fork reaches justified slot 5 and finalized slot 4 on dead_4.
+    - the heavy fork branches off block_3:
+        - heavy_8 includes V0..V5's votes for heavy_7, source block_2.
+        - those 6 votes justify heavy_7 at slot 7.
+        - slots 3, 4, 5, 6 between source block_2 and target heavy_7 are justifiable,
+          so the heavy fork finalizes nothing beyond slot 1.
+
+    When
+    ----
+    - the dead fork is built to justified slot 5 and finalized slot 4, then the
+      heavy fork justifies slot 7, the highest justified checkpoint in the store.
+
+    Then
+    ----
+    - the justified checkpoint moves to heavy_7 at slot 7, on the heavy fork.
+    - head moves onto the heavy fork at heavy_8.
+    - the finalized checkpoint tracks the canonical head heavy_8's state: slot 1 on
+      block_1. It must not stay at the dead fork's higher finalized slot 4 on dead_4,
+      which is not an ancestor of the head.
+
+    Reachability
+    ------------
+    - head selection starts from the justified root at heavy_7.
+    - the dead fork branches off block_3, below the justified root, so the forward
+      walk never reaches it and its finalized checkpoint cannot stay canonical.
+    """
+    fork_choice_test(
+        anchor_state=generate_pre_state(num_validators=8),
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(2),
+                    parent_label="block_1",
+                    label="block_2",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(2),
+                            target_slot=Slot(1),
+                            target_root_label="block_1",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(latest_justified_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(3),
+                    parent_label="block_2",
+                    label="block_3",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(3),
+                            target_slot=Slot(2),
+                            target_root_label="block_2",
+                            source_slot=Slot(1),
+                            source_root_label="block_1",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    latest_justified_slot=Slot(2),
+                    latest_finalized_slot=Slot(1),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(4),
+                    parent_label="block_3",
+                    label="dead_4",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(4),
+                            target_slot=Slot(3),
+                            target_root_label="block_3",
+                            source_slot=Slot(2),
+                            source_root_label="block_2",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    latest_justified_slot=Slot(3),
+                    latest_finalized_slot=Slot(2),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(5),
+                    parent_label="dead_4",
+                    label="dead_5",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(5),
+                            target_slot=Slot(4),
+                            target_root_label="dead_4",
+                            source_slot=Slot(3),
+                            source_root_label="block_3",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    latest_justified_slot=Slot(4),
+                    latest_finalized_slot=Slot(3),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(6),
+                    parent_label="dead_5",
+                    label="dead_6",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(6),
+                            target_slot=Slot(5),
+                            target_root_label="dead_5",
+                            source_slot=Slot(4),
+                            source_root_label="dead_4",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_root_label="dead_6",
+                    latest_justified_slot=Slot(5),
+                    latest_finalized_slot=Slot(4),
+                    latest_finalized_root_label="dead_4",
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(7), parent_label="block_3", label="heavy_7"),
+                checks=StoreChecks(head_root_label="dead_6"),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(8),
+                    parent_label="heavy_7",
+                    label="heavy_8",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(8),
+                            target_slot=Slot(7),
+                            target_root_label="heavy_7",
+                            source_slot=Slot(2),
+                            source_root_label="block_2",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_root_label="heavy_8",
+                    latest_justified_slot=Slot(7),
+                    latest_justified_root_label="heavy_7",
+                    latest_finalized_slot=Slot(1),
+                    latest_finalized_root_label="block_1",
+                ),
+            ),
+        ],
+    )

--- a/tests/node/validator/test_service.py
+++ b/tests/node/validator/test_service.py
@@ -28,6 +28,7 @@ from lean_spec.spec.forks.lstar.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.spec.forks.lstar.containers import (
     AttestationData,
     Block,
+    Checkpoint,
     SignedAttestation,
     SignedBlock,
     SingleMessageAggregate,
@@ -1113,6 +1114,106 @@ class TestValidatorServiceIntegration:
 
         body_attestations = signed_block.block.body.attestations
         assert len(body_attestations) > 0
+
+    async def test_produced_block_does_not_pin_a_higher_finalized(
+        self,
+        key_manager: XmssKeyManager,
+        real_sync_service: SyncService,
+        real_registry: ValidatorRegistry,
+        spec: LstarSpec,
+    ) -> None:
+        """
+        A produced block that finalizes a higher slot, while not yet the head, does not pin it.
+
+        Given
+        -----
+        - 6 validators; 4 votes (2/3) justify a slot.
+        - the chain genesis -> block_1 -> block_2.
+        - block_2 carries 4 votes for block_1, justifying slot 1.
+        - the pool carries 4 votes for block_2 with source slot 1.
+        - block production never advances its own head, so a produced block stays off the head.
+
+        When
+        ----
+        - the proposer produces block_3, whose post-state finalizes slot 1.
+
+        Then
+        ----
+        - the head stays at block_2 at slot 2.
+        - block_2's state finalized is the genesis boundary at slot 0.
+        - the store's finalized tracks that head state, not block_3's higher finalized.
+        - the counted attestation pool is left untouched, since the head did not finalize.
+        """
+        produced: list[SignedBlock] = []
+
+        async def capture(block: SignedBlock) -> None:
+            produced.append(block)
+
+        service = ValidatorService(
+            sync_service=real_sync_service,
+            clock=SlotClock(genesis_time=Uint64(0)),
+            registry=real_registry,
+            on_block=capture,
+        )
+
+        genesis_root = real_sync_service.store.head
+
+        def pool_votes(
+            att_slot: int, block_root: Bytes32, source_root: Bytes32, src_slot: int
+        ) -> None:
+            store = real_sync_service.store
+            data = AttestationData(
+                slot=Slot(att_slot),
+                head=Checkpoint(root=block_root, slot=Slot(att_slot)),
+                target=Checkpoint(root=block_root, slot=Slot(att_slot)),
+                source=Checkpoint(root=source_root, slot=Slot(src_slot)),
+            )
+            participants = [ValidatorIndex(i) for i in range(4)]
+            public_keys = [key_manager[v].attestation_keypair.public_key for v in participants]
+            sigs = [key_manager.sign_attestation_data(v, data) for v in participants]
+            proof = SingleMessageAggregate.aggregate(
+                children=[],
+                raw_xmss=list(zip(participants, public_keys, sigs, strict=True)),
+                message=hash_tree_root(data),
+                slot=data.slot,
+            )
+            real_sync_service.store = store.model_copy(
+                update={
+                    "latest_known_aggregated_payloads": {
+                        **store.latest_known_aggregated_payloads,
+                        data: {proof},
+                    }
+                }
+            )
+
+        # genesis -> block_1
+        await service._maybe_produce_block(Slot(1))
+        real_sync_service.store = spec.update_head(real_sync_service.store)
+        block_1_root = real_sync_service.store.head
+
+        # block_2 includes votes for block_1, justifying slot 1.
+        pool_votes(att_slot=1, block_root=block_1_root, source_root=genesis_root, src_slot=0)
+        await service._maybe_produce_block(Slot(2))
+        real_sync_service.store = spec.update_head(real_sync_service.store)
+        block_2_root = real_sync_service.store.head
+        assert real_sync_service.store.latest_justified.slot == Slot(1)
+
+        # Votes for block_2 with source slot 1; block_3 will finalize slot 1.
+        pool_votes(att_slot=2, block_root=block_2_root, source_root=block_1_root, src_slot=1)
+        pool_before = real_sync_service.store.latest_known_aggregated_payloads
+
+        await service._maybe_produce_block(Slot(3))
+        after = real_sync_service.store
+        block_3_root = hash_tree_root(produced[-1].block)
+
+        # block_3's own state did finalize slot 1 ...
+        assert after.states[block_3_root].latest_finalized.slot == Slot(1)
+        # ... but the head is still block_2, whose state finalized stays at genesis.
+        assert after.blocks[after.head].slot == Slot(2)
+        assert after.latest_finalized == after.states[after.head].latest_finalized
+        assert after.latest_finalized.slot == Slot(0)
+        # The counted pool is untouched: production neither pins finalized nor prunes.
+        assert after.latest_known_aggregated_payloads == pool_before
 
     async def test_multiple_slots_produce_different_attestations(
         self,


### PR DESCRIPTION
## Problem

Fixes #1000.

`store.latest_finalized` was advanced by an **independent monotonic max** over every imported block's post-state, decoupled from the head. A fork that finalizes a **higher** slot but then **loses head selection** left its finalized checkpoint latched in the store, so `store.latest_finalized` could sit on a branch that is **not** the head's while `head` / `latest_justified` were on another.

`get_attestation_target` derives the attestation target against `store.latest_finalized`, while `process_attestations` validates targets against the canonical head state's `latest_finalized` — **both using only the slot** (`is_justifiable_after`). Once the two finalized **slots** diverged, every advancing target was rejected and **finalization froze** — first observed as a network-wide freeze in a long-running multi-subnet devnet (store/banner finalized 27, canonical state 18).

`#194` introduced the independent max; the original store (#53) and the 3sf-mini reference derive finalized from the chosen head's state (full trace in #1000).

## Fix

Derive `store.latest_finalized` from the canonical head's chain, in **`update_head`**, so it is recomputed on **every** head change — block import, acceptance ticks, and proposals:

```python
def _finalized_on_head_chain(self, store):
    finalized_slot = store.states[store.head].latest_finalized.slot
    finalized_root = store.head
    while store.blocks[finalized_root].slot > finalized_slot:
        finalized_root = store.blocks[finalized_root].parent_root
    return Checkpoint(root=finalized_root, slot=finalized_slot)
```

- `store.latest_finalized.slot == head_state.latest_finalized.slot` ⇒ the slot a validator attests against matches the slot the state transition validates against — the freeze is gone.
- The **root** is the head's ancestor at that slot, so it names a real block even for a checkpoint-sync anchor (whose state stores a placeholder it cannot resolve to its own block).

**This restores 3sf-mini.** In `3sf-mini/p2p.py` the staker reads finalized from the head state, not a max:
```python
@property
def latest_finalized_hash(self):
    return self.post_states[self.head].latest_finalized_hash
# in vote():  (state = self.post_states[self.head])
while not is_justifiable_slot(state.latest_finalized_slot, target_block.slot):
```
`#194`'s max-over-blocks was the deviation. (3sf-mini *does* keep a max — `get_latest_justified_hash` — but only for **justified**, the LMD anchor, never for finalized. leanSpec's `store.latest_justified` matches that, and the attestation source keeps using it per #595.)