### PR TITLE
docs: reduce Validator container docstring to a plain noun phrase

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/spec/forks/lstar/containers/validator.py
@@ -6,7 +6,7 @@ from lean_spec.spec.ssz import Bytes52, Container, SSZList
 
 
 class Validator(Container):
-    """A validator's static metadata and operational interface."""
+    """A validator's static registry entry."""
 
     attestation_public_key: Bytes52
     """XMSS public key for signing attestations."""


### PR DESCRIPTION
Problem: the Validator container docstring claimed an "operational interface" it does not have; it holds only static registry fields.
Fix: reduce the summary to a plain noun phrase, per the documentation rules.
Verification: `just check` passes (lint, format, typecheck, spell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)