### PR TITLE
refactor(xmss): unify target_sum_encode parameter order with message_hash

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/encoding.py
+++ b/src/lean_spec/spec/crypto/xmss/encoding.py
@@ -148,9 +148,9 @@ def target_sum_encode(
     poseidon: PoseidonXmss,
     config: XmssConfig,
     parameter: Parameter,
-    message: Bytes32,
-    rho: Randomness,
     epoch: Uint64,
+    rho: Randomness,
+    message: Bytes32,
 ) -> list[int] | None:
     """
     Encode a message into a codeword if it meets the target sum.
@@ -161,9 +161,9 @@ def target_sum_encode(
         poseidon: Cached Poseidon engine.
         config: Active XMSS configuration.
         parameter: Public parameter for domain separation.
-        message: Message being signed.
-        rho: Per-attempt randomness.
         epoch: Current epoch.
+        rho: Per-attempt randomness.
+        message: Message being signed.
 
     Returns:
         Codeword on success, None when the attempt must be retried.

--- a/src/lean_spec/spec/crypto/xmss/interface.py
+++ b/src/lean_spec/spec/crypto/xmss/interface.py
@@ -232,7 +232,7 @@ class GeneralizedXmssScheme(StrictBaseModel):
         for attempts in range(config.MAX_TRIES):
             rho = secret_key.prf_key.derive_randomness(config, slot, message, Uint64(attempts))
             codeword = target_sum_encode(
-                self.poseidon, config, secret_key.parameter, message, rho, slot
+                self.poseidon, config, secret_key.parameter, slot, rho, message
             )
             if codeword is not None:
                 break
@@ -310,7 +310,7 @@ class GeneralizedXmssScheme(StrictBaseModel):
         # Phase 2: rederive the codeword from the signature's randomness.
         # A failing aborting decode means the signature cannot be valid.
         codeword = target_sum_encode(
-            self.poseidon, config, public_key.parameter, message, signature.rho, slot
+            self.poseidon, config, public_key.parameter, slot, signature.rho, message
         )
         if codeword is None:
             return False

--- a/tests/spec/crypto/xmss/test_encoding.py
+++ b/tests/spec/crypto/xmss/test_encoding.py
@@ -108,7 +108,7 @@ def test_target_sum_encode_accepts_codeword_on_target_layer() -> None:
     # Attempt counter three lands the all-zero message on the target-sum layer.
     rho = Randomness(data=int_to_base_p(3, config.RAND_LENGTH_FIELD_ELEMENTS))
 
-    codeword = target_sum_encode(POSEIDON, config, parameter, Bytes32(b"\x00" * 32), rho, Uint64(0))
+    codeword = target_sum_encode(POSEIDON, config, parameter, Uint64(0), rho, Bytes32(b"\x00" * 32))
 
     # The digits sum to the target of six, landing on the accepted layer.
     assert codeword == [3, 0, 3, 0]
@@ -122,7 +122,7 @@ def test_target_sum_encode_rejects_codeword_off_target_layer() -> None:
     rho = Randomness(data=int_to_base_p(0, config.RAND_LENGTH_FIELD_ELEMENTS))
 
     assert (
-        target_sum_encode(POSEIDON, config, parameter, Bytes32(b"\x00" * 32), rho, Uint64(0))
+        target_sum_encode(POSEIDON, config, parameter, Uint64(0), rho, Bytes32(b"\x00" * 32))
         is None
     )
 
@@ -144,9 +144,9 @@ def test_target_sum_encode_propagates_aborting_decode_failure(
             POSEIDON,
             TEST_CONFIG,
             _parameter(),
-            Bytes32(b"\x00" * 32),
-            Randomness(data=int_to_base_p(0, TEST_CONFIG.RAND_LENGTH_FIELD_ELEMENTS)),
             Uint64(0),
+            Randomness(data=int_to_base_p(0, TEST_CONFIG.RAND_LENGTH_FIELD_ELEMENTS)),
+            Bytes32(b"\x00" * 32),
         )
         is None
     )

--- a/tests/spec/crypto/xmss/test_interface.py
+++ b/tests/spec/crypto/xmss/test_interface.py
@@ -60,15 +60,15 @@ def _test_correctness_roundtrip(
     #
     # We detect this by checking if both messages encode to the same codeword.
     original_codeword = target_sum_encode(
-        scheme.poseidon, scheme.config, public_key.parameter, message, signature.rho, test_slot
+        scheme.poseidon, scheme.config, public_key.parameter, test_slot, signature.rho, message
     )
     tampered_codeword = target_sum_encode(
         scheme.poseidon,
         scheme.config,
         public_key.parameter,
-        tampered_message,
-        signature.rho,
         test_slot,
+        signature.rho,
+        tampered_message,
     )
 
     if tampered_codeword != original_codeword:


### PR DESCRIPTION
The two sibling message-to-codeword encoders ordered their shared parameters differently while both are called positionally, a silent mis-binding footgun (CRYPTO-ARCH-01).
Adopt one canonical order (poseidon, config, parameter, epoch, rho, message) mirroring the hashing input layout, and reorder both call sites; this is a pure signature reorder with no behavior change.
Verified with just check (all passing) and the affected xmss encoding/interface unit tests (36 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)