### PR TITLE
docs(aggregation): drop section-banner headings from docstrings

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/aggregation.py
@@ -60,8 +60,6 @@ class SingleMessageAggregate(Container):
         """
         Fold fresh signatures and child proofs into one single-message proof.
 
-        # Overview
-
         Two kinds of contribution merge into one proof.
 
         - A fresh signer contributes a single raw signature.
@@ -311,8 +309,6 @@ class MultiMessageAggregate(Container):
     ) -> None:
         """
         Verify this multi-message proof against its per-component bindings.
-
-        # The message bindings
 
         Each component is checked against one message and slot supplied by the caller.
         Without that binding the proof would accept attacker-chosen data.


### PR DESCRIPTION
## What

Two method docstrings in the lstar aggregation containers opened with Markdown-style section banners:

- `# Overview` in the single-message aggregate fold method
- `# The message bindings` in the multi-message verify method

These render as headings inside Google-style docstrings and are inconsistent with every other method in the file, which use plain prose. They also conflict with the project's lean-docstring and no-banner guidance.

## Why

The banner lines add no information. The prose beneath each one already stands on its own and reads cleanly without the heading.

## Change

Drop the four banner-related lines (the `#` heading plus its blank line, x2). All surrounding wording is preserved verbatim.

Docs-only change. `just check` passes (ruff lint, ruff format, ty, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)