### PR TITLE
refactor(ssz): rename total to packed_integer in bitlist decode

### DIFF
--- a/src/lean_spec/spec/ssz/bitfields.py
+++ b/src/lean_spec/spec/ssz/bitfields.py
@@ -408,10 +408,10 @@ class BaseBitlist(SSZModel):
         #   int.from_bytes(data, "little")  =  511  =  0b111111111
         #   bit_length()                    =  9
         #   delimiter_pos                   =  8      ->  num_bits = 8
-        total = int.from_bytes(data, "little")
-        if total == 0:
+        packed_integer = int.from_bytes(data, "little")
+        if packed_integer == 0:
             raise SSZSerializationError(f"{cls.__name__}: no delimiter bit found")
-        delimiter_pos = total.bit_length() - 1
+        delimiter_pos = packed_integer.bit_length() - 1
 
         # The delimiter must sit in the final byte of the input.
         # Reading the stream as one integer silently drops trailing zero bytes.


### PR DESCRIPTION
Problem: the bitlist decode named the byte stream read into an integer with the vague local total, inconsistent with the encode side.
Fix: rename it to packed_integer at all three uses, mirroring the encode side's packed_bits.
Verification: just check passes (ruff, format, ty, codespell, mdformat); naming-only change with no behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)