### PR TITLE
refactor(ssz): rename ftype to field_type in container deserialize

### DIFF
--- a/src/lean_spec/spec/ssz/container.py
+++ b/src/lean_spec/spec/ssz/container.py
@@ -77,14 +77,14 @@ class Container(SSZModel):
 
         # Phase 1: each slot is either the field itself or an offset to its tail payload.
         for name, field_definition in cls.model_fields.items():
-            ftype: type[SSZType] = field_definition.annotation
-            if ftype.is_fixed_size():
-                width = ftype.get_byte_length()
-                fields[name] = ftype.deserialize(stream, width)
+            field_type: type[SSZType] = field_definition.annotation
+            if field_type.is_fixed_size():
+                width = field_type.get_byte_length()
+                fields[name] = field_type.deserialize(stream, width)
                 bytes_read += width
             else:
                 offset = int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
-                var_fields.append((name, ftype, offset))
+                var_fields.append((name, field_type, offset))
                 bytes_read += BYTES_PER_LENGTH_OFFSET
 
         if not var_fields:
@@ -100,12 +100,14 @@ class Container(SSZModel):
         # Phase 2: each variable payload spans from its offset to the next.
         # Scope closes the final span.
         boundaries = [o for _, _, o in var_fields] + [scope]
-        for (name, ftype, _), (start, end) in zip(var_fields, pairwise(boundaries), strict=True):
+        for (name, field_type, _), (start, end) in zip(
+            var_fields, pairwise(boundaries), strict=True
+        ):
             if end < start:
                 raise SSZSerializationError(
                     f"{cls.__name__}.{name}: non-monotonic offsets ({start} > {end})"
                 )
-            fields[name] = ftype.deserialize(stream, end - start)
+            fields[name] = field_type.deserialize(stream, end - start)
 
         return cls(**fields)
 


### PR DESCRIPTION
The container deserialization loop used the abbreviated local name ftype, which the no-abbreviations rule forbids in a reference spec.
This renames it to field_type at all six occurrences in the deserialize method, with no behavior change.
Verified with just check (lint, format, type check, codespell, mdformat all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)