### PR TITLE
docs(fork-choice): trim step-recap docstrings to summary plus Args/Returns/Raises

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -180,17 +180,8 @@ class ForkChoiceMixin(LstarSpecBase):
         """
         Validate incoming attestation before processing.
 
-        Ensures the vote respects the basic laws of time and topology:
-            1. The blocks voted for must exist in our store.
-            2. A vote cannot span backwards in time (source > target).
-            3. The head must be at least as recent as source and target.
-            4. Checkpoint slots must match the actual block slots.
-            5. Source, target, and head must lie on one parent chain.
-            6. The vote's slot cannot precede the slot of the head it claims to have seen.
-            7. The vote's slot must have started locally (a small disparity margin is allowed).
-
         Raises:
-            SpecRejectionError: If the attestation fails any of the validation checks above.
+            SpecRejectionError: If the attestation fails any of the validation checks below.
         """
         source_checkpoint = attestation_data.source
         target_checkpoint = attestation_data.target
@@ -300,11 +291,6 @@ class ForkChoiceMixin(LstarSpecBase):
     ) -> LstarStore:
         """
         Verify a gossiped attestation and, for aggregators, record its signature.
-
-        Steps:
-            1. Validate the vote: known blocks, matching slots, ancestry, and timing.
-            2. Verify the signature against the validator's key.
-            3. Record the signature, but only when this node aggregates.
 
         Subnet filtering happens at the p2p subscription layer.
         Only attestations from subscribed subnets arrive here, so no subnet check is repeated.
@@ -418,11 +404,6 @@ class ForkChoiceMixin(LstarSpecBase):
         One aggregated attestation carries a single proof that stands in for many
         validators who all signed the same vote.
 
-        Steps:
-            1. Validate the vote: known blocks, matching slots, ancestry, and timing.
-            2. Verify the aggregate proof against every participant's key.
-            3. Record the proof in the pending pool.
-
         Args:
             store: Current fork-choice store.
             signed_attestation: The signed aggregated vote to process.
@@ -528,13 +509,6 @@ class ForkChoiceMixin(LstarSpecBase):
     ) -> LstarStore:
         """
         Process a new block and update the forkchoice state.
-
-        This method integrates a block into the forkchoice store by:
-
-        1. Validating the block's parent exists
-        2. Computing the post-state via the state transition function
-        3. Processing attestations included in the block body (on-chain)
-        4. Updating the forkchoice head
 
         Raises:
             SpecRejectionError: UNKNOWN_PARENT_BLOCK if the parent state is not in the store.


### PR DESCRIPTION
Four fork-choice docstrings re-narrated the algorithm steps that the inline phase comments already carry, duplicating the step detail (audit finding FORKS-DOCS-04).

Reduce each to a one-line summary plus Args/Returns/Raises, leaving the inline comments as the single source of step narration.

Verified with just check (lint, format, ty, codespell, mdformat) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)