### PR TITLE
docs(koalabear): correct the Fp constructor range docstring

### DIFF
--- a/src/lean_spec/spec/crypto/koalabear.py
+++ b/src/lean_spec/spec/crypto/koalabear.py
@@ -42,10 +42,12 @@ class Fp(int, SSZType):
         """
         Create a field element.
 
-        Args:
-            value: The value to wrap. Must be in the range [0, P).
+        The constructor reduces the integer modulo P.
+        Any integer is accepted, including negatives and values at or above P.
+        The Pydantic validation path is stricter and requires the value already in [0, P).
 
-            Negative values will be normalized to the range [0, P).
+        Args:
+            value: The integer to wrap, reduced modulo P into the range [0, P).
 
         Raises:
             SSZTypeError: If value is not an integer.


### PR DESCRIPTION
## Finding (audit P3)

The field element constructor docstring was factually wrong.

It claimed the input value "Must be in the range [0, P)" and that only "Negative values will be normalized." In reality the constructor reduces ANY integer modulo P, so values at or above P are silently normalized too, and nothing is rejected. The two construction paths also differ: the Pydantic validation path is strict and requires the value already be in [0, P), while the direct constructor is not.

## Fix

Documentation only — no code change.

Rewrite the parameter documentation to state the truth:

- The constructor reduces the integer modulo P.
- Any integer is accepted, including negatives and values at or above P.
- The Pydantic validation path is stricter and requires the value already in [0, P).

`just check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)