### PR TITLE
docs(testing): clarify the determinism gate covers hash-seed effects under the mocked prover

### DIFF
--- a/packages/testing/src/consensus_testing/cli/fill.py
+++ b/packages/testing/src/consensus_testing/cli/fill.py
@@ -151,6 +151,16 @@ def verify_fixture_determinism(config_path: Path, project_root: Path, fork: str)
 
     The mocked prover is forced so proof bytes stay deterministic across both runs.
     A single process pins each seed cleanly, so distribution is disabled.
+
+    This gate covers only hash-seed and iteration-order effects under the mocked prover.
+
+    The real prover emits randomized proof bytes by design.
+    Those proofs are intentionally outside this guarantee.
+    They never reproduce across two fills of identical inputs.
+
+    The non-proof fields of real-crypto vectors are not separately re-checked here.
+    Masking out exactly the randomized proof bytes would need a fragile per-container rule.
+    So no real-crypto diff is attempted.
     """
     consensus_tests = project_root / "tests" / "consensus"
     emitted_under_seed: list[Path] = []


### PR DESCRIPTION
Makes the scope of the per-fill determinism gate explicit in its docstring.

The gate re-fills the tree under two hash seeds with the mocked prover and byte-diffs the output, so it catches hash-randomized set and dict ordering only. The docstring now states that the real prover's proof bytes are randomized by design and intentionally outside the guarantee, and that the non-proof fields of real-crypto vectors are not separately re-checked.

Doc-only: a real-crypto opt-in differ is deferred as a follow-up. Real proof bytes are emitted inline across many container shapes, so masking exactly the randomized bytes would need a fragile per-container field rule that would otherwise always fail.

No behavior change to the existing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)