### PR TITLE
refactor(forks): make the attestation-on-chain check a method on AttestationData

### DIFF
--- a/src/lean_spec/spec/forks/lstar/block_production.py
+++ b/src/lean_spec/spec/forks/lstar/block_production.py
@@ -20,7 +20,6 @@ from lean_spec.spec.forks.lstar.containers import (
     State,
     ValidatorIndex,
 )
-from lean_spec.spec.forks.lstar.state_transition import attestation_data_matches_chain
 from lean_spec.spec.ssz import ZERO_HASH, Bytes32
 
 
@@ -147,9 +146,7 @@ class BlockProductionMixin(LstarSpecBase):
                     #
                     # This also rejects any checkpoint past the chain view.
                     # That keeps the bounded lookups below in range.
-                    if not attestation_data_matches_chain(
-                        attestation_data, extended_historical_block_hashes
-                    ):
+                    if not attestation_data.lies_on_chain(extended_historical_block_hashes):
                         continue
 
                     # A vote may only build from an already-justified source.

--- a/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
+++ b/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
@@ -5,8 +5,10 @@ A checkpoint is the (block root, slot) pair that gets justified and finalized.
 An attestation's content is three checkpoints: source, target, and head.
 """
 
+from collections.abc import Sequence
+
 from lean_spec.spec.forks.lstar.slot import Slot
-from lean_spec.spec.ssz import Bytes32, Container
+from lean_spec.spec.ssz import ZERO_HASH, Bytes32, Container
 
 
 class Checkpoint(Container):
@@ -43,3 +45,44 @@ class AttestationData(Container):
 
     source: Checkpoint
     """The checkpoint representing the source block as observed by the validator."""
+
+    def lies_on_chain(self, historical_block_hashes: Sequence[Bytes32]) -> bool:
+        """
+        Check that every checkpoint points to a block on the given chain.
+
+        Args:
+            historical_block_hashes: Chain view indexed by slot.
+                Empty slots carry the zero hash.
+
+        Returns:
+            True when all checkpoint roots match the chain at their slot.
+            False when any root is the zero hash.
+            False when any checkpoint slot is past the end of the chain view.
+        """
+        # Reject zero-hash checkpoints up front.
+        #
+        # Empty slots carry the zero hash on the chain.
+        # A vote whose recorded root equals the zero hash is meaningless.
+        if (
+            self.source.root == ZERO_HASH
+            or self.target.root == ZERO_HASH
+            or self.head.root == ZERO_HASH
+        ):
+            return False
+
+        # Reject checkpoints whose slot is beyond the chain view.
+        #
+        # Without this guard, indexed access raises IndexError.
+        source_slot = int(self.source.slot)
+        target_slot = int(self.target.slot)
+        head_slot = int(self.head.slot)
+        chain_length = len(historical_block_hashes)
+        if source_slot >= chain_length or target_slot >= chain_length or head_slot >= chain_length:
+            return False
+
+        # All checkpoint roots must match the chain at their slot.
+        return (
+            self.source.root == historical_block_hashes[source_slot]
+            and self.target.root == historical_block_hashes[target_slot]
+            and self.head.root == historical_block_hashes[head_slot]
+        )

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -1,13 +1,12 @@
 """Lstar fork — state transition: slots, header, body, finalization."""
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from typing import Any
 
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks.lstar._base import LstarSpecBase
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
-    AttestationData,
     Block,
     Checkpoint,
     HistoricalBlockHashes,
@@ -25,52 +24,6 @@ from lean_spec.spec.observability import (
     observe_state_transition,
 )
 from lean_spec.spec.ssz import ZERO_HASH, Boolean, Bytes32, SSZList, Uint64
-
-
-def attestation_data_matches_chain(
-    attestation_data: AttestationData,
-    historical_block_hashes: Sequence[Bytes32],
-) -> bool:
-    """
-    Check that attestation checkpoints point to blocks on a chain.
-
-    Args:
-        attestation_data: The attestation being validated.
-        historical_block_hashes: Chain view indexed by slot.
-            Empty slots carry the zero hash.
-
-    Returns:
-        True when all checkpoint roots match the chain at their slot.
-        False when any root is the zero hash.
-        False when any checkpoint slot is past the end of the chain view.
-    """
-    # Reject zero-hash checkpoints up front.
-    #
-    # Empty slots carry the zero hash on the chain.
-    # A vote whose recorded root equals the zero hash is meaningless.
-    if (
-        attestation_data.source.root == ZERO_HASH
-        or attestation_data.target.root == ZERO_HASH
-        or attestation_data.head.root == ZERO_HASH
-    ):
-        return False
-
-    # Reject checkpoints whose slot is beyond the chain view.
-    #
-    # Without this guard, indexed access raises IndexError.
-    source_slot = int(attestation_data.source.slot)
-    target_slot = int(attestation_data.target.slot)
-    head_slot = int(attestation_data.head.slot)
-    chain_length = len(historical_block_hashes)
-    if source_slot >= chain_length or target_slot >= chain_length or head_slot >= chain_length:
-        return False
-
-    # All checkpoint roots must match the chain at their slot.
-    return (
-        attestation_data.source.root == historical_block_hashes[source_slot]
-        and attestation_data.target.root == historical_block_hashes[target_slot]
-        and attestation_data.head.root == historical_block_hashes[head_slot]
-    )
 
 
 class StateTransitionMixin(LstarSpecBase):
@@ -416,9 +369,7 @@ class StateTransitionMixin(LstarSpecBase):
             #
             # This prevents votes about unknown or conflicting forks.
             # It also rejects zero-hash source or target roots.
-            if not attestation_data_matches_chain(
-                attestation.data, state.historical_block_hashes.data
-            ):
+            if not attestation.data.lies_on_chain(state.historical_block_hashes.data):
                 continue
 
             # Ensure time flows forward.


### PR DESCRIPTION
## What

Move the module-level `attestation_data_matches_chain` function (in the lstar state-transition module) onto `AttestationData` as a method, `lies_on_chain(self, historical_block_hashes)`.

```python
# before — module function, imported across modules
if not attestation_data_matches_chain(attestation.data, state.historical_block_hashes.data):

# after — method on the container
if not attestation.data.lies_on_chain(state.historical_block_hashes.data):
```

## Why

The function is a pure predicate over the three checkpoints `AttestationData` already owns (source / target / head), compared against a slot-indexed chain view that the caller supplies. It does not reach into `State`, fetch a chain, or mutate anything — so it belongs on the container, matching the established methods-on-containers pattern here (`Checkpoint.advance_to`, `AggregationBits.to_validator_indices`).

Benefits:
- Removes the cross-module import in the block-production module (it previously imported this helper from the state-transition module).
- Reads as `attestation_data.lies_on_chain(...)`; the old `attestation_data_` prefix was redundant.
- The state-transition layer keeps owning the policy (when to call it, what to do with `False`); the container owns the self-consistency check.

The container stays dependency-free: the chain view is injected, not fetched. `checkpoint.py` only gains `ZERO_HASH` (same `ssz` package) and `Sequence` (stdlib) — no import cycle, and no `from __future__ import annotations` (Pydantic model file).

## Verification

- `just check`: all pass (orphaned `AttestationData`/`Sequence` imports removed from the state-transition module).
- `uv run fill --fork=lstar --clean -n auto`: 539 vectors pass, byte-identical across hash seeds — behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)