### PR TITLE
refactor(xmss): rename pos to current_position in subtree path walk

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/merkle.py
+++ b/src/lean_spec/spec/crypto/xmss/merkle.py
@@ -473,18 +473,18 @@ class HashSubTree(Container):
             raise ValueError(f"Position {position} out of bounds.")
 
         siblings: list[HashDigestVector] = []
-        pos = int(position)
+        current_position = int(position)
 
         # Stop one short of the root layer.
         # The root has no sibling.
         for layer in self.layers[:-1]:
             # The sibling sits at the position with the last bit flipped, then we
             # rebase by the layer's start_index because the layer is sparse.
-            sibling_index = (pos ^ 1) - int(layer.start_index)
+            sibling_index = (current_position ^ 1) - int(layer.start_index)
             if not (0 <= sibling_index < len(layer.nodes)):
                 raise ValueError(f"Sibling index {sibling_index} out of bounds.")
             siblings.append(layer.nodes[sibling_index])
-            pos //= 2
+            current_position //= 2
 
         return HashTreeOpening(siblings=HashDigestList(data=siblings))
 


### PR DESCRIPTION
The subtree path walk used the abbreviation `pos` for its loop variable, violating the no-abbreviations rule (audit finding CRYPTO-NAMING-01).

Rename `pos` to `current_position`, matching the position name used in the verify path walk, so the identifier states that it tracks the position climbing the subtree.

Verified with `just check` (lint, format, type, spell, mdformat) — all pass. Naming-only change, no behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)