### PR TITLE
docs(testing): document mocked verifier no-op acceptance invariant

### DIFF
--- a/packages/testing/src/consensus_testing/crypto_mode.py
+++ b/packages/testing/src/consensus_testing/crypto_mode.py
@@ -102,12 +102,36 @@ class AggregationProver:
 
         def make_verifier(real_verifier: Callable[..., None]) -> Callable[..., None]:
             def verify(*positional_args: object, **keyword_args: object) -> None:
+                # A placeholder proof is recognized by its sentinel prefix alone.
+                # Acceptance is then an unconditional no-op.
+                # The message, slot, and public keys go unchecked.
+                #
+                # This is deliberately weaker than recompute-and-compare.
+                # The placeholder is content-bound when the prover builds it.
+                # But the prover hashes inputs the verifier never receives.
+                #
+                # The single-message prover folds in the raw signatures.
+                # It also folds in the child proofs and the rate exponent.
+                # The verifier only sees the public keys, message, slot, and proof.
+                #
+                # Merging and splitting reshape a proof after the fact.
+                # Its bytes then match no single prover call the verifier could replay.
+                # So reconstructing the placeholder to compare it is infeasible.
+                #
+                # Invariant: this no-op acceptance stays sound only because every
+                # vector asserting proof validity or rejection carries the
+                # real_crypto marker and runs against the real prover, not the mock.
+                # A proof-rejection vector lacking that marker would silently pass
+                # here, even though a conforming client must reject it.
+                # Never add a proof-tamper vector under the mock; mark it real_crypto.
                 carries_placeholder = any(
                     isinstance(argument, bytes) and argument.startswith(MOCK_PROOF_PREFIX)
                     for argument in positional_args
                 )
                 if carries_placeholder:
                     return None
+                # A real proof can still arrive when a vector mixes real and mocked
+                # inputs, so fall through to the real verifier for those bytes.
                 return real_verifier(*positional_args, **keyword_args)
 
             return verify


### PR DESCRIPTION
Took PATH B (documentation-only, no behavior change). Verified that PATH A — recompute-and-compare in the mocked verifier — is infeasible: the prover hashes the raw signatures, child proofs, and rate exponent that the verifier never receives, and merge/split reshape a proof so its emitted bytes match no single prover call to replay.

Confirmed the load-bearing assumption holds: every vector under tests/consensus/lstar/verify_proofs/ (valid and tamper alike) carries the module-level real_crypto marker, and the filler skips or real-runs those under the default mocked scheme, so the mocked no-op acceptance is relied upon only for happy-path proofs.

This documents the invariant in code so a future contributor does not add a non-real_crypto proof-rejection vector that would silently pass.

Tested: just check passes clean (ruff, format, ty, codespell, mdformat). No behavior change, so no fill regression is possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)