### PR TITLE
docs(testing): state StoreSnapshot field rationale as plain prose

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/store_snapshot.py
+++ b/packages/testing/src/consensus_testing/test_types/store_snapshot.py
@@ -60,9 +60,8 @@ class StoreSnapshot(StrictBaseModel):
     Recorded by the framework after every step, including rejected ones.
     Clients must reproduce every field, not just authored checks.
 
-    Why explicit fields instead of an opaque digest:
-    a digest needs a spec-defined canonical store encoding.
-    Explicit fields are self-describing and language-neutral.
+    Explicit fields avoid needing a spec-defined canonical store encoding.
+    They are self-describing and language-neutral.
     """
 
     time: Interval


### PR DESCRIPTION
The store-snapshot class docstring opened its explicit-fields rationale with a banned "Why ..." lead-in.

The documentation rule bans opening docstrings with "Why ..." phrasing; the reasoning must be stated directly as plain prose.

This rewrites the two lines to state the rationale plainly, with no behavior or code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)