### PR TITLE
test(testing): pin rejection message-match precedence and restrict message_substring

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/base.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/base.py
@@ -56,6 +56,11 @@ class ExpectedRejection(StrictBaseModel):
 
     When None, any exception classified to the expected reason is accepted.
     Fill-time self-check only; never serialized into vectors.
+
+    Permitted only when the full message embeds nondeterministic data
+    that a literal string cannot pin.
+    A substring keeps passing while the rest of the message drifts or regresses.
+    Prefer the full-equality form whenever the message is stable.
     """
 
     exact_message: str | None = None

--- a/packages/testing/tests/consensus_testing/test_fixtures/test_base.py
+++ b/packages/testing/tests/consensus_testing/test_fixtures/test_base.py
@@ -1,0 +1,90 @@
+"""Tests for the rejection message matcher in the consensus fixture base module."""
+
+import pytest
+
+from consensus_testing.test_fixtures.base import ExpectedRejection
+from lean_spec.spec.forks import RejectionReason
+
+
+class TestAssertMessageMatchesExactMessage:
+    """Tests for full-equality matching against exact_message."""
+
+    def test_equal_message_passes(self) -> None:
+        """A raised message equal to exact_message matches without raising."""
+        expectation = ExpectedRejection(
+            reason=RejectionReason.STATE_ROOT_MISMATCH,
+            exact_message="state root mismatch",
+        )
+        expectation.assert_message_matches(ValueError("state root mismatch"), "Verifier")
+
+    def test_message_differing_by_suffix_fails(self) -> None:
+        """A raised message differing only by a trailing suffix fails full equality."""
+        expectation = ExpectedRejection(
+            reason=RejectionReason.STATE_ROOT_MISMATCH,
+            exact_message="state root mismatch",
+        )
+        with pytest.raises(AssertionError) as exception_info:
+            expectation.assert_message_matches(
+                ValueError("state root mismatch at head"), "Verifier"
+            )
+        assert str(exception_info.value) == (
+            "Verifier failed with wrong error message.\n"
+            "  Expected exact message: 'state root mismatch'\n"
+            "  Actual message: 'state root mismatch at head'"
+        )
+
+
+class TestAssertMessageMatchesSubstring:
+    """Tests for substring matching against message_substring."""
+
+    def test_substring_present_passes(self) -> None:
+        """A raised message containing the substring matches without raising."""
+        expectation = ExpectedRejection(
+            reason=RejectionReason.UNKNOWN_PARENT_BLOCK,
+            message_substring="parent block",
+        )
+        expectation.assert_message_matches(ValueError("unknown parent block"), "Verifier")
+
+    def test_substring_absent_fails(self) -> None:
+        """A raised message missing the substring fails with the full matcher message."""
+        expectation = ExpectedRejection(
+            reason=RejectionReason.UNKNOWN_PARENT_BLOCK,
+            message_substring="missing source",
+        )
+        with pytest.raises(AssertionError) as exception_info:
+            expectation.assert_message_matches(ValueError("unknown parent block"), "Verifier")
+        assert str(exception_info.value) == (
+            "Verifier failed with wrong error message.\n"
+            "  Expected message containing: 'missing source'\n"
+            "  Actual message: 'unknown parent block'"
+        )
+
+
+class TestAssertMessageMatchesPrecedence:
+    """Tests pinning that exact_message governs when both fields are set."""
+
+    def test_exact_message_rejects_a_message_that_only_contains_the_substring(self) -> None:
+        """A message holding the substring but not exactly equal still fails on exact_message."""
+        expectation = ExpectedRejection(
+            reason=RejectionReason.STATE_ROOT_MISMATCH,
+            exact_message="state root mismatch",
+            message_substring="mismatch",
+        )
+        with pytest.raises(AssertionError) as exception_info:
+            expectation.assert_message_matches(
+                ValueError("state root mismatch at head"), "Verifier"
+            )
+        assert str(exception_info.value) == (
+            "Verifier failed with wrong error message.\n"
+            "  Expected exact message: 'state root mismatch'\n"
+            "  Actual message: 'state root mismatch at head'"
+        )
+
+    def test_both_satisfied_passes(self) -> None:
+        """A message equal to exact_message and containing the substring matches cleanly."""
+        expectation = ExpectedRejection(
+            reason=RejectionReason.STATE_ROOT_MISMATCH,
+            exact_message="state root mismatch",
+            message_substring="mismatch",
+        )
+        expectation.assert_message_matches(ValueError("state root mismatch"), "Verifier")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ known-first-party = ["lean_spec", "consensus_testing"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D"]
+"packages/testing/tests/**" = ["D"]
 "src/lean_spec/spec/crypto/xmss/constants.py" = ["N802"]
 
 [tool.ty.environment]
@@ -104,7 +105,7 @@ error-on-warning = true
 
 [tool.pytest.ini_options]
 minversion = "8.3.3"
-testpaths = ["tests"]
+testpaths = ["tests", "packages/testing/tests"]
 python_files = "test_*.py"
 pythonpath = ["."]
 addopts = [


### PR DESCRIPTION
Adds a unit test pinning the rejection matcher: full-equality against `exact_message`, substring against `message_substring`, and the precedence where `exact_message` is checked first, so a message that merely contains the substring but is not exactly equal still fails.
Restricts the `message_substring` field docstring to allow it only when the full message embeds nondeterministic data, preferring the full-equality form otherwise.
Re-applies the rootless collection contract (`testpaths` + the `packages/testing/tests/**` D ruff ignore) to collect the mirrored test; this trivially overlaps with #1056.
The mass migration of existing negative vectors to `exact_message` is a deferred follow-up, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)