### PR TITLE
docs(ssz): cross-reference duplicated offset validation

### DIFF
--- a/src/lean_spec/spec/ssz/collections.py
+++ b/src/lean_spec/spec/ssz/collections.py
@@ -61,6 +61,9 @@ def _validate_offsets(offsets: list[int], scope: int, type_name: str) -> None:
     - Offsets are monotonically non-decreasing, so no body has negative width.
     - The final offset stays within scope, so no body reads past its budget.
 
+    The container decoder repeats these same checks inline.
+    The duplication is intentional: inlining there keeps the per-field name in each error.
+
     Raises:
         SSZSerializationError: When a later offset is smaller than an earlier one.
         SSZSerializationError: When the final offset exceeds the available scope.

--- a/src/lean_spec/spec/ssz/container.py
+++ b/src/lean_spec/spec/ssz/container.py
@@ -90,6 +90,9 @@ class Container(SSZModel):
         if not var_fields:
             return cls(**fields)
 
+        # These offset checks mirror the variable-length collection decoder.
+        # The duplication is intentional: inlining keeps the per-field name in each error.
+        #
         # Canonical form: the first offset must point to the end of the fixed part.
         # Any other value leaves a gap or overlap, allowing two encodings of one value.
         if var_fields[0][2] != bytes_read:


### PR DESCRIPTION
The container decoder and the variable-length collection decoder both enforce the same offset-table invariants (monotonic offsets, final offset within scope) in separate code.
Audit finding SSZ-ARCH-02 recommends documenting this intentional duplication rather than forcing a shared helper, which would lose the per-field error context the container decoder provides.
Adds a one-line cross-reference comment in each spot noting the sibling check and why the duplication is intentional.
Verified with `just check` (lint, format, typecheck, spell, mdformat, lock) all passing; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)