### PR TITLE
refactor(forks): inline single-use get_proposal_head

### DIFF
--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -15,28 +15,11 @@ from lean_spec.spec.forks.lstar.containers import (
     ValidatorIndex,
 )
 from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
-from lean_spec.spec.ssz import Bytes32, Uint64
+from lean_spec.spec.ssz import Uint64
 
 
 class ValidatorDutiesMixin(LstarSpecBase):
     """Validator duties for the lstar fork."""
-
-    def get_proposal_head(self, store: LstarStore, slot: Slot) -> tuple[LstarStore, Bytes32]:
-        """
-        Get the head for block proposal at given slot.
-
-        Ensures store is up-to-date and processes any pending attestations
-        before returning the canonical head. This guarantees the proposer
-        builds on the most recent view of the chain.
-        """
-        # Advance time to this slot's first interval
-        target_interval = Interval.from_slot(slot)
-        store, _ = self.on_tick(store, target_interval, True)
-
-        # Process any pending attestations before proposal
-        store = self.accept_new_attestations(store)
-
-        return store, store.head
 
     def get_attestation_target(self, store: LstarStore) -> Checkpoint:
         """
@@ -147,11 +130,15 @@ class ValidatorDutiesMixin(LstarSpecBase):
                 or if the produced block fails to close a justified divergence
                 between the store and the head chain.
         """
-        # Retrieve parent block.
+        # Build on the freshest canonical head.
         #
-        # The proposal head reflects the latest chain view after processing
-        # all pending attestations. Building on stale state would orphan the block.
-        store, head_root = self.get_proposal_head(store, slot)
+        # Advance time to this slot's first interval, then fold in pending attestations.
+        # The proposal head then reflects the latest chain view.
+        # Building on stale state would orphan the block.
+        target_interval = Interval.from_slot(slot)
+        store, _ = self.on_tick(store, target_interval, True)
+        store = self.accept_new_attestations(store)
+        head_root = store.head
         head_state = store.states[head_root]
 
         # Verify proposer authorization.


### PR DESCRIPTION
## What

Remove the `get_proposal_head` helper and inline its logic into its single caller, `produce_block_with_signatures`.

## Why

- **Single caller.** `get_proposal_head` was called from exactly one place and is not part of any abstract contract (not on the fork protocol or the mixin base).
- **Redundant return.** It returned `tuple[LstarStore, Bytes32]` as `(store, store.head)` — the second element is derivable from the first, so the caller unpacked a value it already had on the store.

Inlining its three steps (advance time via the tick, accept pending attestations, then read the head) makes the proposer flow read top-to-bottom without the indirection, and drops the redundant tuple. The rationale comments are preserved at the call site. The now-unused `Bytes32` import is removed.

## Verification

- `just check`: all pass.
- `uv run fill --fork=lstar --clean -n auto`: 539 vectors pass, byte-identical across hash seeds — behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)