### PR TITLE
refactor(node/sync): tidy block cache and fix internal-node eviction

### DIFF
--- a/src/lean_spec/node/sync/block_cache.py
+++ b/src/lean_spec/node/sync/block_cache.py
@@ -1,41 +1,4 @@
-"""
-Block cache for downloaded blocks awaiting parent resolution.
-
-Why Cache Blocks?
-
-In an ideal world, blocks arrive in perfect order: parent before child, always.
-Reality differs. Network latency, parallel downloads, and gossip propagation
-mean blocks often arrive before their parents are known.
-
-Without caching, we would have two bad choices:
-
-1. **Drop the block**: Wasteful. We will need it later.
-2. **Re-request later**: Slow. Network round-trips add latency.
-
-The block cache provides a third option: hold the block until its parent
-arrives, then process both.
-
-How It Works
-
-The cache maintains three data structures:
-
-1. **Block storage**: Maps block root to PendingBlock (the block + metadata)
-2. **Orphan set**: Roots of blocks whose parents are completely unknown
-3. **Parent index**: Maps parent_root to child roots for descendant lookup
-
-When a parent arrives:
-
-1. Look up children via the parent index
-2. Check if those children can now be processed
-3. Process children in slot order (ensuring parent-before-child)
-4. Recursively check if processed children have their own waiting children
-
-Memory Safety
-
-The cache is bounded by MAX_CACHED_BLOCKS (1024). When full, FIFO eviction
-removes the oldest blocks. This prevents memory exhaustion from attacks or
-prolonged network partitions that could otherwise grow the cache unboundedly.
-"""
+"""Block cache for downloaded blocks awaiting parent resolution."""
 
 from __future__ import annotations
 
@@ -49,89 +12,39 @@ from lean_spec.spec.forks import SignedBlock, Slot
 from lean_spec.spec.ssz import Bytes32
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class PendingBlock:
-    """
-    A block awaiting integration into the Store.
-
-    PendingBlock wraps a SignedBlock with metadata needed for
-    cache management. This metadata answers key questions:
-
-    - **Who sent it?** For peer scoring when we determine validity
-    - **When did it arrive?** For timeout and staleness decisions
-    - **How deep is the backfill?** To enforce MAX_BACKFILL_DEPTH limit
-
-    Blocks remain pending until:
-
-    1. Their parent arrives and they can be processed (success)
-    2. They are evicted due to cache capacity limits (dropped)
-    3. They are determined to be invalid (rejected)
-    """
+    """A cached block plus the metadata needed to resolve and score it later."""
 
     block: SignedBlock
     """The complete signed block."""
 
     root: Bytes32
-    """
-    The SSZ hash tree root of the block.
-
-    Computed once at cache insertion for efficiency. All subsequent lookups
-    and comparisons use this cached value rather than recomputing.
-    """
+    """Hash tree root of the block, computed once at insertion to avoid recomputing."""
 
     parent_root: Bytes32
-    """
-    Root of the parent block.
-
-    Stored separately for quick parent relationship lookups without
-    deserializing the full block. This is the key to efficient descendant
-    processing.
-    """
+    """Root of the parent, stored separately so lookups need not deserialize the block."""
 
     slot: Slot
-    """
-    Slot of the block.
-
-    Used for ordering during batch processing. We must process blocks in
-    slot order to ensure parents are processed before children.
-    """
+    """Slot of the block, used to order batch processing so parents precede children."""
 
     received_from: PeerId | None
-    """
-    Peer that sent this block.
-
-    Essential for peer scoring.
-        - If the block is valid, the peer gets credit.
-        - If invalid, they get penalized.
-
-    This creates incentives for good behavior.
-    None for self-produced blocks.
-    """
+    """Peer that sent the block, for later scoring. None for self-produced blocks."""
 
     backfill_depth: int = 0
     """
-    Depth of backfill chain from original request.
+    How many ancestors deep this block was fetched while chasing a missing parent.
 
-    When fetching missing parents recursively, this tracks how deep we are.
-        - A block at depth 0 came directly from gossip or an explicit request.
-        - A block at depth 5 is the 5th ancestor we fetched while backfilling.
-
-    Blocks with depth >= MAX_BACKFILL_DEPTH trigger backfill termination
-    to prevent unbounded recursion during attacks or deep forks.
+    Bounds recursion so deep forks or attacks cannot backfill without limit.
     """
 
 
 @dataclass(slots=True)
 class BlockCache:
-    """
-    Cache for blocks awaiting parent resolution.
-
-    Holds blocks that cannot be immediately processed because their parent
-    blocks are not yet in the Store.
-    """
+    """Cache for blocks that cannot be processed yet because their parent is unknown."""
 
     _blocks: OrderedDict[Bytes32, PendingBlock] = field(default_factory=OrderedDict)
-    """Block storage ordered by insertion time for FIFO eviction."""
+    """Blocks ordered by insertion time, so the oldest can be evicted first."""
 
     _orphans: set[Bytes32] = field(default_factory=set)
     """Roots of blocks whose parents are completely unknown."""
@@ -154,82 +67,66 @@ class BlockCache:
         backfill_depth: int = 0,
     ) -> PendingBlock:
         """
-        Add a block to the cache.
+        Cache a block, evicting the oldest entry first if at capacity.
 
-        This is the primary entry point for caching blocks. The method handles:
-
-        1. Deduplication (same block added twice returns existing entry)
-        2. Capacity management (evicts oldest if full)
-        3. Index maintenance (updates parent->children mapping)
-
-        Args:
-            block: The signed block to cache.
-            peer: The peer that sent this block (for later scoring).
-            backfill_depth: How deep in the backfill chain (0 = direct request).
-
-        Returns:
-            The PendingBlock wrapper, either newly created or existing.
+        Returns the existing entry if the block is already cached.
         """
         block_inner = block.block
         root = hash_tree_root(block_inner)
 
-        # Deduplication: if we already have this block, return the existing entry.
+        # The same block can arrive from several peers, or be re-requested while pending.
         #
-        # This can happen when multiple peers send the same block via gossip,
-        # or when a block is requested while already pending.
+        # Return the existing entry instead of caching a duplicate.
         if root in self._blocks:
             return self._blocks[root]
 
-        # Capacity management: evict before adding to ensure we stay within bounds.
-        #
-        # We check >= rather than > because we are about to add one more.
+        # Use >= here, not >: we are about to add one entry, so evict at the limit.
         if len(self._blocks) >= MAX_CACHED_BLOCKS:
-            self._evict_oldest()
+            # Evict the oldest block (FIFO).
+            #
+            # Oldest-first means an attacker cannot keep a block cached by re-sending it.
+            evicted_root, evicted = self._blocks.popitem(last=False)
+            self._orphans.discard(evicted_root)
 
-        parent_root = block_inner.parent_root
+            # Detach the evicted block from its parent's child set.
+            siblings = self._by_parent.get(evicted.parent_root)
+            if siblings:
+                siblings.discard(evicted_root)
+                if not siblings:
+                    del self._by_parent[evicted.parent_root]
+
+            # Its cached children just lost their parent, so they are orphans again.
+            for child_root in self._by_parent.get(evicted_root, set()):
+                self.mark_orphan(child_root)
 
         pending = PendingBlock(
             block=block,
             root=root,
-            parent_root=parent_root,
+            parent_root=block_inner.parent_root,
             slot=block_inner.slot,
             received_from=peer,
             backfill_depth=backfill_depth,
         )
-
-        # Insert into primary storage.
         self._blocks[root] = pending
 
-        # Update parent index so we can find this block when its parent arrives.
-        self._by_parent[parent_root].add(root)
-
+        # Index by parent so this block is found when its parent is processed.
+        self._by_parent[block_inner.parent_root].add(root)
         return pending
 
     def remove(self, root: Bytes32) -> PendingBlock | None:
         """
-        Remove a block from the cache.
+        Remove a block and clean up its orphan and parent-index entries.
 
-        Called after a block has been successfully processed or determined
-        invalid. Maintains all index consistency automatically.
-
-        Args:
-            root: The block root to remove.
-
-        Returns:
-            The removed PendingBlock if it existed, None otherwise.
+        Returns the removed block, or None if it was not cached.
         """
         pending = self._blocks.pop(root, None)
         if pending is None:
             return None
 
-        # Clean up orphan tracking.
-        self.unmark_orphan(root)
+        self._orphans.discard(root)
 
-        # Clean up parent index.
-        #
-        # We must remove this block from its parent's child set. If that
-        # leaves the parent with no children, remove the parent entry entirely
-        # to avoid memory leaks from empty sets accumulating.
+        # Drop this child from its parent's set.
+        # Delete the parent entry once empty, so empty sets do not accumulate.
         children = self._by_parent.get(pending.parent_root)
         if children:
             children.discard(root)
@@ -240,95 +137,21 @@ class BlockCache:
 
     def mark_orphan(self, root: Bytes32) -> None:
         """
-        Mark a block as an orphan (parent not in Store or cache).
+        Mark a block as an orphan: its parent is in neither the store nor the cache.
 
-        An orphan is a block whose parent is completely unknown. This differs
-        from a block whose parent is simply pending: orphans need backfill,
-        pending blocks just need to wait.
-
-        Typical flow:
-        1. Block arrives
-        2. Check if parent in Store -> no
-        3. Check if parent in cache -> no
-        4. Mark as orphan, trigger backfill for parent
-
-        Args:
-            root: The block root to mark as orphan.
+        Unlike a block waiting on a pending parent, an orphan needs its parent backfilled.
         """
         if root in self._blocks:
             self._orphans.add(root)
 
-    def unmark_orphan(self, root: Bytes32) -> None:
-        """
-        Remove orphan status from a block.
-
-        Called when a block's parent has been received. The block is no longer
-        an orphan because its parent now exists (in cache or Store).
-
-        Args:
-            root: The block root to unmark.
-        """
-        self._orphans.discard(root)
-
     def get_children(self, parent_root: Bytes32) -> list[PendingBlock]:
-        """
-        Get all cached children of a given parent root.
-
-        This is the core of descendant processing. When a parent block is
-        successfully processed, call this method to find children that were
-        waiting for it. Those children can now be processed.
-
-        Results are sorted by slot to ensure parent-before-child ordering when
-        processing a chain of descendants.
-
-        Args:
-            parent_root: The root of the parent block that was just processed.
-
-        Returns:
-            List of pending child blocks, sorted by slot (earliest first).
-        """
+        """Return the cached children of a parent, sorted by slot so parents process first."""
         child_roots = self._by_parent.get(parent_root, set())
-        children = [self._blocks[r] for r in child_roots if r in self._blocks]
-
-        # Sort by slot ensures correct processing order.
-        #
-        # If block A at slot 100 and block B at slot 101 both waited for
-        # parent P, we must process A before B.
-        return sorted(children, key=lambda p: p.slot)
+        children = [self._blocks[root] for root in child_roots if root in self._blocks]
+        # If two blocks at slots 100 and 101 share a parent, 100 must process first.
+        return sorted(children, key=lambda pending: pending.slot)
 
     @property
     def orphan_count(self) -> int:
         """Number of orphan blocks in the cache."""
         return len(self._orphans)
-
-    def _evict_oldest(self) -> None:
-        """
-        Evict the oldest block to make room for new entries.
-
-        FIFO (First-In-First-Out) eviction is used because:
-
-        1. **Simplicity**: No scoring or prioritization needed
-        2. **Fairness**: Old blocks had their chance; new ones deserve theirs
-        3. **Attack resistance**: Attackers cannot keep malicious blocks cached
-           by refreshing them
-
-        More sophisticated strategies (LRU, priority queues) add complexity
-        without clear benefits for this use case.
-        """
-        if not self._blocks:
-            return
-
-        # popitem(last=False) removes the first (oldest) entry.
-        #
-        # This is O(1) due to OrderedDict's doubly-linked list implementation.
-        oldest_root, oldest_block = self._blocks.popitem(last=False)
-
-        # Clean up orphan tracking.
-        self._orphans.discard(oldest_root)
-
-        # Clean up parent index to prevent memory leaks.
-        children = self._by_parent.get(oldest_block.parent_root)
-        if children:
-            children.discard(oldest_root)
-            if not children:
-                del self._by_parent[oldest_block.parent_root]

--- a/tests/node/sync/test_block_cache.py
+++ b/tests/node/sync/test_block_cache.py
@@ -224,31 +224,6 @@ class TestBlockCacheOrphanTracking:
 
         assert cache.orphan_count == 0
 
-    def test_unmark_orphan(self, peer_id: PeerId) -> None:
-        """Unmarking an orphan removes it from the orphan set."""
-        cache = BlockCache()
-        block = make_signed_block(
-            slot=Slot(1),
-            proposer_index=ValidatorIndex(0),
-            parent_root=Bytes32.zero(),
-            state_root=Bytes32.zero(),
-        )
-
-        pending = cache.add(block, peer_id)
-        cache.mark_orphan(pending.root)
-        cache.unmark_orphan(pending.root)
-
-        assert cache.orphan_count == 0
-
-    def test_unmark_orphan_nonexistent_does_nothing(self) -> None:
-        """Unmarking a nonexistent orphan does nothing."""
-        cache = BlockCache()
-
-        # Should not raise
-        cache.unmark_orphan(Bytes32.zero())
-
-        assert cache.orphan_count == 0
-
     def test_remove_clears_orphan_status(self, peer_id: PeerId) -> None:
         """Removing a block also removes its orphan status."""
         cache = BlockCache()
@@ -462,6 +437,42 @@ class TestBlockCacheCapacityManagement:
 
         # The original orphan should be evicted
         assert pending.root not in cache
+
+    def test_eviction_remarks_orphaned_children(self, peer_id: PeerId) -> None:
+        """Evicting a parent re-marks its still-cached children as orphans."""
+        cache = BlockCache()
+
+        # Parent (oldest), then a child whose parent is that block, so the child is not an orphan.
+        parent = make_signed_block(
+            slot=Slot(1),
+            proposer_index=ValidatorIndex(0),
+            parent_root=Bytes32(b"\xaa" * 32),
+            state_root=Bytes32.zero(),
+        )
+        parent_pending = cache.add(parent, peer_id)
+        child = make_signed_block(
+            slot=Slot(2),
+            proposer_index=ValidatorIndex(0),
+            parent_root=parent_pending.root,
+            state_root=Bytes32(b"\x02" * 32),
+        )
+        child_pending = cache.add(child, peer_id)
+        assert cache.orphan_count == 0
+
+        # Add fillers until exactly one eviction fires, removing the oldest (the parent).
+        for i in range(MAX_CACHED_BLOCKS - 1):
+            filler = make_signed_block(
+                slot=Slot(1000 + i),
+                proposer_index=ValidatorIndex(0),
+                parent_root=Bytes32((1000 + i).to_bytes(32, "big")),
+                state_root=Bytes32((2000 + i).to_bytes(32, "big")),
+            )
+            cache.add(filler, peer_id)
+
+        # The parent was evicted; the child remains but is now an orphan again.
+        assert parent_pending.root not in cache
+        assert child_pending.root in cache
+        assert cache.orphan_count == 1
 
 
 class TestBlockCacheBackfillDepth:


### PR DESCRIPTION
## Summary

Clarity, modern-Python, and one correctness fix in `BlockCache` (`src/lean_spec/node/sync/block_cache.py`). All sync tests pass.

### Documentation
- Trim the banner-essay module docstring ("Why Cache Blocks? / How It Works / Memory Safety"), the `PendingBlock` class + five multi-line field docstrings, and the verbose method `Args/Returns` blocks to the project rules. Keep the genuine rationale (why `>=` in the capacity check, why empty parent-sets are deleted, the slot-order example, FIFO attack-resistance).

### Structure
- **Inline `_evict_oldest` into `add`** (single caller) and **drop `unmark_orphan`** (no external callers; its only caller was `remove`, so its one-line `discard` is now inline). Deleted its two now-redundant direct tests (the behavior stays covered by the remove-clears-orphan test).
- **Keep `mark_orphan`**: it has callers in `head_sync` and `backfill_sync` plus internal use, and guards the orphan set against phantom entries — inlining would duplicate the guard and break the cache's encapsulation.
- **`PendingBlock` is now `frozen=True`** — nothing mutates it, matching the frozen-by-default convention.
- On stdlib: no `itertools.batched` fit here (no chunking), and `OrderedDict` stays (FIFO eviction needs `popitem(last=False)`).

### Eviction correctness fix
Evicting an **internal node** (a cached block that is itself a parent of other cached blocks) left its children stranded: they stayed cached, were no longer linked to a present parent, and were **never re-marked as orphans** — so backfill never refetched the parent and `orphan_count` under-reported. Since `service.py` gates sync-completion on `orphan_count`, the node could flip to **synced with stuck blocks**. Eviction now re-marks the evicted block's still-cached children as orphans (keeping the parent-index link so they reconnect if the parent returns), with a regression test (`test_eviction_remarks_orphaned_children`).

Deferred (noted): the dedup-keeps-deeper-`backfill_depth` nit, and gating sync-completion on more than `orphan_count` — both lower-severity, separate concerns.

## Testing
- `just check` passes (ruff, format, ty, codespell, mdformat).
- `uv run pytest tests/node/sync` — 141 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)