### PR TITLE
refactor(ssz): drop test-only raw-buffer hash_tree_root handlers

### DIFF
--- a/src/lean_spec/spec/crypto/merkleization.py
+++ b/src/lean_spec/spec/crypto/merkleization.py
@@ -229,16 +229,6 @@ def _htr_bytes(value: bytes) -> Bytes32:
 
 
 @hash_tree_root.register
-def _htr_bytearray(value: bytearray) -> Bytes32:
-    return merkleize(_pack_bytes(bytes(value)))
-
-
-@hash_tree_root.register
-def _htr_memoryview(value: memoryview) -> Bytes32:
-    return merkleize(_pack_bytes(value.tobytes()))
-
-
-@hash_tree_root.register
 def _htr_bytevector(value: BaseBytes) -> Bytes32:
     return merkleize(_pack_bytes(value.encode_bytes()))
 

--- a/tests/spec/crypto/test_merkleization.py
+++ b/tests/spec/crypto/test_merkleization.py
@@ -438,27 +438,6 @@ def test_hash_tree_root_fp(integer_value: int) -> None:
 
 
 @pytest.mark.parametrize(
-    "payload",
-    [
-        b"",
-        b"\x00",
-        b"\x01",
-        b"\xab",
-        b"\x00\x01\x02\x03",
-        b"\xff" * 31,
-        b"\xff" * 32,
-        b"\xff" * 33,
-    ],
-)
-def test_hash_tree_root_raw_bytes_like(payload: bytes) -> None:
-    """Raw bytes, bytearray, and memoryview hash identically."""
-    from_bytes = hash_tree_root(payload)
-    from_bytearray = hash_tree_root(bytearray(payload))
-    from_memoryview = hash_tree_root(memoryview(payload))
-    assert from_bytes == from_bytearray == from_memoryview
-
-
-@pytest.mark.parametrize(
     "payload, expected_root",
     [
         # Empty: zero chunks merkleizes to the all-zero leaf.

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -19,8 +19,6 @@ _htr_uint
 _htr_boolean
 _htr_fp
 _htr_bytes
-_htr_bytearray
-_htr_memoryview
 _htr_bytevector
 _htr_bytelist
 _htr_bitvector_base


### PR DESCRIPTION
## Why these handlers are test-only

The `hash_tree_root` singledispatch registered two handlers for raw buffer types:

- `_htr_bytearray` (for `bytearray`)
- `_htr_memoryview` (for `memoryview`)

SSZ values always reach `hash_tree_root` as typed `BaseBytes` or `BaseByteList`, never as raw mutable buffers. The genuine raw-bytes entry point (`_htr_bytes`) is untouched.

## Gate result

A repo-wide search across `src/`, `src/lean_spec/node/`, `packages/`, `docs/`, and public `__init__` exports found:

- The ONLY caller of the bytearray/memoryview dispatch paths was a single dedicated unit test (`test_hash_tree_root_raw_bytes_like` in `tests/spec/crypto/test_merkleization.py`) that constructed `bytearray(...)` and `memoryview(...)` purely to exercise these handlers.
- No production code roots a raw `bytearray` or `memoryview` — every `hash_tree_root` call in `node/` passes a typed SSZ value (State, Block, attestation_data, etc.).
- No package `__init__` re-exports them and no documentation references them.
- The `vulture_whitelist.py` entries were dead-code suppression, not real callers.

The gate passed, so this PR removes both handler registrations, their whitelist entries, and the self-referential test.

## Verification

- `just check` passes (ruff lint + format, ty, codespell, mdformat, vulture, lock).
- `uv run fill --fork=lstar --clean -n auto` passes: 539 vectors, determinism check byte-identical across hash seeds.
- Unit tests for the merkleization module pass (97 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)