### PR TITLE
docs: correct fill-determinism recipe comment to describe the whole-tree gate

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -93,10 +93,10 @@ fill-ci *args:
     uv run --group test fill --fork=Lstar --clean -n "${FILL_WORKERS:-auto}" --dist=worksteal "$@"
 
 # Standalone determinism audit: regenerate vectors twice under different hash seeds and diff.
-# The fill command already gates the order_sensitive subset on every run.
-# This recipe runs that audit on its own, or widens it past the marked subset.
-# Pass a path to cover the whole tree (for example tests/consensus) and catch a
-# filler that should be marked order_sensitive but is not.
+# Every fill run already does this over the whole consensus tree as its per-fill gate.
+# That gate covers all emitted vectors, with no opt-in marker or subset.
+# This recipe runs the same audit on its own, scoped to whatever target it is given.
+# Pass a path to point the audit at part of the tree (for example a single filler).
 # A difference means an emitted vector depends on set or dict iteration order,
 # which is hash-seeded and would break cross-client reproducibility.
 [group('tests')]
@@ -108,8 +108,8 @@ fill-determinism *args:
     first="$(mktemp -d)"
     second="$(mktemp -d)"
     trap 'rm -rf "$first" "$second"' EXIT
-    # Single process: the marked subset is small, so xdist worker startup would
-    # cost more than it saves, and one process pins the hash seed cleanly.
+    # Single process: xdist worker startup would cost more than it saves here,
+    # and one process pins the hash seed cleanly.
     # This recipe is itself the determinism check, so the per-fill gate is skipped.
     PYTHONHASHSEED=1 uv run --group test fill --fork=Lstar --clean --no-check-determinism -n 0 -o "$first" $target -q
     PYTHONHASHSEED=2 uv run --group test fill --fork=Lstar --clean --no-check-determinism -n 0 -o "$second" $target -q


### PR DESCRIPTION
The fill-determinism recipe comments claimed the fill command gates an order_sensitive subset on every run. That marker is never registered or used anywhere in the repo; it appears only in these comments.

The actual per-fill gate re-fills the entire consensus tree under two hash seeds and byte-diffs the output, with no marker and no opt-in subset — stronger than the comment described.

This docs-only change rewrites the comments to describe that whole-tree gate accurately and drops the order_sensitive references. Recipe behavior is unchanged.

Follow-up: the recipe's default target still selects via the non-existent marker, so a bare `just fill-determinism` collects no tests. Fixing that is a behavior change left out of this docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)