### PR TITLE
test(testing): add mirrored unit-test tree for the consensus-testing framework

### DIFF
--- a/packages/testing/tests/consensus_testing/test_package.py
+++ b/packages/testing/tests/consensus_testing/test_package.py
@@ -1,0 +1,32 @@
+"""Tests for the consensus_testing package entry point."""
+
+from __future__ import annotations
+
+import typing
+
+import consensus_testing
+
+
+class TestPackageExports:
+    """Tests for the public surface exported by the framework package."""
+
+    def test_documented_public_symbols_are_importable(self) -> None:
+        """Every name listed in the package's public export list resolves to an attribute."""
+        missing_exports = [
+            name for name in consensus_testing.__all__ if not hasattr(consensus_testing, name)
+        ]
+        assert missing_exports == []
+
+    def test_filler_aliases_return_their_matching_fixture_type(self) -> None:
+        """Each headline filler alias is a callable returning its paired fixture class."""
+        _, state_transition_return_type = typing.get_args(
+            consensus_testing.StateTransitionTestFiller
+        )
+        _, fork_choice_return_type = typing.get_args(consensus_testing.ForkChoiceTestFiller)
+        assert state_transition_return_type is consensus_testing.StateTransitionFixture
+        assert fork_choice_return_type is consensus_testing.ForkChoiceFixture
+
+    def test_genesis_builders_are_exposed_as_callables(self) -> None:
+        """The genesis builders documented for unit tests are present and callable."""
+        assert callable(consensus_testing.make_genesis_state)
+        assert callable(consensus_testing.make_genesis_store)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ known-first-party = ["lean_spec", "consensus_testing"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D"]
+"packages/testing/tests/**" = ["D"]
 "src/lean_spec/spec/crypto/xmss/constants.py" = ["N802"]
 
 [tool.ty.environment]
@@ -104,7 +105,7 @@ error-on-warning = true
 
 [tool.pytest.ini_options]
 minversion = "8.3.3"
-testpaths = ["tests"]
+testpaths = ["tests", "packages/testing/tests"]
 python_files = "test_*.py"
 pythonpath = ["."]
 addopts = [


### PR DESCRIPTION
The consensus-testing framework that generates every consensus vector had no mirrored unit-test tree, so a regression in a framework helper could silently corrupt all emitted vectors. These helpers are non-fork infrastructure, so pytest is the correct target.

This PR establishes the foundation other framework test PRs build on: it adds the mirrored test tree at `packages/testing/tests/consensus_testing` (one-to-one with the source package) and wires collection by appending `packages/testing/tests` to the root `testpaths`. The new tree is rootless (no `__init__.py`) to avoid a package-name collision with the repo-root `tests` package under pytest prepend import mode.

It ships one foundational smoke test asserting the framework package imports and exposes its documented public surface, chosen to not overlap planned helper tests. `just check` passes clean and the full suite collects 2914 tests (was 2911) at 91.47% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)