### PR TITLE
docs: fix SignedAttestation.signature docstring

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/attestation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/attestation.py
@@ -23,7 +23,7 @@ class SignedAttestation(Attestation):
     """Validator attestation bundled with its signature."""
 
     signature: Signature
-    """Signature aggregation produced by the leanVM (SNARKs in the future)."""
+    """Signature over the attestation data, from the validator's attestation key."""
 
 
 class AggregatedAttestation(Container):


### PR DESCRIPTION
A signed attestation holds one validator's signature over one vote, not an aggregation produced by the leanVM.
This corrects the field docstring to describe a single signature from the validator's attestation key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)