### PR TITLE
fix(testing): keep dead-code CI green by avoiding a vulture-flagged rebind

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -443,9 +443,12 @@ class StoreChecks(SelectiveCheck):
             participants_by_target_slot: dict[Slot, set[int]] = {}
             for attestation_data, proofs in store.latest_new_aggregated_payloads.items():
                 target_slot = attestation_data.target.slot
-                covered = participants_by_target_slot.setdefault(target_slot, set())
+                participants = participants_by_target_slot.setdefault(target_slot, set())
                 for proof in proofs:
-                    covered |= {int(i) for i in proof.participants.to_validator_indices()}
+                    participants.update(
+                        int(validator_index)
+                        for validator_index in proof.participants.to_validator_indices()
+                    )
             for target_slot, expected_participants in self.new_pool_proof_participants.items():
                 _check(
                     f"new_pool_proof_participants[{target_slot}]",


### PR DESCRIPTION
## Problem

The dead-code CI job (`just deadcode` / vulture) exits non-zero on `main`.

The pending-pool participant-union store check builds its per-target-slot set with an augmented-assignment rebind:

```python
covered = participants_by_target_slot.setdefault(target_slot, set())
for proof in proofs:
    covered |= {int(i) for i in proof.participants.to_validator_indices()}
```

`covered |= ...` rebinds the name each iteration, and nothing reads it after the loop, so vulture flags it as an unused variable (60% confidence) and exits 3. The variable is not actually dead — the set is mutated in place through the dict reference — but the rebind pattern trips the check.

## Fix

Use an in-place `set.update(...)` instead of the augmented-assignment rebind, which vulture reads as a genuine use, and spell out the loop index per the no-abbreviation rule:

```python
participants = participants_by_target_slot.setdefault(target_slot, set())
for proof in proofs:
    participants.update(
        int(validator_index) for validator_index in proof.participants.to_validator_indices()
    )
```

Behavior is identical (in-place set union over the same proofs).

## Verification

- `vulture` on real source: clean, exit 0.
- `just check`: all pass.
- `test_fallback_pool_set_cover` (the vector that exercises this check) and the full lstar vector suite fill green, byte-identical across hash seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)