### PR TITLE
docs(forks): trim interval enumeration in tick_interval docstring

### DIFF
--- a/src/lean_spec/spec/forks/lstar/timeline.py
+++ b/src/lean_spec/spec/forks/lstar/timeline.py
@@ -19,28 +19,23 @@ class TimelineMixin(LstarSpecBase):
         has_proposal: bool,
         is_aggregator: bool = False,
     ) -> tuple[LstarStore, list[SignedAggregatedAttestation]]:
-        """
-        Advance store time by one interval and perform interval-specific actions.
-
-        Different actions are performed based on interval within slot:
-        - Interval 0: Process attestations if proposal exists
-        - Interval 1: Validator attesting period (no action)
-        - Interval 2: Aggregators create proofs & broadcast
-        - Interval 3: Update safe target (fast confirm)
-        - Interval 4: Process accumulated attestations
-        """
+        """Advance store time by one interval and perform interval-specific actions."""
         # Advance time by one interval
         store = store.model_copy(update={"time": store.time + Interval(1)})
         current_interval = Interval(int(store.time) % int(INTERVALS_PER_SLOT))
         new_aggregates: list[SignedAggregatedAttestation] = []
 
         match int(current_interval):
+            # Slot start: ingest pending attestations once the slot's proposal lands.
             case 0 if has_proposal:
                 store = self.accept_new_attestations(store)
+            # Aggregators build proofs over the slot's attestations and broadcast them.
             case 2 if is_aggregator:
                 store, new_aggregates = self.aggregate(store)
+            # Fast-confirmation point: advance the safe target from the latest votes.
             case 3:
                 store = self.update_safe_target(store)
+            # Ingest the attestations that accumulated through the slot.
             case 4:
                 store = self.accept_new_attestations(store)
 


### PR DESCRIPTION
The interval-ticking docstring re-enumerated every interval, including a no-op interval line with no match arm, duplicating the match block below it.

This keeps the one-line summary and moves each interval's behavior into an inline comment glued to the match arm it describes.

Verification: just check passes (lint, format, type check, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)