### PR TITLE
docs(testing): move CLI usage examples from docstrings to Click epilog

### DIFF
--- a/packages/testing/src/consensus_testing/cli/apitest.py
+++ b/packages/testing/src/consensus_testing/cli/apitest.py
@@ -12,7 +12,19 @@ import pytest
     context_settings={
         "ignore_unknown_options": True,
         "allow_extra_args": True,
-    }
+    },
+    epilog="""\
+\b
+Examples:
+    # Run against external server
+    apitest http://localhost:5052
+\b
+    # Run with verbose output
+    apitest http://localhost:5052 -v
+\b
+    # Run specific test
+    apitest http://localhost:5052 -k test_health
+""",
 )
 @click.argument("server_url")
 @click.argument("pytest_args", nargs=-1, type=click.UNPROCESSED)
@@ -27,18 +39,8 @@ def apitest(
 
     SERVER_URL is the base URL of the API server (e.g., http://localhost:5052).
 
-    For testing the local leanSpec implementation, use `uv run pytest tests/api`
-    which automatically starts a local server.
-
-    Examples:
-        # Run against external server
-        apitest http://localhost:5052
-
-        # Run with verbose output
-        apitest http://localhost:5052 -v
-
-        # Run specific test
-        apitest http://localhost:5052 -k test_health
+    For testing the local leanSpec implementation, use the local pytest suite under
+    tests/api, which automatically starts a local server.
     """
     config_path = Path(__file__).parent / "pytest_ini_files" / "pytest-apitest.ini"
 

--- a/packages/testing/src/consensus_testing/cli/fill.py
+++ b/packages/testing/src/consensus_testing/cli/fill.py
@@ -17,7 +17,16 @@ from consensus_testing.keys_cli import PINNED_KEY_SET_DIGESTS, download_keys
     context_settings={
         "ignore_unknown_options": True,
         "allow_extra_args": True,
-    }
+    },
+    epilog="""\
+\b
+Examples:
+    # Generate consensus fixtures
+    fill tests/consensus/devnet --fork=Lstar --clean -v
+\b
+    # Use specific XMSS scheme (overrides LEAN_ENV env var)
+    fill --fork=Lstar --scheme=prod --clean -v
+""",
 )
 @click.argument("pytest_args", nargs=-1, type=click.UNPROCESSED)
 @click.option(
@@ -65,16 +74,7 @@ def fill(
     crypto: str,
     check_determinism: bool,
 ) -> None:
-    """
-    Generate consensus test fixtures from test specifications.
-
-    Examples:
-        # Generate consensus fixtures
-        fill tests/consensus/devnet --fork=Lstar --clean -v
-
-        # Use specific XMSS scheme (overrides LEAN_ENV env var)
-        fill --fork=Lstar --scheme=prod --clean -v
-    """
+    """Generate consensus test fixtures from test specifications."""
     # The spec config reads this flag once, at import time.
     # The current process froze the old value when the package imported.
     # Only the pytest subprocess below starts fresh and sees this export.

--- a/packages/testing/src/consensus_testing/keys_cli.py
+++ b/packages/testing/src/consensus_testing/keys_cli.py
@@ -1,17 +1,4 @@
-"""
-CLI for generating or downloading the pre-generated XMSS test keys.
-
-Downloading Pre-generated Keys:
-
-    uv run keys --download --scheme test    # test scheme
-    uv run keys --download --scheme prod    # prod scheme
-
-Regenerating Keys:
-
-    uv run keys                   # defaults
-    uv run keys --count 20        # more validators
-    uv run keys --max-slot 200    # longer lifetime
-"""
+"""CLI for generating or downloading the pre-generated XMSS test keys."""
 
 from __future__ import annotations
 
@@ -256,7 +243,19 @@ def download_keys(scheme: str) -> None:
     print("Download complete!")
 
 
-@click.command()
+@click.command(
+    epilog="""\
+\b
+Downloading pre-generated keys:
+    uv run keys --download --scheme test    # test scheme
+    uv run keys --download --scheme prod    # prod scheme
+\b
+Regenerating keys:
+    uv run keys                   # defaults
+    uv run keys --count 20        # more validators
+    uv run keys --max-slot 200    # longer lifetime
+""",
+)
 @click.option(
     "--download",
     is_flag=True,


### PR DESCRIPTION
The code-style rule bans Example sections with code blocks in docstrings. The fill, apitest, and keys CLI commands carried usage examples in their docstrings (the keys examples lived in the module docstring), violating that rule.

This moves each example block into the Click command epilog so --help still renders the examples, and trims the docstrings to clean one-line summaries.

Verified locally: uv run fill --help, uv run apitest --help, and uv run keys --help all still show the usage examples. just check passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)