### PR TITLE
test: vector for proposer scheduling on empty validator registry

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -130,8 +130,6 @@ class BlockSpec(CamelModel):
 
     def resolve_proposer_index(self, num_validators: int) -> ValidatorIndex:
         """Return the proposer index, falling back to the spec's round-robin schedule."""
-        # Delegate to the spec so an empty registry surfaces the spec's typed
-        # rejection instead of a bare division-by-zero in the test framework.
         return self.proposer_index or ValidatorIndex.proposer_for_slot(
             self.slot, Uint64(num_validators)
         )

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -27,7 +27,7 @@ from lean_spec.spec.forks.lstar.containers import (
     Store,
 )
 from lean_spec.spec.forks.lstar.spec import LstarSpec
-from lean_spec.spec.ssz import ByteList512KiB, Bytes32
+from lean_spec.spec.ssz import ByteList512KiB, Bytes32, Uint64
 
 
 class BlockSpec(CamelModel):
@@ -129,8 +129,12 @@ class BlockSpec(CamelModel):
     """
 
     def resolve_proposer_index(self, num_validators: int) -> ValidatorIndex:
-        """Return the proposer index, falling back to round-robin by slot."""
-        return self.proposer_index or ValidatorIndex(int(self.slot) % num_validators)
+        """Return the proposer index, falling back to the spec's round-robin schedule."""
+        # Delegate to the spec so an empty registry surfaces the spec's typed
+        # rejection instead of a bare division-by-zero in the test framework.
+        return self.proposer_index or ValidatorIndex.proposer_for_slot(
+            self.slot, Uint64(num_validators)
+        )
 
     def resolve_parent_root(
         self,

--- a/tests/consensus/lstar/state_transition/test_empty_validator_registry.py
+++ b/tests/consensus/lstar/state_transition/test_empty_validator_registry.py
@@ -1,0 +1,45 @@
+"""State Transition: Proposer Scheduling Against An Empty Validator Registry."""
+
+import pytest
+
+from consensus_testing import (
+    BlockSpec,
+    ExpectedRejection,
+    StateTransitionTestFiller,
+    generate_pre_state,
+)
+from lean_spec.spec.forks import RejectionReason, Slot
+
+pytestmark = pytest.mark.valid_until("Lstar")
+
+
+def test_proposer_scheduling_on_empty_registry_rejected(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    An empty validator registry has no validator to schedule as proposer.
+
+    Given
+    -----
+    - the genesis state carries zero validators.
+
+    When
+    ----
+    - a block at slot 1 is processed, driving round-robin proposer selection.
+
+    Then
+    ----
+    - proposer selection has no registry size to take a modulo against.
+    - the block is rejected as scheduling against an empty registry.
+    """
+    state_transition_test(
+        pre=generate_pre_state(num_validators=0),
+        blocks=[
+            BlockSpec(slot=Slot(1)),
+        ],
+        post=None,
+        expected_rejection=ExpectedRejection(
+            reason=RejectionReason.EMPTY_VALIDATOR_REGISTRY,
+            message_substring="Cannot schedule a proposer for an empty validator registry",
+        ),
+    )


### PR DESCRIPTION
Adds a state_transition negative vector driving round-robin proposer
selection against a zero-validator registry, pinning the empty-registry
rejection that previously had no fixture coverage. The filler's proposer
fallback now delegates to the spec schedule, so the typed rejection
surfaces instead of a bare division-by-zero in the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)