### PR TITLE
refactor(testing): reduce step max-slot loop to a single max() over a generator

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -154,21 +154,16 @@ class ForkChoiceTest(BaseTestSpec):
         if self.max_slot is not None:
             return self.max_slot
 
-        max_slot_value = Slot(0)
-
         # Find the maximum slot across all block and attestation steps.
         #
         # XMSS signatures are slot-dependent.
         # Keys must be generated up to this slot before signing.
-        for step in self.steps:
-            if isinstance(step, BlockStep):
-                max_slot_value = max(max_slot_value, step.block.slot)
-            elif isinstance(step, AttestationStep):
-                max_slot_value = max(max_slot_value, step.attestation.slot)
-            elif isinstance(step, GossipAggregatedAttestationStep):
-                max_slot_value = max(max_slot_value, step.attestation.slot)
-
-        return max_slot_value
+        slots_needing_keys = (
+            step.block.slot if isinstance(step, BlockStep) else step.attestation.slot
+            for step in self.steps
+            if isinstance(step, (BlockStep, AttestationStep, GossipAggregatedAttestationStep))
+        )
+        return max(slots_needing_keys, default=Slot(0))
 
     def generate(self) -> ForkChoiceFixture:
         """


### PR DESCRIPTION
Collapse the hand-rolled max-slot accumulator, with its three `isinstance` arms, into a single `max(..., default=Slot(0))` over a generator of the relevant step slots.

Behavior is identical, including the empty-steps case returning `Slot(0)`. Both attestation step kinds already expose `.attestation.slot` and the block step exposes `.block.slot`, so the generator covers exactly the same cases as before. `just check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)