### PR TITLE
docs: drop Why prefix from xmss import-cycle comment

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/__init__.py
+++ b/src/lean_spec/spec/crypto/xmss/__init__.py
@@ -10,7 +10,7 @@ References:
 
 from lean_multisig_py import setup_prover
 
-# Why: break the import cycle between the signature and fork containers.
+# Break the import cycle between the signature and fork containers.
 # The signature containers need the fork slot type, while the fork
 # aggregation containers import the signature containers back.
 # Loading the forks package first lets the cycle resolve from any entry point.


### PR DESCRIPTION
The cycle-break import comment in the XMSS package used a Why: prefix, which the documentation rules ban as redundant filler.
Drop the prefix and state the reason as plain prose; the surrounding explanation is unchanged.
Verified with just check (lint, format, ty, codespell, mdformat) all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)