### PR TITLE
fix: make fill-determinism default to the whole consensus tree

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -104,12 +104,12 @@ fill-determinism *args:
     #!/usr/bin/env bash
     set -euo pipefail
     target="{{args}}"
-    [ -z "$target" ] && target="tests/consensus -m order_sensitive"
+    [ -z "$target" ] && target="tests/consensus"
     first="$(mktemp -d)"
     second="$(mktemp -d)"
     trap 'rm -rf "$first" "$second"' EXIT
-    # Single process: xdist worker startup would cost more than it saves here,
-    # and one process pins the hash seed cleanly.
+    # Single process: one process pins the hash seed cleanly, which is what the
+    # audit needs, so the xdist worker fan-out is intentionally skipped here.
     # This recipe is itself the determinism check, so the per-fill gate is skipped.
     PYTHONHASHSEED=1 uv run --group test fill --fork=Lstar --clean --no-check-determinism -n 0 -o "$first" $target -q
     PYTHONHASHSEED=2 uv run --group test fill --fork=Lstar --clean --no-check-determinism -n 0 -o "$second" $target -q


### PR DESCRIPTION
A bare `just fill-determinism` was broken: its default target was `tests/consensus -m order_sensitive`, but the `order_sensitive` marker is unregistered (absent from `pyproject.toml` `markers`) and used by no test, so pytest collected zero vectors and `fill` exited with code 5 (no tests collected).

This defaults the standalone audit to the whole consensus tree (`tests/consensus`), matching its documented whole-tree purpose; the explicit-path override (`just fill-determinism <path>`) is unchanged. It follows up the comment-only correction in #1050, which fixed the recipe's comments but left this default-target line untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)