### PR TITLE
refactor(ssz): rename err to exception in container hex validator

### DIFF
--- a/src/lean_spec/spec/ssz/container.py
+++ b/src/lean_spec/spec/ssz/container.py
@@ -27,8 +27,8 @@ class Container(SSZModel):
         if isinstance(value, str):
             try:
                 return cls.from_hex(value)
-            except SSZError as err:
-                raise ValueError(f"invalid {cls.__name__} hex: {err}") from err
+            except SSZError as exception:
+                raise ValueError(f"invalid {cls.__name__} hex: {exception}") from exception
         return handler(value)
 
     @classmethod


### PR DESCRIPTION
The hex-string validator in the SSZ container bound its caught exception to the abbreviated name err, violating the no-abbreviations naming rule.

Renamed the except-clause binding to exception, updating the f-string and from clause to match.

Verified with just check (ruff, format, ty, codespell, mdformat all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)