### PR TITLE
fix(xmss): bound verify path length against the scheme's own config

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/interface.py
+++ b/src/lean_spec/spec/crypto/xmss/interface.py
@@ -321,6 +321,12 @@ class GeneralizedXmssScheme(StrictBaseModel):
         if len(signature.hashes) != config.DIMENSION:
             return False
 
+        # The authentication path must carry exactly one sibling per tree level.
+        # Bound it against this scheme's own height rather than a global default.
+        # A mismatched height would have the rebuild climb a tree that does not match this key.
+        if len(signature.path.siblings) != config.LOG_LIFETIME:
+            return False
+
         # Phase 3: finish each chain from the released hash to its endpoint.
         chain_ends: list[HashDigestVector] = []
         for chain_index, digit in enumerate(codeword):


### PR DESCRIPTION
verify() bounded the released-hash count against its own config but checked the authentication-path length only via a container validator pinned to a module-global config, so a scheme instance with a different lifetime would verify against a tree of the wrong height.
Reject a path whose sibling count differs from this scheme's own height before rebuilding the root, mirroring the existing hash-count check.
Verified with `just check` (all green) and `uv run pytest tests/spec/crypto/xmss/` (182 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)