### PR TITLE
docs(validator-duties): correct the produce-block Raises clause

### DIFF
--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -126,9 +126,10 @@ class ValidatorDutiesMixin(LstarSpecBase):
         proof carried by the signed block envelope.
 
         Raises:
-            AssertionError: If validator is not the proposer for this slot,
-                or if the produced block fails to close a justified divergence
-                between the store and the head chain.
+            SpecRejectionError: WRONG_PROPOSER if the validator is not the
+                proposer for the target slot.
+            AssertionError: If the produced block fails to close a justified
+                divergence between the store and the head chain.
         """
         # Build on the freshest canonical head.
         #


### PR DESCRIPTION
## What

The `produce_block_with_signatures` docstring documented `AssertionError` for the wrong-proposer case:

```
Raises:
    AssertionError: If validator is not the proposer for this slot,
        or if the produced block fails to close a justified divergence
        between the store and the head chain.
```

But that path actually raises `SpecRejectionError(RejectionReason.WRONG_PROPOSER)`. Only the justified-divergence invariant is an `AssertionError`. A caller catching `AssertionError` for the proposer case would miss the real exception.

## Change

Split the `Raises:` clause so each documented exception matches what the code actually raises — `SpecRejectionError: WRONG_PROPOSER` for the proposer check, `AssertionError` for the divergence invariant.

Docs-only; no behavior change. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)