### PR TITLE
docs(testing): note make_signed_attestation output is structurally valid only

### DIFF
--- a/packages/testing/src/consensus_testing/values.py
+++ b/packages/testing/src/consensus_testing/values.py
@@ -59,6 +59,10 @@ def make_signed_attestation(
 
     Head and target share the target checkpoint.
     Source defaults to a zero checkpoint.
+
+    The output is structurally valid only, not guaranteed consistent with any chain.
+    The source, target, and head triple is never checked for realizability.
+    Keep this out of the real spec's attestation processing.
     """
     return SignedAttestation(
         validator_index=validator,


### PR DESCRIPTION
The single-validator attestation builder for unit tests produces attestation data whose source, target, and head triple is never checked for chain realizability.

This adds a documentation-only note that the output is structurally valid only, not chain-consistent, and must not be routed through the real spec's attestation processing. No behavior changes; this is a safety guardrail against a future caller injecting an impossible attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)