### PR TITLE
fix(quic): implement libp2p-TLS inbound peer-identity verification

### DIFF
--- a/src/lean_spec/node/networking/transport/quic/connection.py
+++ b/src/lean_spec/node/networking/transport/quic/connection.py
@@ -44,7 +44,10 @@ from lean_spec.node.networking.transport.identity import IdentityKeypair
 from lean_spec.node.networking.transport.peer_id import PeerId
 from lean_spec.node.networking.transport.quic.stream import QuicStream, QuicTransportError
 from lean_spec.node.networking.transport.quic.stream_adapter import QuicStreamAdapter
-from lean_spec.node.networking.transport.quic.tls import generate_libp2p_certificate
+from lean_spec.node.networking.transport.quic.tls import (
+    generate_libp2p_certificate,
+    verify_libp2p_certificate,
+)
 from lean_spec.node.networking.types import ProtocolId
 
 logger = logging.getLogger(__name__)
@@ -207,15 +210,35 @@ class LibP2PQuicProtocol(QuicConnectionProtocol):
         """Initialize the libp2p QUIC protocol handler."""
         super().__init__(*args, **kwargs)
         self.connection: QuicConnection | None = None
+        self.verified_peer_id: PeerId | None = None
+        self.verification_error: QuicTransportError | None = None
         self.handshake_complete = asyncio.Event()
         self._buffered_events: list[QuicEvent] = []
 
     def quic_event_received(self, event: QuicEvent) -> None:
         """Handle QUIC events."""
         if isinstance(event, HandshakeCompleted):
-            # TODO: extract and verify the peer certificate from the TLS session.
-            # aioquic stores it in the underlying QUIC connection, but does not
-            # expose it directly, so the libp2p identity is not yet recovered.
+            # Recover the remote peer identity from the certificate it presented.
+            #
+            # aioquic stores the peer's TLS 1.3 certificate on the TLS context
+            # once the handshake completes, for both client and server roles.
+            # The libp2p extension on that certificate proves which identity key
+            # the peer controls, so we verify it and key the connection by it.
+            #
+            # Verification failures are recorded rather than raised here.
+            # This callback runs inside aioquic's datagram processing, where a
+            # raised error would not reach the awaiting caller.
+            # The waiter inspects the recorded error and fails the connection.
+            try:
+                peer_certificate = self._quic.tls._peer_certificate
+                if peer_certificate is None:
+                    raise QuicTransportError(
+                        "Peer completed the QUIC handshake without presenting a certificate."
+                    )
+                self.verified_peer_id = verify_libp2p_certificate(peer_certificate)
+            except QuicTransportError as exception:
+                self.verification_error = exception
+
             self.handshake_complete.set()
 
             # For server-side connections, invoke the handshake callback.
@@ -391,13 +414,11 @@ class QuicConnectionManager:
         if transport != "quic":
             raise QuicTransportError(f"Not a QUIC multiaddr: {multiaddr}")
 
-        # The remote peer identity must come from the dialed multiaddr.
+        # The dialed multiaddr must name the peer we expect to reach.
         #
-        # We do not yet extract identity from the verified libp2p
-        # certificate extension, so the multiaddr is the only trustworthy
-        # source of the remote peer identity.
-        # A missing identity means the connection cannot be keyed, so we
-        # fail cleanly rather than invent a fabricated one.
+        # After the handshake we verify the certificate's identity against this
+        # expected value, so a missing identity leaves nothing to check against.
+        # We fail cleanly rather than accept whichever peer happens to answer.
         # This is checked before dialing so it is not re-wrapped as a
         # connection failure below.
         if expected_peer_id is None:
@@ -426,6 +447,21 @@ class QuicConnectionManager:
             # Wait for handshake to complete.
             await protocol.handshake_complete.wait()
 
+            # Surface any certificate verification failure from the handshake.
+            if protocol.verification_error is not None:
+                raise protocol.verification_error
+            assert protocol.verified_peer_id is not None
+
+            # The peer we reached must be the one the multiaddr named.
+            #
+            # Anything else means we connected to an impostor, so reject it.
+            if protocol.verified_peer_id != expected_peer_id:
+                raise QuicTransportError(
+                    "Peer identity mismatch: dialed "
+                    f"{expected_peer_id} but the certificate proves "
+                    f"{protocol.verified_peer_id}."
+                )
+
             connection = QuicConnection(
                 _protocol=protocol,
                 _peer_id=expected_peer_id,
@@ -451,19 +487,15 @@ class QuicConnectionManager:
         Creates a server using aioquic with libp2p-tls authentication.
         Runs until shutdown is requested.
 
-        Inbound connections are rejected until peer identity verification
-        from the libp2p certificate extension is implemented.
-        Without it the remote peer identity is unknown, and keying a
-        connection by a fabricated identity is unsafe.
+        Each inbound connection is keyed by the peer identity proven in its
+        libp2p certificate extension, then handed to the connection callback.
 
         Args:
             multiaddr: Address to listen on (e.g., "/ip4/0.0.0.0/udp/9000/quic-v1").
-            on_connection: Async callback to invoke once inbound connections are supported.
+            on_connection: Async callback invoked with each verified inbound connection.
 
         Raises:
             QuicTransportError: If the multiaddr is not a QUIC address.
-            QuicTransportError: When an inbound connection completes its handshake,
-                because the remote peer identity cannot yet be verified.
         """
         host, port, transport, _ = parse_multiaddr(multiaddr)
 
@@ -485,21 +517,71 @@ class QuicConnectionManager:
 
         # Callback invoked when an inbound TLS handshake completes.
         def handle_handshake(protocol_instance: LibP2PQuicProtocol) -> None:
-            # An inbound connection has no multiaddr to carry the peer identity.
+            # An inbound connection carries no dialed multiaddr.
             #
-            # The only trustworthy source is the libp2p certificate extension,
-            # whose verification is not yet implemented on this side.
-            # Until that exists we cannot key the connection by a real identity,
-            # so we fail cleanly rather than invent a fabricated one.
-            raise QuicTransportError(
-                "Cannot accept inbound connection: "
-                "peer identity verification from the libp2p certificate is not implemented"
+            # The peer identity comes solely from its libp2p certificate, which
+            # the handshake handler has already verified by this point.
+            # A verification failure leaves no trustworthy identity, so the
+            # connection is dropped rather than keyed by an unverified peer.
+            if protocol_instance.verification_error is not None:
+                logger.warning(
+                    "[QUIC] Rejecting inbound connection: %s",
+                    protocol_instance.verification_error,
+                )
+                protocol_instance._quic.close()
+                protocol_instance.transmit()
+                return
+
+            verified_peer_id = protocol_instance.verified_peer_id
+            assert verified_peer_id is not None
+
+            # Recover the peer address from the validated network path.
+            #
+            # The server socket is shared across peers, so the per-connection
+            # address lives on the QUIC connection rather than the transport.
+            network_paths = protocol_instance._quic._network_paths
+            host, udp_port = network_paths[0].addr[:2]
+            remote_address = f"/ip4/{host}/udp/{udp_port}/quic-v1/p2p/{verified_peer_id}"
+
+            connection = QuicConnection(
+                _protocol=protocol_instance,
+                _peer_id=verified_peer_id,
+                _remote_address=remote_address,
             )
+            protocol_instance.connection = connection
+            protocol_instance._replay_buffered_events()
+
+            self._connections[verified_peer_id] = connection
+
+            # Hand the connection to the caller on the running event loop.
+            #
+            # This callback is synchronous, but the consumer is async, so the
+            # work is scheduled as a task rather than awaited inline.
+            asyncio.ensure_future(on_connection(connection))
 
         # Protocol factory that attaches our callback to each new instance.
         def create_protocol(*args, **kwargs) -> LibP2PQuicProtocol:
             protocol = LibP2PQuicProtocol(*args, **kwargs)
             protocol._on_handshake = handle_handshake
+
+            # libp2p authenticates both peers, so the server must ask the
+            # client for its certificate.
+            #
+            # aioquic defaults to not requesting a client certificate, which
+            # would leave the inbound certificate unset and fail verification.
+            # The TLS context is created lazily the first time aioquic builds
+            # the connection, so the request flag is set by wrapping that
+            # initialization rather than touching a context that does not exist
+            # yet.
+            quic_connection = protocol._quic
+            original_initialize = quic_connection._initialize
+
+            def initialize_requesting_client_certificate(peer_cid: bytes) -> None:
+                original_initialize(peer_cid)
+                quic_connection.tls._request_client_certificate = True
+
+            quic_connection._initialize = initialize_requesting_client_certificate  # type: ignore[method-assign]
+
             return protocol
 
         await quic_serve(

--- a/src/lean_spec/node/networking/transport/quic/tls.py
+++ b/src/lean_spec/node/networking/transport/quic/tls.py
@@ -30,8 +30,10 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from lean_spec.node.networking.transport.identity import IdentityKeypair
-from lean_spec.node.networking.transport.peer_id import KeyType
+from lean_spec.node.networking.transport.identity import IdentityKeypair, Secp256k1PublicKey
+from lean_spec.node.networking.transport.peer_id import KeyType, PeerId, PublicKeyProtobuf
+from lean_spec.node.networking.transport.quic.stream import QuicTransportError
+from lean_spec.node.networking.varint import VarintError, decode_varint
 
 LIBP2P_EXTENSION_OID: Final = x509.ObjectIdentifier("1.3.6.1.4.1.53594.1.1")
 """libp2p TLS extension OID (Protocol Labs assigned)."""
@@ -222,3 +224,249 @@ def _encode_asn1_length(length: int) -> bytes:
         return bytes([0x81, length])
     else:
         return bytes([0x82, length >> 8, length & 0xFF])
+
+
+def verify_libp2p_certificate(certificate: x509.Certificate) -> PeerId:
+    """
+    Verify a peer's libp2p certificate and recover its PeerId.
+
+    This is the exact inverse of the generation side.
+    It locates the libp2p extension, decodes the SignedKey structure,
+    and checks that the identity key signed this certificate's TLS key.
+
+    A passing verification proves the peer controls the secp256k1 identity key
+    bound to the ephemeral TLS key used in the handshake.
+
+    Args:
+        certificate: The peer's self-signed certificate from the TLS handshake.
+
+    Returns:
+        The PeerId derived from the verified identity public key.
+
+    Raises:
+        QuicTransportError: If the extension is absent or malformed.
+        QuicTransportError: If the key type is not secp256k1.
+        QuicTransportError: If the identity signature does not verify.
+    """
+    # Locate the libp2p extension by its OID.
+    #
+    # Without it the certificate carries no identity proof, so it is unusable.
+    try:
+        extension = certificate.extensions.get_extension_for_oid(LIBP2P_EXTENSION_OID)
+    except x509.ExtensionNotFound as exception:
+        raise QuicTransportError(
+            "Peer certificate is missing the libp2p identity extension."
+        ) from exception
+
+    # The extension value is an UnrecognizedExtension carrying the DER payload.
+    extension_payload = extension.value
+    if not isinstance(extension_payload, x509.UnrecognizedExtension):
+        raise QuicTransportError("Peer certificate libp2p extension has an unexpected encoding.")
+
+    # Decode the SignedKey SEQUENCE into its two OCTET STRINGs.
+    public_key_protobuf, signature = _decode_asn1_signed_key(extension_payload.value)
+
+    # Parse the protobuf PublicKey into its key type and raw key bytes.
+    identity_public_key_protobuf = _decode_public_key_protobuf(public_key_protobuf)
+
+    # Only secp256k1 identities are valid on this network.
+    if identity_public_key_protobuf.key_type != KeyType.SECP256K1:
+        raise QuicTransportError(
+            f"Peer identity key type is not secp256k1: {identity_public_key_protobuf.key_type!r}."
+        )
+
+    # Reconstruct the signed payload exactly as the generator built it.
+    #
+    # The generator signed the prefix followed by the SubjectPublicKeyInfo
+    # DER encoding of the certificate's own TLS public key.
+    tls_public_key_der = certificate.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    signed_payload = SIGNATURE_PREFIX + tls_public_key_der
+
+    # Reconstruct the secp256k1 identity public key from the compressed bytes.
+    #
+    # A malformed point is rejected here before any signature check runs.
+    try:
+        identity_public_key = Secp256k1PublicKey(
+            _key=ec.EllipticCurvePublicKey.from_encoded_point(
+                ec.SECP256K1(),
+                identity_public_key_protobuf.key_data,
+            )
+        )
+    except ValueError as exception:
+        raise QuicTransportError(
+            "Peer identity public key is not a valid secp256k1 point."
+        ) from exception
+
+    # Verify the DER signature over the payload using ECDSA-SHA256.
+    if not identity_public_key.verify(signed_payload, signature):
+        raise QuicTransportError("Peer identity signature does not match the certificate TLS key.")
+
+    # Derive the PeerId from the verified identity public key.
+    return PeerId.from_public_key(identity_public_key_protobuf)
+
+
+def _decode_asn1_signed_key(data: bytes) -> tuple[bytes, bytes]:
+    """
+    Decode a SignedKey SEQUENCE of two OCTET STRINGs.
+
+    The inverse of the SignedKey encoder.
+
+    Args:
+        data: DER-encoded SignedKey SEQUENCE.
+
+    Returns:
+        The (public_key_protobuf, signature) pair.
+
+    Raises:
+        QuicTransportError: If the structure is malformed or has trailing bytes.
+    """
+    # The whole payload must be exactly one SEQUENCE.
+    sequence_content, sequence_end = _decode_asn1_sequence(data, 0)
+    if sequence_end != len(data):
+        raise QuicTransportError("Peer certificate SignedKey has trailing bytes.")
+
+    # The SEQUENCE holds two OCTET STRINGs back to back.
+    public_key_protobuf, after_first = _decode_asn1_octet_string(sequence_content, 0)
+    signature, after_second = _decode_asn1_octet_string(sequence_content, after_first)
+    if after_second != len(sequence_content):
+        raise QuicTransportError("Peer certificate SignedKey has unexpected extra fields.")
+
+    return public_key_protobuf, signature
+
+
+def _decode_public_key_protobuf(data: bytes) -> PublicKeyProtobuf:
+    """
+    Decode a libp2p protobuf PublicKey message.
+
+    The wire format is field 1 (KeyType varint) then field 2 (length-delimited Data).
+
+    Args:
+        data: Protobuf-encoded PublicKey bytes.
+
+    Returns:
+        The decoded public key in protobuf form.
+
+    Raises:
+        QuicTransportError: If the message is malformed or has trailing bytes.
+    """
+    # Field 1: Type, tag 0x08, varint.
+    if len(data) < 1 or data[0] != 0x08:
+        raise QuicTransportError("Peer identity protobuf is missing the key type field.")
+    try:
+        key_type_value, type_consumed = decode_varint(data, 1)
+    except VarintError as exception:
+        raise QuicTransportError("Peer identity protobuf has a malformed key type.") from exception
+
+    # Field 2: Data, tag 0x12, length-delimited bytes.
+    data_tag_offset = 1 + type_consumed
+    if len(data) <= data_tag_offset or data[data_tag_offset] != 0x12:
+        raise QuicTransportError("Peer identity protobuf is missing the key data field.")
+    try:
+        key_data_length, length_consumed = decode_varint(data, data_tag_offset + 1)
+    except VarintError as exception:
+        raise QuicTransportError(
+            "Peer identity protobuf has a malformed key data length."
+        ) from exception
+
+    key_data_offset = data_tag_offset + 1 + length_consumed
+    key_data_end = key_data_offset + key_data_length
+    if key_data_end != len(data):
+        raise QuicTransportError("Peer identity protobuf has an inconsistent key data length.")
+    key_data = data[key_data_offset:key_data_end]
+
+    try:
+        key_type = KeyType(key_type_value)
+    except ValueError as exception:
+        raise QuicTransportError(
+            f"Peer identity protobuf has an unknown key type: {key_type_value}."
+        ) from exception
+
+    return PublicKeyProtobuf(key_type=key_type, key_data=key_data)
+
+
+def _decode_asn1_sequence(data: bytes, offset: int) -> tuple[bytes, int]:
+    """
+    Decode an ASN.1 SEQUENCE and return its content bytes.
+
+    Args:
+        data: Buffer containing the SEQUENCE.
+        offset: Position of the SEQUENCE tag.
+
+    Returns:
+        The (content, end_offset) pair, where end_offset is just past the content.
+
+    Raises:
+        QuicTransportError: If the tag is wrong or the length overflows the buffer.
+    """
+    # Tag 0x30 = SEQUENCE.
+    if offset >= len(data) or data[offset] != 0x30:
+        raise QuicTransportError("Peer certificate SignedKey is not an ASN.1 SEQUENCE.")
+    length, length_end = _decode_asn1_length(data, offset + 1)
+    content_end = length_end + length
+    if content_end > len(data):
+        raise QuicTransportError("Peer certificate SignedKey SEQUENCE length overflows.")
+    return data[length_end:content_end], content_end
+
+
+def _decode_asn1_octet_string(data: bytes, offset: int) -> tuple[bytes, int]:
+    """
+    Decode an ASN.1 OCTET STRING and return its content bytes.
+
+    Args:
+        data: Buffer containing the OCTET STRING.
+        offset: Position of the OCTET STRING tag.
+
+    Returns:
+        The (content, end_offset) pair, where end_offset is just past the content.
+
+    Raises:
+        QuicTransportError: If the tag is wrong or the length overflows the buffer.
+    """
+    # Tag 0x04 = OCTET STRING.
+    if offset >= len(data) or data[offset] != 0x04:
+        raise QuicTransportError("Peer certificate SignedKey field is not an ASN.1 OCTET STRING.")
+    length, length_end = _decode_asn1_length(data, offset + 1)
+    content_end = length_end + length
+    if content_end > len(data):
+        raise QuicTransportError("Peer certificate SignedKey OCTET STRING length overflows.")
+    return data[length_end:content_end], content_end
+
+
+def _decode_asn1_length(data: bytes, offset: int) -> tuple[int, int]:
+    """
+    Decode an ASN.1 DER length field.
+
+    The inverse of the length encoder, supporting short form and one or two
+    long-form length octets.
+
+    Args:
+        data: Buffer containing the length field.
+        offset: Position of the first length octet.
+
+    Returns:
+        The (length, end_offset) pair, where end_offset is just past the length octets.
+
+    Raises:
+        QuicTransportError: If the length encoding is truncated or unsupported.
+    """
+    if offset >= len(data):
+        raise QuicTransportError("Peer certificate ASN.1 length is truncated.")
+
+    first = data[offset]
+
+    # Short form: the length fits in the low seven bits of one octet.
+    if first < 0x80:
+        return first, offset + 1
+
+    # Long form: the low seven bits give the number of length octets that follow.
+    num_length_octets = first & 0x7F
+    if num_length_octets == 0 or num_length_octets > 2:
+        raise QuicTransportError("Peer certificate ASN.1 length uses an unsupported form.")
+    if offset + 1 + num_length_octets > len(data):
+        raise QuicTransportError("Peer certificate ASN.1 length is truncated.")
+
+    length = int.from_bytes(data[offset + 1 : offset + 1 + num_length_octets], "big")
+    return length, offset + 1 + num_length_octets

--- a/tests/interop/helpers/node_runner.py
+++ b/tests/interop/helpers/node_runner.py
@@ -54,6 +54,17 @@ class TestNode:
     index: int
     """Node index in the cluster."""
 
+    @property
+    def dial_address(self) -> str:
+        """
+        Listen address with this node's peer identity appended.
+
+        Dialers must supply the remote peer identity in the multiaddr.
+        The transport refuses to connect without it, since the identity
+        is the only trustworthy source for keying the connection.
+        """
+        return f"{self.listen_address}/p2p/{self.event_source.connection_manager.peer_id}"
+
     _task: asyncio.Task[None] | None = field(default=None, repr=False)
     """Background task running the node."""
 
@@ -479,7 +490,7 @@ class NodeCluster:
         for dialer_index, listener_index in topology:
             dialer = self.nodes[dialer_index]
             listener = self.nodes[listener_index]
-            success = await dialer.dial(listener.listen_address)
+            success = await dialer.dial(listener.dial_address)
             if success:
                 logger.info("Connected node %d -> node %d", dialer_index, listener_index)
             else:

--- a/tests/node/networking/transport/quic/test_connection.py
+++ b/tests/node/networking/transport/quic/test_connection.py
@@ -8,12 +8,17 @@ from __future__ import annotations
 
 import asyncio
 import ssl
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
 
 from lean_spec.node.networking.config import LIBP2P_ALPN_PROTOCOL
+from lean_spec.node.networking.transport.identity.keypair import IdentityKeypair
 from lean_spec.node.networking.transport.peer_id import PeerId
 from lean_spec.node.networking.transport.quic.connection import (
     ConnectionTerminated,
@@ -28,6 +33,7 @@ from lean_spec.node.networking.transport.quic.connection import (
     parse_multiaddr,
 )
 from lean_spec.node.networking.transport.quic.stream import QuicTransportError
+from lean_spec.node.networking.transport.quic.tls import generate_libp2p_certificate
 from lean_spec.node.networking.types import ProtocolId
 
 # Shared fixtures
@@ -683,10 +689,14 @@ class TestQuicConnectionManagerConnect:
         """
 
         # Simulate a protocol whose TLS handshake already completed.
+        #
+        # The certificate verified to the same identity the multiaddr names.
         mock_protocol = MagicMock(spec=LibP2PQuicProtocol)
         mock_protocol.handshake_complete = asyncio.Event()
         mock_protocol.handshake_complete.set()
         mock_protocol.connection = None
+        mock_protocol.verification_error = None
+        mock_protocol.verified_peer_id = PeerId.from_base58("peerB")
         mock_protocol._buffered_events = []
         mock_protocol._replay_buffered_events = MagicMock()
 
@@ -705,6 +715,38 @@ class TestQuicConnectionManagerConnect:
 
         # Buffered events from the handshake window are replayed.
         mock_protocol._replay_buffered_events.assert_called_once()
+
+    @patch("lean_spec.node.networking.transport.quic.connection.quic_connect")
+    async def test_connect_identity_mismatch_is_rejected(
+        self, mock_quic_connect: MagicMock, manager: QuicConnectionManager
+    ) -> None:
+        """
+        Reaching a peer whose proven identity differs from the dialed one is rejected.
+
+        The dialed multiaddr names one peer, but the certificate proves another.
+        The connection is refused and not registered.
+        """
+        mock_protocol = MagicMock(spec=LibP2PQuicProtocol)
+        mock_protocol.handshake_complete = asyncio.Event()
+        mock_protocol.handshake_complete.set()
+        mock_protocol.connection = None
+        mock_protocol.verification_error = None
+        mock_protocol.verified_peer_id = PeerId.from_base58("peerC")
+        mock_protocol._buffered_events = []
+        mock_protocol._replay_buffered_events = MagicMock()
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_protocol)
+        mock_quic_connect.return_value = mock_cm
+
+        with pytest.raises(QuicTransportError) as exception_info:
+            await manager.connect("/ip4/127.0.0.1/udp/9000/quic-v1/p2p/peerB")
+        assert str(exception_info.value) == (
+            "Failed to connect: Peer identity mismatch: "
+            f"dialed {PeerId.from_base58('peerB')} but the certificate proves "
+            f"{PeerId.from_base58('peerC')}."
+        )
+        assert manager._connections == {}
 
     @patch("lean_spec.node.networking.transport.quic.connection.quic_connect")
     async def test_connect_without_peer_id_raises(
@@ -834,23 +876,23 @@ class TestQuicConnectionManagerListen:
 
     @patch("lean_spec.node.networking.transport.quic.connection.QuicConfiguration")
     @patch("lean_spec.node.networking.transport.quic.connection.quic_serve")
-    async def test_listen_handle_handshake_rejects_inbound_connection(
+    async def test_listen_handle_handshake_fails_closed_on_invalid_certificate(
         self,
         mock_quic_serve: MagicMock,
         mock_config_cls: MagicMock,
         manager_with_temp_directory: QuicConnectionManager,
     ) -> None:
         """
-        The handshake callback rejects inbound connections, never fabricating one.
+        An inbound peer with an unverifiable certificate is never registered or accepted.
 
-        Peer identity verification from the libp2p certificate is not
-        implemented, so the remote identity is unknown.
-        The callback raises rather than register a connection under a
-        fabricated identity.
+        The peer presents a self-signed certificate without the libp2p identity
+        extension.
+        The handshake handling records a verification error, registers no
+        connection, and never invokes the inbound callback.
         """
         mock_config_cls.return_value = MagicMock()
 
-        # Capture the protocol factory that listen() passes to quic_serve.
+        # Capture the protocol factory that the listener passes to the server.
         captured_create_protocol = None
 
         async def capture_serve(*args: object, **kwargs: object) -> MagicMock:
@@ -862,7 +904,7 @@ class TestQuicConnectionManagerListen:
 
         callback = AsyncMock()
 
-        # Force the shutdown event to raise immediately so listen() exits.
+        # Force the shutdown event to raise immediately so the listener exits.
         mock_event = MagicMock()
         mock_event.wait = AsyncMock(side_effect=asyncio.CancelledError)
 
@@ -875,37 +917,143 @@ class TestQuicConnectionManagerListen:
             mock_event_cls.return_value = mock_event
             await manager_with_temp_directory.listen("/ip4/0.0.0.0/udp/9000/quic-v1", callback)
 
-        # The factory must have been captured from quic_serve kwargs.
         assert captured_create_protocol is not None
 
-        # Create a protocol instance using the captured factory.
+        # Build a protocol via the captured factory.
         #
-        # The parent constructor is patched to avoid aioquic dependencies.
-        with patch.object(LibP2PQuicProtocol.__bases__[0], "__init__", return_value=None):
-            protocol_instance = captured_create_protocol()
+        # The parent constructor is patched to avoid aioquic socket dependencies,
+        # while still attaching the underlying connection the factory wraps.
+        def init_with_quic(self_instance: LibP2PQuicProtocol, *args: object) -> None:
+            self_instance._quic = MagicMock()
 
-        # The factory must have attached a handshake callback.
+        with patch.object(LibP2PQuicProtocol.__bases__[0], "__init__", init_with_quic):
+            protocol_instance = captured_create_protocol()
+        protocol_instance.connection = None
+        protocol_instance.verified_peer_id = None
+        protocol_instance.verification_error = None
+        protocol_instance.handshake_complete = asyncio.Event()
+        protocol_instance._buffered_events = []
+        protocol_instance.transmit = MagicMock()
         assert protocol_instance._on_handshake is not None
 
-        # Simulate the handshake callback being invoked by aioquic.
-        protocol_instance._quic = MagicMock()
-        protocol_instance.transmit = MagicMock()
-        protocol_instance.connection = None
-        protocol_instance._buffered_events = []
+        # The peer presents a real certificate that lacks the libp2p extension.
+        tls_private = ec.generate_private_key(ec.SECP256R1())
+        certificate_without_extension = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([]))
+            .issuer_name(x509.Name([]))
+            .public_key(tls_private.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .sign(tls_private, hashes.SHA256())
+        )
+        protocol_instance._quic.tls._peer_certificate = certificate_without_extension
 
-        with pytest.raises(QuicTransportError) as exception_info:
-            protocol_instance._on_handshake(protocol_instance)
-        assert str(exception_info.value) == (
-            "Cannot accept inbound connection: "
-            "peer identity verification from the libp2p certificate is not implemented"
+        # Drive the real handshake completion path.
+        protocol_instance.quic_event_received(
+            HandshakeCompleted(
+                alpn_protocol="libp2p", early_data_accepted=False, session_resumed=False
+            )
         )
 
-        # No connection is wired up and none is registered under a fabricated identity.
+        # Verification failed, so no identity was recovered.
+        assert protocol_instance.verified_peer_id is None
+        assert isinstance(protocol_instance.verification_error, QuicTransportError)
+        assert str(protocol_instance.verification_error) == (
+            "Peer certificate is missing the libp2p identity extension."
+        )
+
+        # No connection is wired onto the protocol and none is registered.
         assert protocol_instance.connection is None
         assert manager_with_temp_directory._connections == {}
 
-        # The inbound callback is never invoked.
+        # The inbound callback is never invoked for an unverified peer.
         callback.assert_not_called()
+
+    @patch("lean_spec.node.networking.transport.quic.connection.QuicConfiguration")
+    @patch("lean_spec.node.networking.transport.quic.connection.quic_serve")
+    async def test_listen_handle_handshake_registers_verified_peer(
+        self,
+        mock_quic_serve: MagicMock,
+        mock_config_cls: MagicMock,
+        manager_with_temp_directory: QuicConnectionManager,
+    ) -> None:
+        """
+        An inbound peer with a valid certificate is keyed and accepted by its proven identity.
+
+        The peer presents a generated libp2p certificate.
+        The handshake handling recovers the proven peer identity, registers the
+        connection under it, and schedules the inbound callback with that connection.
+        """
+        mock_config_cls.return_value = MagicMock()
+
+        captured_create_protocol = None
+
+        async def capture_serve(*args: object, **kwargs: object) -> MagicMock:
+            nonlocal captured_create_protocol
+            captured_create_protocol = kwargs.get("create_protocol")
+            return MagicMock()
+
+        mock_quic_serve.side_effect = capture_serve
+
+        accepted_connections: list[QuicConnection] = []
+
+        async def callback(connection: QuicConnection) -> None:
+            accepted_connections.append(connection)
+
+        mock_event = MagicMock()
+        mock_event.wait = AsyncMock(side_effect=asyncio.CancelledError)
+
+        with (
+            patch(
+                "lean_spec.node.networking.transport.quic.connection.asyncio.Event"
+            ) as mock_event_cls,
+            pytest.raises(asyncio.CancelledError),
+        ):
+            mock_event_cls.return_value = mock_event
+            await manager_with_temp_directory.listen("/ip4/0.0.0.0/udp/9000/quic-v1", callback)
+
+        assert captured_create_protocol is not None
+
+        def init_with_quic(self_instance: LibP2PQuicProtocol, *args: object) -> None:
+            self_instance._quic = MagicMock()
+
+        with patch.object(LibP2PQuicProtocol.__bases__[0], "__init__", init_with_quic):
+            protocol_instance = captured_create_protocol()
+        protocol_instance.connection = None
+        protocol_instance.verified_peer_id = None
+        protocol_instance.verification_error = None
+        protocol_instance.handshake_complete = asyncio.Event()
+        protocol_instance._buffered_events = []
+        protocol_instance.transmit = MagicMock()
+
+        # The peer presents a valid certificate for a known identity key.
+        peer_identity_key = IdentityKeypair.generate()
+        _, _, peer_certificate = generate_libp2p_certificate(peer_identity_key)
+        protocol_instance._quic.tls._peer_certificate = peer_certificate
+        protocol_instance._quic._network_paths = [MagicMock(addr=("127.0.0.1", 9000))]
+
+        protocol_instance.quic_event_received(
+            HandshakeCompleted(
+                alpn_protocol="libp2p", early_data_accepted=False, session_resumed=False
+            )
+        )
+
+        # Drain the scheduled inbound callback.
+        await asyncio.sleep(0)
+
+        verified_peer_id = peer_identity_key.to_peer_id()
+        assert protocol_instance.verification_error is None
+        assert protocol_instance.verified_peer_id == verified_peer_id
+
+        # The connection is registered and handed to the callback under the proven identity.
+        assert protocol_instance.connection is not None
+        assert protocol_instance.connection.peer_id == verified_peer_id
+        assert manager_with_temp_directory._connections == {
+            verified_peer_id: protocol_instance.connection
+        }
+        assert accepted_connections == [protocol_instance.connection]
 
     @patch("lean_spec.node.networking.transport.quic.connection.QuicConfiguration")
     @patch("lean_spec.node.networking.transport.quic.connection.quic_serve")

--- a/tests/node/networking/transport/quic/test_tls.py
+++ b/tests/node/networking/transport/quic/test_tls.py
@@ -12,14 +12,16 @@ generation pipeline, including signature verification of the identity proof.
 from __future__ import annotations
 
 import hashlib
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from cryptography import x509
-from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from lean_spec.node.networking.transport.identity.keypair import IdentityKeypair
 from lean_spec.node.networking.transport.peer_id import KeyType
+from lean_spec.node.networking.transport.quic.stream import QuicTransportError
 from lean_spec.node.networking.transport.quic.tls import (
     LIBP2P_EXTENSION_OID,
     SIGNATURE_PREFIX,
@@ -29,6 +31,7 @@ from lean_spec.node.networking.transport.quic.tls import (
     _encode_asn1_sequence,
     _encode_asn1_signed_key,
     generate_libp2p_certificate,
+    verify_libp2p_certificate,
 )
 
 # Shared fixtures
@@ -278,8 +281,6 @@ class TestGenerateLibp2pCertificate:
 
     def test_validity_window(self, identity_key: IdentityKeypair) -> None:
         """not_valid_before is ~1 day before now, not_valid_after is ~365 days after now."""
-        from datetime import datetime, timedelta, timezone
-
         now = datetime.now(timezone.utc)
         _, _, certificate = generate_libp2p_certificate(identity_key)
 
@@ -350,6 +351,217 @@ class TestGenerateLibp2pCertificate:
         _, certificate_pem, certificate = generate_libp2p_certificate(identity_key)
         reparsed = x509.load_pem_x509_certificate(certificate_pem)
         assert reparsed == certificate
+
+
+# Certificate verification — the inverse of generation
+
+
+class TestVerifyLibp2pCertificate:
+    """Tests for recovering and validating a peer identity from its certificate."""
+
+    def test_roundtrip_recovers_peer_id(self, identity_key: IdentityKeypair) -> None:
+        """Verifying a freshly generated certificate recovers the generating peer identity."""
+        _, _, certificate = generate_libp2p_certificate(identity_key)
+        assert verify_libp2p_certificate(certificate) == identity_key.to_peer_id()
+
+    def test_tampered_signature_is_rejected(self, identity_key: IdentityKeypair) -> None:
+        """Flipping one byte of the identity signature makes verification fail."""
+        tls_private = ec.generate_private_key(ec.SECP256R1())
+        tls_public_bytes = tls_private.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        public_key_protobuf = (
+            bytes([0x08, KeyType.SECP256K1, 0x12, 33]) + identity_key.public_key.to_bytes()
+        )
+        signature = bytearray(identity_key.sign(SIGNATURE_PREFIX + tls_public_bytes))
+        signature[-1] ^= 0x01
+        tampered_extension_payload = _encode_asn1_signed_key(public_key_protobuf, bytes(signature))
+
+        tampered_certificate = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([]))
+            .issuer_name(x509.Name([]))
+            .public_key(tls_private.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .add_extension(
+                x509.UnrecognizedExtension(LIBP2P_EXTENSION_OID, tampered_extension_payload),
+                critical=False,
+            )
+            .sign(tls_private, hashes.SHA256())
+        )
+
+        with pytest.raises(QuicTransportError) as exception_info:
+            verify_libp2p_certificate(tampered_certificate)
+        assert str(exception_info.value) == (
+            "Peer identity signature does not match the certificate TLS key."
+        )
+
+    def test_missing_extension_is_rejected(self) -> None:
+        """A self-signed certificate without the libp2p extension is rejected."""
+        tls_private = ec.generate_private_key(ec.SECP256R1())
+        certificate_without_extension = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([]))
+            .issuer_name(x509.Name([]))
+            .public_key(tls_private.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .sign(tls_private, hashes.SHA256())
+        )
+
+        with pytest.raises(QuicTransportError) as exception_info:
+            verify_libp2p_certificate(certificate_without_extension)
+        assert str(exception_info.value) == (
+            "Peer certificate is missing the libp2p identity extension."
+        )
+
+    def test_wrong_key_type_is_rejected(self, identity_key: IdentityKeypair) -> None:
+        """A SignedKey declaring a non-secp256k1 key type is rejected."""
+        tls_private = ec.generate_private_key(ec.SECP256R1())
+        tls_public_bytes = tls_private.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        ed25519_public_key_protobuf = (
+            bytes([0x08, KeyType.ED25519, 0x12, 33]) + identity_key.public_key.to_bytes()
+        )
+        signature = identity_key.sign(SIGNATURE_PREFIX + tls_public_bytes)
+        extension_payload = _encode_asn1_signed_key(ed25519_public_key_protobuf, signature)
+
+        certificate_with_wrong_key_type = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([]))
+            .issuer_name(x509.Name([]))
+            .public_key(tls_private.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .add_extension(
+                x509.UnrecognizedExtension(LIBP2P_EXTENSION_OID, extension_payload),
+                critical=False,
+            )
+            .sign(tls_private, hashes.SHA256())
+        )
+
+        with pytest.raises(QuicTransportError) as exception_info:
+            verify_libp2p_certificate(certificate_with_wrong_key_type)
+        assert str(exception_info.value) == (
+            "Peer identity key type is not secp256k1: <KeyType.ED25519: 1>."
+        )
+
+    def test_trailing_bytes_in_extension_are_rejected(self, identity_key: IdentityKeypair) -> None:
+        """Extra bytes after the SignedKey SEQUENCE are rejected as malformed ASN.1."""
+        tls_private = ec.generate_private_key(ec.SECP256R1())
+        tls_public_bytes = tls_private.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        public_key_protobuf = (
+            bytes([0x08, KeyType.SECP256K1, 0x12, 33]) + identity_key.public_key.to_bytes()
+        )
+        signature = identity_key.sign(SIGNATURE_PREFIX + tls_public_bytes)
+        extension_payload_with_trailing_byte = (
+            _encode_asn1_signed_key(public_key_protobuf, signature) + b"\x00"
+        )
+
+        certificate_with_trailing_byte = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([]))
+            .issuer_name(x509.Name([]))
+            .public_key(tls_private.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .add_extension(
+                x509.UnrecognizedExtension(
+                    LIBP2P_EXTENSION_OID, extension_payload_with_trailing_byte
+                ),
+                critical=False,
+            )
+            .sign(tls_private, hashes.SHA256())
+        )
+
+        with pytest.raises(QuicTransportError) as exception_info:
+            verify_libp2p_certificate(certificate_with_trailing_byte)
+        assert str(exception_info.value) == "Peer certificate SignedKey has trailing bytes."
+
+    def test_off_curve_public_key_is_rejected(self, identity_key: IdentityKeypair) -> None:
+        """A compressed point that is not on the secp256k1 curve is rejected."""
+        tls_private = ec.generate_private_key(ec.SECP256R1())
+        tls_public_bytes = tls_private.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        off_curve_compressed_point = bytes([0x02]) + b"\xff" * 32
+        off_curve_public_key_protobuf = (
+            bytes([0x08, KeyType.SECP256K1, 0x12, 33]) + off_curve_compressed_point
+        )
+        signature = identity_key.sign(SIGNATURE_PREFIX + tls_public_bytes)
+        extension_payload = _encode_asn1_signed_key(off_curve_public_key_protobuf, signature)
+
+        certificate_with_off_curve_key = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([]))
+            .issuer_name(x509.Name([]))
+            .public_key(tls_private.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .add_extension(
+                x509.UnrecognizedExtension(LIBP2P_EXTENSION_OID, extension_payload),
+                critical=False,
+            )
+            .sign(tls_private, hashes.SHA256())
+        )
+
+        with pytest.raises(QuicTransportError) as exception_info:
+            verify_libp2p_certificate(certificate_with_off_curve_key)
+        assert str(exception_info.value) == (
+            "Peer identity public key is not a valid secp256k1 point."
+        )
+
+    def test_signature_over_foreign_tls_key_is_rejected(
+        self, identity_key: IdentityKeypair
+    ) -> None:
+        """A proof signed over another certificate's TLS key fails on the wrong certificate."""
+        # Sign the identity proof over a foreign TLS public key.
+        foreign_tls_private = ec.generate_private_key(ec.SECP256R1())
+        foreign_tls_public_bytes = foreign_tls_private.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        public_key_protobuf = (
+            bytes([0x08, KeyType.SECP256K1, 0x12, 33]) + identity_key.public_key.to_bytes()
+        )
+        signature_over_foreign_key = identity_key.sign(SIGNATURE_PREFIX + foreign_tls_public_bytes)
+        extension_payload = _encode_asn1_signed_key(public_key_protobuf, signature_over_foreign_key)
+
+        # Embed that proof in a certificate carrying a different TLS key.
+        own_tls_private = ec.generate_private_key(ec.SECP256R1())
+        certificate_with_mismatched_proof = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([]))
+            .issuer_name(x509.Name([]))
+            .public_key(own_tls_private.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+            .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+            .add_extension(
+                x509.UnrecognizedExtension(LIBP2P_EXTENSION_OID, extension_payload),
+                critical=False,
+            )
+            .sign(own_tls_private, hashes.SHA256())
+        )
+
+        with pytest.raises(QuicTransportError) as exception_info:
+            verify_libp2p_certificate(certificate_with_mismatched_proof)
+        assert str(exception_info.value) == (
+            "Peer identity signature does not match the certificate TLS key."
+        )
 
 
 # DER parsing helpers (test-only)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -84,11 +84,12 @@ source_type
 exitstatus
 amount
 
-# Inbound-connection callback on the QUIC listener.
-# Callers pass it across modules, so the use is real but invisible here.
-# It stays reserved until inbound peer-identity verification is implemented,
-# at which point the handshake stops rejecting and invokes it.
-on_connection
+# aioquic server-side TLS attribute, read by aioquic during the handshake to
+# decide whether to request the client certificate.
+# aioquic defaults to not requesting it, so we set it by wrapping the lazy
+# connection initializer.
+# aioquic reads it internally, so the assignment looks unused here.
+_._request_client_certificate
 
 # logging.Formatter.format override, invoked by the logging framework.
 _.format


### PR DESCRIPTION
## Problem

The `tests/interop/` CI job fails: `test_consensus_lifecycle` times out at the connectivity phase with peer counts `[0, 0, 0]`.

This is a **functional regression**, not a test bug. PR #964 (`5169c80b`, "reject missing peer-id instead of fabricating a random one") removed the old "fabricate a random peer ID" fallback in the QUIC transport but never implemented the real identity path meant to replace it. As a result the transport could not form connections at all, failing outward through three layers:

1. **Outbound** dials required a `/p2p/<peer_id>` in the multiaddr → bare-address dials raised `Multiaddr is missing a peer identity`.
2. **Inbound** rejected *every* connection unconditionally (`peer identity verification ... is not implemented`).
3. The aioquic **server never requested the client certificate** (its default), so the server-side peer certificate was always `None`.

The symptom marched outward as each layer was addressed: `[0,0,0]` → `[2,1,0]` → full mesh.

## Fix

- Add `verify_libp2p_certificate`, the exact inverse of the existing certificate generator: locate the libp2p extension (OID `1.3.6.1.4.1.53594.1.1`), ASN.1-decode the `SignedKey`, enforce the secp256k1 key type, verify the identity signature over the peer's **own** TLS public key (the MITM/replay binding), and derive the `PeerId`.
- Wire verification into the handshake:
  - **Inbound** connections are keyed by the verified identity instead of being rejected.
  - **Outbound** connections assert the verified identity equals the dialed `/p2p/<id>`.
  - Both paths **fail closed**: an unverified peer is never registered.
- Make the listener request the client certificate so mutual authentication actually happens.
- Fix the interop harness to dial `/p2p/<peer_id>` instead of the bare listen address.

## Tests

- Verifier unit tests: positive roundtrip plus negative vectors — tampered signature, missing extension, wrong key type, trailing ASN.1 bytes, off-curve key, and a signature over a foreign TLS key.
- Inbound **fail-closed** and outbound **identity-mismatch** behavior.
- `just check` passes; the full `tests/node/networking/transport/quic/` suite passes; `test_consensus_lifecycle` now passes with a full 3-node mesh.

## Note

The interop test retains some pre-existing wall-clock/slot-timing sensitivity (an occasional Phase-2 block-propagation timeout unrelated to connectivity). That is orthogonal to this fix and could be a follow-up if CI runners are slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)