### PR TITLE
test: vector for fallback-pool set-cover contribution

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -246,6 +246,15 @@ class StoreChecks(SelectiveCheck):
     aggregated proof map.
     """
 
+    new_pool_proof_participants: dict[Slot, set[int]] | None = None
+    """
+    Expected union of participants across pending-pool proofs, keyed by target slot.
+
+    Compares the set of validator indices covered by every proof in the
+    pending aggregated proof map for each target slot.
+    Pins the coverage a fresh aggregation round produced in the pending pool.
+    """
+
     block_attestation_count: int | None = None
     """
     Expected number of aggregated attestations in the block body.
@@ -427,6 +436,22 @@ class StoreChecks(SelectiveCheck):
             )
             expected_target_slots = sorted(getattr(self, field_name))
             _check(field_name, actual_target_slots, expected_target_slots)
+
+        # Participant union across pending-pool proofs, per target slot
+        if "new_pool_proof_participants" in fields:
+            assert self.new_pool_proof_participants is not None
+            participants_by_target_slot: dict[Slot, set[int]] = {}
+            for attestation_data, proofs in store.latest_new_aggregated_payloads.items():
+                target_slot = attestation_data.target.slot
+                covered = participants_by_target_slot.setdefault(target_slot, set())
+                for proof in proofs:
+                    covered |= {int(i) for i in proof.participants.to_validator_indices()}
+            for target_slot, expected_participants in self.new_pool_proof_participants.items():
+                _check(
+                    f"new_pool_proof_participants[{target_slot}]",
+                    participants_by_target_slot.get(target_slot, set()),
+                    expected_participants,
+                )
 
         # Block body attestation count
         if "block_attestation_count" in fields:

--- a/tests/consensus/lstar/fork_choice/test_fallback_pool_set_cover.py
+++ b/tests/consensus/lstar/fork_choice/test_fallback_pool_set_cover.py
@@ -1,0 +1,99 @@
+"""Greedy set-cover draws from the fallback pool after the priority pool."""
+
+import pytest
+
+from consensus_testing import (
+    AggregatedAttestationCheck,
+    AggregatedAttestationSpec,
+    BlockSpec,
+    BlockStep,
+    ForkChoiceTestFiller,
+    GossipAggregatedAttestationStep,
+    StoreChecks,
+    TickStep,
+)
+from lean_spec.spec.forks import Interval, Slot, ValidatorIndex
+
+pytestmark = pytest.mark.valid_until("Lstar")
+
+
+def test_aggregate_covers_union_of_priority_and_fallback_pools(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Aggregation merges a fallback-pool proof with a priority-pool proof for one target.
+
+    Given
+    -----
+    - 4 validators.
+    - the chain:
+        genesis -> block_1(1)
+    - one proof covers V0, V1 targeting block_1.
+    - an acceptance tick migrates that proof into the accepted pool.
+    - one proof covers V1, V2 targeting block_1.
+    - that proof stays in the pending pool.
+    - the two proofs share V1 and carry identical attestation data.
+
+    When
+    ----
+    - the aggregation interval runs with both pools populated.
+    - an acceptance tick migrates the merged proof into the accepted pool.
+    - block_3 is built on block_1, carrying no votes of its own.
+
+    Then
+    ----
+    - the pending (priority) proof is taken before the accepted (fallback) proof.
+    - the fallback proof adds V0, the one validator still uncovered.
+    - the pending pool holds one proof covering V0, V1, V2 for target slot 1.
+    - block_3 holds 1 aggregated attestation.
+    - that aggregation covers V0, V1, V2.
+    - head is block_3.
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            TickStep(interval=int(Interval.from_slot(Slot(1))) + 3),
+            GossipAggregatedAttestationStep(
+                attestation=AggregatedAttestationSpec(
+                    validator_indices=[ValidatorIndex(0), ValidatorIndex(1)],
+                    slot=Slot(1),
+                    target_slot=Slot(1),
+                    target_root_label="block_1",
+                ),
+            ),
+            TickStep(interval=int(Interval.from_slot(Slot(1))) + 4),
+            GossipAggregatedAttestationStep(
+                attestation=AggregatedAttestationSpec(
+                    validator_indices=[ValidatorIndex(1), ValidatorIndex(2)],
+                    slot=Slot(1),
+                    target_slot=Slot(1),
+                    target_root_label="block_1",
+                ),
+            ),
+            TickStep(
+                interval=int(Interval.from_slot(Slot(2))) + 2,
+                checks=StoreChecks(
+                    new_pool_proof_participants={Slot(1): {0, 1, 2}},
+                ),
+            ),
+            TickStep(interval=int(Interval.from_slot(Slot(2))) + 4),
+            BlockStep(
+                block=BlockSpec(slot=Slot(3), label="block_3"),
+                checks=StoreChecks(
+                    head_slot=Slot(3),
+                    head_root_label="block_3",
+                    block_attestation_count=1,
+                    block_attestations=[
+                        AggregatedAttestationCheck(
+                            participants={0, 1, 2},
+                            attestation_slot=Slot(1),
+                            target_slot=Slot(1),
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )


### PR DESCRIPTION
Adds a fork_choice vector that seeds the accepted and pending proof pools
with partially overlapping subsets for one attestation data, so the
aggregation round's greedy set-cover must draw from the fallback pool after
the priority pool. A new pending-pool participant-union store check pins the
merged proof to the union, isolating the fallback path from single-pool
block production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)