### PR TITLE
fix(xmss): bind verify_path depth to config log lifetime

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/merkle.py
+++ b/src/lean_spec/spec/crypto/xmss/merkle.py
@@ -580,12 +580,12 @@ def verify_path(
         True when the path reconstructs the trusted root, false otherwise.
     """
     # Guard against malformed openings.
-    # The opening list caps at 32 entries.
-    # A depth greater than 32 would overflow the position bound check below.
-    depth = len(opening.siblings)
-    if depth > 32:
+    # The opening holds exactly one sibling per tree level.
+    # That count is the scheme height, equal to the configured log lifetime.
+    if len(opening.siblings) != config.LOG_LIFETIME:
         return False
-    if int(position) >= (1 << depth):
+    # The leaf position must fall inside the tree the configured lifetime spans.
+    if int(position) >= int(config.LIFETIME):
         return False
 
     # Phase 1: hash the leaf parts to derive the starting node.

--- a/tests/spec/crypto/xmss/test_merkle.py
+++ b/tests/spec/crypto/xmss/test_merkle.py
@@ -94,8 +94,11 @@ def test_commit_open_verify_roundtrip(
 ) -> None:
     """A built tree opens and verifies every leaf for various shapes."""
     assert start_index + num_leaves <= (1 << depth)
+    # Verification binds the opening length to the configured log lifetime.
+    # Match the configured height to this tree's depth so every opening is well formed.
+    config_for_depth = PROD_CONFIG.model_copy(update={"LOG_LIFETIME": depth})
     _run_commit_open_verify_roundtrip(
-        POSEIDON, PROD_CONFIG, num_leaves, depth, start_index, leaf_parts_length
+        POSEIDON, config_for_depth, num_leaves, depth, start_index, leaf_parts_length
     )
 
 
@@ -365,19 +368,42 @@ def test_verify_path_rejects_excessive_depth_at_ssz_level() -> None:
         HashDigestList(data=[random_domain(PROD_CONFIG) for _ in range(33)])
 
 
-@pytest.mark.parametrize("position", [16, 100])
-def test_verify_path_rejects_position_exceeding_capacity(position: int) -> None:
-    """A position at or beyond two-to-the-depth fails without raising."""
-    siblings = [random_domain(PROD_CONFIG) for _ in range(4)]
+@pytest.mark.parametrize("sibling_count", [3, 5])
+def test_verify_path_rejects_opening_length_mismatch(sibling_count: int) -> None:
+    """An opening whose length differs from the configured log lifetime fails without raising."""
+    # A configured lifetime of two-to-the-four demands exactly four siblings per opening.
+    config_with_lifetime_sixteen = PROD_CONFIG.model_copy(update={"LOG_LIFETIME": 4})
+    siblings = [random_domain(config_with_lifetime_sixteen) for _ in range(sibling_count)]
     opening = HashTreeOpening(siblings=HashDigestList(data=siblings))
     assert (
         verify_path(
             poseidon=POSEIDON,
-            config=PROD_CONFIG,
-            parameter=random_parameter(PROD_CONFIG),
-            root=random_domain(PROD_CONFIG),
+            config=config_with_lifetime_sixteen,
+            parameter=random_parameter(config_with_lifetime_sixteen),
+            root=random_domain(config_with_lifetime_sixteen),
+            position=Uint64(0),
+            leaf_parts=[random_domain(config_with_lifetime_sixteen)],
+            opening=opening,
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize("position", [16, 100])
+def test_verify_path_rejects_position_exceeding_capacity(position: int) -> None:
+    """A position at or beyond the configured lifetime fails without raising."""
+    # A configured lifetime of two-to-the-four caps valid positions at fifteen.
+    config_with_lifetime_sixteen = PROD_CONFIG.model_copy(update={"LOG_LIFETIME": 4})
+    siblings = [random_domain(config_with_lifetime_sixteen) for _ in range(4)]
+    opening = HashTreeOpening(siblings=HashDigestList(data=siblings))
+    assert (
+        verify_path(
+            poseidon=POSEIDON,
+            config=config_with_lifetime_sixteen,
+            parameter=random_parameter(config_with_lifetime_sixteen),
+            root=random_domain(config_with_lifetime_sixteen),
             position=Uint64(position),
-            leaf_parts=[random_domain(PROD_CONFIG)],
+            leaf_parts=[random_domain(config_with_lifetime_sixteen)],
             opening=opening,
         )
         is False
@@ -385,16 +411,18 @@ def test_verify_path_rejects_position_exceeding_capacity(position: int) -> None:
 
 
 def test_verify_path_accepts_boundary_position_without_raising() -> None:
-    """The maximum valid position for the depth does not trip the bounds guard."""
-    siblings = [random_domain(PROD_CONFIG) for _ in range(4)]
+    """The maximum valid position for the configured lifetime does not trip the bounds guard."""
+    # A configured lifetime of two-to-the-four makes fifteen the last valid position.
+    config_with_lifetime_sixteen = PROD_CONFIG.model_copy(update={"LOG_LIFETIME": 4})
+    siblings = [random_domain(config_with_lifetime_sixteen) for _ in range(4)]
     opening = HashTreeOpening(siblings=HashDigestList(data=siblings))
     verification_result = verify_path(
         poseidon=POSEIDON,
-        config=PROD_CONFIG,
-        parameter=random_parameter(PROD_CONFIG),
-        root=random_domain(PROD_CONFIG),
+        config=config_with_lifetime_sixteen,
+        parameter=random_parameter(config_with_lifetime_sixteen),
+        root=random_domain(config_with_lifetime_sixteen),
         position=Uint64(15),
-        leaf_parts=[random_domain(PROD_CONFIG)],
+        leaf_parts=[random_domain(config_with_lifetime_sixteen)],
         opening=opening,
     )
     assert isinstance(verification_result, bool)


### PR DESCRIPTION
Merkle path verification hardcoded a maximum opening depth of 32 and bounded the leaf position by two-to-the-length of the attacker-supplied opening, an undeclared coupling to the production log lifetime that silently caps or over-permits under any non-production configuration.

The verifier now requires the opening to hold exactly the configured log lifetime in siblings and bounds the position by the configured lifetime, so the check tracks the actual scheme height. (CRYPTO-SAFETY-02)

Verified with the full xmss unit suite and just check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)