### PR TITLE
test(testing): cover classify_rejection's three branches

### DIFF
--- a/packages/testing/tests/consensus_testing/test_rejection.py
+++ b/packages/testing/tests/consensus_testing/test_rejection.py
@@ -1,0 +1,30 @@
+"""Tests for consensus_testing.rejection."""
+
+from __future__ import annotations
+
+import pytest
+
+from consensus_testing.rejection import classify_rejection
+from lean_spec.spec.forks import RejectionReason, SpecRejectionError
+from lean_spec.spec.forks.lstar.containers import AggregationError
+
+
+def test_spec_rejection_error_returns_its_carried_reason() -> None:
+    """A SpecRejectionError resolves to the reason it carries."""
+    rejection = SpecRejectionError(RejectionReason.STATE_ROOT_MISMATCH, "state root drift")
+    assert classify_rejection(rejection) == RejectionReason.STATE_ROOT_MISMATCH
+
+
+def test_aggregation_error_returns_invalid_signature() -> None:
+    """An AggregationError resolves to the INVALID_SIGNATURE reason."""
+    assert classify_rejection(AggregationError("proof failed")) == RejectionReason.INVALID_SIGNATURE
+
+
+def test_exception_without_reason_raises_value_error_with_full_message() -> None:
+    """An exception carrying no reason raises ValueError with the full guidance message."""
+    with pytest.raises(ValueError) as exception_info:
+        classify_rejection(ValueError("x"))
+    assert str(exception_info.value) == (
+        "no rejection reason carried by ValueError: x\n"
+        "Spec rejections must raise the typed rejection error with a reason."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ known-first-party = ["lean_spec", "consensus_testing"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D"]
+"packages/testing/tests/**" = ["D"]
 "src/lean_spec/spec/crypto/xmss/constants.py" = ["N802"]
 
 [tool.ty.environment]
@@ -104,7 +105,7 @@ error-on-warning = true
 
 [tool.pytest.ini_options]
 minversion = "8.3.3"
-testpaths = ["tests"]
+testpaths = ["tests", "packages/testing/tests"]
 python_files = "test_*.py"
 pythonpath = ["."]
 addopts = [


### PR DESCRIPTION
Pins the language-neutral rejection mapping `classify_rejection` bakes into every negative consensus vector: a `SpecRejectionError` returns its carried `reason`, an `AggregationError` returns `INVALID_SIGNATURE`, and any other exception raises `ValueError` with the exact guidance message (asserted in full via string equality).

Depends on / overlaps with #1056 (CT-01): re-applies that collection contract so the rootless framework test tree is collected — `testpaths` gains `packages/testing/tests` and ruff ignores `D` there. Trivial expected conflict with #1056 on those two `pyproject.toml` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)