### PR TITLE
refactor(crypto): inline single-use P_BITS into P_BYTES

### DIFF
--- a/src/lean_spec/spec/crypto/koalabear.py
+++ b/src/lean_spec/spec/crypto/koalabear.py
@@ -20,11 +20,11 @@ The KoalaBear Prime: P = 2^31 - 2^24 + 1
 The prime is chosen because the cube map (x -> x^3) is an automorphism of the multiplicative group.
 """
 
-P_BITS: Final = 31
-"""The number of bits in the prime P."""
+P_BYTES: Final = math.ceil(P.bit_length() / 8)
+"""The size of a KoalaBear field element in bytes.
 
-P_BYTES: Final = math.ceil(P_BITS / 8)
-"""The size of a KoalaBear field element in bytes."""
+The prime spans 31 bits, so a field element fits in 4 bytes.
+"""
 
 
 class Fp(int, SSZType):


### PR DESCRIPTION
## Summary

`P_BITS: Final = 31` in `src/lean_spec/spec/crypto/koalabear.py` was read only by the immediately following line that computes `P_BYTES`. A repo-wide grep over `src`, `packages`, and `tests` confirmed those two lines were its only occurrences.

This inlines it: `P_BYTES` is now derived directly from the prime's bit-length:

```python
P_BYTES: Final = math.ceil(P.bit_length() / 8)
```

Deriving from the existing prime constant keeps the "31 = bit-width of the KoalaBear prime" meaning visible at the value, with the rationale moved into the `P_BYTES` docstring. The value is unchanged at 4.

## Verification

- `P_BYTES == 4` confirmed via import.
- `just check` passes (lint, format, typecheck, spell, mdformat, lock).
- `uv run fill --fork=lstar --clean -n auto` passes (539 vectors, determinism check passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)