### PR TITLE
fix(forks): enforce distinct-attestation-data cap in state transition

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -571,8 +571,8 @@ class ForkChoiceMixin(LstarSpecBase):
             #     votes  ->  { vote A, vote B, vote B }  ->  distinct { vote A, vote B }
             #
             # A repeat (fewer distinct than total) is rejected as duplicate data.
-            # The transition itself bounds the distinct-data count, so only the
-            # wire-level duplicate prohibition lives here.
+            # The transition itself bounds the distinct-data count.
+            # Only the wire-level duplicate prohibition lives here.
             aggregated_attestations = block.body.attestations
             attestation_data_set = {attestation.data for attestation in aggregated_attestations}
             if len(attestation_data_set) != len(aggregated_attestations):

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -10,7 +10,6 @@ from lean_spec.spec.forks.lstar._base import LstarSpecBase, LstarStore
 from lean_spec.spec.forks.lstar.config import (
     GOSSIP_DISPARITY_INTERVALS,
     INTERVALS_PER_SLOT,
-    MAX_ATTESTATIONS_DATA,
 )
 from lean_spec.spec.forks.lstar.containers import (
     AggregationError,
@@ -565,14 +564,15 @@ class ForkChoiceMixin(LstarSpecBase):
                     f"Sync parent chain before processing block at slot {block.slot}.",
                 )
 
-            # Bound the distinct votes the block may carry.
+            # Reject a block body that repeats the same vote data.
             #
             # Collapsing the votes to their distinct data exposes any repeat:
             #
             #     votes  ->  { vote A, vote B, vote B }  ->  distinct { vote A, vote B }
             #
             # A repeat (fewer distinct than total) is rejected as duplicate data.
-            # More distinct votes than the cap is rejected to bound import work.
+            # The transition itself bounds the distinct-data count, so only the
+            # wire-level duplicate prohibition lives here.
             aggregated_attestations = block.body.attestations
             attestation_data_set = {attestation.data for attestation in aggregated_attestations}
             if len(attestation_data_set) != len(aggregated_attestations):
@@ -580,12 +580,6 @@ class ForkChoiceMixin(LstarSpecBase):
                     RejectionReason.DUPLICATE_ATTESTATION_DATA,
                     "Block contains duplicate AttestationData entries; "
                     "each AttestationData must appear at most once",
-                )
-            if len(attestation_data_set) > int(MAX_ATTESTATIONS_DATA):
-                raise SpecRejectionError(
-                    RejectionReason.TOO_MANY_ATTESTATION_DATA,
-                    f"Block contains {len(attestation_data_set)} distinct AttestationData "
-                    f"entries; maximum is {MAX_ATTESTATIONS_DATA}",
                 )
 
             # Validate cryptographic signatures.

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -263,16 +263,16 @@ class StateTransitionMixin(LstarSpecBase):
         """
         # Bound the distinct votes the block may carry.
         #
-        # This is a property of the transition itself, not of any one caller.
-        # The state transition and block-production trial blocks both rely on it.
+        # The cap belongs to the transition itself, not to any one caller.
+        # Both the state transition and block-production trial blocks rely on it.
         #
-        # Each distinct attestation data builds a tally proportional to the
-        # validator count, so an unbounded distinct count amplifies import work.
+        # Each distinct attestation data builds a tally sized to the validator set.
+        # An unbounded count of them amplifies import work.
         # The SSZ list limit sits far above the consensus cap, so it cannot substitute.
         #
-        # Split aggregates for one target share their data, so they count once.
-        # Re-marking a voter is idempotent, so repeated data stays valid here.
-        # Only the number of distinct data entries is bounded.
+        # Only the distinct count is bounded, not the total.
+        # Split aggregates for one target share their data and count once.
+        # Re-marking a voter from a repeated entry is idempotent, so it stays valid.
         aggregated_attestations = tuple(attestations)
         distinct_attestation_data = {attestation.data for attestation in aggregated_attestations}
         if len(distinct_attestation_data) > int(MAX_ATTESTATIONS_DATA):

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks.lstar._base import LstarSpecBase
+from lean_spec.spec.forks.lstar.config import MAX_ATTESTATIONS_DATA
 from lean_spec.spec.forks.lstar.containers import (
     AggregatedAttestation,
     Block,
@@ -253,11 +254,34 @@ class StateTransitionMixin(LstarSpecBase):
         Apply attestations and update justification and finalization under 3SF-mini rules.
 
         Raises:
+            SpecRejectionError: TOO_MANY_ATTESTATION_DATA if the distinct data
+                count exceeds the per-block cap.
             SpecRejectionError: EMPTY_AGGREGATION_BITS if an attestation that passes
                 the vote filters has no set bits.
             SpecRejectionError: VALIDATOR_INDEX_OUT_OF_RANGE if a set bit points
                 outside the validator registry.
         """
+        # Bound the distinct votes the block may carry.
+        #
+        # This is a property of the transition itself, not of any one caller.
+        # The state transition and block-production trial blocks both rely on it.
+        #
+        # Each distinct attestation data builds a tally proportional to the
+        # validator count, so an unbounded distinct count amplifies import work.
+        # The SSZ list limit sits far above the consensus cap, so it cannot substitute.
+        #
+        # Split aggregates for one target share their data, so they count once.
+        # Re-marking a voter is idempotent, so repeated data stays valid here.
+        # Only the number of distinct data entries is bounded.
+        aggregated_attestations = tuple(attestations)
+        distinct_attestation_data = {attestation.data for attestation in aggregated_attestations}
+        if len(distinct_attestation_data) > int(MAX_ATTESTATIONS_DATA):
+            raise SpecRejectionError(
+                RejectionReason.TOO_MANY_ATTESTATION_DATA,
+                f"Block contains {len(distinct_attestation_data)} distinct AttestationData "
+                f"entries; maximum is {MAX_ATTESTATIONS_DATA}",
+            )
+
         # Reconstruct the vote-tracking structure
         #
         # The state stores justification data in a compact SSZ layout:
@@ -312,7 +336,7 @@ class StateTransitionMixin(LstarSpecBase):
         # "I vote to extend the chain from SOURCE to TARGET."
         #
         # The rules below filter out invalid or irrelevant votes.
-        for attestation in attestations:
+        for attestation in aggregated_attestations:
             source = attestation.data.source
             target = attestation.data.target
 

--- a/tests/consensus/lstar/fork_choice/test_block_attestation_limits.py
+++ b/tests/consensus/lstar/fork_choice/test_block_attestation_limits.py
@@ -6,12 +6,11 @@ from consensus_testing import (
     AggregatedAttestationSpec,
     BlockSpec,
     BlockStep,
-    ExpectedRejection,
     ForkChoiceStep,
     ForkChoiceTestFiller,
     StoreChecks,
 )
-from lean_spec.spec.forks import RejectionReason, Slot, ValidatorIndex
+from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.config import MAX_ATTESTATIONS_DATA
 
 pytestmark = pytest.mark.valid_until("Lstar")
@@ -82,85 +81,6 @@ def test_block_with_maximum_attestations(
                 ],
             ),
             checks=StoreChecks(head_slot=proposal_slot),
-        )
-    )
-
-    fork_choice_test(
-        steps=chain,
-    )
-
-
-def test_block_exceeding_maximum_attestations_is_rejected(
-    fork_choice_test: ForkChoiceTestFiller,
-) -> None:
-    """
-    A block holding one more than the maximum number of distinct votes is rejected.
-
-    Given
-    -----
-    - 4 validators; a slot needs 3 votes (2/3) to be justified.
-    - the chain:
-        genesis -> one block per justifiable slot after genesis
-    - the chain holds one more justifiable slot than the maximum allows.
-
-    When
-    ----
-    - a final block carries the maximum number of votes from the builder.
-    - one forced vote pushes the count one over the limit.
-
-    Then
-    ----
-    - the store rejects the block for exceeding the distinct attestation data limit.
-    """
-    n = int(MAX_ATTESTATIONS_DATA)
-    targets = _justifiable_slots(n + 1)
-    proposal_slot = Slot(targets[-1] + Slot(1))
-
-    chain: list[ForkChoiceStep] = [
-        BlockStep(
-            block=BlockSpec(
-                slot=s,
-                label=f"b_{s}",
-                parent_label=f"b_{targets[i - 1]}" if i > 0 else None,
-            )
-        )
-        for i, s in enumerate(targets)
-    ]
-
-    builder_targets = targets[:n]
-    forced_target = targets[n]
-
-    chain.append(
-        BlockStep(
-            block=BlockSpec(
-                slot=proposal_slot,
-                parent_label=f"b_{targets[-1]}",
-                attestations=[
-                    AggregatedAttestationSpec(
-                        validator_indices=[ValidatorIndex(i % 4)],
-                        slot=proposal_slot,
-                        target_slot=s,
-                        target_root_label=f"b_{s}",
-                    )
-                    for i, s in enumerate(builder_targets)
-                ],
-                forced_attestations=[
-                    AggregatedAttestationSpec(
-                        validator_indices=[ValidatorIndex(0)],
-                        slot=proposal_slot,
-                        target_slot=forced_target,
-                        target_root_label=f"b_{forced_target}",
-                    ),
-                ],
-            ),
-            valid=False,
-            expected_rejection=ExpectedRejection(
-                reason=RejectionReason.TOO_MANY_ATTESTATION_DATA,
-                exact_message=(
-                    f"Block contains {n + 1} distinct AttestationData entries; "
-                    f"maximum is {MAX_ATTESTATIONS_DATA}"
-                ),
-            ),
         )
     )
 

--- a/tests/consensus/lstar/state_transition/test_attestation_data_limits.py
+++ b/tests/consensus/lstar/state_transition/test_attestation_data_limits.py
@@ -1,0 +1,91 @@
+"""State Transition: Attestation Data Limits"""
+
+import pytest
+
+from consensus_testing import (
+    AggregatedAttestationSpec,
+    BlockSpec,
+    ExpectedRejection,
+    StateTransitionTestFiller,
+)
+from lean_spec.spec.forks import RejectionReason, Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.config import MAX_ATTESTATIONS_DATA
+
+pytestmark = pytest.mark.valid_until("Lstar")
+
+
+def _justifiable_slots(count: int) -> list[Slot]:
+    """Return the first COUNT justifiable slots after finalized genesis (slot 0)."""
+    justifiable_slots: list[Slot] = []
+    candidate_slot = Slot(1)
+    while len(justifiable_slots) < count:
+        if candidate_slot.is_justifiable_after(Slot(0)):
+            justifiable_slots.append(candidate_slot)
+        candidate_slot = Slot(candidate_slot + Slot(1))
+    return justifiable_slots
+
+
+def test_block_exceeding_distinct_attestation_data_cap_rejects_block(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    A block carrying more distinct attestation data than the cap rejects in the transition.
+
+    Given
+    -----
+    - 4 validators.
+    - the cap on distinct attestation data per block is 8.
+    - the chain:
+        genesis -> one block per justifiable slot, one more than the cap allows
+    - the final block carries one forced vote per distinct target.
+    - the forced votes bypass the proposer-side builder cap.
+
+    When
+    ----
+    - the chain processes the final block.
+
+    Then
+    ----
+    - the block is rejected with TOO_MANY_ATTESTATION_DATA.
+    - the count over the cap is 9 distinct entries against a maximum of 8.
+    """
+    over_cap_count = int(MAX_ATTESTATIONS_DATA) + 1
+    target_slots = _justifiable_slots(over_cap_count)
+    proposal_slot = Slot(target_slots[-1] + Slot(1))
+
+    chain: list[BlockSpec] = [
+        BlockSpec(
+            slot=target_slot,
+            label=f"block_{target_slot}",
+            parent_label=f"block_{target_slots[position - 1]}" if position > 0 else None,
+        )
+        for position, target_slot in enumerate(target_slots)
+    ]
+
+    chain.append(
+        BlockSpec(
+            slot=proposal_slot,
+            parent_label=f"block_{target_slots[-1]}",
+            forced_attestations=[
+                AggregatedAttestationSpec(
+                    validator_indices=[ValidatorIndex(position % 4)],
+                    slot=proposal_slot,
+                    target_slot=target_slot,
+                    target_root_label=f"block_{target_slot}",
+                )
+                for position, target_slot in enumerate(target_slots)
+            ],
+        )
+    )
+
+    state_transition_test(
+        blocks=chain,
+        post=None,
+        expected_rejection=ExpectedRejection(
+            reason=RejectionReason.TOO_MANY_ATTESTATION_DATA,
+            exact_message=(
+                f"Block contains {over_cap_count} distinct AttestationData "
+                f"entries; maximum is {MAX_ATTESTATIONS_DATA}"
+            ),
+        ),
+    )


### PR DESCRIPTION
The per-block cap on distinct attestation data (MAX_ATTESTATIONS_DATA) was enforced only at the fork-choice caller, so the raw state transition and block-production trial blocks inherited an unbounded count of distinct AttestationData, each an allocation proportional to the validator count (the SSZ list limit sits far above the consensus cap).

Move the distinct-data cap into the attestation-processing step so the bound is a property of the transition itself; the wire-level duplicate prohibition stays at the caller, since split aggregates sharing one data entry are a legitimate, idempotently merged transition input.

Verified: full `uv run fill --fork=lstar --clean -n auto` green with the determinism check passing, and `just check` passes. Adds a state-transition over-cap vector and relocates the fork-choice over-cap vector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)