### PR TITLE
docs(xmss): clarify HashTreeLayers LIMIT vs subtree depth

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/merkle.py
+++ b/src/lean_spec/spec/crypto/xmss/merkle.py
@@ -120,8 +120,9 @@ class HashTreeLayers(SSZList[HashTreeLayer]):
     """
     The layers of a subtree, ordered from the lowest layer up to the root.
 
-    A bottom tree and a top tree each cover half the depth.
-    The cap admits the full lifetime tree.
+    A resident bottom or top subtree spans half the depth.
+    It holds half-depth-plus-one layers, counting both the lowest layer and the root.
+    The cap is set higher, to the layer count of a full-lifetime tree.
     """
 
     LIMIT = TARGET_CONFIG.LOG_LIFETIME + 1


### PR DESCRIPTION
## Finding

The `HashTreeLayers` class docstring in `src/lean_spec/spec/crypto/xmss/merkle.py` said a bottom tree and a top tree "each cover half the depth" and that "the cap admits the full lifetime tree". Sitting side by side, this read as if the cap (`LIMIT`) matched a half-depth subtree.

But `LIMIT = LOG_LIFETIME + 1` is the layer count of a FULL-depth tree (levels 0..depth inclusive), not a half-depth subtree. A resident top or bottom subtree only ever holds half-depth-plus-one layers. The confusing class wording sat right above the correct `LIMIT` field docstring.

## Fix

Documentation only — no code changed. The class docstring now states clearly:

- A resident bottom or top subtree spans half the depth.
- It holds half-depth-plus-one layers, counting both the lowest layer and the root.
- The cap is set higher, to the layer count of a full-lifetime tree.

The (correct) `LIMIT` field docstring is left untouched. `just check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)