### PR TITLE
docs: trim numbered-step recaps duplicating inline comments

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -179,16 +179,8 @@ class ForkChoiceMixin(LstarSpecBase):
         """
         Validate incoming attestation before processing.
 
-        Ensures the vote respects the basic laws of time and topology:
-            1. The blocks voted for must exist in our store.
-            2. A vote cannot span backwards in time (source > target).
-            3. The head must be at least as recent as source and target.
-            4. Checkpoint slots must match the actual block slots.
-            5. Source, target, and head must lie on one parent chain.
-            6. The vote's slot must have started locally (a small disparity margin is allowed).
-
         Raises:
-            SpecRejectionError: If the attestation fails any of the validation checks above.
+            SpecRejectionError: If the attestation fails any of the validation checks below.
         """
         source_checkpoint = attestation_data.source
         target_checkpoint = attestation_data.target
@@ -196,7 +188,7 @@ class ForkChoiceMixin(LstarSpecBase):
 
         # Availability Check
         #
-        # We cannot count a vote if we haven't seen the blocks involved.
+        # A vote cannot be counted until the blocks it references are known.
         if source_checkpoint.root not in store.blocks:
             raise SpecRejectionError(
                 RejectionReason.UNKNOWN_SOURCE_BLOCK,
@@ -284,11 +276,6 @@ class ForkChoiceMixin(LstarSpecBase):
     ) -> LstarStore:
         """
         Verify a gossiped attestation and, for aggregators, record its signature.
-
-        Steps:
-            1. Validate the vote: known blocks, matching slots, ancestry, and timing.
-            2. Verify the signature against the validator's key.
-            3. Record the signature, but only when this node aggregates.
 
         Subnet filtering happens at the p2p subscription layer.
         Only attestations from subscribed subnets arrive here, so no subnet check is repeated.
@@ -400,11 +387,6 @@ class ForkChoiceMixin(LstarSpecBase):
 
         One aggregated attestation carries a single proof that stands in for many
         validators who all signed the same vote.
-
-        Steps:
-            1. Validate the vote: known blocks, matching slots, ancestry, and timing.
-            2. Verify the aggregate proof against every participant's key.
-            3. Record the proof in the pending pool.
 
         Args:
             store: Current fork-choice store.

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -123,11 +123,6 @@ class StateTransitionMixin(LstarSpecBase):
         """
         Advance the state through empty slots up to, but not including, target_slot.
 
-        The loop:
-          - Performs per-slot maintenance (e.g., state root caching).
-          - Increments the slot counter after each call.
-        The function returns a new state with slot == target_slot.
-
         Raises:
             SpecRejectionError: BLOCK_SLOT_NOT_IN_FUTURE if target_slot is not in the future.
         """
@@ -164,19 +159,6 @@ class StateTransitionMixin(LstarSpecBase):
     def process_block_header(self, state: State, block: Block) -> State:
         """
         Validate the block header and update header-linked state.
-
-        Checks:
-          - The block slot equals the current state slot.
-          - The block slot is newer than the latest header slot.
-          - The proposer index matches the round-robin selection.
-          - The parent root matches the hash of the latest block header.
-
-        Updates:
-          - For the first post-genesis block, mark genesis as justified/finalized.
-          - Append the parent root to historical hashes.
-          - Append the justified bit for the parent (true only for genesis).
-          - Insert ZERO_HASH entries for any skipped empty slots.
-          - Set latest_block_header for the new block with an empty state_root.
 
         Raises:
             SpecRejectionError: If any header check fails (slot mismatch, block older
@@ -322,13 +304,7 @@ class StateTransitionMixin(LstarSpecBase):
         attestations: Iterable[AggregatedAttestation],
     ) -> State:
         """
-        Apply attestations and update justification/finalization
-        according to the Lean Consensus 3SF-mini rules.
-
-        This simplified consensus mechanism:
-        1. Processes each attestation
-        2. Updates justified status for target checkpoints
-        3. Applies finalization rules based on justified status
+        Apply attestations and update justification and finalization under the 3SF-mini rules.
 
         Raises:
             SpecRejectionError: EMPTY_AGGREGATION_BITS if an attestation that passes


### PR DESCRIPTION
Several state-transition and fork-choice docstrings enumerated steps already carried as labeled inline comments, which is the algorithm-recap anti-pattern.
This reduces each docstring to its one-line summary plus its Raises section and rephrases a first-person comment impersonally. The inline comments and code are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)