### PR TITLE
fix: cap slot gap a block may advance

### DIFF
--- a/src/lean_spec/spec/forks/lstar/config.py
+++ b/src/lean_spec/spec/forks/lstar/config.py
@@ -11,6 +11,7 @@ __all__ = [
     "INTERVALS_PER_SLOT",
     "JUSTIFICATION_LOOKBACK_SLOTS",
     "MAX_ATTESTATIONS_DATA",
+    "MAX_SLOTS_PER_IMPORT",
     "MILLISECONDS_PER_INTERVAL",
     "MILLISECONDS_PER_SLOT",
     "SECONDS_PER_SLOT",
@@ -47,6 +48,19 @@ HISTORICAL_ROOTS_LIMIT: Final = Uint64(2**18)
 The maximum number of historical block roots to store in the state.
 
 With a 4-second slot, this corresponds to a history of approximately 12.1 days.
+"""
+
+MAX_SLOTS_PER_IMPORT: Final = HISTORICAL_ROOTS_LIMIT
+"""
+Largest slot gap a single block may advance the state across during import.
+
+Slot processing walks one state copy per skipped slot and appends one history
+entry per skipped slot.
+A block whose slot exceeds the current state slot by more than the historical
+roots capacity would overflow the history list anyway, so it can never extend
+the chain.
+Bounding the advance here turns an unbounded loop on a far-future wire slot into
+a clean rejection instead of an effective hang.
 """
 
 ATTESTATION_COMMITTEE_COUNT: Final = Uint64(1)

--- a/src/lean_spec/spec/forks/lstar/config.py
+++ b/src/lean_spec/spec/forks/lstar/config.py
@@ -52,15 +52,11 @@ With a 4-second slot, this corresponds to a history of approximately 12.1 days.
 
 MAX_SLOTS_PER_IMPORT: Final = HISTORICAL_ROOTS_LIMIT
 """
-Largest slot gap a single block may advance the state across during import.
+Largest slot gap a single block may advance the state during import.
 
-Slot processing walks one state copy per skipped slot and appends one history
-entry per skipped slot.
-A block whose slot exceeds the current state slot by more than the historical
-roots capacity would overflow the history list anyway, so it can never extend
-the chain.
-Bounding the advance here turns an unbounded loop on a far-future wire slot into
-a clean rejection instead of an effective hang.
+Slot processing copies the state once per skipped slot.
+A far-future wire slot would otherwise spin the loop for billions of iterations.
+The value is the historical roots capacity: a larger gap would overflow the history list anyway.
 """
 
 ATTESTATION_COMMITTEE_COUNT: Final = Uint64(1)

--- a/src/lean_spec/spec/forks/lstar/errors.py
+++ b/src/lean_spec/spec/forks/lstar/errors.py
@@ -10,6 +10,9 @@ class RejectionReason(StrEnum):
     BLOCK_SLOT_NOT_IN_FUTURE = "BLOCK_SLOT_NOT_IN_FUTURE"
     """The block slot is not strictly greater than the current state slot."""
 
+    BLOCK_SLOT_TOO_FAR_IN_FUTURE = "BLOCK_SLOT_TOO_FAR_IN_FUTURE"
+    """The block slot exceeds the current state slot by more than one import may advance."""
+
     BLOCK_OLDER_THAN_LATEST_HEADER = "BLOCK_OLDER_THAN_LATEST_HEADER"
     """The block slot is not newer than the latest block header."""
 

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks.lstar._base import LstarSpecBase
+from lean_spec.spec.forks.lstar.config import MAX_SLOTS_PER_IMPORT
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
     AttestationData,
@@ -130,11 +131,24 @@ class StateTransitionMixin(LstarSpecBase):
 
         Raises:
             SpecRejectionError: BLOCK_SLOT_NOT_IN_FUTURE if target_slot is not in the future.
+            SpecRejectionError: BLOCK_SLOT_TOO_FAR_IN_FUTURE if the target slot advances the
+                state by more than one import may cover.
         """
         # The target must be strictly greater than the current slot.
         if state.slot >= target_slot:
             raise SpecRejectionError(
                 RejectionReason.BLOCK_SLOT_NOT_IN_FUTURE, "Target slot must be in the future"
+            )
+
+        # Bound the advance before walking a slot at a time.
+        #
+        # The loop below copies the state once per skipped slot.
+        # A far-future wire slot would otherwise spin for billions of iterations.
+        # Past the history capacity the advance cannot extend the chain anyway,
+        # so reject it here instead of grinding through the work first.
+        if int(target_slot) - int(state.slot) > int(MAX_SLOTS_PER_IMPORT):
+            raise SpecRejectionError(
+                RejectionReason.BLOCK_SLOT_TOO_FAR_IN_FUTURE, "Block slot too far in future"
             )
 
         # Step through each missing slot.

--- a/tests/consensus/lstar/state_transition/test_block_processing.py
+++ b/tests/consensus/lstar/state_transition/test_block_processing.py
@@ -10,6 +10,7 @@ from consensus_testing import (
     generate_pre_state,
 )
 from lean_spec.spec.forks import RejectionReason, Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import MAX_SLOTS_PER_IMPORT
 from lean_spec.spec.forks.lstar.containers import JustifiedSlots
 from lean_spec.spec.forks.lstar.spec import LstarSpec
 from lean_spec.spec.ssz import Boolean, Bytes32
@@ -184,6 +185,44 @@ def test_block_at_very_large_slot_with_many_skipped(
             slot=Slot(500),
             historical_block_hashes_count=500,
             justified_slots=JustifiedSlots(data=[Boolean(False)] * 499),
+        ),
+    )
+
+
+def test_block_slot_too_far_in_future_rejected(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    A block advancing the state by more than one import may cover is rejected.
+
+    Given
+    -----
+    - the default genesis state at slot 0.
+    - the import advance bound is the historical roots capacity.
+
+    When
+    ----
+    - a block claims a slot one past the import advance bound.
+
+    Then
+    ----
+    - slot processing rejects the block before walking the gap.
+    - the block is rejected as too far in the future.
+
+    Regression
+    ----------
+    - slot processing once looped once per skipped slot with no upper bound.
+    - a far-future wire slot forced billions of iterations, an effective hang.
+    """
+    state_transition_test(
+        pre=generate_pre_state(),
+        blocks=[
+            BlockSpec(slot=Slot(int(MAX_SLOTS_PER_IMPORT) + 1)),
+        ],
+        post=None,
+        expected_rejection=ExpectedRejection(
+            reason=RejectionReason.BLOCK_SLOT_TOO_FAR_IN_FUTURE,
+            message_substring="Block slot too far in future",
         ),
     )
 

--- a/tests/consensus/lstar/state_transition/test_block_processing.py
+++ b/tests/consensus/lstar/state_transition/test_block_processing.py
@@ -206,13 +206,13 @@ def test_block_slot_too_far_in_future_rejected(
 
     Then
     ----
-    - slot processing rejects the block before walking the gap.
+    - the gap exceeds what one import may advance.
     - the block is rejected as too far in the future.
 
     Regression
     ----------
-    - slot processing once looped once per skipped slot with no upper bound.
-    - a far-future wire slot forced billions of iterations, an effective hang.
+    - slot processing once advanced one slot at a time with no upper bound.
+    - a far-future wire slot forced billions of iterations.
     """
     state_transition_test(
         pre=generate_pre_state(),


### PR DESCRIPTION
## Hazard

Slot processing loops one state copy per skipped slot with no upper bound on the block's slot. A far-future wire slot (for example `2**40`) forces every importing node to copy the state and recompute its hash tree root that many times, an effective hang. The same gap drives a giant historical-hashes allocation, bounded only by an SSZ length check that raises outside the rejection funnel. Round-robin proposer selection (`slot % num_validators`) lets a single scheduled validator pick an arbitrarily distant slot and amplify the cost onto every honest node.

## Property at risk

- Liveness / availability: a single block with a far-future slot can hang every importing node.

## Fix

Introduces a named `MAX_SLOTS_PER_IMPORT` bound, set to the historical roots capacity. Past that capacity the advance would overflow the history list anyway, so it can never extend the chain; the bound is therefore the protocol-justified ceiling. Slot processing now rejects a block whose slot exceeds the current state slot by more than that bound, before entering the per-slot loop, surfaced as a new `BLOCK_SLOT_TOO_FAR_IN_FUTURE` rejection.

Adds a negative state-transition vector for a block one slot past the bound. The existing 500-slot single-block advance vector stays green, and the full lstar consensus suite fills green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)