### PR TITLE
refactor(ssz): drop dead BaseByteList add/radd/hex methods

### DIFF
--- a/src/lean_spec/spec/ssz/byte_arrays.py
+++ b/src/lean_spec/spec/ssz/byte_arrays.py
@@ -393,14 +393,6 @@ class BaseByteList(SSZModel):
         """Return the underlying raw bytes."""
         return self.data
 
-    def __add__(self, other: Any) -> bytes:
-        """Concatenate with a bytes-like value on the right, returning plain bytes."""
-        return self.data + bytes(other)
-
-    def __radd__(self, other: Any) -> bytes:
-        """Concatenate with a bytes-like value on the left, returning plain bytes."""
-        return bytes(other) + self.data
-
     def __repr__(self) -> str:
         """Return the official form: ClassName(hex_string)."""
         tname = type(self).__name__
@@ -431,10 +423,6 @@ class BaseByteList(SSZModel):
     def __hash__(self) -> int:
         """Return a hash that ties the value to its concrete type."""
         return hash((type(self), self.data))
-
-    def hex(self) -> str:
-        """Return the hexadecimal string representation of the underlying bytes."""
-        return self.data.hex()
 
 
 class ByteList512KiB(BaseByteList):

--- a/tests/spec/ssz/test_byte_arrays.py
+++ b/tests/spec/ssz/test_byte_arrays.py
@@ -368,33 +368,15 @@ class TestBaseByteListEquality:
 
 
 class TestBaseByteListOperations:
-    """Repr, hex, bytes coercion, and concatenation."""
+    """Repr and bytes coercion."""
 
     def test_repr(self) -> None:
         """The repr is the class name with the hex content in parentheses."""
         assert repr(ByteList16(data=b"\x00\x01\x02")) == "ByteList16(000102)"
 
-    def test_hex(self) -> None:
-        """The hex method returns the lowercase hex string."""
-        assert ByteList16(data=b"\x00\x01\x02").hex() == "000102"
-
     def test_bytes_dunder(self) -> None:
         """Calling bytes() on an instance returns the underlying bytes."""
         assert bytes(ByteList16(data=b"\x00\x01\x02")) == b"\x00\x01\x02"
-
-    def test_concatenation_returns_plain_bytes(self) -> None:
-        """Concatenation with a bytes-like value returns plain bytes."""
-        byte_list = ByteList16(data=b"\x00\x01\x02")
-        concatenated = byte_list + b"\x03\x04"
-        assert type(concatenated) is bytes
-        assert concatenated == b"\x00\x01\x02\x03\x04"
-
-    def test_reverse_concatenation_returns_plain_bytes(self) -> None:
-        """Concatenation with raw bytes on the left returns plain bytes."""
-        byte_list = ByteList16(data=b"\x00\x01")
-        concatenated = b"\xff" + byte_list
-        assert type(concatenated) is bytes
-        assert concatenated == b"\xff\x00\x01"
 
 
 class TestBaseByteListSSZ:
@@ -496,7 +478,7 @@ def test_json_dumpable_via_hex() -> None:
     hex_encoded_fields = {
         "root": Bytes32(b"\x11" * 32).hex(),
         "key": Bytes4(b"\x00\x01\x02\x03").hex(),
-        "payload": ByteList5(data=b"\x00\x01\x02").hex(),
+        "payload": bytes(ByteList5(data=b"\x00\x01\x02")).hex(),
     }
     assert json.loads(json.dumps(hex_encoded_fields)) == hex_encoded_fields
 


### PR DESCRIPTION
The right/left concatenation operators and the hex method on the variable-length byte list have no production callers, and concatenation silently downgraded a typed byte list to plain bytes.
This removes those three methods and their dedicated unit tests, keeping the bytes coercion and the equality/hash/repr contract intact.
Verified with just check (lint, format, ty, codespell, mdformat all pass) and the byte_arrays unit tests (84 passed, byte_arrays.py at 100% coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)