### PR TITLE
refactor(ssz): collapse identical hash_tree_root leaf handlers

### DIFF
--- a/src/lean_spec/spec/crypto/merkleization.py
+++ b/src/lean_spec/spec/crypto/merkleization.py
@@ -208,29 +208,19 @@ def hash_tree_root(value: object) -> Bytes32:
     raise TypeError(f"hash_tree_root: unsupported value type {type(value).__name__}")
 
 
-@hash_tree_root.register
-def _htr_uint(value: BaseUint) -> Bytes32:
-    return merkleize(_pack_bytes(value.encode_bytes()))
-
-
-@hash_tree_root.register
-def _htr_boolean(value: Boolean) -> Bytes32:
-    return merkleize(_pack_bytes(value.encode_bytes()))
-
-
-@hash_tree_root.register
-def _htr_fp(value: Fp) -> Bytes32:
+@hash_tree_root.register(BaseUint)
+@hash_tree_root.register(Boolean)
+@hash_tree_root.register(Fp)
+@hash_tree_root.register(BaseBytes)
+def _htr_packed_leaf(value: BaseUint | Boolean | Fp | BaseBytes) -> Bytes32:
+    # Each of these encodes to a fixed-width byte string with no length prefix.
+    # The root is the Merkle root of those bytes packed into 32-byte chunks.
     return merkleize(_pack_bytes(value.encode_bytes()))
 
 
 @hash_tree_root.register
 def _htr_bytes(value: bytes) -> Bytes32:
     return merkleize(_pack_bytes(value))
-
-
-@hash_tree_root.register
-def _htr_bytevector(value: BaseBytes) -> Bytes32:
-    return merkleize(_pack_bytes(value.encode_bytes()))
 
 
 @hash_tree_root.register

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -15,11 +15,8 @@
 
 # Single-dispatch handlers for the hash_tree_root generic function.
 # Dispatched by argument type, so they have no direct call site.
-_htr_uint
-_htr_boolean
-_htr_fp
+_htr_packed_leaf
 _htr_bytes
-_htr_bytevector
 _htr_bytelist
 _htr_bitvector_base
 _htr_bitlist_base


### PR DESCRIPTION
## What

Four `hash_tree_root` singledispatch handlers had byte-identical bodies, each returning `merkleize(_pack_bytes(value.encode_bytes()))`:

- unsigned integer base type
- boolean
- field element
- fixed-size byte vector base type

This collapses the four into a single handler registered against all four base types with stacked explicit registrations:

```python
@hash_tree_root.register(BaseUint)
@hash_tree_root.register(Boolean)
@hash_tree_root.register(Fp)
@hash_tree_root.register(BaseBytes)
def _htr_packed_leaf(value: BaseUint | Boolean | Fp | BaseBytes) -> Bytes32:
    return merkleize(_pack_bytes(value.encode_bytes()))
```

## Precedence is unchanged

`singledispatch` always resolves to the most specific registered type. The fixed byte-vector base type is a subclass of the `bytes` builtin, so its instances still dispatch to the collapsed handler, while plain `bytes`, `bytearray`, and `memoryview` keep their own distinct handlers — exactly as before. Verified empirically that all five base types resolve to the new handler and the three byte builtins resolve to their own.

Every other handler (`bytes`, `bytearray`, `memoryview`, byte-list, bitvector, bitlist, vector, list, container) is left untouched because their bodies genuinely differ.

## Verification

`hash_tree_root` is consensus-critical, so this was verified end to end:

- `just check` passes (lint, format, type check, spell, mdformat, lock)
- `uv run fill --fork=lstar --clean -n auto`: 539 vectors pass and the cross-seed determinism check is green ("all vectors are byte-identical across hash seeds")

🤖 Generated with [Claude Code](https://claude.com/claude-code)