### PR TITLE
refactor(node/storage): tighten docs and fix two pruning defects

### DIFF
--- a/src/lean_spec/node/storage/__init__.py
+++ b/src/lean_spec/node/storage/__init__.py
@@ -1,9 +1,4 @@
-"""
-Storage module for persistent block and state storage.
-
-Provides database abstraction for consensus data persistence.
-Uses SQLite for simplicity and correctness.
-"""
+"""Persistent storage for consensus blocks, states, and checkpoints."""
 
 from lean_spec.node.storage.database import Database
 from lean_spec.node.storage.exceptions import (

--- a/src/lean_spec/node/storage/database.py
+++ b/src/lean_spec/node/storage/database.py
@@ -1,9 +1,4 @@
-"""
-Abstract database interface for consensus data storage.
-
-Defines the Protocol that all database implementations must follow.
-Uses structural subtyping for flexibility.
-"""
+"""Abstract database interface for consensus data storage."""
 
 from __future__ import annotations
 
@@ -21,147 +16,71 @@ from lean_spec.spec.ssz import Bytes32, Uint64
 
 class Database(Protocol):
     """
-    Protocol for consensus data storage.
+    Storage interface for consensus data.
 
-    All database implementations must provide these methods.
-    Uses structural subtyping - any class with matching methods satisfies the protocol.
-
-    Storage Organization
-    --------------------
-    - Blocks: Indexed by block root hash
-    - States: Indexed by associated block root hash (not state root)
-    - Checkpoints: Justified and finalized tracking
-    - State root index: Maps state roots to block roots
+    States are keyed by their associated block root, not their state root.
     """
 
     # Block Operations
 
     def get_block(self, root: Bytes32) -> SpecBlockType | None:
-        """
-        Retrieve a block by its root hash.
-
-        Args:
-            root: SSZ hash tree root of the block.
-
-        Returns:
-            Block if found, None otherwise.
-        """
+        """Retrieve a block by its root hash."""
         ...
 
     def put_block(self, block: SpecBlockType, root: Bytes32) -> None:
         """
-        Store a block with its root hash.
+        Store a block under its root hash.
 
-        Args:
-            block: Block to store.
-            root: Pre-computed root hash (avoids recomputation).
+        The caller passes the precomputed root to avoid recomputing it.
         """
         ...
 
     # State Operations
 
     def get_state(self, root: Bytes32) -> SpecStateType | None:
-        """
-        Retrieve a state by its associated block root.
-
-        Args:
-            root: Block root hash associated with this state.
-
-        Returns:
-            State if found, None otherwise.
-        """
+        """Retrieve a state by its associated block root."""
         ...
 
     def put_state(self, state: SpecStateType, root: Bytes32) -> None:
-        """
-        Store a state indexed by its associated block root.
-
-        Args:
-            state: State to store.
-            root: Block root hash associated with this state.
-        """
+        """Store a state under its associated block root."""
         ...
 
     # Checkpoint Operations
 
     def get_justified_checkpoint(self) -> Checkpoint | None:
-        """
-        Retrieve the latest justified checkpoint.
-
-        Returns:
-            Latest justified checkpoint, or None if not set.
-        """
+        """Retrieve the latest justified checkpoint, or None if unset."""
         ...
 
     def put_justified_checkpoint(self, checkpoint: Checkpoint) -> None:
-        """
-        Store the latest justified checkpoint.
-
-        Args:
-            checkpoint: New justified checkpoint.
-        """
+        """Store the latest justified checkpoint."""
         ...
 
     def get_finalized_checkpoint(self) -> Checkpoint | None:
-        """
-        Retrieve the latest finalized checkpoint.
-
-        Returns:
-            Latest finalized checkpoint, or None if not set.
-        """
+        """Retrieve the latest finalized checkpoint, or None if unset."""
         ...
 
     def put_finalized_checkpoint(self, checkpoint: Checkpoint) -> None:
-        """
-        Store the latest finalized checkpoint.
-
-        Args:
-            checkpoint: New finalized checkpoint.
-        """
+        """Store the latest finalized checkpoint."""
         ...
 
     # Head Tracking
 
     def get_head_root(self) -> Bytes32 | None:
-        """
-        Retrieve the current head block root.
-
-        Returns:
-            Head block root, or None if not set.
-        """
+        """Retrieve the current head block root, or None if unset."""
         ...
 
     def put_head_root(self, root: Bytes32) -> None:
-        """
-        Store the current head block root.
-
-        Args:
-            root: New head block root.
-        """
+        """Store the current head block root."""
         ...
 
     # Slot Index Operations
 
     def get_block_root_by_slot(self, slot: Slot) -> Bytes32 | None:
-        """
-        Retrieve block root for a specific slot.
-
-        Args:
-            slot: Slot number to look up.
-
-        Returns:
-            Block root at that slot, or None if no block.
-        """
+        """Retrieve the canonical block root at a slot, or None if none."""
         ...
 
     def put_block_root_by_slot(self, slot: Slot, root: Bytes32) -> None:
-        """
-        Index a block root by its slot.
-
-        Args:
-            slot: Slot of the block.
-            root: Root hash of the block.
-        """
+        """Index a block root by its slot."""
         ...
 
     # State Root Index Operations
@@ -170,46 +89,26 @@ class Database(Protocol):
         """
         Look up the block root associated with a state root.
 
-        Needed for checkpoint sync and API endpoints that query by state root.
-
-        Args:
-            state_root: SSZ hash tree root of the state.
-
-        Returns:
-            Associated block root, or None if not indexed.
+        Needed for checkpoint sync and queries that key on state root.
         """
         ...
 
     def put_block_root_by_state_root(self, state_root: Bytes32, block_root: Bytes32) -> None:
-        """
-        Index a block root by the state root it produced.
-
-        Args:
-            state_root: SSZ hash tree root of the post-state.
-            block_root: Root of the block that produced this state.
-        """
+        """Index a block root by the state root it produced."""
         ...
 
     # Genesis Time
 
     def get_genesis_time(self) -> Uint64 | None:
         """
-        Retrieve the stored genesis time.
+        Retrieve the stored genesis time, or None if unset.
 
-        Enables self-contained restarts without external genesis config.
-
-        Returns:
-            Genesis time as Unix timestamp, or None if not set.
+        Persisting it lets the node restart without external genesis config.
         """
         ...
 
     def put_genesis_time(self, genesis_time: Uint64) -> None:
-        """
-        Store genesis time for future restarts.
-
-        Args:
-            genesis_time: Unix timestamp of genesis (slot 0).
-        """
+        """Store the genesis time as a Unix timestamp."""
         ...
 
     # Transaction Control
@@ -217,10 +116,9 @@ class Database(Protocol):
     @contextmanager
     def batch_write(self) -> Generator[None]:
         """
-        Context manager for atomic multi-write operations.
+        Group writes into one atomic transaction.
 
-        All writes within the block are committed atomically on exit.
-        Rolls back on exception to prevent partial writes.
+        Commits on clean exit, rolls back on any exception.
         """
         ...
 
@@ -228,17 +126,11 @@ class Database(Protocol):
 
     def prune_before_slot(self, slot: Slot, keep_roots: frozenset[Bytes32]) -> int:
         """
-        Remove blocks and states with slots strictly before the given slot.
+        Remove blocks and states with slots strictly below the given slot.
 
-        Preserves entries whose roots are in keep_roots (e.g., the finalized block).
-        Cleans up associated slot index entries.
-
-        Args:
-            slot: Prune entries with slots strictly below this value.
-            keep_roots: Roots to preserve regardless of slot.
-
-        Returns:
-            Total number of entries pruned across all tables.
+        Roots in the keep set survive regardless of slot.
+        Associated slot-index and state-root-index entries are removed with them.
+        Returns the total number of rows removed.
         """
         ...
 

--- a/src/lean_spec/node/storage/exceptions.py
+++ b/src/lean_spec/node/storage/exceptions.py
@@ -1,10 +1,4 @@
-"""
-Storage exception hierarchy.
-
-Wraps low-level database and serialization errors with storage-specific context.
-This allows callers to handle storage failures uniformly without knowing the
-underlying backend (SQLite, etc.).
-"""
+"""Storage exceptions that wrap backend and serialization failures."""
 
 
 class StorageError(Exception):

--- a/src/lean_spec/node/storage/namespaces.py
+++ b/src/lean_spec/node/storage/namespaces.py
@@ -1,9 +1,4 @@
-"""
-Database namespace definitions for storage tables.
-
-Defines table names and schema constants for SQLite storage.
-Each prefix marks a logical grouping of related data.
-"""
+"""Table names and schema SQL for the SQLite storage backend."""
 
 from __future__ import annotations
 
@@ -12,7 +7,6 @@ from typing import Final
 # Blocks: SSZ root primary key, SSZ-encoded bytes stored directly.
 
 BLOCKS_TABLE_NAME: Final = "blocks"
-"""Table name for block storage."""
 
 BLOCKS_CREATE_TABLE: Final = """
     CREATE TABLE IF NOT EXISTS blocks (
@@ -21,17 +15,14 @@ BLOCKS_CREATE_TABLE: Final = """
         data BLOB NOT NULL
     )
 """
-"""SQL to create blocks table."""
 
 BLOCKS_CREATE_INDEX: Final = """
     CREATE INDEX IF NOT EXISTS idx_blocks_slot ON blocks(slot)
 """
-"""SQL to create slot index."""
 
 # States: SSZ root primary key, SSZ-encoded bytes stored directly.
 
 STATES_TABLE_NAME: Final = "states"
-"""Table name for state storage."""
 
 STATES_CREATE_TABLE: Final = """
     CREATE TABLE IF NOT EXISTS states (
@@ -40,29 +31,23 @@ STATES_CREATE_TABLE: Final = """
         data BLOB NOT NULL
     )
 """
-"""SQL to create states table."""
 
 STATES_CREATE_INDEX: Final = """
     CREATE INDEX IF NOT EXISTS idx_states_slot ON states(slot)
 """
-"""SQL to create slot index."""
 
 # Checkpoints: key-value table with fixed keys for justified/finalized/head/genesis-time.
 
 CHECKPOINTS_TABLE_NAME: Final = "checkpoints"
-"""Table name for checkpoint storage."""
 
 CHECKPOINTS_KEY_JUSTIFIED: Final = "justified"
-"""Key for justified checkpoint."""
 
 CHECKPOINTS_KEY_FINALIZED: Final = "finalized"
-"""Key for finalized checkpoint."""
 
 CHECKPOINTS_KEY_HEAD: Final = "head"
-"""Key for head block root."""
 
 CHECKPOINTS_KEY_GENESIS_TIME: Final = "genesis_time"
-"""Key for genesis time. Enables self-contained restarts without external config."""
+"""Persisted so the node can restart without external genesis config."""
 
 CHECKPOINTS_CREATE_TABLE: Final = """
     CREATE TABLE IF NOT EXISTS checkpoints (
@@ -70,12 +55,10 @@ CHECKPOINTS_CREATE_TABLE: Final = """
         data BLOB NOT NULL
     )
 """
-"""SQL to create checkpoints table."""
 
 # Slot index: slot-to-root mapping for historical queries.
 
 SLOT_INDEX_TABLE_NAME: Final = "slot_index"
-"""Table name for slot index."""
 
 SLOT_INDEX_CREATE_TABLE: Final = """
     CREATE TABLE IF NOT EXISTS slot_index (
@@ -83,12 +66,10 @@ SLOT_INDEX_CREATE_TABLE: Final = """
         root BLOB NOT NULL
     )
 """
-"""SQL to create slot index table."""
 
 # State root index: state-root-to-block-root mapping for checkpoint sync and API.
 
 STATE_ROOT_INDEX_TABLE_NAME: Final = "state_root_index"
-"""Table name for state root index."""
 
 STATE_ROOT_INDEX_CREATE_TABLE: Final = """
     CREATE TABLE IF NOT EXISTS state_root_index (
@@ -96,4 +77,3 @@ STATE_ROOT_INDEX_CREATE_TABLE: Final = """
         block_root BLOB NOT NULL
     )
 """
-"""SQL to create state root index table."""

--- a/src/lean_spec/node/storage/sqlite.py
+++ b/src/lean_spec/node/storage/sqlite.py
@@ -1,19 +1,10 @@
 """
-SQLite database implementation for consensus data storage.
+SQLite-backed persistent storage for consensus data.
 
-This module provides persistent storage for Ethereum consensus data:
-
-- Blocks and states indexed by their SSZ root hash
-- Checkpoints for tracking justification and finalization
-- Attestations indexed by validator
-- Slot-to-root mappings for historical queries
-- State root to block root index for checkpoint sync
-
-All data is stored as SSZ-encoded bytes in BLOB columns.
-The SSZ format ensures deterministic serialization across implementations.
-
-Writes are not auto-committed. Callers must use batch_write() for multi-write
-atomicity or commit() for single-write durability.
+All values are stored as SSZ-encoded bytes in BLOB columns.
+Writes do not persist on their own.
+Every write must run inside a batch-write block, which commits atomically on
+exit and rolls back on error.
 """
 
 from __future__ import annotations
@@ -56,15 +47,10 @@ from lean_spec.spec.ssz import Bytes32, Uint64
 
 class SQLiteDatabase:
     """
-    SQLite implementation of the Database protocol.
+    SQLite-backed implementation of the storage interface.
 
-    Stores consensus data in a single SQLite file.
-    Thread-safe through SQLite's built-in locking.
-
-    Data is stored as SSZ-encoded bytes.
-    Deserialization happens on read.
-
-    Writes are buffered until explicitly committed via commit() or batch_write().
+    All access must come from a single writer on the node's event-loop thread.
+    A shared connection with buffered writes is not safe for concurrent writers.
     """
 
     def __init__(
@@ -73,33 +59,19 @@ class SQLiteDatabase:
         state_class: type[SpecStateType],
         block_class: type[SpecBlockType],
     ) -> None:
-        """
-        Initialize SQLite database.
-
-        Creates database file and tables if they don't exist.
-
-        Args:
-            path: Path to SQLite database file.
-                  Use ":memory:" for in-memory database.
-            state_class: State class used to decode SSZ bytes.
-            block_class: Block class used to decode SSZ bytes.
-        """
+        """Open the database file (or ":memory:") and create tables if absent."""
         self._path = Path(path) if isinstance(path, str) else path
         self._state_class = state_class
         self._block_class = block_class
 
-        # SQLite handles concurrent access through file-level locking.
-        #
-        # The check_same_thread=False flag allows multiple threads to share
-        # this connection. SQLite serializes writes internally.
+        # Disable the per-thread guard so a reader on another thread does not raise.
+        # This grants no synchronization: writes must still come from one thread.
         self._connection = sqlite3.connect(
             str(self._path),
             check_same_thread=False,
         )
 
-        # Row factory enables dict-like access: row["column_name"].
-        #
-        # This makes the code more readable than tuple indexing.
+        # Row factory enables access by column name: row["column_name"].
         self._connection.row_factory = sqlite3.Row
 
         self._init_schema()
@@ -108,28 +80,15 @@ class SQLiteDatabase:
         """Create tables if they don't exist."""
         cursor = self._connection.cursor()
 
-        # Block and state tables use root hash as primary key.
-        #
-        # This matches how consensus clients identify data: by SSZ merkle root.
-        # The slot index enables efficient range queries for historical data.
         cursor.execute(BLOCKS_CREATE_TABLE)
         cursor.execute(BLOCKS_CREATE_INDEX)
         cursor.execute(STATES_CREATE_TABLE)
         cursor.execute(STATES_CREATE_INDEX)
 
-        # Checkpoints use a key-value pattern for singleton values.
-        #
-        # Only one justified and one finalized checkpoint exist at any time.
+        # Checkpoints are singletons, so a small key-value table suffices.
         cursor.execute(CHECKPOINTS_CREATE_TABLE)
 
-        # Slot index maps slot numbers to block roots.
-        #
-        # Enables queries like "what block was at slot N?"
         cursor.execute(SLOT_INDEX_CREATE_TABLE)
-
-        # State root index maps state roots to block roots.
-        #
-        # Needed for checkpoint sync and API endpoints that query by state root.
         cursor.execute(STATE_ROOT_INDEX_CREATE_TABLE)
 
         self._connection.commit()
@@ -140,11 +99,6 @@ class SQLiteDatabase:
         """Retrieve a block by its root hash."""
         try:
             cursor = self._connection.cursor()
-
-            # Query by root hash, the canonical identifier in consensus.
-            #
-            # The root is the SSZ merkle root of the block.
-            # This 32-byte hash uniquely identifies the block content.
             cursor.execute(
                 f"SELECT data FROM {BLOCKS_TABLE_NAME} WHERE root = ?",
                 (bytes(root),),
@@ -167,12 +121,6 @@ class SQLiteDatabase:
         """Store a block with its root hash."""
         try:
             cursor = self._connection.cursor()
-
-            # INSERT OR REPLACE handles both new blocks and updates.
-            #
-            # While blocks should be immutable (same root = same content),
-            # this pattern simplifies the code without correctness issues.
-            # The slot column enables efficient historical range queries.
             cursor.execute(
                 f"""
                 INSERT OR REPLACE INTO {BLOCKS_TABLE_NAME} (root, slot, data)
@@ -186,11 +134,6 @@ class SQLiteDatabase:
             ) from exception
 
     # State Operations
-
-    #
-    # States are the full beacon chain state at a given slot.
-    # They are large (~2MB+) and expensive to compute from scratch.
-    # Storing states enables fast re-initialization and historical queries.
 
     def get_state(self, root: Bytes32) -> SpecStateType | None:
         """Retrieve a state by its associated block root."""
@@ -220,11 +163,6 @@ class SQLiteDatabase:
         """Store a state indexed by its associated block root."""
         try:
             cursor = self._connection.cursor()
-
-            # States should be stored at epoch boundaries for efficient access.
-            #
-            # Clients typically store one state per epoch to balance
-            # storage costs against replay costs for intermediate slots.
             cursor.execute(
                 f"""
                 INSERT OR REPLACE INTO {STATES_TABLE_NAME} (root, slot, data)
@@ -239,20 +177,10 @@ class SQLiteDatabase:
 
     # Checkpoint Operations
 
-    #
-    # Checkpoints mark finality progress in the consensus protocol.
-    # Justified checkpoints have 2/3 validator support.
-    # Finalized checkpoints are irreversible - blocks before them never reorg.
-
     def get_justified_checkpoint(self) -> Checkpoint | None:
         """Retrieve the latest justified checkpoint."""
         try:
             cursor = self._connection.cursor()
-
-            # Justified checkpoint: has received 2/3 attestation weight.
-            #
-            # This checkpoint may still be reverted if a competing
-            # checkpoint gains more support. Not yet final.
             cursor.execute(
                 f"SELECT data FROM {CHECKPOINTS_TABLE_NAME} WHERE key = ?",
                 (CHECKPOINTS_KEY_JUSTIFIED,),
@@ -293,11 +221,6 @@ class SQLiteDatabase:
         """Retrieve the latest finalized checkpoint."""
         try:
             cursor = self._connection.cursor()
-
-            # Finalized checkpoint: irreversible under normal operation.
-            #
-            # Once finalized, all blocks in the checkpoint's chain are permanent.
-            # Reorging past finality requires 1/3 validators to be slashed.
             cursor.execute(
                 f"SELECT data FROM {CHECKPOINTS_TABLE_NAME} WHERE key = ?",
                 (CHECKPOINTS_KEY_FINALIZED,),
@@ -336,19 +259,10 @@ class SQLiteDatabase:
 
     # Head Tracking
 
-    #
-    # The head is the tip of the canonical chain as determined by fork choice.
-    # This is a singleton value that changes as new blocks arrive.
-
     def get_head_root(self) -> Bytes32 | None:
         """Retrieve the current head block root."""
         try:
             cursor = self._connection.cursor()
-
-            # The head root identifies the current best block.
-            #
-            # Fork choice updates this after processing each new block.
-            # Stored in the checkpoints table as a special singleton key.
             cursor.execute(
                 f"SELECT data FROM {CHECKPOINTS_TABLE_NAME} WHERE key = ?",
                 (CHECKPOINTS_KEY_HEAD,),
@@ -379,20 +293,10 @@ class SQLiteDatabase:
 
     # Slot Index Operations
 
-    #
-    # Slots are time intervals.
-    # This index maps slot numbers to blocks, enabling historical queries.
-    # Note: not every slot has a block (missed slots happen).
-
     def get_block_root_by_slot(self, slot: Slot) -> Bytes32 | None:
         """Retrieve block root for a specific slot."""
         try:
             cursor = self._connection.cursor()
-
-            # Returns the canonical block at this slot.
-            #
-            # A slot may have no block (proposer missed their turn).
-            # A slot may have had multiple competing blocks (only one is canonical).
             cursor.execute(
                 f"SELECT root FROM {SLOT_INDEX_TABLE_NAME} WHERE slot = ?",
                 (int(slot),),
@@ -411,11 +315,6 @@ class SQLiteDatabase:
         """Index a block root by its slot."""
         try:
             cursor = self._connection.cursor()
-
-            # Updates as the canonical chain changes.
-            #
-            # During reorgs, the same slot may point to different blocks
-            # at different times. This always reflects the current canonical chain.
             cursor.execute(
                 f"""
                 INSERT OR REPLACE INTO {SLOT_INDEX_TABLE_NAME} (slot, root)
@@ -429,11 +328,6 @@ class SQLiteDatabase:
             ) from exception
 
     # State Root Index Operations
-
-    #
-    # Maps state roots to block roots.
-    # Both ream (Rust) and zeam (Zig) maintain this index.
-    # Needed for checkpoint sync and API endpoints that query by state root.
 
     def get_block_root_by_state_root(self, state_root: Bytes32) -> Bytes32 | None:
         """Look up the block root associated with a state root."""
@@ -471,10 +365,6 @@ class SQLiteDatabase:
 
     # Genesis Time
 
-    #
-    # Storing genesis time in the database enables self-contained restarts.
-    # Without it, the node needs external configuration to know when genesis was.
-
     def get_genesis_time(self) -> Uint64 | None:
         """Retrieve the stored genesis time."""
         try:
@@ -490,7 +380,7 @@ class SQLiteDatabase:
         if row is None:
             return None
 
-        # Genesis time is stored as 8-byte little-endian integer.
+        # Genesis time is stored as an 8-byte little-endian integer.
         return Uint64(int.from_bytes(row["data"], byteorder="little"))
 
     def put_genesis_time(self, genesis_time: Uint64) -> None:
@@ -512,10 +402,9 @@ class SQLiteDatabase:
     @contextmanager
     def batch_write(self) -> Generator[None]:
         """
-        Context manager for atomic multi-write operations.
+        Group writes into one atomic transaction.
 
-        All writes within the block are committed atomically on exit.
-        Rolls back on exception to prevent partial writes.
+        Commits on clean exit, rolls back on any exception.
         """
         try:
             yield
@@ -532,34 +421,22 @@ class SQLiteDatabase:
 
     # Pruning
 
-    #
-    # When finalization advances, blocks/states before the finalized slot
-    # can be removed. Both ream (Rust) and zeam (Zig) implement pruning.
-
     def prune_before_slot(self, slot: Slot, keep_roots: frozenset[Bytes32]) -> int:
         """
-        Remove blocks and states with slots strictly before the given slot.
+        Remove blocks and states with slots strictly below the given slot.
 
-        Preserves entries whose roots are in keep_roots (e.g., the finalized block).
-        Cleans up associated slot index entries.
-
-        Args:
-            slot: Prune entries with slots strictly below this value.
-            keep_roots: Roots to preserve regardless of slot.
-
-        Returns:
-            Total number of entries pruned across all tables.
+        Roots in the keep set survive regardless of slot.
+        Associated slot-index and state-root-index entries are removed with them.
+        Returns the total number of rows removed.
         """
         try:
             cursor = self._connection.cursor()
             total_pruned = 0
 
-            # Build the exclusion set for parameterized queries.
             keep_root_bytes = [bytes(root) for root in keep_roots]
             placeholders = ",".join("?" for _ in keep_root_bytes)
 
             def prune_table_below_slot(table_name: str) -> int:
-                # Delete rows below the threshold, preserving kept roots.
                 # An empty keep set omits the NOT IN clause to avoid invalid empty parentheses.
                 if keep_root_bytes:
                     cursor.execute(
@@ -573,14 +450,19 @@ class SQLiteDatabase:
                     )
                 return cursor.rowcount
 
-            # Blocks and states share the same root and slot columns, so prune both identically.
+            # Blocks, states, and the slot index all carry root and slot columns,
+            # so the same keep-aware delete prunes each of them.
             total_pruned += prune_table_below_slot(BLOCKS_TABLE_NAME)
             total_pruned += prune_table_below_slot(STATES_TABLE_NAME)
+            total_pruned += prune_table_below_slot(SLOT_INDEX_TABLE_NAME)
 
-            # Prune slot index entries below the threshold.
+            # The state root index has no slot column, so drop the entries that
+            # now point at blocks no longer present.
             cursor.execute(
-                f"DELETE FROM {SLOT_INDEX_TABLE_NAME} WHERE slot < ?",
-                (int(slot),),
+                f"""
+                DELETE FROM {STATE_ROOT_INDEX_TABLE_NAME}
+                WHERE block_root NOT IN (SELECT root FROM {BLOCKS_TABLE_NAME})
+                """
             )
             total_pruned += cursor.rowcount
 
@@ -591,10 +473,6 @@ class SQLiteDatabase:
             ) from exception
 
     # Lifecycle
-
-    #
-    # SQLite connections should be explicitly closed when done.
-    # The context manager pattern ensures cleanup even on exceptions.
 
     def close(self) -> None:
         """Close database connection."""

--- a/tests/node/storage/test_sqlite.py
+++ b/tests/node/storage/test_sqlite.py
@@ -517,6 +517,53 @@ class TestPruning:
         with db.batch_write():
             assert db.prune_before_slot(Slot(100), keep_roots=frozenset()) == 0
 
+    def test_prune_removes_orphaned_state_root_index(
+        self, db: SQLiteDatabase, genesis_state: State
+    ) -> None:
+        """Pruning a block also removes its state-root index entry."""
+        block = Block(
+            slot=Slot(1),
+            proposer_index=ValidatorIndex(0),
+            parent_root=Bytes32.zero(),
+            state_root=hash_tree_root(genesis_state),
+            body=BlockBody(attestations=AggregatedAttestations(data=[])),
+        )
+        block_root = hash_tree_root(block)
+        state_root = Bytes32(b"\x0d" * 32)
+
+        with db.batch_write():
+            db.put_block(block, block_root)
+            db.put_block_root_by_state_root(state_root, block_root)
+
+        with db.batch_write():
+            db.prune_before_slot(Slot(3), keep_roots=frozenset())
+
+        assert db.get_block(block_root) is None
+        assert db.get_block_root_by_state_root(state_root) is None
+
+    def test_prune_keeps_slot_index_for_kept_root(
+        self, db: SQLiteDatabase, genesis_state: State
+    ) -> None:
+        """A kept root below the prune slot retains its slot index entry."""
+        block = Block(
+            slot=Slot(0),
+            proposer_index=ValidatorIndex(0),
+            parent_root=Bytes32.zero(),
+            state_root=hash_tree_root(genesis_state),
+            body=BlockBody(attestations=AggregatedAttestations(data=[])),
+        )
+        block_root = hash_tree_root(block)
+
+        with db.batch_write():
+            db.put_block(block, block_root)
+            db.put_block_root_by_slot(block.slot, block_root)
+
+        with db.batch_write():
+            db.prune_before_slot(Slot(3), keep_roots=frozenset({block_root}))
+
+        assert db.get_block(block_root) == block
+        assert db.get_block_root_by_slot(Slot(0)) == block_root
+
 
 class TestLifecycle:
     """Tests for database lifecycle management."""


### PR DESCRIPTION
## Summary

Clarity/documentation pass over `src/lean_spec/node/storage/`, plus two real pruning correctness fixes surfaced during review. The storage module is otherwise well-built — the get/put boilerplate, checkpoint accessors, and connection model are left as-is (refactoring them would trade readability for indirection and the rollback tests pin the current transaction model).

### Documentation
- Trim verbose docstrings and consensus-tutorial comments across all five files to the project rules. Kept the load-bearing rationale only: head is a raw root (not SSZ), genesis time is little-endian, the empty-keep-set branch, and blocks/states sharing columns.
- Fix three **doc inaccuracies** in the SQLite backend:
  - It referenced a `commit()` method that **does not exist** — durability is exclusively via the batch-write block, and a lone write outside it is rolled back on close. The docstring invited silent data loss.
  - It claimed thread-safety the shared-connection-with-buffered-writes design does not provide (it is single-writer / event-loop-only; the API server never touches the DB).
  - It listed "attestations indexed by validator" storage that does not exist.

### Pruning correctness
- **Prune the state-root index.** `prune_before_slot` never cleaned `state_root_index`, leaking rows indefinitely and leaving `get_block_root_by_state_root` able to resolve to a block that was already pruned. Now drops index entries whose block is no longer present.
- **Honor the keep set in the slot-index delete.** Blocks and states preserved roots in the keep set, but the slot index was deleted unconditionally by slot — so a preserved finalized block below the prune slot kept its block row but lost its slot mapping. Now consistent across all three tables.
- Added two tests covering the orphan-removal and kept-root cases. Existing prune count assertions are unaffected.

## Testing
- `just check` passes (ruff, format, ty, codespell, mdformat).
- `uv run pytest tests/node/storage tests/node/sync tests/node/test_node.py` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)