### PR TITLE
refactor(crypto): rename op to op_symbol in koalabear _reject

### DIFF
--- a/src/lean_spec/spec/crypto/koalabear.py
+++ b/src/lean_spec/spec/crypto/koalabear.py
@@ -110,10 +110,10 @@ class Fp(int, SSZType):
             raise SSZValueError(f"Value {decoded_integer} exceeds field modulus {P}")
         return cls(decoded_integer)
 
-    def _reject(self, other: Any, op: str) -> NoReturn:
+    def _reject(self, other: Any, op_symbol: str) -> NoReturn:
         """Raise a consistent TypeError for a non-Fp operand."""
         raise TypeError(
-            f"Unsupported operand type(s) for {op}: "
+            f"Unsupported operand type(s) for {op_symbol}: "
             f"'{type(self).__name__}' and '{type(other).__name__}'"
         )
 


### PR DESCRIPTION
## What

Rename the operator-symbol parameter `op` to `op_symbol` in the KoalaBear field rejection helper, in its signature and the f-string body that builds the error message.

## Why

The parameter `op` abbreviates "operator symbol", which the no-abbreviations rule forbids. The analogous helper in the SSZ uint module already spells it `op_symbol`, so this aligns the two.

## Scope

Pure, behavior-preserving rename. The call sites pass the symbol positionally, so no call site changes. `just check` passes (lint, format, type check, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)