### PR TITLE
docs(lstar): trim step-recap docstrings in state transition

### DIFF
--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -66,10 +66,8 @@ class StateTransitionMixin(LstarSpecBase):
         """
         Advance the state through empty slots up to, but not including, target_slot.
 
-        The loop:
-          - Performs per-slot maintenance (e.g., state root caching).
-          - Increments the slot counter after each call.
-        The function returns a new state with slot == target_slot.
+        The pre-block state root is cached at most once per block.
+        Only the first empty slot after a block finds an empty root to fill.
 
         Raises:
             SpecRejectionError: BLOCK_SLOT_NOT_IN_FUTURE if target_slot is not in the future.
@@ -107,19 +105,6 @@ class StateTransitionMixin(LstarSpecBase):
     def process_block_header(self, state: State, block: Block) -> State:
         """
         Validate the block header and update header-linked state.
-
-        Checks:
-          - The block slot equals the current state slot.
-          - The block slot is newer than the latest header slot.
-          - The proposer index matches the round-robin selection.
-          - The parent root matches the hash of the latest block header.
-
-        Updates:
-          - For the first post-genesis block, mark genesis as justified/finalized.
-          - Append the parent root to historical hashes.
-          - Append the justified bit for the parent (true only for genesis).
-          - Insert ZERO_HASH entries for any skipped empty slots.
-          - Set latest_block_header for the new block with an empty state_root.
 
         Raises:
             SpecRejectionError: If any header check fails (slot mismatch, block older
@@ -265,13 +250,7 @@ class StateTransitionMixin(LstarSpecBase):
         attestations: Iterable[AggregatedAttestation],
     ) -> State:
         """
-        Apply attestations and update justification/finalization
-        according to the Lean Consensus 3SF-mini rules.
-
-        This simplified consensus mechanism:
-        1. Processes each attestation
-        2. Updates justified status for target checkpoints
-        3. Applies finalization rules based on justified status
+        Apply attestations and update justification and finalization under 3SF-mini rules.
 
         Raises:
             SpecRejectionError: EMPTY_AGGREGATION_BITS if an attestation that passes
@@ -529,11 +508,6 @@ class StateTransitionMixin(LstarSpecBase):
     ) -> State:
         """
         Apply the complete state transition function for a block.
-
-        This method represents the full state transition function:
-        1. Process slots up to the block's slot
-        2. Process the block header and body
-        3. Validate the computed state root
 
         Signatures are verified outside this function, before it is called.
 


### PR DESCRIPTION
Several state-transition method docstrings recapped the algorithm with bullet/numbered lists that mirrored the body's inline phase comments (audit finding FORKS-DOCS-03).

Trimmed each to a one-line summary, the non-obvious invariant (at-most-once state-root caching), and the Raises section, deleting the step recaps.

Verified with `just check` (lint, format, type check, spell, mdformat) — all pass; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)