### PR TITLE
docs: correct AggregatedAttestation class docstring

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/attestation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/attestation.py
@@ -27,7 +27,7 @@ class SignedAttestation(Attestation):
 
 
 class AggregatedAttestation(Container):
-    """Aggregated attestation consisting of participation bits and message."""
+    """Attestation shared by many validators, with a bitfield naming them."""
 
     aggregation_bits: AggregationBits
     """Bitfield indicating which validators participated in the aggregation."""


### PR DESCRIPTION
The container holds aggregation bits and attestation data; it has no "message" field.
This rewrites the docstring to describe an attestation shared by many validators, named by a bitfield.

🤖 Generated with [Claude Code](https://claude.com/claude-code)