### PR TITLE
refactor(testing): collapse duplicate step-rejection classification into BaseTestSpec

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -290,6 +290,43 @@ class BaseTestSpec(CamelModel):
             )
         return classified_reason
 
+    @staticmethod
+    def check_rejection_against_expectation(
+        expected_rejection: ExpectedRejection | None,
+        exception_raised: Exception,
+        context: str,
+    ) -> RejectionReason:
+        """
+        Check a rejection's message and reason against an explicit expectation.
+
+        The expectation is passed in rather than read from the spec.
+        A single processing run can carry several independent rejection points.
+        Each point names its own authored expectation and failure label.
+
+        Args:
+            expected_rejection: The authored expectation, or None when unconstrained.
+            exception_raised: The exception the spec raised for the invalid input.
+            context: Caller label woven into the failure messages.
+
+        Returns:
+            The reason emitted into the test vector.
+
+        Raises:
+            AssertionError: When the message or classified reason contradicts the expectation.
+        """
+        # Verify the failure message matches when an expectation is given.
+        if expected_rejection is not None:
+            expected_rejection.assert_message_matches(exception_raised, context)
+
+        # Emit the language-neutral reason clients assert against.
+        classified_reason = classify_rejection(exception_raised)
+        if expected_rejection is not None and classified_reason is not expected_rejection.reason:
+            raise AssertionError(
+                f"{context} rejection classified as {classified_reason} "
+                f"but the test expects {expected_rejection.reason}"
+            )
+        return classified_reason
+
     def assert_decode_rejection(
         self,
         exception_raised: Exception | None,

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -8,7 +8,6 @@ from pydantic import Field
 
 from consensus_testing.genesis import generate_pre_state, reconstruct_block_from_header
 from consensus_testing.keys import XmssKeyManager
-from consensus_testing.rejection import classify_rejection
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
 from consensus_testing.test_types import (
     AttestationStep,
@@ -384,7 +383,11 @@ class ForkChoiceTest(BaseTestSpec):
                         f"failed unexpectedly: {exception}"
                     ) from exception
 
-                rejection_reason = self._classify_step_rejection(step, step_index, exception)
+                rejection_reason = self.check_rejection_against_expectation(
+                    step.expected_rejection,
+                    exception,
+                    f"Step {step_index} ({type(step).__name__})",
+                )
 
                 # The rejected call returned nothing, so the store is unchanged.
                 # Snapshot it anyway: clients must verify the no-op.
@@ -494,45 +497,17 @@ class ForkChoiceTest(BaseTestSpec):
                 validator_index=ValidatorIndex(0),
             )
         except SpecRejectionError as exception:
-            self.expected_rejection.assert_message_matches(exception, "Store.from_anchor")
             # Emit the language-neutral reason clients assert against.
             return ForkChoiceFixture(
                 anchor_state=self.anchor_state,
                 anchor_block=anchor_block,
                 steps=[],
                 max_slot=max_slot,
-                rejection_reason=self.resolve_rejection_reason(exception),
+                rejection_reason=self.check_rejection_against_expectation(
+                    self.expected_rejection,
+                    exception,
+                    "Store.from_anchor",
+                ),
             )
 
         raise AssertionError("Store.from_anchor was expected to fail but succeeded")
-
-    @staticmethod
-    def _classify_step_rejection(
-        step: TickStep | BlockStep | AttestationStep | GossipAggregatedAttestationStep,
-        step_index: int,
-        exception: Exception,
-    ) -> RejectionReason:
-        """
-        Classify an expected step failure and check it against the authored expectation.
-
-        Returns:
-            The reason emitted into the filled step.
-
-        Raises:
-            AssertionError: If the failure contradicts the authored expectation.
-        """
-        # Verify the failure reason matches when specified.
-        expected_rejection = step.expected_rejection
-        if expected_rejection is not None:
-            expected_rejection.assert_message_matches(
-                exception, f"Step {step_index} ({type(step).__name__})"
-            )
-
-        # Emit the language-neutral reason clients assert against.
-        rejection_reason = classify_rejection(exception)
-        if expected_rejection is not None and rejection_reason is not expected_rejection.reason:
-            raise AssertionError(
-                f"Step {step_index} ({type(step).__name__}) rejection classified as "
-                f"{rejection_reason} but the test expects {expected_rejection.reason}"
-            )
-        return rejection_reason


### PR DESCRIPTION
**What:** The fork-choice fixture had a 30-line static method that re-implemented the rejection-classification logic already on `BaseTestSpec`: classify a raised rejection, assert its message against the authored expectation, assert the classified reason matches. The only difference was it read the expectation from the step instead of `self`.

**Why:** Two independent copies of the same check is a drift hazard. Saves ~25 lines.

**How:** Added one shared classifier on `BaseTestSpec` that takes the expectation and a context label explicitly (message check + classification + reason-equality), and routed both the anchor-init path and the per-step path through it. The duplicate static method is deleted (no shim); the now-unused `classify_rejection` import is dropped from the fork-choice module.

**Verified:** `just check` passes clean; the full fork-choice vector suite refills cleanly (`uv run fill --fork=Lstar --clean -n 0 tests/consensus/lstar/fork_choice`) with the cross-seed determinism check passing. Step failure messages stay byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)