### PR TITLE
docs(aggregation): split multi-clause binding rationale into one idea per line

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/aggregation.py
@@ -320,7 +320,8 @@ class MultiMessageAggregate(Container):
         # The message bindings
 
         Each component is checked against one message and slot supplied by the caller.
-        Without that binding the proof would accept attacker-chosen data resolving to the same keys.
+        Without that binding the proof would accept attacker-chosen data.
+        That data could resolve to the same keys.
         The parallel lists pin every component to the message it actually signed.
 
         Args:


### PR DESCRIPTION
Problem: the multi-message verify docstring packed the per-component binding rationale onto one long line that joined two ideas, violating the one-sentence-per-line documentation rule.
Fix: split that line into two short lines, one idea each, preserving the surrounding rationale verbatim.
Verification: `just check` passes (ruff lint+format, ty, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)