### PR TITLE
test(consensus): assert full rejection messages with exact_message

### DIFF
--- a/tests/consensus/lstar/fork_choice/test_ancestry_branches.py
+++ b/tests/consensus/lstar/fork_choice/test_ancestry_branches.py
@@ -99,7 +99,7 @@ def test_attestation_source_on_same_slot_fork_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.SOURCE_NOT_ANCESTOR_OF_TARGET,
-                    message_substring="Source checkpoint must be ancestor of target",
+                    exact_message="Source checkpoint must be ancestor of target",
                 ),
             ),
         ],

--- a/tests/consensus/lstar/fork_choice/test_block_attestation_limits.py
+++ b/tests/consensus/lstar/fork_choice/test_block_attestation_limits.py
@@ -156,7 +156,7 @@ def test_block_exceeding_maximum_attestations_is_rejected(
             valid=False,
             expected_rejection=ExpectedRejection(
                 reason=RejectionReason.TOO_MANY_ATTESTATION_DATA,
-                message_substring=(
+                exact_message=(
                     f"Block contains {n + 1} distinct AttestationData entries; "
                     f"maximum is {MAX_ATTESTATIONS_DATA}"
                 ),

--- a/tests/consensus/lstar/fork_choice/test_checkpoint_sync.py
+++ b/tests/consensus/lstar/fork_choice/test_checkpoint_sync.py
@@ -386,7 +386,7 @@ def test_store_from_anchor_rejects_mismatched_state_root(
         anchor_valid=False,
         expected_rejection=ExpectedRejection(
             reason=RejectionReason.ANCHOR_STATE_ROOT_MISMATCH,
-            message_substring="Anchor block state root must match anchor state hash",
+            exact_message="Anchor block state root must match anchor state hash",
         ),
         steps=[],
     )

--- a/tests/consensus/lstar/fork_choice/test_duplicate_attestation_data.py
+++ b/tests/consensus/lstar/fork_choice/test_duplicate_attestation_data.py
@@ -63,7 +63,10 @@ def test_block_with_duplicate_aggregated_attestation_data_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.DUPLICATE_ATTESTATION_DATA,
-                    message_substring="Block contains duplicate AttestationData",
+                    exact_message=(
+                        "Block contains duplicate AttestationData entries; "
+                        "each AttestationData must appear at most once"
+                    ),
                 ),
             ),
         ],

--- a/tests/consensus/lstar/fork_choice/test_gossip_aggregated_attestation_validation.py
+++ b/tests/consensus/lstar/fork_choice/test_gossip_aggregated_attestation_validation.py
@@ -207,7 +207,7 @@ def test_aggregated_attestation_head_slot_mismatch_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.HEAD_SLOT_MISMATCH,
-                    message_substring="Head checkpoint slot mismatch",
+                    exact_message="Head checkpoint slot mismatch",
                 ),
             ),
         ]
@@ -260,7 +260,7 @@ def test_aggregated_attestation_source_after_target_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.SOURCE_AFTER_TARGET,
-                    message_substring="Source checkpoint slot must not exceed target",
+                    exact_message="Source checkpoint slot must not exceed target",
                 ),
             ),
         ]
@@ -308,7 +308,7 @@ def test_aggregated_attestation_too_far_in_future_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE,
-                    message_substring="Attestation too far in future",
+                    exact_message="Attestation too far in future",
                 ),
             ),
         ]
@@ -401,7 +401,7 @@ def test_aggregated_attestation_just_beyond_disparity_boundary_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE,
-                    message_substring="Attestation too far in future",
+                    exact_message="Attestation too far in future",
                 ),
             ),
         ]
@@ -454,7 +454,7 @@ def test_aggregated_attestation_one_full_slot_in_future_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE,
-                    message_substring="Attestation too far in future",
+                    exact_message="Attestation too far in future",
                 ),
             ),
         ]

--- a/tests/consensus/lstar/fork_choice/test_gossip_aggregated_empty_participants.py
+++ b/tests/consensus/lstar/fork_choice/test_gossip_aggregated_empty_participants.py
@@ -58,9 +58,7 @@ def test_gossip_aggregated_attestation_empty_participants_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.EMPTY_AGGREGATION_BITS,
-                    message_substring=(
-                        "Aggregated attestation must reference at least one validator"
-                    ),
+                    exact_message="Aggregated attestation must reference at least one validator",
                 ),
             ),
         ]

--- a/tests/consensus/lstar/fork_choice/test_gossip_attestation_validation.py
+++ b/tests/consensus/lstar/fork_choice/test_gossip_attestation_validation.py
@@ -108,7 +108,7 @@ def test_attestation_target_slot_mismatch_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.TARGET_SLOT_MISMATCH,
-                    message_substring="Target checkpoint slot mismatch",
+                    exact_message="Target checkpoint slot mismatch",
                 ),
             ),
         ],
@@ -156,7 +156,7 @@ def test_attestation_too_far_in_future_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE,
-                    message_substring="Attestation too far in future",
+                    exact_message="Attestation too far in future",
                 ),
             ),
         ],
@@ -249,7 +249,7 @@ def test_attestation_just_beyond_disparity_boundary_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE,
-                    message_substring="Attestation too far in future",
+                    exact_message="Attestation too far in future",
                 ),
             ),
         ],
@@ -302,7 +302,7 @@ def test_attestation_one_full_slot_in_future_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE,
-                    message_substring="Attestation too far in future",
+                    exact_message="Attestation too far in future",
                 ),
             ),
         ],
@@ -423,7 +423,7 @@ def test_gossip_attestation_with_invalid_signature(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.INVALID_SIGNATURE,
-                    message_substring="Signature verification failed",
+                    exact_message="Signature verification failed",
                 ),
             ),
         ],
@@ -525,7 +525,7 @@ def test_attestation_source_slot_exceeds_target_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.SOURCE_AFTER_TARGET,
-                    message_substring="Source checkpoint slot must not exceed target",
+                    exact_message="Source checkpoint slot must not exceed target",
                 ),
             ),
         ],
@@ -577,7 +577,7 @@ def test_attestation_head_older_than_target_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.HEAD_OLDER_THAN_TARGET,
-                    message_substring="Head checkpoint must not be older than target",
+                    exact_message="Head checkpoint must not be older than target",
                 ),
             ),
         ],
@@ -625,7 +625,7 @@ def test_attestation_source_slot_override_exceeds_target_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.SOURCE_AFTER_TARGET,
-                    message_substring="Source checkpoint slot must not exceed target",
+                    exact_message="Source checkpoint slot must not exceed target",
                 ),
             ),
         ],
@@ -675,7 +675,7 @@ def test_attestation_source_slot_mismatch_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.SOURCE_SLOT_MISMATCH,
-                    message_substring="Source checkpoint slot mismatch",
+                    exact_message="Source checkpoint slot mismatch",
                 ),
             ),
         ],
@@ -723,7 +723,7 @@ def test_attestation_head_slot_mismatch_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.HEAD_SLOT_MISMATCH,
-                    message_substring="Head checkpoint slot mismatch",
+                    exact_message="Head checkpoint slot mismatch",
                 ),
             ),
         ],
@@ -994,7 +994,7 @@ def test_attestation_head_on_sibling_fork_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.TARGET_NOT_ANCESTOR_OF_HEAD,
-                    message_substring="Target checkpoint must be ancestor of head",
+                    exact_message="Target checkpoint must be ancestor of head",
                 ),
             ),
         ],
@@ -1051,7 +1051,7 @@ def test_attestation_slot_near_uint64_max_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.ATTESTATION_TOO_FAR_IN_FUTURE,
-                    message_substring="Attestation too far in future",
+                    exact_message="Attestation too far in future",
                 ),
             ),
         ],
@@ -1106,7 +1106,7 @@ def test_attestation_slot_before_head_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.ATTESTATION_SLOT_BEFORE_HEAD,
-                    message_substring="Attestation slot precedes head",
+                    exact_message="Attestation slot precedes head",
                 ),
             ),
         ],
@@ -1167,7 +1167,7 @@ def test_attestation_source_on_sibling_fork_rejected(
                 valid=False,
                 expected_rejection=ExpectedRejection(
                     reason=RejectionReason.SOURCE_NOT_ANCESTOR_OF_TARGET,
-                    message_substring="Source checkpoint must be ancestor of target",
+                    exact_message="Source checkpoint must be ancestor of target",
                 ),
             ),
         ],

--- a/tests/consensus/lstar/state_transition/test_block_processing.py
+++ b/tests/consensus/lstar/state_transition/test_block_processing.py
@@ -313,7 +313,7 @@ def test_block_with_wrong_slot(state_transition_test: StateTransitionTestFiller)
         post=None,
         expected_rejection=ExpectedRejection(
             reason=RejectionReason.BLOCK_SLOT_MISMATCH,
-            message_substring="Block slot mismatch",
+            exact_message="Block slot mismatch",
         ),
     )
 

--- a/tests/consensus/lstar/state_transition/test_empty_validator_registry.py
+++ b/tests/consensus/lstar/state_transition/test_empty_validator_registry.py
@@ -40,6 +40,6 @@ def test_proposer_scheduling_on_empty_registry_rejected(
         post=None,
         expected_rejection=ExpectedRejection(
             reason=RejectionReason.EMPTY_VALIDATOR_REGISTRY,
-            message_substring="Cannot schedule a proposer for an empty validator registry",
+            exact_message="Cannot schedule a proposer for an empty validator registry",
         ),
     )

--- a/tests/consensus/lstar/state_transition/test_slot_monotonicity.py
+++ b/tests/consensus/lstar/state_transition/test_slot_monotonicity.py
@@ -44,7 +44,7 @@ def test_process_slots_target_equal_to_state_slot_rejected(
         post=None,
         expected_rejection=ExpectedRejection(
             reason=RejectionReason.BLOCK_SLOT_NOT_IN_FUTURE,
-            message_substring="Target slot must be in the future",
+            exact_message="Target slot must be in the future",
         ),
     )
 
@@ -82,6 +82,6 @@ def test_block_at_parent_slot_rejected_when_slot_processing_skipped(
         post=None,
         expected_rejection=ExpectedRejection(
             reason=RejectionReason.BLOCK_OLDER_THAN_LATEST_HEADER,
-            message_substring="Block is older than latest header",
+            exact_message="Block is older than latest header",
         ),
     )


### PR DESCRIPTION
Many lstar negative-path vectors pinned rejections with `message_substring` even where the substring equaled the full static source message, which is strictly weaker (an appended clause or two converging reasons would pass undetected).

This switches every such substring to `exact_message` carrying the complete message, keeping `message_substring` only where the source message has a genuinely dynamic tail (validator index, block root hex, or nested exception text).

Verified with `just check` (all green) and `uv run fill --fork=lstar --clean -n auto` (539 vectors pass, determinism check passes; the fill self-check confirms each exact message matches the source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)