### PR TITLE
test(testing): pin StateExpectation selective-check skip/match/fail behavior

### DIFF
--- a/packages/testing/tests/consensus_testing/test_types/test_state_expectation.py
+++ b/packages/testing/tests/consensus_testing/test_types/test_state_expectation.py
@@ -1,0 +1,46 @@
+"""Tests for the selective-check behavior of StateExpectation."""
+
+import pytest
+
+from consensus_testing.genesis import make_genesis_state
+from consensus_testing.test_types.state_expectation import StateExpectation
+from lean_spec.spec.forks import Slot
+
+
+def test_set_field_matching_actual_value_passes() -> None:
+    """A set field that equals the state's actual value validates without error."""
+    genesis_state = make_genesis_state(num_validators=3)
+
+    StateExpectation(slot=Slot(0)).validate_against_state(genesis_state)
+
+
+def test_set_field_mismatching_actual_value_raises_with_full_message() -> None:
+    """A set field that disagrees with the state raises the exact mismatch message."""
+    genesis_state = make_genesis_state(num_validators=3)
+
+    with pytest.raises(AssertionError) as assertion_failure:
+        StateExpectation(slot=Slot(99)).validate_against_state(genesis_state)
+
+    assert str(assertion_failure.value) == "State validation failed: slot = 0, expected 99"
+
+
+def test_unset_field_is_never_validated() -> None:
+    """An omitted field is skipped even when its actual value would mismatch."""
+    genesis_state_with_five_validators = make_genesis_state(num_validators=5)
+
+    # The expectation sets only the slot, leaving validator_count unset.
+    # The state holds five validators, so a set validator_count of three would fail.
+    expectation_omitting_validator_count = StateExpectation(slot=Slot(0))
+
+    # Omission means skip, so the mismatching count is never checked.
+    expectation_omitting_validator_count.validate_against_state(genesis_state_with_five_validators)
+
+    # Setting that same field to the mismatching value does enforce it and fails.
+    with pytest.raises(AssertionError) as assertion_failure:
+        StateExpectation(validator_count=3).validate_against_state(
+            genesis_state_with_five_validators
+        )
+
+    assert str(assertion_failure.value) == (
+        "State validation failed: validator_count = 5, expected 3"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ known-first-party = ["lean_spec", "consensus_testing"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D"]
+"packages/testing/tests/**" = ["D"]
 "src/lean_spec/spec/crypto/xmss/constants.py" = ["N802"]
 
 [tool.ty.environment]
@@ -104,7 +105,7 @@ error-on-warning = true
 
 [tool.pytest.ini_options]
 minversion = "8.3.3"
-testpaths = ["tests"]
+testpaths = ["tests", "packages/testing/tests"]
 python_files = "test_*.py"
 pythonpath = ["."]
 addopts = [


### PR DESCRIPTION
Pins the selective-check contract of StateExpectation, which validates only the fields a test explicitly set: a set field matching the actual value passes, a set field mismatching raises the exact full message, and an omitted field is never validated even when it would mismatch (the silent-pass guard).

This is the StateExpectation half of the SelectiveCheck finding (CT-06); the StoreChecks half is a sibling PR against the same shared base class.

Re-applies the rootless collection contract (testpaths + the packages/testing/tests docstring-lint exemption) and so overlaps trivially with #1056 — expect a small conflict on those two pyproject lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)