### PR TITLE
refactor: drop no-op wildcard arm in interval match

### DIFF
--- a/src/lean_spec/spec/forks/lstar/timeline.py
+++ b/src/lean_spec/spec/forks/lstar/timeline.py
@@ -43,8 +43,6 @@ class TimelineMixin(LstarSpecBase):
                 store = self.update_safe_target(store)
             case 4:
                 store = self.accept_new_attestations(store)
-            case _:
-                pass
 
         return store, new_aggregates
 


### PR DESCRIPTION
The catch-all arm of the per-interval match statement only executed pass. A structural match needs no exhaustive default, so remove the dead arm.

Behavior is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)