### PR TITLE
refactor(state-transition): simplify slot increment and module docstring

### DIFF
--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -1,4 +1,4 @@
-"""Lstar fork — state transition: slots, header, body, finalization."""
+"""Lstar fork — state transition."""
 
 from collections.abc import Iterable
 from typing import Any
@@ -95,7 +95,7 @@ class StateTransitionMixin(LstarSpecBase):
                     "latest_block_header": state.latest_block_header.model_copy(
                         update={"state_root": cached_state_root}
                     ),
-                    "slot": Slot(state.slot + Slot(1)),
+                    "slot": state.slot + Slot(1),
                 }
             )
 


### PR DESCRIPTION
## Summary

Two small cleanups in the lstar state transition module:

- Drop the redundant `Slot(...)` wrapper around `state.slot + Slot(1)` — the sum is already a `Slot`, so re-wrapping adds noise.
- Shorten the module header to a single plain summary line, matching the terse-docstring convention.

## Testing

- `just check` passes (ruff lint, format, ty, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)