### PR TITLE
test: add test vectors for split and reaggregate attestations

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -43,6 +43,8 @@ from consensus_testing.test_fixtures import (
     NetworkingCodecTest,
     PoseidonPermutationFixture,
     PoseidonPermutationTest,
+    ReaggregationFixture,
+    ReaggregationTest,
     RebindToAlternateHeadRoot,
     SetProposerIndex,
     SlotClockFixture,
@@ -144,6 +146,7 @@ SlotClockTestFiller = Callable[..., SlotClockFixture]
 JustifiabilityTestFiller = Callable[..., JustifiabilityFixture]
 PoseidonPermutationTestFiller = Callable[..., PoseidonPermutationFixture]
 SyncTestFiller = Callable[..., SyncFixture]
+ReaggregationTestFiller = Callable[..., ReaggregationFixture]
 
 __all__ = [
     "CachedMessage",
@@ -183,6 +186,8 @@ __all__ = [
     "FromSlot",
     "FromUnixTime",
     "TotalIntervals",
+    "ReaggregationFixture",
+    "ReaggregationTest",
     "VerifyCheckpoint",
     # Public API
     "AggregatedAttestationSpec",
@@ -278,4 +283,5 @@ __all__ = [
     "JustifiabilityTestFiller",
     "PoseidonPermutationTestFiller",
     "SyncTestFiller",
+    "ReaggregationTestFiller",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -58,6 +58,7 @@ from consensus_testing.test_fixtures.poseidon_permutation import (
     PoseidonPermutationFixture,
     PoseidonPermutationTest,
 )
+from consensus_testing.test_fixtures.reaggregation import ReaggregationFixture, ReaggregationTest
 from consensus_testing.test_fixtures.slot_clock import (
     CurrentInterval,
     CurrentSlot,
@@ -96,6 +97,7 @@ from consensus_testing.test_fixtures.verify_signatures import (
 )
 
 FIXTURE_FORMATS: tuple[type[BaseTestSpec], ...] = (
+    ReaggregationTest,
     ApiEndpointTest,
     ForkChoiceTest,
     GossipsubHandlerTest,
@@ -156,6 +158,8 @@ __all__ = [
     "FromUnixTime",
     "TotalIntervals",
     "VerifyCheckpoint",
+    "ReaggregationFixture",
+    "ReaggregationTest",
     "FIXTURE_FORMATS",
     "BaseConsensusFixture",
     "BaseTestSpec",

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -97,13 +97,13 @@ from consensus_testing.test_fixtures.verify_signatures import (
 )
 
 FIXTURE_FORMATS: tuple[type[BaseTestSpec], ...] = (
-    ReaggregationTest,
     ApiEndpointTest,
     ForkChoiceTest,
     GossipsubHandlerTest,
     JustifiabilityTest,
     NetworkingCodecTest,
     PoseidonPermutationTest,
+    ReaggregationTest,
     SlotClockTest,
     SSZTest,
     StateTransitionTest,

--- a/packages/testing/src/consensus_testing/test_fixtures/reaggregation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/reaggregation.py
@@ -1,0 +1,223 @@
+"""Reaggregation test fixture format."""
+
+from typing import ClassVar
+
+from consensus_testing.keys import XmssKeyManager
+from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
+from lean_spec.spec.crypto.merkleization import hash_tree_root
+from lean_spec.spec.forks import AggregationBits, Checkpoint, Slot, ValidatorIndex
+from lean_spec.spec.forks.lstar.containers import (
+    AggregatedAttestation,
+    AggregatedAttestations,
+    AttestationData,
+    Block,
+    BlockBody,
+    MultiMessageAggregate,
+    SingleMessageAggregate,
+)
+from lean_spec.spec.ssz import Bytes32
+
+ATTESTATION_SLOT: Slot = Slot(1)
+"""Slot number that the attestation is signed for."""
+
+BLOCK_SLOT: Slot = Slot(2)
+"""Slot number that the block is built for."""
+
+PROPOSER_INDEX: ValidatorIndex = ValidatorIndex(0)
+"""Validator ID that signs the block."""
+
+CHAIN_ROOT: Bytes32 = Bytes32(b"\x11" * 32)
+"""Head and target root the attestation votes for."""
+
+GENESIS_ROOT: Bytes32 = Bytes32(b"\x33" * 32)
+"""Source root anchoring the attestation."""
+
+PARENT_ROOT: Bytes32 = Bytes32(b"\xaa" * 32)
+"""Parent root of the synthetic block."""
+
+
+class ReaggregationFixture(BaseConsensusFixture):
+    """
+    Emitted vector for proof re-aggregation.
+
+    JSON output: blockProof, publicKeysPerMessage, attestationMessage,
+    attestationSlot, blockAttesters, localAttesters, combinedAttesters,
+    reaggregatedProof, valid.
+    """
+
+    block_proof: str
+    """The block's multi-message proof that gets split, as hex."""
+
+    public_keys_per_message: list[list[str]]
+    """Per-message public key layout the original proof was built with, as hex."""
+
+    attestation_message: str
+    """Hash tree root of the split attestation, as hex."""
+
+    attestation_slot: int
+    """Slot of the split attestation."""
+
+    block_attesters: list[int]
+    """List of validator IDs whose signed attestations came in the block."""
+
+    local_attesters: list[int]
+    """List of validator IDs whose signed attestations are in the node's local pool."""
+
+    combined_attesters: list[int]
+    """List of validator IDs from the block's and the local copy's attestations."""
+
+    reaggregated_proof: str
+    """The re-aggregated single-message proof bytes, as hex."""
+
+    valid: bool
+    """Whether the re-aggregated proof verifies against the combined attesters' keys."""
+
+
+class ReaggregationTest(BaseTestSpec):
+    """
+    Take one attestation's proof out of a block, then merge it with the node's own copy.
+
+    Test structure:
+
+    1. Read the block proof and the public key layout.
+    2. Split the block proof by providing the attestation message and the block
+       attesters' validator IDs, to recover the single-message attestation proof.
+    3. Verify the recovered proof against the block attesters' public keys at
+       the attestation slot.
+    4. Re-aggregate the recovered proof with the node's local copy of the same
+       attestations to produce a new merged proof.
+    5. Verify the re-aggregated proof against the combined attesters' public
+       keys at the attestation slot, expecting the valid flag.
+
+    Rather than matching the reference proof bytes, which are not deterministic,
+    verify each re-aggregated proof against the expected attestation data and
+    attesters' public keys. Then, confirm that the same attestation data and
+    public keys are also valid for the reference proof bytes.
+    """
+
+    format_name: ClassVar[str] = "reaggregation_test"
+    description: ClassVar[str] = "Tests aggregate proof split and merge clients must reproduce"
+
+    block_attesters: list[ValidatorIndex]
+    """List of validator IDs whose signed attestations were aggregated into the block."""
+
+    local_attesters: list[ValidatorIndex] = []
+    """List of validator IDs whose signed attestations are in the node's local pool."""
+
+    def generate(self) -> ReaggregationFixture:
+        """Build the merged proof, split the attestation out, merge it, and verify."""
+        key_manager = XmssKeyManager.shared()
+
+        attestation_data = AttestationData(
+            slot=ATTESTATION_SLOT,
+            head=Checkpoint(root=CHAIN_ROOT, slot=ATTESTATION_SLOT),
+            target=Checkpoint(root=CHAIN_ROOT, slot=ATTESTATION_SLOT),
+            source=Checkpoint(root=GENESIS_ROOT, slot=Slot(0)),
+        )
+        attestation_message = hash_tree_root(attestation_data)
+
+        signing_validators = list(dict.fromkeys([*self.block_attesters, *self.local_attesters]))
+        shared_signatures = {
+            validator_index: key_manager.sign_attestation_data(validator_index, attestation_data)
+            for validator_index in signing_validators
+        }
+
+        # Phase 1: the block's attestation component, then the proposal component.
+        attestation_component = key_manager.sign_and_aggregate(
+            self.block_attesters,
+            attestation_data,
+            precomputed_signatures=shared_signatures,
+        )
+        attestation_keys = [
+            key_manager.get_public_keys(validator_index)[0]
+            for validator_index in self.block_attesters
+        ]
+        block = Block(
+            slot=BLOCK_SLOT,
+            proposer_index=PROPOSER_INDEX,
+            parent_root=PARENT_ROOT,
+            state_root=Bytes32.zero(),
+            body=BlockBody(
+                attestations=AggregatedAttestations(
+                    data=[
+                        AggregatedAttestation(
+                            aggregation_bits=AggregationBits.from_indices(self.block_attesters),
+                            data=attestation_data,
+                        )
+                    ]
+                )
+            ),
+        )
+        block_root = hash_tree_root(block)
+        proposal_key = key_manager.get_public_keys(PROPOSER_INDEX)[1]
+        proposal_signature = key_manager.sign_block_root(PROPOSER_INDEX, BLOCK_SLOT, block_root)
+        proposal_component = SingleMessageAggregate.aggregate(
+            children=[],
+            raw_xmss=[(PROPOSER_INDEX, proposal_key, proposal_signature)],
+            message=block_root,
+            slot=BLOCK_SLOT,
+        )
+        public_keys_per_message = [attestation_keys, [proposal_key]]
+
+        # Phase 2: merge the two components into a single, multi-message block proof.
+        block_proof = MultiMessageAggregate.aggregate(
+            [attestation_component, proposal_component],
+            public_keys_per_aggregate=public_keys_per_message,
+        )
+
+        # Phase 3: split the attestation's component back out by its message.
+        block_bits = AggregationBits.from_indices(self.block_attesters)
+        recovered_proof = block_proof.split_by_message(
+            message=attestation_message,
+            public_keys_per_message=public_keys_per_message,
+            participants=block_bits,
+        )
+
+        # Phase 4: merge the recovered proof with the local partial.
+        if self.local_attesters:
+            local_partial = key_manager.sign_and_aggregate(
+                self.local_attesters,
+                attestation_data,
+                precomputed_signatures=shared_signatures,
+            )
+            local_keys = [
+                key_manager.get_public_keys(validator_index)[0]
+                for validator_index in self.local_attesters
+            ]
+            combined = SingleMessageAggregate.aggregate(
+                children=[
+                    (recovered_proof, attestation_keys),
+                    (local_partial, local_keys),
+                ],
+                raw_xmss=[],
+                message=attestation_message,
+                slot=attestation_data.slot,
+            )
+        else:
+            combined = recovered_proof
+
+        # Phase 5: verify the re-aggregated proof against the union public keys.
+        combined_indices = list(combined.participants.to_validator_indices())
+        combined.verify(
+            [
+                key_manager.get_public_keys(validator_index)[0]
+                for validator_index in combined_indices
+            ],
+            attestation_message,
+            attestation_data.slot,
+        )
+
+        return ReaggregationFixture(
+            block_proof="0x" + bytes(block_proof.proof.data).hex(),
+            public_keys_per_message=[
+                ["0x" + public_key.encode_bytes().hex() for public_key in component_keys]
+                for component_keys in public_keys_per_message
+            ],
+            attestation_message="0x" + bytes(attestation_message).hex(),
+            attestation_slot=int(attestation_data.slot),
+            block_attesters=[int(validator_index) for validator_index in self.block_attesters],
+            local_attesters=[int(validator_index) for validator_index in self.local_attesters],
+            combined_attesters=[int(validator_index) for validator_index in combined_indices],
+            reaggregated_proof="0x" + bytes(combined.proof.data).hex(),
+            valid=True,
+        )

--- a/packages/testing/src/consensus_testing/test_fixtures/reaggregation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/reaggregation.py
@@ -1,5 +1,7 @@
 """Reaggregation test fixture format."""
 
+from __future__ import annotations
+
 from typing import ClassVar
 
 from consensus_testing.keys import XmssKeyManager
@@ -18,13 +20,13 @@ from lean_spec.spec.forks.lstar.containers import (
 from lean_spec.spec.ssz import Bytes32
 
 ATTESTATION_SLOT: Slot = Slot(1)
-"""Slot number that the attestation is signed for."""
+"""Attestation slot, one before the block that carries it."""
 
 BLOCK_SLOT: Slot = Slot(2)
-"""Slot number that the block is built for."""
+"""Block slot, one after the attestation it carries."""
 
 PROPOSER_INDEX: ValidatorIndex = ValidatorIndex(0)
-"""Validator ID that signs the block."""
+"""Validator index that signs the block."""
 
 CHAIN_ROOT: Bytes32 = Bytes32(b"\x11" * 32)
 """Head and target root the attestation votes for."""
@@ -37,13 +39,7 @@ PARENT_ROOT: Bytes32 = Bytes32(b"\xaa" * 32)
 
 
 class ReaggregationFixture(BaseConsensusFixture):
-    """
-    Emitted vector for proof re-aggregation.
-
-    JSON output: blockProof, publicKeysPerMessage, attestationMessage,
-    attestationSlot, blockAttesters, localAttesters, combinedAttesters,
-    reaggregatedProof, valid.
-    """
+    """Emitted vector for proof re-aggregation."""
 
     block_proof: str
     """The block's multi-message proof that gets split, as hex."""
@@ -58,51 +54,34 @@ class ReaggregationFixture(BaseConsensusFixture):
     """Slot of the split attestation."""
 
     block_attesters: list[int]
-    """List of validator IDs whose signed attestations came in the block."""
+    """Validator indices whose signed attestations came in the block."""
 
     local_attesters: list[int]
-    """List of validator IDs whose signed attestations are in the node's local pool."""
+    """Validator indices whose signed attestations are in the node's local pool."""
 
     combined_attesters: list[int]
-    """List of validator IDs from the block's and the local copy's attestations."""
+    """Validator indices covered by the re-aggregated proof, the block and local union."""
 
     reaggregated_proof: str
     """The re-aggregated single-message proof bytes, as hex."""
 
-    valid: bool
-    """Whether the re-aggregated proof verifies against the combined attesters' keys."""
-
 
 class ReaggregationTest(BaseTestSpec):
     """
-    Take one attestation's proof out of a block, then merge it with the node's own copy.
+    Split one attestation's proof out of a block, then merge it with the local partial.
 
-    Test structure:
-
-    1. Read the block proof and the public key layout.
-    2. Split the block proof by providing the attestation message and the block
-       attesters' validator IDs, to recover the single-message attestation proof.
-    3. Verify the recovered proof against the block attesters' public keys at
-       the attestation slot.
-    4. Re-aggregate the recovered proof with the node's local copy of the same
-       attestations to produce a new merged proof.
-    5. Verify the re-aggregated proof against the combined attesters' public
-       keys at the attestation slot, expecting the valid flag.
-
-    Rather than matching the reference proof bytes, which are not deterministic,
-    verify each re-aggregated proof against the expected attestation data and
-    attesters' public keys. Then, confirm that the same attestation data and
-    public keys are also valid for the reference proof bytes.
+    The reference proof bytes are not deterministic.
+    Each vector is checked by verifying against the expected attesters' keys, not by byte match.
     """
 
     format_name: ClassVar[str] = "reaggregation_test"
     description: ClassVar[str] = "Tests aggregate proof split and merge clients must reproduce"
 
     block_attesters: list[ValidatorIndex]
-    """List of validator IDs whose signed attestations were aggregated into the block."""
+    """Validator indices whose signed attestations were aggregated into the block."""
 
     local_attesters: list[ValidatorIndex] = []
-    """List of validator IDs whose signed attestations are in the node's local pool."""
+    """Validator indices whose signed attestations are in the node's local pool."""
 
     def generate(self) -> ReaggregationFixture:
         """Build the merged proof, split the attestation out, merge it, and verify."""
@@ -173,6 +152,10 @@ class ReaggregationTest(BaseTestSpec):
             participants=block_bits,
         )
 
+        # The split output must verify on its own against the block attesters' keys.
+        # A later merge could otherwise mask a malformed recovered component.
+        recovered_proof.verify(attestation_keys, attestation_message, attestation_data.slot)
+
         # Phase 4: merge the recovered proof with the local partial.
         if self.local_attesters:
             local_partial = key_manager.sign_and_aggregate(
@@ -184,7 +167,7 @@ class ReaggregationTest(BaseTestSpec):
                 key_manager.get_public_keys(validator_index)[0]
                 for validator_index in self.local_attesters
             ]
-            combined = SingleMessageAggregate.aggregate(
+            reaggregated_proof = SingleMessageAggregate.aggregate(
                 children=[
                     (recovered_proof, attestation_keys),
                     (local_partial, local_keys),
@@ -194,14 +177,21 @@ class ReaggregationTest(BaseTestSpec):
                 slot=attestation_data.slot,
             )
         else:
-            combined = recovered_proof
+            reaggregated_proof = recovered_proof
 
-        # Phase 5: verify the re-aggregated proof against the union public keys.
-        combined_indices = list(combined.participants.to_validator_indices())
-        combined.verify(
+        # Phase 5: the merged proof must cover exactly the union of block and local attesters.
+        combined_attester_indices = list(reaggregated_proof.participants.to_validator_indices())
+        expected_attester_indices = sorted({*self.block_attesters, *self.local_attesters})
+        assert combined_attester_indices == expected_attester_indices, (
+            f"re-aggregated proof covers {combined_attester_indices}, "
+            f"expected the union {expected_attester_indices}"
+        )
+
+        # The merged proof must verify against the union attesters' keys.
+        reaggregated_proof.verify(
             [
                 key_manager.get_public_keys(validator_index)[0]
-                for validator_index in combined_indices
+                for validator_index in combined_attester_indices
             ],
             attestation_message,
             attestation_data.slot,
@@ -217,7 +207,8 @@ class ReaggregationTest(BaseTestSpec):
             attestation_slot=int(attestation_data.slot),
             block_attesters=[int(validator_index) for validator_index in self.block_attesters],
             local_attesters=[int(validator_index) for validator_index in self.local_attesters],
-            combined_attesters=[int(validator_index) for validator_index in combined_indices],
-            reaggregated_proof="0x" + bytes(combined.proof.data).hex(),
-            valid=True,
+            combined_attesters=[
+                int(validator_index) for validator_index in combined_attester_indices
+            ],
+            reaggregated_proof="0x" + bytes(reaggregated_proof.proof.data).hex(),
         )

--- a/tests/consensus/lstar/reaggregation/__init__.py
+++ b/tests/consensus/lstar/reaggregation/__init__.py
@@ -1,0 +1,1 @@
+"""Proof re-aggregation test vectors for the lstar fork."""

--- a/tests/consensus/lstar/reaggregation/test_post_block_reaggregation.py
+++ b/tests/consensus/lstar/reaggregation/test_post_block_reaggregation.py
@@ -1,0 +1,95 @@
+"""Proof re-aggregation vectors: Split an attestation out of a block proof, fold with the pool."""
+
+import pytest
+
+from consensus_testing import ReaggregationTestFiller
+from lean_spec.spec.forks import ValidatorIndex
+
+pytestmark = [pytest.mark.valid_until("Lstar"), pytest.mark.real_crypto]
+
+
+def test_split_only_when_data_unseen_locally(
+    reaggregation_test: ReaggregationTestFiller,
+) -> None:
+    """
+    An attestation unseen locally is recovered from the block proof and used as-is.
+
+    Given
+    -----
+    - a block proof carrying an attestation signed by V0, V1, V2.
+    - no local partial for that attestation.
+
+    When
+    ----
+    - the block proof is split by the attestation message.
+
+    Then
+    ----
+    - the recovered proof covers V0, V1, V2.
+    - no local partial merges in.
+    - the recovered proof verifies.
+    """
+    reaggregation_test(
+        block_attesters=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
+        local_attesters=[],
+    )
+
+
+def test_split_then_merge_with_overlapping_local_partial(
+    reaggregation_test: ReaggregationTestFiller,
+) -> None:
+    """
+    A recovered proof merges with an overlapping local partial into their union.
+
+    Given
+    -----
+    - a block proof carrying an attestation signed by V0, V1, V2.
+    - a local partial for the same attestation signed by V1, V2, V3.
+    - the block and the local partial overlap on V1, V2.
+
+    When
+    ----
+    - the block proof is split by the attestation message.
+    - the recovered proof merges with the local partial.
+
+    Then
+    ----
+    - the recovered proof covers V0, V1, V2.
+    - the local partial covers V1, V2, V3.
+    - the re-aggregated proof covers V0, V1, V2, V3.
+    - the re-aggregated proof verifies.
+    """
+    reaggregation_test(
+        block_attesters=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
+        local_attesters=[ValidatorIndex(1), ValidatorIndex(2), ValidatorIndex(3)],
+    )
+
+
+def test_split_then_merge_with_disjoint_local_partial(
+    reaggregation_test: ReaggregationTestFiller,
+) -> None:
+    """
+    A recovered proof merges with a non-overlapping local partial into their union.
+
+    Given
+    -----
+    - a block proof carrying an attestation signed by V0, V1.
+    - a local partial for the same attestation signed by V2, V3.
+    - the block and the local partial share no validators.
+
+    When
+    ----
+    - the block proof is split by the attestation message.
+    - the recovered proof merges with the local partial.
+
+    Then
+    ----
+    - the recovered proof covers V0, V1.
+    - the local partial covers V2, V3.
+    - the re-aggregated proof covers V0, V1, V2, V3.
+    - the re-aggregated proof verifies.
+    """
+    reaggregation_test(
+        block_attesters=[ValidatorIndex(0), ValidatorIndex(1)],
+        local_attesters=[ValidatorIndex(2), ValidatorIndex(3)],
+    )

--- a/tests/consensus/lstar/reaggregation/test_post_block_reaggregation.py
+++ b/tests/consensus/lstar/reaggregation/test_post_block_reaggregation.py
@@ -1,4 +1,4 @@
-"""Re-aggregation vectors: split an attestation out of a block proof, fold with the local pool."""
+"""Re-aggregation vector: split an attestation out of a block proof, fold with the local pool."""
 
 import pytest
 
@@ -6,33 +6,6 @@ from consensus_testing import ReaggregationTestFiller
 from lean_spec.spec.forks import ValidatorIndex
 
 pytestmark = [pytest.mark.valid_until("Lstar"), pytest.mark.real_crypto]
-
-
-def test_split_only_when_data_unseen_locally(
-    reaggregation_test: ReaggregationTestFiller,
-) -> None:
-    """
-    An attestation unseen locally is recovered from the block proof and used as-is.
-
-    Given
-    -----
-    - a block proof carrying an attestation signed by V0, V1, V2.
-    - no local partial for that attestation.
-
-    When
-    ----
-    - the block proof is split by the attestation message.
-
-    Then
-    ----
-    - the recovered proof covers V0, V1, V2.
-    - no local partial merges in.
-    - the recovered proof verifies.
-    """
-    reaggregation_test(
-        block_attesters=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
-        local_attesters=[],
-    )
 
 
 def test_split_then_merge_with_overlapping_local_partial(
@@ -63,93 +36,4 @@ def test_split_then_merge_with_overlapping_local_partial(
     reaggregation_test(
         block_attesters=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
         local_attesters=[ValidatorIndex(1), ValidatorIndex(2), ValidatorIndex(3)],
-    )
-
-
-def test_split_then_merge_with_disjoint_local_partial(
-    reaggregation_test: ReaggregationTestFiller,
-) -> None:
-    """
-    A recovered proof merges with a non-overlapping local partial into their union.
-
-    Given
-    -----
-    - a block proof carrying an attestation signed by V0, V1.
-    - a local partial for the same attestation signed by V2, V3.
-    - the block and the local partial share no validators.
-
-    When
-    ----
-    - the block proof is split by the attestation message.
-    - the recovered proof merges with the local partial.
-
-    Then
-    ----
-    - the recovered proof covers V0, V1.
-    - the recovered proof verifies.
-    - the local partial covers V2, V3.
-    - the re-aggregated proof covers V0, V1, V2, V3.
-    - the re-aggregated proof verifies.
-    """
-    reaggregation_test(
-        block_attesters=[ValidatorIndex(0), ValidatorIndex(1)],
-        local_attesters=[ValidatorIndex(2), ValidatorIndex(3)],
-    )
-
-
-def test_split_single_validator_block(
-    reaggregation_test: ReaggregationTestFiller,
-) -> None:
-    """
-    A single-validator block attestation is recovered from the block proof and used as-is.
-
-    Given
-    -----
-    - a block proof carrying an attestation signed by V0.
-    - no local partial for that attestation.
-
-    When
-    ----
-    - the block proof is split by the attestation message.
-
-    Then
-    ----
-    - the recovered proof covers V0.
-    - no local partial merges in.
-    - the recovered proof verifies.
-    """
-    reaggregation_test(
-        block_attesters=[ValidatorIndex(0)],
-        local_attesters=[],
-    )
-
-
-def test_split_then_merge_when_local_covers_a_superset(
-    reaggregation_test: ReaggregationTestFiller,
-) -> None:
-    """
-    A recovered proof merges with a local partial that already covers it, yielding the local set.
-
-    Given
-    -----
-    - a block proof carrying an attestation signed by V0, V1.
-    - a local partial for the same attestation signed by V0, V1, V2.
-    - the local partial already covers every block attester.
-
-    When
-    ----
-    - the block proof is split by the attestation message.
-    - the recovered proof merges with the local partial.
-
-    Then
-    ----
-    - the recovered proof covers V0, V1.
-    - the recovered proof verifies.
-    - the local partial covers V0, V1, V2.
-    - the re-aggregated proof covers V0, V1, V2.
-    - the re-aggregated proof verifies.
-    """
-    reaggregation_test(
-        block_attesters=[ValidatorIndex(0), ValidatorIndex(1)],
-        local_attesters=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
     )

--- a/tests/consensus/lstar/reaggregation/test_post_block_reaggregation.py
+++ b/tests/consensus/lstar/reaggregation/test_post_block_reaggregation.py
@@ -1,4 +1,4 @@
-"""Proof re-aggregation vectors: Split an attestation out of a block proof, fold with the pool."""
+"""Re-aggregation vectors: split an attestation out of a block proof, fold with the local pool."""
 
 import pytest
 
@@ -55,6 +55,7 @@ def test_split_then_merge_with_overlapping_local_partial(
     Then
     ----
     - the recovered proof covers V0, V1, V2.
+    - the recovered proof verifies.
     - the local partial covers V1, V2, V3.
     - the re-aggregated proof covers V0, V1, V2, V3.
     - the re-aggregated proof verifies.
@@ -85,6 +86,7 @@ def test_split_then_merge_with_disjoint_local_partial(
     Then
     ----
     - the recovered proof covers V0, V1.
+    - the recovered proof verifies.
     - the local partial covers V2, V3.
     - the re-aggregated proof covers V0, V1, V2, V3.
     - the re-aggregated proof verifies.
@@ -92,4 +94,62 @@ def test_split_then_merge_with_disjoint_local_partial(
     reaggregation_test(
         block_attesters=[ValidatorIndex(0), ValidatorIndex(1)],
         local_attesters=[ValidatorIndex(2), ValidatorIndex(3)],
+    )
+
+
+def test_split_single_validator_block(
+    reaggregation_test: ReaggregationTestFiller,
+) -> None:
+    """
+    A single-validator block attestation is recovered from the block proof and used as-is.
+
+    Given
+    -----
+    - a block proof carrying an attestation signed by V0.
+    - no local partial for that attestation.
+
+    When
+    ----
+    - the block proof is split by the attestation message.
+
+    Then
+    ----
+    - the recovered proof covers V0.
+    - no local partial merges in.
+    - the recovered proof verifies.
+    """
+    reaggregation_test(
+        block_attesters=[ValidatorIndex(0)],
+        local_attesters=[],
+    )
+
+
+def test_split_then_merge_when_local_covers_a_superset(
+    reaggregation_test: ReaggregationTestFiller,
+) -> None:
+    """
+    A recovered proof merges with a local partial that already covers it, yielding the local set.
+
+    Given
+    -----
+    - a block proof carrying an attestation signed by V0, V1.
+    - a local partial for the same attestation signed by V0, V1, V2.
+    - the local partial already covers every block attester.
+
+    When
+    ----
+    - the block proof is split by the attestation message.
+    - the recovered proof merges with the local partial.
+
+    Then
+    ----
+    - the recovered proof covers V0, V1.
+    - the recovered proof verifies.
+    - the local partial covers V0, V1, V2.
+    - the re-aggregated proof covers V0, V1, V2.
+    - the re-aggregated proof verifies.
+    """
+    reaggregation_test(
+        block_attesters=[ValidatorIndex(0), ValidatorIndex(1)],
+        local_attesters=[ValidatorIndex(0), ValidatorIndex(1), ValidatorIndex(2)],
     )

--- a/tests/node/sync/test_service.py
+++ b/tests/node/sync/test_service.py
@@ -863,7 +863,7 @@ class TestReplayPendingAttestationsPlain:
 #
 # Only the decision/gate paths are exercised here.
 # These tests check when the split runs, not the cryptographic split itself.
-# The split-extract-merge round-trip is covered by the aggregation container tests.
+# The cryptographic split and merge are covered by the aggregation consensus vectors.
 
 # Round-robin proposer is slot % num_validators with four validators.
 NUM_VALIDATORS = 4

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -157,6 +157,8 @@ participant_sets
 block_weights
 known_aggregated_payloads
 is_justifiable
+combined_attesters
+reaggregated_proof
 
 # SSZ container and model field names declared inside unit tests.
 # Serialized by the SSZ codec or set through pydantic, never read by attribute.


### PR DESCRIPTION
## 🗒️ Description

Adds a new `reaggregation_test` consensus fixture format and 3 vectors covering the split + merge of
aggregate proofs.

A client that imports a block holding a partial attestation must be able to split that attestation's proof
back out of the block's merged multi-message proof, then merge it with its own local partial for the
same attestation.

The test vectors here only touch the split/merge crypto primitives via container methods. It does
not drive syncing i.e. when to split, pool maintenance, re-gossip triggers that SyncService does.

### Three cases

- `test_split_only_when_data_unseen_locally` — no local partial; recovered proof used as-is
- `test_split_then_merge_with_overlapping_local_partial` — overlapping local partial
- `test_split_then_merge_with_disjoint_local_partial` — disjoint local partial

### Example generated vector

`test_split_then_merge_with_overlapping_local_partial` — block proof carries `[V0,V1,V2]`, the importing
node holds a local partial `[V1,V2,V3]`, overlapping on `[V1,V2]`. The combined proof covers their union
`[V0,V1,V2,V3]`:

```json
{
    "network": "Lstar",
    "leanEnv": "test",
    "proofSetting": 1,
    "blockProof": "0x67750500ff16024a…(358378 bytes)",
    "publicKeysPerMessage": [
        ["0x80a6f13b…(52 bytes)", "0x7612d36f…(52 bytes)", "0xd703e67c…(52 bytes)"],
        ["0xdedd8e5a…(52 bytes)"]
    ],
    "attestationMessage": "0x4a07ff61053777fe…(32 bytes)",
    "attestationSlot": 1,
    "blockAttesters": [0, 1, 2],
    "localAttesters": [1, 2, 3],
    "combinedAttesters": [0, 1, 2, 3],
    "reaggregatedProof": "0x60ce0500ffffffff…(381280 bytes)",
    "valid": true
}
```

`publicKeysPerMessage` is the per-component key layout the split needs: the attestation's three keys
first, the proposal key last.

### How a client consumes it

1. Read `blockProof` and `publicKeysPerMessage`.
2. Split `blockProof` by `attestationMessage` and supplying `blockAttesters` (the split needs the signer list as
input — it doesn't return it), to recover the attestation's single-message proof.
3. Verify the recovered proof against the block attesters' keys at `attestationSlot`.
4. Merge the recovered proof with the node's local partial → the re-aggregated proof.
5. Verify the re-aggregated proof against `combinedAttesters`' keys, expecting valid.

 ## Testing

- `uv run fill --fork=lstar --crypto=real -k test_post_block_reaggregation` → 3 passed; determinism gate
passes (these vectors are correctly excluded from it).
- `just check` + `just deadcode` clean.