### PR TITLE
refactor(ssz): rename single-letter offset loop variable

### DIFF
--- a/src/lean_spec/spec/ssz/container.py
+++ b/src/lean_spec/spec/ssz/container.py
@@ -99,7 +99,7 @@ class Container(SSZModel):
 
         # Phase 2: each variable payload spans from its offset to the next.
         # Scope closes the final span.
-        boundaries = [o for _, _, o in var_fields] + [scope]
+        boundaries = [offset for _, _, offset in var_fields] + [scope]
         for (name, ftype, _), (start, end) in zip(var_fields, pairwise(boundaries), strict=True):
             if end < start:
                 raise SSZSerializationError(


### PR DESCRIPTION
The container deserializer built its offset boundary list with a single-letter comprehension variable o, obscuring what the value held (SSZ-NAMING-06).
Rename it to offset, matching the offset field of the tuples it iterates over; no behavior change.
Verified with just check (ruff lint, ruff format, ty, codespell, mdformat) — all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)