### PR TITLE
docs: drop unsupported subnet id range

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/identifiers.py
+++ b/src/lean_spec/spec/forks/lstar/containers/identifiers.py
@@ -7,7 +7,7 @@ from lean_spec.spec.ssz import SSZList, Uint64
 
 
 class SubnetId(Uint64):
-    """Subnet identifier (0-63) for attestation subnet partitioning."""
+    """Subnet identifier for attestation subnet partitioning."""
 
 
 class ValidatorIndex(Uint64):


### PR DESCRIPTION
Nothing in the spec establishes a fixed count of 64 subnets.
This removes the unsupported "(0-63)" claim from the subnet identifier docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)