### PR TITLE
docs: replace filler on_tick docstring body

### DIFF
--- a/src/lean_spec/spec/forks/lstar/timeline.py
+++ b/src/lean_spec/spec/forks/lstar/timeline.py
@@ -58,9 +58,7 @@ class TimelineMixin(LstarSpecBase):
         """
         Advance forkchoice store time to given interval count.
 
-        Ticks store forward interval by interval, performing appropriate
-        actions for each interval type. This method handles time progression
-        incrementally to ensure all interval-specific actions are performed.
+        Stepping one interval at a time runs every interval's action without skipping any.
         """
         all_new_aggregates: list[SignedAggregatedAttestation] = []
 


### PR DESCRIPTION
The docstring body restated the summary and opened with a filler phrase.
This keeps the one-line summary and states plainly that stepping one interval at a time runs every interval's action without skipping any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)