### PR TITLE
refactor(crypto): give vague locals descriptive names

### DIFF
--- a/src/lean_spec/spec/crypto/merkleization.py
+++ b/src/lean_spec/spec/crypto/merkleization.py
@@ -212,19 +212,19 @@ def hash_tree_root(value: object) -> Bytes32:
 @hash_tree_root.register(Boolean)
 @hash_tree_root.register(Fp)
 @hash_tree_root.register(BaseBytes)
-def _htr_packed_leaf(value: BaseUint | Boolean | Fp | BaseBytes) -> Bytes32:
+def _hash_tree_root_packed_leaf(value: BaseUint | Boolean | Fp | BaseBytes) -> Bytes32:
     # Each of these encodes to a fixed-width byte string with no length prefix.
     # The root is the Merkle root of those bytes packed into 32-byte chunks.
     return merkleize(_pack_bytes(value.encode_bytes()))
 
 
 @hash_tree_root.register
-def _htr_bytes(value: bytes) -> Bytes32:
+def _hash_tree_root_bytes(value: bytes) -> Bytes32:
     return merkleize(_pack_bytes(value))
 
 
 @hash_tree_root.register
-def _htr_bytelist(value: BaseByteList) -> Bytes32:
+def _hash_tree_root_bytelist(value: BaseByteList) -> Bytes32:
     serialized_bytes = value.encode_bytes()
     limit_chunks = math.ceil(type(value).LIMIT / BYTES_PER_CHUNK)
     return mix_in_length(
@@ -233,13 +233,13 @@ def _htr_bytelist(value: BaseByteList) -> Bytes32:
 
 
 @hash_tree_root.register
-def _htr_bitvector_base(value: BaseBitvector) -> Bytes32:
+def _hash_tree_root_bitvector_base(value: BaseBitvector) -> Bytes32:
     limit = math.ceil(type(value).LENGTH / BITS_PER_CHUNK)
     return merkleize(_pack_bits(value.data), limit=limit)
 
 
 @hash_tree_root.register
-def _htr_bitlist_base(value: BaseBitlist) -> Bytes32:
+def _hash_tree_root_bitlist_base(value: BaseBitlist) -> Bytes32:
     limit = math.ceil(type(value).LIMIT / BITS_PER_CHUNK)
     return mix_in_length(
         merkleize(_pack_bits(value.data), limit=limit),
@@ -248,12 +248,12 @@ def _htr_bitlist_base(value: BaseBitlist) -> Bytes32:
 
 
 @hash_tree_root.register
-def _htr_vector(value: SSZVector) -> Bytes32:
+def _hash_tree_root_vector(value: SSZVector) -> Bytes32:
     cls = type(value)
-    element_t, length = cls.ELEMENT_TYPE, cls.LENGTH
-    if issubclass(element_t, (BaseUint, Boolean, Fp)):
+    element_type, length = cls.ELEMENT_TYPE, cls.LENGTH
+    if issubclass(element_type, (BaseUint, Boolean, Fp)):
         # Basic elements pack their serialized bytes into a single byte stream before chunking.
-        element_size = element_t.get_byte_length()
+        element_size = element_type.get_byte_length()
         limit_chunks = math.ceil(length * element_size / BYTES_PER_CHUNK)
         return merkleize(
             _pack_bytes(b"".join(e.encode_bytes() for e in value)),
@@ -264,11 +264,11 @@ def _htr_vector(value: SSZVector) -> Bytes32:
 
 
 @hash_tree_root.register
-def _htr_list(value: SSZList) -> Bytes32:
+def _hash_tree_root_list(value: SSZList) -> Bytes32:
     cls = type(value)
-    element_t, limit = cls.ELEMENT_TYPE, cls.LIMIT
-    if issubclass(element_t, (BaseUint, Boolean, Fp)):
-        element_size = element_t.get_byte_length()
+    element_type, limit = cls.ELEMENT_TYPE, cls.LIMIT
+    if issubclass(element_type, (BaseUint, Boolean, Fp)):
+        element_size = element_type.get_byte_length()
         limit_chunks = math.ceil(limit * element_size / BYTES_PER_CHUNK)
         root = merkleize(
             _pack_bytes(b"".join(e.encode_bytes() for e in value)),
@@ -280,7 +280,7 @@ def _htr_list(value: SSZList) -> Bytes32:
 
 
 @hash_tree_root.register
-def _htr_container(value: Container) -> Bytes32:
+def _hash_tree_root_container(value: Container) -> Bytes32:
     # Pydantic preserves declaration order, which is the canonical SSZ field order.
     cls = type(value)
     return merkleize([hash_tree_root(getattr(value, name)) for name in cls.model_fields])

--- a/src/lean_spec/spec/crypto/xmss/interface.py
+++ b/src/lean_spec/spec/crypto/xmss/interface.py
@@ -139,15 +139,15 @@ class GeneralizedXmssScheme(StrictBaseModel):
         ]
 
         # Phase 4: build every other bottom tree and remember only its root.
-        for i in range(start_bottom_tree_index + 2, end_bottom_tree_index):
-            tree = HashSubTree.from_prf_key(
+        for bottom_tree_index in range(start_bottom_tree_index + 2, end_bottom_tree_index):
+            bottom_tree = HashSubTree.from_prf_key(
                 poseidon=self.poseidon,
                 config=config,
                 prf_key=prf_key,
-                bottom_tree_index=Uint64(i),
+                bottom_tree_index=Uint64(bottom_tree_index),
                 parameter=parameter,
             )
-            bottom_tree_roots.append(tree.root())
+            bottom_tree_roots.append(bottom_tree.root())
 
         # Phase 5: assemble the top tree from all bottom-tree roots.
         top_tree = HashSubTree.new_top_tree(

--- a/src/lean_spec/spec/crypto/xmss/merkle.py
+++ b/src/lean_spec/spec/crypto/xmss/merkle.py
@@ -224,10 +224,10 @@ class HashSubTree(Container):
                 poseidon.tweak_hash(
                     config,
                     parameter,
-                    TreeTweak(level=level + 1, index=parent_start + Uint64(i)),
+                    TreeTweak(level=level + 1, index=parent_start + Uint64(pair_index)),
                     [left, right],
                 )
-                for i, (left, right) in enumerate(batched(current_layer.nodes, 2))
+                for pair_index, (left, right) in enumerate(batched(current_layer.nodes, 2))
             ]
             current_layer = HashTreeLayer.padded(config, parents, parent_start)
             layers.append(current_layer)
@@ -339,11 +339,11 @@ class HashSubTree(Container):
         # Phase 2: the top built layer is padded to a sibling pair.
         # The real root is the node at this tree's index, not always position zero.
         # An odd index leaves a random pad at position zero, so select by absolute index.
-        top = subtree.layers[-1]
-        root_index = int(bottom_tree_index - top.start_index)
+        top_layer = subtree.layers[-1]
+        root_index = int(bottom_tree_index - top_layer.start_index)
         root_layer = HashTreeLayer(
             start_index=bottom_tree_index,
-            nodes=HashDigestList(data=[top.nodes[root_index]]),
+            nodes=HashDigestList(data=[top_layer.nodes[root_index]]),
         )
         return cls(
             depth=Uint64(depth),
@@ -468,8 +468,12 @@ class HashSubTree(Container):
         if not self.layers:
             raise ValueError("Empty subtree.")
 
-        first = self.layers[0]
-        if not (first.start_index <= position < first.start_index + Uint64(len(first.nodes))):
+        leaf_layer = self.layers[0]
+        if not (
+            leaf_layer.start_index
+            <= position
+            < leaf_layer.start_index + Uint64(len(leaf_layer.nodes))
+        ):
             raise ValueError(f"Position {position} out of bounds.")
 
         siblings: list[HashDigestVector] = []

--- a/src/lean_spec/spec/crypto/xmss/poseidon.py
+++ b/src/lean_spec/spec/crypto/xmss/poseidon.py
@@ -72,7 +72,10 @@ class PoseidonXmss(StrictBaseModel):
 
         # Permute, then add the original padded input element-wise.
         permuted_state = engine.permute(padded_input)
-        final_state = [p + i for p, i in zip(permuted_state, padded_input, strict=True)]
+        final_state = [
+            permuted_element + input_element
+            for permuted_element, input_element in zip(permuted_state, padded_input, strict=True)
+        ]
 
         return final_state[:output_length]
 
@@ -131,25 +134,25 @@ class PoseidonXmss(StrictBaseModel):
         rate = width - len(capacity_value)
 
         # Zero-pad to a multiple of the rate so absorption iterates exact chunks.
-        num_extra = (rate - (len(input_elements) % rate)) % rate
-        padded_input = input_elements + [Fp(value=0)] * num_extra
+        num_padding_elements = (rate - (len(input_elements) % rate)) % rate
+        padded_input = input_elements + [Fp(value=0)] * num_padding_elements
 
         # Layout: capacity slots first, then rate slots.
-        cap_length = len(capacity_value)
+        capacity_length = len(capacity_value)
         state = [Fp(value=0)] * width
-        state[:cap_length] = capacity_value
+        state[:capacity_length] = capacity_value
 
         # Phase 2: absorb each chunk by overwriting the rate slots.
         #
         # Padding makes every chunk exactly rate wide, so the slice always matches.
         for chunk in batched(padded_input, rate):
-            state[cap_length : cap_length + rate] = chunk
+            state[capacity_length : capacity_length + rate] = chunk
             state = engine.permute(state)
 
         # Phase 3: squeeze rate slots, permuting until enough output is available.
         output: list[Fp] = []
         while len(output) < output_length:
-            output.extend(state[cap_length : cap_length + rate])
+            output.extend(state[capacity_length : capacity_length + rate])
             state = engine.permute(state)
 
         return output[:output_length]


### PR DESCRIPTION
## Finding

Several locals in the crypto specs were vague single words or stray loop indices, violating the descriptive-name rule (a reader should understand a name in isolation, without scanning surrounding code).

## Fix

Pure renames, no behavior/format/algorithm change. Numbers and the numba kernel math indices are untouched.

- `xmss/interface.py`: the bottom-tree build loop now binds `bottom_tree_index` and `bottom_tree` (was `i` / `tree`), simplifying the body.
- `xmss/merkle.py`: `top_layer` (was `top`, a HashTreeLayer), `leaf_layer` (was `first`), `pair_index` (was `i` in the sibling-pair enumeration).
- `xmss/poseidon.py`: the absorb element-wise add now reads `permuted_element + input_element` (was `p + i`), `num_padding_elements` (was `num_extra`), `capacity_length` (was `cap_length`, matching the spelled-out name already used elsewhere in the file).
- `merkleization.py`: the singledispatch handlers `_htr_*` become `_hash_tree_root_*`, and the `element_t` parameter becomes `element_type`.

## Verification

- `just check` clean (ruff, format, ty, codespell, mdformat).
- All 364 `tests/spec/crypto/` tests pass.
- `rg` for each old name (`_htr_`, `element_t`, `cap_length`, `num_extra`) is clean across source, tests, and packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)