### PR TITLE
docs(testing): document ENR signature verdict as the canonical deterministic contract

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -530,6 +530,11 @@ class EnrRoundtrip(StrictBaseModel):
                 else None
             ),
             is_aggregator=enr.is_aggregator,
+            # The accept/reject verdict is the canonical contract a client must reproduce.
+            # Both verdicts are a deterministic function of the record bytes alone.
+            # Structural validity reads the record fields.
+            # Signature validity is secp256k1 ECDSA verification over keccak256 of the content.
+            # Verification takes no time, nonce, or RNG input, so the emitted value is stable.
             signature_valid=enr.verify_signature(),
             is_valid=enr.is_valid(),
         )


### PR DESCRIPTION
The ENR networking-codec fixture case emits a signature-validity and structural-validity verdict as reference output, unlike the surrounding pure encode/decode roundtrips. Verified the verdict is a deterministic, pure function of the record bytes: structural validity reads record fields, and signature validity is secp256k1 ECDSA verification (EIP-778 "v4" scheme) over keccak256 of the content RLP, with no time, nonce, or RNG input. The per-fill determinism gate re-fills under two hash seeds and the ENR vector is byte-identical. This adds a docstring note pinning the verdict as the canonical accept/reject contract clients must reproduce. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)