### PR TITLE
refactor(testing): extract duplicated workspace-root walk into find_workspace_root

### DIFF
--- a/packages/testing/src/consensus_testing/cli/_workspace.py
+++ b/packages/testing/src/consensus_testing/cli/_workspace.py
@@ -1,0 +1,19 @@
+"""Locate the uv workspace root for the CLI commands."""
+
+from pathlib import Path
+
+
+def find_workspace_root() -> Path:
+    """
+    Walk upward to the first ancestor whose pyproject.toml declares the uv workspace.
+
+    Pytest is invoked with this directory as its rootdir.
+    Falls back to the filesystem root when no ancestor declares the workspace table.
+    """
+    root = Path.cwd()
+    while root != root.parent:
+        candidate = root / "pyproject.toml"
+        if candidate.exists() and "[tool.uv.workspace]" in candidate.read_text():
+            return root
+        root = root.parent
+    return root

--- a/packages/testing/src/consensus_testing/cli/apitest.py
+++ b/packages/testing/src/consensus_testing/cli/apitest.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import click
 import pytest
 
+from consensus_testing.cli._workspace import find_workspace_root
+
 
 @click.command(
     context_settings={
@@ -42,14 +44,7 @@ def apitest(
     """
     config_path = Path(__file__).parent / "pytest_ini_files" / "pytest-apitest.ini"
 
-    # Find project root
-    project_root = Path.cwd()
-    while project_root != project_root.parent:
-        if (project_root / "pyproject.toml").exists():
-            pyproject = project_root / "pyproject.toml"
-            if "[tool.uv.workspace]" in pyproject.read_text():
-                break
-        project_root = project_root.parent
+    project_root = find_workspace_root()
 
     # Build pytest arguments
     args = [

--- a/packages/testing/src/consensus_testing/cli/fill.py
+++ b/packages/testing/src/consensus_testing/cli/fill.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import click
 
+from consensus_testing.cli._workspace import find_workspace_root
 from consensus_testing.keys import compute_key_set_digest, get_keys_directory
 from consensus_testing.keys_cli import PINNED_KEY_SET_DIGESTS, download_keys
 
@@ -97,15 +98,7 @@ def fill(
         download_keys(scheme.lower())
 
     config_path = Path(__file__).parent / "pytest_ini_files" / "pytest-fill.ini"
-    # Find project root by looking for pyproject.toml with [tool.uv.workspace]
-    project_root = Path.cwd()
-    while project_root != project_root.parent:
-        if (project_root / "pyproject.toml").exists():
-            # Check if this is the workspace root
-            pyproject = project_root / "pyproject.toml"
-            if "[tool.uv.workspace]" in pyproject.read_text():
-                break
-        project_root = project_root.parent
+    project_root = find_workspace_root()
 
     # Build pytest arguments
     args = [


### PR DESCRIPTION
The identical upward walk for the uv workspace root was copied verbatim across the apitest and fill CLI commands. This extracts it into a single shared helper in a small cli/_workspace.py module, so both commands locate the pytest rootdir through one implementation.

Behavior is preserved exactly: both call sites previously fell back to the filesystem root when no ancestor declared the workspace table, and the helper keeps that same fallback. No call site changed its semantics.

`just check` passes clean and `uv run fill --help` confirms import wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)