### PR TITLE
docs(slot): list only reachable justifiable-slot examples

### DIFF
--- a/src/lean_spec/spec/forks/lstar/slot.py
+++ b/src/lean_spec/spec/forks/lstar/slot.py
@@ -60,7 +60,8 @@ class Slot(Uint64):
 
         # Rule 2: Slots at perfect square distances are justifiable.
         #
-        # Examples: delta = 1, 4, 9, 16, 25, 36, 49, 64, ...
+        # Smaller squares 1 and 4 already returned under Rule 1.
+        # First square that reaches here is 9: delta = 9, 16, 25, 36, 49, 64, ...
         # Check: integer square root squared equals delta
         if math.isqrt(delta) ** 2 == delta:
             return True
@@ -68,6 +69,8 @@ class Slot(Uint64):
         # Rule 3: Slots at pronic number distances are justifiable.
         #
         # Pronic numbers have the form n(n+1): 2, 6, 12, 20, 30, 42, 56, ...
+        # The smallest pronic 2 already returned under Rule 1.
+        # First pronic that reaches here is 6: delta = 6, 12, 20, 30, 42, 56, ...
         # Mathematical insight: For pronic delta = n(n+1), we have:
         #   4*delta + 1 = 4n(n+1) + 1 = (2n+1)^2
         # Check: 4*delta+1 is an odd perfect square


### PR DESCRIPTION
## What

The inline comments documenting the justifiable-slot rules listed delta examples that are unreachable at the point of the check.

The immediate-justification window returns early for any delta of 5 or less. So:

- The perfect-square comment listed `delta = 1, 4, 9, ...`, but 1 and 4 are caught by Rule 1 first. The first square that reaches the check is 9.
- The pronic comment listed `2, 6, 12, ...` as if 2 reached the check, but 2 is caught by Rule 1 first. The first pronic that reaches the check is 6.

This made the comments teach a false attribution of which rule admits which slot.

## Fix

Annotate that the small values are handled by the immediate window and show the first delta that actually reaches each rule (square 9, pronic 6). The docstring summary was already correct and is untouched; only the two inline comment blocks change.

## Notes

- Docs-only change, no behavior change. Forks are tested by vectors, and a comment fix changes no behavior, so no test vectors are needed.
- `just check` passes (lint, format, typecheck, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)