### PR TITLE
test(testing): cover _placeholder_proof determinism and input-injectivity

### DIFF
--- a/packages/testing/tests/consensus_testing/test_crypto_mode.py
+++ b/packages/testing/tests/consensus_testing/test_crypto_mode.py
@@ -1,0 +1,39 @@
+"""Tests for the mocked prover's placeholder proof builder."""
+
+import pytest
+
+from consensus_testing.crypto_mode import AggregationProver
+
+
+class TestPlaceholderProof:
+    """Tests for AggregationProver._placeholder_proof."""
+
+    def test_identical_arguments_produce_identical_bytes(self) -> None:
+        """Two calls with equal arguments return byte-identical proofs."""
+        first_proof = AggregationProver._placeholder_proof((b"block", 7, True, None))
+        second_proof = AggregationProver._placeholder_proof((b"block", 7, True, None))
+        assert first_proof == second_proof
+
+    def test_length_framing_disambiguates_concatenation(self) -> None:
+        """One two-byte argument differs from two one-byte arguments."""
+        single_two_byte_argument = AggregationProver._placeholder_proof((b"ab",))
+        two_one_byte_arguments = AggregationProver._placeholder_proof((b"a", b"b"))
+        assert single_two_byte_argument != two_one_byte_arguments
+
+    def test_true_is_distinguished_from_one(self) -> None:
+        """A boolean True hashes differently from the integer one."""
+        boolean_true_proof = AggregationProver._placeholder_proof((True,))
+        integer_one_proof = AggregationProver._placeholder_proof((1,))
+        assert boolean_true_proof != integer_one_proof
+
+    def test_false_is_distinguished_from_zero(self) -> None:
+        """A boolean False hashes differently from the integer zero."""
+        boolean_false_proof = AggregationProver._placeholder_proof((False,))
+        integer_zero_proof = AggregationProver._placeholder_proof((0,))
+        assert boolean_false_proof != integer_zero_proof
+
+    def test_unsupported_argument_type_raises(self) -> None:
+        """An argument the framing cannot tag raises a typed error."""
+        with pytest.raises(TypeError) as exception_info:
+            AggregationProver._placeholder_proof(({1},))
+        assert str(exception_info.value) == "unmockable prover argument of type set"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ known-first-party = ["lean_spec", "consensus_testing"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D"]
+"packages/testing/tests/**" = ["D"]
 "src/lean_spec/spec/crypto/xmss/constants.py" = ["N802"]
 
 [tool.ty.environment]
@@ -104,7 +105,7 @@ error-on-warning = true
 
 [tool.pytest.ini_options]
 minversion = "8.3.3"
-testpaths = ["tests"]
+testpaths = ["tests", "packages/testing/tests"]
 python_files = "test_*.py"
 pythonpath = ["."]
 addopts = [


### PR DESCRIPTION
Covers the mocked prover's placeholder proof builder, which underpins the fast fill path. Its docstring claims distinct inputs never collide, but nothing verified that guarantee.

Adds unit tests for: determinism (equal args yield identical bytes), length-framing injectivity (one two-byte arg differs from two one-byte args), bool-vs-int disambiguation (True != 1, False != 0), and the unsupported-type guard (a set raises TypeError with the full message "unmockable prover argument of type set").

Wires packages/testing/tests into testpaths and the docstring per-file-ignore (rootless tree, no __init__.py). This overlaps trivially with #1056 (same testpaths and per-file-ignores lines) — expect a small conflict to resolve depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)