### PR TITLE
docs: fix proposal_public_key docstring

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/spec/forks/lstar/containers/validator.py
@@ -12,7 +12,7 @@ class Validator(Container):
     """XMSS public key for signing attestations."""
 
     proposal_public_key: Bytes52
-    """XMSS public key for signing proposer attestations in blocks."""
+    """XMSS public key the proposer signs the block root with."""
 
     index: ValidatorIndex = ValidatorIndex(0)
     """Validator index in the registry."""


### PR DESCRIPTION
The proposer signs the block root with this key, not proposer attestations.
This corrects the field docstring to describe what the proposal key actually signs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)