### PR TITLE
test: support anchored full-message match on expected rejection

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -58,6 +58,43 @@ class ExpectedRejection(StrictBaseModel):
     Fill-time self-check only; never serialized into vectors.
     """
 
+    exact_message: str | None = None
+    """
+    Full exception message the rejection must equal.
+
+    Opt-in for negative paths where the message disambiguates one reason
+    shared by several code paths.
+    When set, the raised message must equal this string exactly.
+    Fill-time self-check only; never serialized into vectors.
+    """
+
+    def assert_message_matches(self, exception: Exception, context: str) -> None:
+        """
+        Check the raised message against the authored expectation.
+
+        The exact match takes precedence over the substring when both are set.
+
+        Args:
+            exception: The exception the negative path raised.
+            context: Caller label woven into the failure message.
+
+        Raises:
+            AssertionError: When the message contradicts the expectation.
+        """
+        actual_message = str(exception)
+        if self.exact_message is not None and actual_message != self.exact_message:
+            raise AssertionError(
+                f"{context} failed with wrong error message.\n"
+                f"  Expected exact message: {self.exact_message!r}\n"
+                f"  Actual message: {actual_message!r}"
+            )
+        if self.message_substring is not None and self.message_substring not in actual_message:
+            raise AssertionError(
+                f"{context} failed with wrong error message.\n"
+                f"  Expected message containing: {self.message_substring!r}\n"
+                f"  Actual message: {actual_message!r}"
+            )
+
 
 class ProofSetting(IntEnum):
     """Aggregation proof regime emitted with each fixture."""
@@ -227,12 +264,7 @@ class BaseTestSpec(CamelModel):
             )
 
         # A wrong message means the rejection fired for the wrong reason.
-        expected_substring = self.expected_rejection.message_substring
-        if expected_substring is not None and expected_substring not in str(exception_raised):
-            raise AssertionError(
-                f"Expected exception message containing {expected_substring!r} "
-                f"but got '{exception_raised}'"
-            )
+        self.expected_rejection.assert_message_matches(exception_raised, "Verifier")
 
     def resolve_rejection_reason(self, exception_raised: Exception) -> RejectionReason:
         """

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -494,13 +494,7 @@ class ForkChoiceTest(BaseTestSpec):
                 validator_index=ValidatorIndex(0),
             )
         except SpecRejectionError as exception:
-            expected_substring = self.expected_rejection.message_substring
-            if expected_substring is not None and expected_substring not in str(exception):
-                raise AssertionError(
-                    "Store.from_anchor failed with wrong error.\n"
-                    f"  Expected error containing: {expected_substring!r}\n"
-                    f"  Actual error: {exception!r}"
-                ) from exception
+            self.expected_rejection.assert_message_matches(exception, "Store.from_anchor")
             # Emit the language-neutral reason clients assert against.
             return ForkChoiceFixture(
                 anchor_state=self.anchor_state,
@@ -530,13 +524,9 @@ class ForkChoiceTest(BaseTestSpec):
         # Verify the failure reason matches when specified.
         expected_rejection = step.expected_rejection
         if expected_rejection is not None:
-            expected_substring = expected_rejection.message_substring
-            if expected_substring is not None and expected_substring not in str(exception):
-                raise AssertionError(
-                    f"Step {step_index} ({type(step).__name__}) failed with wrong error.\n"
-                    f"  Expected error containing: {expected_substring!r}\n"
-                    f"  Actual error: {exception!r}"
-                ) from exception
+            expected_rejection.assert_message_matches(
+                exception, f"Step {step_index} ({type(step).__name__})"
+            )
 
         # Emit the language-neutral reason clients assert against.
         rejection_reason = classify_rejection(exception)

--- a/tests/consensus/lstar/fork_choice/test_gossip_aggregated_attestation_validation.py
+++ b/tests/consensus/lstar/fork_choice/test_gossip_aggregated_attestation_validation.py
@@ -158,7 +158,7 @@ def test_aggregated_attestation_target_slot_mismatch_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.TARGET_SLOT_MISMATCH,
-                    message_substring="Target checkpoint slot mismatch",
+                    exact_message="Target checkpoint slot mismatch",
                 ),
             ),
         ]


### PR DESCRIPTION
Adds an opt-in exact-message field to the negative-path expectation and
routes all three substring matchers through one shared helper, so a vector
can pin the full rejection message where it disambiguates a reason shared by
several code paths. Existing substring vectors keep working unchanged; one
representative aggregated-gossip rejection opts into the anchored check to
exercise the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)