### PR TITLE
refactor(ssz): rename tname to type_name in byte-array reprs

### DIFF
--- a/src/lean_spec/spec/ssz/byte_arrays.py
+++ b/src/lean_spec/spec/ssz/byte_arrays.py
@@ -206,8 +206,8 @@ class BaseBytes(bytes, SSZType):
 
     def __repr__(self) -> str:
         """Return the official form: ClassName(hex_string)."""
-        tname = type(self).__name__
-        return f"{tname}({self.hex()})"
+        type_name = type(self).__name__
+        return f"{type_name}({self.hex()})"
 
     def __eq__(self, other: object) -> bool:
         """Strict equality — only another byte-array instance compares; anything else raises."""
@@ -403,8 +403,8 @@ class BaseByteList(SSZModel):
 
     def __repr__(self) -> str:
         """Return the official form: ClassName(hex_string)."""
-        tname = type(self).__name__
-        return f"{tname}({self.data.hex()})"
+        type_name = type(self).__name__
+        return f"{type_name}({self.data.hex()})"
 
     def __eq__(self, other: object) -> bool:
         """Strict equality — only another byte-list instance compares; anything else raises."""


### PR DESCRIPTION
The two byte-array __repr__ methods used the abbreviated local name tname for the class name, violating the no-abbreviations rule.

Spell it out as type_name in both methods. No behavior change — the repr output is identical.

Verified with just check (lint, format, ty, codespell, mdformat) all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)