### PR TITLE
docs(xmss): replace "Why ..." docstring banners with noun-phrase headings

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/encoding.py
+++ b/src/lean_spec/spec/crypto/xmss/encoding.py
@@ -24,7 +24,7 @@ https://eprint.iacr.org/2026/016.pdf
 
 The target-sum filter is the top-level acceptance test from the canonical Rust instantiation.
 
-# Why the decode can abort
+# Abort condition
 
 The decode turns each uniform field element into uniform base-BASE digits.
 Uniform output is what lets the security analysis model the hash as a random oracle.

--- a/src/lean_spec/spec/crypto/xmss/merkle.py
+++ b/src/lean_spec/spec/crypto/xmss/merkle.py
@@ -68,7 +68,7 @@ class HashTreeLayer(Container):
         """
         Build a layer whose nodes can all be paired at the next level up.
 
-        # Why pad
+        # Padding
 
         The level above pairs nodes two at a time, then hashes each pair.
         - A run starting on an odd index lacks a left neighbor for its first node.
@@ -561,7 +561,7 @@ def verify_path(
     The leaf is hashed, then folded with each sibling while climbing one level per step.
     The walk succeeds when the recomputed root equals the trusted root.
 
-    # Why return false instead of raising
+    # Failure handling
 
     The opening arrives inside an untrusted signature.
     A malformed opening must be a quiet verification failure, never a crash.


### PR DESCRIPTION
Three XMSS docstring section headers opened with a question-style "Why ..." banner, which the documentation rules ban as AI-filler phrasing (CRYPTO-DOCS-02).
Renamed them to plain noun-phrase headings ("Abort condition", "Padding", "Failure handling") while leaving the explanatory prose untouched.
Verified with just check (lint, format, type check, codespell, mdformat) all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)