### PR TITLE
refactor(testing): state the proof-catch rationale as plain prose

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
@@ -251,7 +251,7 @@ class VerifySingleMessageProofsTest(BaseTestSpec):
         # Phase 3: self-verify and assert the outcome against the configured expectation.
         candidate = SingleMessageAggregate(participants=aggregation_bits, proof=proof)
         exception_raised: Exception | None = None
-        # Why this catch: the aggregation layer raises exactly one error type.
+        # The aggregation layer raises exactly one error type.
         # Anything else is a harness bug and propagates unswallowed.
         try:
             candidate.verify(public_keys, message, slot)
@@ -506,7 +506,7 @@ class VerifyMultiMessageProofsTest(BaseTestSpec):
 
         # Phase 4: self-verify and assert the outcome against the configured expectation.
         exception_raised: Exception | None = None
-        # Why this catch: the aggregation layer raises exactly one error type.
+        # The aggregation layer raises exactly one error type.
         # Anything else is a harness bug and propagates unswallowed.
         try:
             merged.verify(


### PR DESCRIPTION
The proof self-verify catch in both verify-proofs fixture generators opened its comment with a banned "Why ..." prefix.

This drops the prefix and states the rationale directly as plain prose, matching the documentation rule that bans "Why"-style comment openers.

No code behavior changes; the edit touches only the two inline comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)