### PR TITLE
refactor(forks): drop unused cross-fork upgrade_state scaffolding

### DIFF
--- a/src/lean_spec/spec/forks/lstar/spec.py
+++ b/src/lean_spec/spec/forks/lstar/spec.py
@@ -20,7 +20,6 @@ from lean_spec.spec.forks.lstar.signatures import SignatureMixin
 from lean_spec.spec.forks.lstar.state_transition import StateTransitionMixin
 from lean_spec.spec.forks.lstar.timeline import TimelineMixin
 from lean_spec.spec.forks.lstar.validator_duties import ValidatorDutiesMixin
-from lean_spec.spec.forks.protocol import ForkProtocol
 
 __all__ = ["LstarSpec", "LstarStore"]
 
@@ -40,8 +39,6 @@ class LstarSpec(
     NAME: ClassVar[str] = "lstar"
     VERSION: ClassVar[int] = 4
     GOSSIP_DIGEST: ClassVar[str] = "12345678"
-
-    previous: ClassVar[type[ForkProtocol] | None] = None
 
     state_class: type[State] = State
     block_class: type[Block] = Block

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -20,7 +20,6 @@ from lean_spec.spec.forks.lstar.containers import (
     Validators,
 )
 from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
-from lean_spec.spec.forks.protocol import SpecStateType
 from lean_spec.spec.observability import (
     observe_state_transition,
 )
@@ -75,15 +74,6 @@ def attestation_data_matches_chain(
 
 class StateTransitionMixin(LstarSpecBase):
     """State transition function for the lstar fork."""
-
-    def upgrade_state(self, state: SpecStateType) -> State:
-        """
-        Lstar is the root fork: there is no predecessor, so no migration.
-
-        Returns the input state unchanged.
-        """
-        assert isinstance(state, State)
-        return state
 
     def generate_genesis(self, genesis_time: Uint64, validators: SSZList[Any]) -> State:
         """Generate a genesis state with empty history and proper initial values."""

--- a/src/lean_spec/spec/forks/protocol.py
+++ b/src/lean_spec/spec/forks/protocol.py
@@ -126,14 +126,6 @@ class ForkProtocol(ABC):
     block, attestation, and aggregation topics route compatibly.
     """
 
-    previous: ClassVar[type[ForkProtocol] | None]
-    """
-    Predecessor fork in the upgrade chain, or None for the root fork.
-
-    Forms a linked chain that the registry can walk to derive ordering
-    and that upgrade_state can traverse for cross-fork state migrations.
-    """
-
     state_class: type[SpecStateType]
     """Concrete State container class owned by this fork."""
 
@@ -173,17 +165,3 @@ class ForkProtocol(ABC):
         validator_index: ValidatorIndex | None,
     ) -> SpecStoreType:
         """Construct a forkchoice store anchored at the given state and block."""
-
-    @abstractmethod
-    def upgrade_state(self, state: SpecStateType) -> SpecStateType:
-        """
-        Migrate state from the previous fork's shape into this fork's shape.
-
-        Every concrete fork must declare this explicitly. The root fork
-        (previous is None) returns the input unchanged. Later forks return a
-        state of their own shape derived from the predecessor's state.
-
-        Making this abstract is intentional: a silent no-op default would
-        hide missed migrations whenever a fork adds a field but forgets to
-        override.
-        """


### PR DESCRIPTION
## What

Remove the cross-fork state-migration scaffolding that is currently dead:

- `ForkProtocol.upgrade_state` (abstract method) and its Lstar identity no-op override
- the `previous` fork-chaining `ClassVar` on the protocol and its `= None` assignment on Lstar
- the imports those left orphaned (`SpecStateType` in the lstar state-transition module, `ForkProtocol` in the lstar spec module)

## Why

Lstar is the only fork (`FORK_SEQUENCE = [LstarSpec()]`), so there is no fork boundary at which a state migration could occur.

- `upgrade_state` had **zero call sites** — nothing ever dispatches through it (unlike `generate_genesis`/`create_store`, which the node and fixtures call).
- `previous` was set once to `None` and **read nowhere**; the registry derives ordering from `VERSION`, never from the `previous` link.

This is exactly the speculative generality the project's no-dead-code rule forbids. Reintroduce it alongside the second fork that actually needs a migration.

## Verification

- `just check`: all pass (ruff, format, ty, codespell, mdformat).
- `LstarSpec` still instantiates and `DEFAULT_REGISTRY.current` still resolves to lstar (the two remaining abstract methods are satisfied).
- No remaining references to `upgrade_state` or the `previous` classvar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)