### PR TITLE
refactor(ssz): rename var_fields to variable_fields in container deserialize

### DIFF
--- a/src/lean_spec/spec/ssz/container.py
+++ b/src/lean_spec/spec/ssz/container.py
@@ -72,7 +72,7 @@ class Container(SSZModel):
     def deserialize(cls, stream: IO[bytes], scope: int) -> Self:
         """Read the fixed part with offsets, then each variable payload by its offset window."""
         fields: dict[str, SSZType] = {}
-        var_fields: list[tuple[str, type[SSZType], int]] = []
+        variable_fields: list[tuple[str, type[SSZType], int]] = []
         bytes_read = 0
 
         # Phase 1: each slot is either the field itself or an offset to its tail payload.
@@ -84,23 +84,26 @@ class Container(SSZModel):
                 bytes_read += width
             else:
                 offset = int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
-                var_fields.append((name, ftype, offset))
+                variable_fields.append((name, ftype, offset))
                 bytes_read += BYTES_PER_LENGTH_OFFSET
 
-        if not var_fields:
+        if not variable_fields:
             return cls(**fields)
 
         # Canonical form: the first offset must point to the end of the fixed part.
         # Any other value leaves a gap or overlap, allowing two encodings of one value.
-        if var_fields[0][2] != bytes_read:
+        if variable_fields[0][2] != bytes_read:
+            first_offset = variable_fields[0][2]
             raise SSZSerializationError(
-                f"{cls.__name__}: first offset {var_fields[0][2]} != fixed-part end {bytes_read}"
+                f"{cls.__name__}: first offset {first_offset} != fixed-part end {bytes_read}"
             )
 
         # Phase 2: each variable payload spans from its offset to the next.
         # Scope closes the final span.
-        boundaries = [o for _, _, o in var_fields] + [scope]
-        for (name, ftype, _), (start, end) in zip(var_fields, pairwise(boundaries), strict=True):
+        boundaries = [o for _, _, o in variable_fields] + [scope]
+        for (name, ftype, _), (start, end) in zip(
+            variable_fields, pairwise(boundaries), strict=True
+        ):
             if end < start:
                 raise SSZSerializationError(
                     f"{cls.__name__}.{name}: non-monotonic offsets ({start} > {end})"


### PR DESCRIPTION
Problem: the container deserializer used the abbreviated local name var_fields, violating the no-abbreviations naming rule (audit finding SSZ-NAMING-05).
Fix: rename every occurrence to variable_fields; emitted error messages and behavior are unchanged.
Verification: just check passes (ruff lint, format, ty, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)