### PR TITLE
docs: split two-sentence docstring lines in observer timing helpers

### DIFF
--- a/src/lean_spec/spec/observability/observer.py
+++ b/src/lean_spec/spec/observability/observer.py
@@ -87,8 +87,8 @@ def observe_state_transition() -> Iterator[None]:
     Time the wrapped state transition and publish the elapsed duration.
 
     Spec code wraps the body of a state transition in this block instead
-    of calling a stopwatch primitive directly. On clean exit the elapsed
-    wall time is published through the observer singleton.
+    of calling a stopwatch primitive directly.
+    On clean exit the elapsed wall time is published through the observer singleton.
 
     Semantics
 
@@ -126,8 +126,8 @@ def observe_on_attestation() -> Iterator[None]:
     Time the wrapped gossip-attestation validation and publish the duration.
 
     Semantics mirror observe_state_transition: publishes only on clean exit,
-    propagates exceptions without emitting an event. The caller remains
-    responsible for classifying the outcome (valid vs invalid counters),
+    propagates exceptions without emitting an event.
+    The caller remains responsible for classifying the outcome (valid vs invalid counters),
     because that classification is a caller-side concern.
     """
     start = time.perf_counter()


### PR DESCRIPTION
Two docstrings in the observability timing helpers put two sentences on one line, breaking the one-sentence-per-line documentation rule (OBS-DOCS-02).

Split each so the following sentence starts a new line: after the directly-callable note in the state-transition helper, and after the no-event clause in the attestation helper.

Verified with `just check` (lint, format, typecheck, spell, mdformat, lock) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)