### PR TITLE
docs: tighten is_justifiable_after docstring

### DIFF
--- a/src/lean_spec/spec/forks/lstar/slot.py
+++ b/src/lean_spec/spec/forks/lstar/slot.py
@@ -27,13 +27,7 @@ class Slot(Uint64):
 
     def is_justifiable_after(self, finalized_slot: "Slot") -> bool:
         """
-        Checks if this slot is a valid candidate for justification after a given finalized slot.
-
-        According to the 3SF-mini specification, a slot is justifiable if its
-        distance (delta) from the last finalized slot is:
-          1. Less than or equal to 5.
-          2. A perfect square (e.g., 9, 16, 25...).
-          3. A pronic number (of the form x^2 + x, e.g., 6, 12, 20...).
+        Check whether this slot may be justified after the given finalized slot.
 
         Args:
             finalized_slot: The last slot that was finalized.


### PR DESCRIPTION
The docstring hardcoded the window literal and gave an incomplete perfect-square example that omitted 0, 1, and 4.
This trims it to a one-line summary plus Args/Returns/Raises, letting the existing inline comments carry the three rules. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)