### PR TITLE
test: vector for empty-participant aggregated gossip attestation

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/attestation_specs.py
+++ b/packages/testing/src/consensus_testing/test_types/attestation_specs.py
@@ -204,6 +204,19 @@ class AggregatedAttestationSpec(AttestationSpec):
         validator_indices = self.validator_indices
         signer_indices = self.signer_indices or self.validator_indices
 
+        # Path 0: Raw bit override.
+        #
+        # Use the bits verbatim with placeholder proof bytes.
+        # An honest aggregate can never carry zero participants, so this is the
+        # only way to feed the gossip path an adversarial empty-bit aggregate.
+        if self.aggregation_bits is not None:
+            placeholder = ByteList512KiB(data=b"\x00" * 32)
+            proof = SingleMessageAggregate(
+                participants=self.aggregation_bits,
+                proof=placeholder,
+            )
+            return SignedAggregatedAttestation(data=attestation_data, proof=proof)
+
         # Path 1: Invalid signature.
         #
         # Correct participant bitfield but zeroed-out proof bytes.

--- a/tests/consensus/lstar/fork_choice/test_gossip_aggregated_empty_participants.py
+++ b/tests/consensus/lstar/fork_choice/test_gossip_aggregated_empty_participants.py
@@ -1,0 +1,67 @@
+"""Gossip aggregated attestation with an empty participant set is rejected."""
+
+import pytest
+
+from consensus_testing import (
+    AggregatedAttestationSpec,
+    BlockSpec,
+    BlockStep,
+    ExpectedRejection,
+    ForkChoiceTestFiller,
+    GossipAggregatedAttestationStep,
+    StoreChecks,
+)
+from lean_spec.spec.forks import AggregationBits, RejectionReason, Slot
+
+pytestmark = pytest.mark.valid_until("Lstar")
+
+
+def test_gossip_aggregated_attestation_empty_participants_rejected(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    An aggregated gossip attestation naming no participants is rejected.
+
+    Given
+    -----
+    - 4 validators.
+    - the chain:
+        block_1(1) -> block_2(2)
+
+    When
+    ----
+    - an aggregate voting for block_2 at slot 2 carries no participants.
+
+    Then
+    ----
+    - the aggregate names no validator to verify against.
+    - validation fails with empty aggregation bits.
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), label="block_2"),
+                checks=StoreChecks(head_slot=Slot(2)),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=AggregatedAttestationSpec(
+                    validator_indices=[],
+                    aggregation_bits=AggregationBits(data=[]),
+                    slot=Slot(2),
+                    target_slot=Slot(2),
+                    target_root_label="block_2",
+                ),
+                valid=False,
+                expected_rejection=ExpectedRejection(
+                    reason=RejectionReason.EMPTY_AGGREGATION_BITS,
+                    message_substring=(
+                        "Aggregated attestation must reference at least one validator"
+                    ),
+                ),
+            ),
+        ]
+    )


### PR DESCRIPTION
Adds a fork_choice vector feeding the aggregated-gossip entry point an
aggregate with zero participant bits, pinning the empty-bits rejection on
that path (only the block-body path was covered before). Since an honest
aggregate can never carry zero participants, the filler now honors an
explicit aggregation-bits override to emit the adversarial proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)