### PR TITLE
fix: raise domain rejection on out-of-range justified-slot query

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/state.py
+++ b/src/lean_spec/spec/forks/lstar/containers/state.py
@@ -7,6 +7,7 @@ from lean_spec.spec.forks.lstar.containers.block import BlockHeader
 from lean_spec.spec.forks.lstar.containers.checkpoint import Checkpoint
 from lean_spec.spec.forks.lstar.containers.genesis import GenesisConfig
 from lean_spec.spec.forks.lstar.containers.validator import Validators
+from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
 from lean_spec.spec.forks.lstar.slot import Slot
 from lean_spec.spec.ssz import Boolean, Bytes32, Container, SSZList
 from lean_spec.spec.ssz.bitfields import BaseBitlist
@@ -45,7 +46,8 @@ class JustifiedSlots(BaseBitlist):
             True if the slot is justified or finalized, False otherwise.
 
         Raises:
-            IndexError: If the target slot is active but outside the tracked range.
+            SpecRejectionError: JUSTIFIED_SLOT_OUT_OF_RANGE if the target slot is active
+                but outside the tracked range.
         """
         # First, determine the position of the target relative to the anchor.
         #
@@ -59,12 +61,15 @@ class JustifiedSlots(BaseBitlist):
         # We assume the slot is within the tracked range.
         #
         # If the caller asks for a slot too far in the future, it indicates a logic error.
+        # Surface it as a domain rejection so the uniform rejection funnel catches it,
+        # rather than a bare index error escaping a block-processing path.
         try:
             return self[relative_index]
         except IndexError as exception:
-            raise IndexError(
+            raise SpecRejectionError(
+                RejectionReason.JUSTIFIED_SLOT_OUT_OF_RANGE,
                 f"Slot {target_slot} is outside the tracked range "
-                f"(finalized_boundary={finalized_slot}, tracked_length={len(self)})"
+                f"(finalized_boundary={finalized_slot}, tracked_length={len(self)})",
             ) from exception
 
     def extend_to_slot(self, finalized_slot: Slot, target_slot: Slot) -> Self:

--- a/src/lean_spec/spec/forks/lstar/errors.py
+++ b/src/lean_spec/spec/forks/lstar/errors.py
@@ -83,6 +83,9 @@ class RejectionReason(StrEnum):
     VALIDATOR_INDEX_OUT_OF_RANGE = "VALIDATOR_INDEX_OUT_OF_RANGE"
     """The validator index does not address any registered validator."""
 
+    JUSTIFIED_SLOT_OUT_OF_RANGE = "JUSTIFIED_SLOT_OUT_OF_RANGE"
+    """A justification query named a slot beyond the tracked justification window."""
+
     # Cryptographic verification
     INVALID_SIGNATURE = "INVALID_SIGNATURE"
     """An attestation signature or aggregate proof fails cryptographic verification."""


### PR DESCRIPTION
## Hazard

The justified-slot query re-raises a bare `IndexError` when asked about a slot beyond the tracked justification window. That bare error escapes the uniform `SpecRejectionError` funnel that wraps block processing. The query is fed checkpoint slots during attestation accounting; those slots are window-validated upstream today, so this branch is defense-in-depth.

## Property at risk

- Uniform error handling: any future gap in the upstream window-coverage reasoning would surface as an uncaught exception on a block-processing path rather than a clean, language-neutral rejection that clients can assert against.

## Fix

Raise a `SpecRejectionError` carrying a new precise `JUSTIFIED_SLOT_OUT_OF_RANGE` reason instead of a bare `IndexError`, preserving the informative message (target slot, finalized boundary, tracked length).

## On the missing vector

No new consensus vector accompanies this change. The branch is unreachable from the consensus-vector surface: the spec's own upstream window validation guarantees the queried source and target slots are within range before this query runs, so no fillable input exercises it. No existing vector asserts the previous message. The full lstar consensus suite fills green and `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)