### PR TITLE
refactor(testing): unquote annotations on already-imported types

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/state_expectation.py
+++ b/packages/testing/src/consensus_testing/test_types/state_expectation.py
@@ -29,7 +29,7 @@ class StateExpectation(SelectiveCheck):
     making tests more focused and maintainable.
     """
 
-    _SCALAR_ACCESSORS: ClassVar[dict[str, Callable[["State"], Any]]] = {
+    _SCALAR_ACCESSORS: ClassVar[dict[str, Callable[[State], Any]]] = {
         "slot": lambda s: s.slot,
         "latest_justified_slot": lambda s: s.latest_justified.slot,
         "latest_justified_root": lambda s: s.latest_justified.root,
@@ -139,7 +139,7 @@ class StateExpectation(SelectiveCheck):
 
     def validate_against_state(
         self,
-        state: "State",
+        state: State,
         block_registry: dict[str, Block] | None = None,
     ) -> None:
         """

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -83,7 +83,7 @@ class AttestationCheck(CamelModel):
     """
 
     def validate_attestation(
-        self, attestation: "AttestationData", location: str, step_index: int
+        self, attestation: AttestationData, location: str, step_index: int
     ) -> None:
         """Validate attestation properties."""
         for field_name in self.model_fields_set & _ATTESTATION_SLOT_ACCESSORS.keys():
@@ -312,11 +312,11 @@ class StoreChecks(SelectiveCheck):
 
     def validate_against_store(
         self,
-        store: "Store",
+        store: Store,
         step_index: int,
-        block_registry: dict[str, "Block"] | None = None,
-        filled_block: "Block | None" = None,
-        old_head: "Bytes32 | None" = None,
+        block_registry: dict[str, Block] | None = None,
+        filled_block: Block | None = None,
+        old_head: Bytes32 | None = None,
     ) -> None:
         """
         Validate these checks against actual Store state.
@@ -523,8 +523,8 @@ class StoreChecks(SelectiveCheck):
 
     @staticmethod
     def _validate_block_attestations(
-        expected_checks: list["AggregatedAttestationCheck"],
-        filled_block: "Block",
+        expected_checks: list[AggregatedAttestationCheck],
+        filled_block: Block,
         step_index: int,
     ) -> None:
         """Validate detailed attestation structure in the block body."""
@@ -578,8 +578,8 @@ class StoreChecks(SelectiveCheck):
     @staticmethod
     def _validate_lexicographic_head(
         fork_labels: list[str],
-        store: "Store",
-        block_registry: dict[str, "Block"],
+        store: Store,
+        block_registry: dict[str, Block],
         step_index: int,
     ) -> None:
         """Validate lexicographic tiebreaker behavior."""


### PR DESCRIPTION
Two selective-check models annotate parameters with types (State, Store, Block, Bytes32, AttestationData, AggregatedAttestationCheck) that are already concrete top-level imports in the same file, so the quotes were unnecessary forward-reference noise.

These files define Pydantic models, so they must NOT take `from __future__ import annotations`; the fix removes only the quotes and leaves the imports untouched.

Verified clean with `just check` (ty confirms the unquoted annotations still resolve) and an import smoke confirming Pydantic model building still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)