### PR TITLE
docs(xmss): document the 4-byte epoch packing precondition in the PRF

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/prf.py
+++ b/src/lean_spec/spec/crypto/xmss/prf.py
@@ -74,6 +74,10 @@ class PRFKey(BaseBytes):
         #     domain_sep || 0x00 || key || epoch (4 bytes) || chain_index (8 bytes)
         #
         # The 0x00 byte separates chain-start derivation from randomness derivation.
+        #
+        # The epoch is bounded by the key lifetime, which fits in four bytes for every
+        # supported configuration (LOG_LIFETIME <= 32).
+        # A config beyond that bound would overflow this fixed-width packing.
         input_data = (
             PRF_DOMAIN_SEP
             + PRF_DOMAIN_SEP_DOMAIN_ELEMENT
@@ -128,6 +132,10 @@ class PRFKey(BaseBytes):
         # Layout:
         #
         #     domain_sep || 0x01 || key || epoch || message || counter
+        #
+        # The epoch is bounded by the key lifetime, which fits in four bytes for every
+        # supported configuration (LOG_LIFETIME <= 32).
+        # A config beyond that bound would overflow this fixed-width packing.
         input_data = (
             PRF_DOMAIN_SEP
             + PRF_DOMAIN_SEP_RANDOMNESS


### PR DESCRIPTION
## Summary

The XMSS PRF packs the `epoch` (a `Uint64`) into four big-endian bytes in both `derive_chain_start` and `derive_randomness`:

```python
+ epoch.to_bytes(4, "big")
```

This is sound only because the epoch is bounded by the key lifetime `2 ** LOG_LIFETIME`, and every supported configuration keeps `LOG_LIFETIME <= 32` (the production config uses 32, the test config uses 8). So the epoch always fits in four bytes.

If a future config ever set `LOG_LIFETIME > 32`, the packing would silently raise `OverflowError` at signing time with no explanation, and the precondition was previously undocumented.

## Fix

Add a short prose note next to each `to_bytes(4, "big")` site stating the precondition. This is documentation only:

- No change to the wire encoding — the 4-byte big-endian layout is part of the PRF input domain and stays byte-for-byte identical.
- The existing byte-layout diagrams remain accurate.
- No test change (doc-only change to non-fork crypto).

`just check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)