### PR TITLE
refactor(testing): drop unused lean_env parameter from build_signed_block_with_store

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -23,7 +23,6 @@ from consensus_testing.test_types import (
     StoreSnapshot,
     TickStep,
 )
-from lean_spec.config import LEAN_ENV
 from lean_spec.node.chain.clock import SlotClock
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import (
@@ -300,7 +299,6 @@ class ForkChoiceTest(BaseTestSpec):
                             store,
                             block_registry,
                             key_manager,
-                            LEAN_ENV,
                             deliver_unknown_parent=deliver_unknown_parent,
                         )
                         filled_block = signed_block.block

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -466,7 +466,6 @@ class BlockSpec(CamelModel):
         store: Store,
         block_registry: dict[str, Block],
         key_manager: XmssKeyManager,
-        lean_env: str,
         deliver_unknown_parent: bool = False,
     ) -> tuple[SignedBlock, Store]:
         """
@@ -489,7 +488,6 @@ class BlockSpec(CamelModel):
             store: Fork choice store for head state lookup and gossip processing.
             block_registry: Labeled blocks for fork creation.
             key_manager: Key manager for signing.
-            lean_env: Signature scheme environment name ("test" or "prod").
             deliver_unknown_parent: When True and the parent state is absent,
                 build a structurally valid block against the anchor state with
                 its parent root overridden, instead of raising.


### PR DESCRIPTION
The lean_env parameter on the signed-block builder was never read in the method body — it was pure dead code.

The only caller is the fork-choice fixture builder, which passed LEAN_ENV positionally. That argument is removed, the remaining arguments line up positionally, and the now-unused LEAN_ENV import is dropped.

just check passes clean and a fork_choice fill smoke run regenerates all vectors byte-identically across hash seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)