### PR TITLE
refactor(crypto): use Self for the XmssConfig validator return annotation

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/constants.py
+++ b/src/lean_spec/spec/crypto/xmss/constants.py
@@ -1,7 +1,7 @@
 """Cryptographic constants and configuration presets for the XMSS spec."""
 
 import math
-from typing import Final
+from typing import Final, Self
 
 from pydantic import model_validator
 
@@ -57,7 +57,7 @@ class XmssConfig(StrictBaseModel):
     """The capacity of the Poseidon sponge, defining its security level."""
 
     @model_validator(mode="after")
-    def _validate_decomposition(self) -> "XmssConfig":
+    def _validate_decomposition(self) -> Self:
         """Verify that Q * BASE^Z == P - 1."""
         if self.Q * self.BASE**self.Z != P - 1:
             raise ValueError(f"Q * BASE^Z must equal P-1={P - 1}")


### PR DESCRIPTION
## Summary

The post-validation model validator in the XMSS constants module returns the model instance unchanged. Its return type was annotated with the quoted forward-ref class name, which is redundant for a "returns the same class" contract.

This replaces the quoted forward reference with `Self` from `typing`, which expresses the intent directly and removes the need for the quoted string. `Self` is added to the existing `typing` import.

This is an annotation-only, behavior-preserving change. No `from __future__ import annotations` was added (this is a Pydantic model file).

## Verification

`just check` passes (ruff lint, ruff format, ty type check, codespell, mdformat). The `ty` type checker validates that `Self` is correct for the return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)