### PR TITLE
docs: trim duplicated docstrings on lstar base stubs

### DIFF
--- a/src/lean_spec/spec/forks/lstar/_base.py
+++ b/src/lean_spec/spec/forks/lstar/_base.py
@@ -43,12 +43,12 @@ class LstarSpecBase(ForkProtocol):
 
     @abstractmethod
     def process_slots(self, state: State, target_slot: Slot) -> State:
-        """Advance the state through empty slots up to the target slot."""
+        """Slot-advance contract."""
         ...
 
     @abstractmethod
     def process_block(self, state: State, block: Block) -> State:
-        """Apply full block processing including header and body."""
+        """Block-processing contract."""
         ...
 
     @abstractmethod
@@ -57,7 +57,7 @@ class LstarSpecBase(ForkProtocol):
         state: State,
         block: Block,
     ) -> State:
-        """Apply the complete state transition function for a block."""
+        """State-transition contract."""
         ...
 
     @abstractmethod
@@ -70,7 +70,7 @@ class LstarSpecBase(ForkProtocol):
         known_block_roots: AbstractSet[Bytes32],
         aggregated_payloads: dict[AttestationData, set[SingleMessageAggregate]] | None = None,
     ) -> tuple[Block, State, list[AggregatedAttestation], list[SingleMessageAggregate]]:
-        """Build a valid block on top of the given pre-state."""
+        """Block-building contract."""
         ...
 
     @abstractmethod
@@ -79,27 +79,27 @@ class LstarSpecBase(ForkProtocol):
         signed_block: SignedBlock,
         validators: Validators,
     ) -> bool:
-        """Verify the merged aggregate proof carried by a signed block."""
+        """Signature-verification contract."""
         ...
 
     @abstractmethod
     def prune_stale_attestation_data(self, store: LstarStore) -> LstarStore:
-        """Remove attestation data that can no longer influence fork choice."""
+        """Attestation-pruning contract."""
         ...
 
     @abstractmethod
     def accept_new_attestations(self, store: LstarStore) -> LstarStore:
-        """Migrate pending payloads into the known pool and update the head."""
+        """Pending-attestation acceptance contract."""
         ...
 
     @abstractmethod
     def update_safe_target(self, store: LstarStore) -> LstarStore:
-        """Update the deepest block with supermajority attestation weight."""
+        """Safe-target update contract."""
         ...
 
     @abstractmethod
     def aggregate(self, store: LstarStore) -> tuple[LstarStore, list[SignedAggregatedAttestation]]:
-        """Combine raw validator votes into compact aggregated attestations."""
+        """Vote-aggregation contract."""
         ...
 
     @abstractmethod
@@ -110,5 +110,5 @@ class LstarSpecBase(ForkProtocol):
         has_proposal: bool,
         is_aggregator: bool = False,
     ) -> tuple[LstarStore, list[SignedAggregatedAttestation]]:
-        """Advance store time to the target interval, performing interval actions."""
+        """Interval-tick contract."""
         ...


### PR DESCRIPTION
The abstract stubs in the shared base are the typed contract that lets the type checker resolve cross-mixin calls, so all stubs, signatures, and abstractmethod decorators are kept untouched.

Their one-line docstrings restated each implementation summary, a drift surface that had already diverged in several cases. Trim each to a minimal, distinct contract label. Type checking still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)