### PR TITLE
docs(checkpoint): clarify forward-progression docstring

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
+++ b/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
@@ -22,11 +22,11 @@ class Checkpoint(Container):
 
     def advance_to(self, candidate: "Checkpoint") -> "Checkpoint":
         """
-        Return the later of two checkpoints, keeping self on a slot tie.
+        Return the later of two checkpoints, keeping this one on a slot tie.
 
         Forward-only progression for justified and finalized checkpoints.
 
-        The candidate replaces the receiver only when its slot is strictly higher.
+        The candidate replaces this checkpoint only when its slot is strictly higher.
         """
         return candidate if candidate.slot > self.slot else self
 


### PR DESCRIPTION
The checkpoint forward-progression docstring used 'self' and 'the receiver', method-receiver jargon that does not name the object plainly.

This rewrites those phrases to 'this checkpoint' so the prose reads clearly. No behavior change.

Verified with just check (lint, format, typecheck, spell, mdformat, lock all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)