### PR TITLE
refactor(xmss): rename vague 'parts' locals to descriptive names

### DIFF
--- a/src/lean_spec/spec/crypto/xmss/interface.py
+++ b/src/lean_spec/spec/crypto/xmss/interface.py
@@ -351,7 +351,7 @@ class GeneralizedXmssScheme(StrictBaseModel):
             parameter=public_key.parameter,
             root=public_key.root,
             position=slot,
-            leaf_parts=chain_ends,
+            leaf_chain_ends=chain_ends,
             opening=signature.path,
         )
 

--- a/src/lean_spec/spec/crypto/xmss/merkle.py
+++ b/src/lean_spec/spec/crypto/xmss/merkle.py
@@ -549,7 +549,7 @@ def verify_path(
     parameter: Parameter,
     root: HashDigestVector,
     position: Uint64,
-    leaf_parts: list[HashDigestVector],
+    leaf_chain_ends: list[HashDigestVector],
     opening: HashTreeOpening,
 ) -> bool:
     """
@@ -573,7 +573,7 @@ def verify_path(
         parameter: Public parameter for the hash function.
         root: Trusted root taken from the public key.
         position: Absolute index of the leaf being verified.
-        leaf_parts: Digests that constitute the original leaf.
+        leaf_chain_ends: Digests that constitute the original leaf.
         opening: Sibling path from leaf to root.
 
     Returns:
@@ -593,7 +593,7 @@ def verify_path(
         config,
         parameter,
         TreeTweak(level=0, index=Uint64(position)),
-        leaf_parts,
+        leaf_chain_ends,
     )
     current_position = int(position)
 

--- a/src/lean_spec/spec/crypto/xmss/poseidon.py
+++ b/src/lean_spec/spec/crypto/xmss/poseidon.py
@@ -159,7 +159,7 @@ class PoseidonXmss(StrictBaseModel):
         config: XmssConfig,
         parameter: Parameter,
         tweak: TreeTweak | ChainTweak,
-        message_parts: list[HashDigestVector],
+        message_digests: list[HashDigestVector],
     ) -> HashDigestVector:
         """
         Apply the tweakable hash to one or more digests.
@@ -174,7 +174,7 @@ class PoseidonXmss(StrictBaseModel):
             config: Active XMSS configuration.
             parameter: Public parameter that personalizes the hash.
             tweak: Position tweak for domain separation.
-            message_parts: Digests to hash together.
+            message_digests: Digests to hash together.
 
         Returns:
             A digest of HASH_LENGTH_FIELD_ELEMENTS field elements.
@@ -195,25 +195,25 @@ class PoseidonXmss(StrictBaseModel):
                 )
         encoded_tweak = int_to_base_p(packed_tweak, config.TWEAK_LENGTH_FIELD_ELEMENTS)
 
-        if len(message_parts) == 1:
+        if len(message_digests) == 1:
             # Hash chain step: width-16 compression of (digest || parameter || tweak).
-            input_elements = message_parts[0].elements + parameter.elements + encoded_tweak
+            input_elements = message_digests[0].elements + parameter.elements + encoded_tweak
             digest = self.compress(input_elements, 16, config.HASH_LENGTH_FIELD_ELEMENTS)
 
-        elif len(message_parts) == 2:
+        elif len(message_digests) == 2:
             # Merkle node: width-24 compression of (parameter || tweak || left || right).
             input_elements = (
                 parameter.elements
                 + encoded_tweak
-                + message_parts[0].elements
-                + message_parts[1].elements
+                + message_digests[0].elements
+                + message_digests[1].elements
             )
             digest = self.compress(input_elements, 24, config.HASH_LENGTH_FIELD_ELEMENTS)
 
         else:
             # Merkle leaf: sponge mode over many concatenated digests.
             flattened_message = [
-                element for message_part in message_parts for element in message_part.elements
+                element for message_digest in message_digests for element in message_digest.elements
             ]
             input_elements = parameter.elements + encoded_tweak + flattened_message
 

--- a/tests/spec/crypto/xmss/test_merkle.py
+++ b/tests/spec/crypto/xmss/test_merkle.py
@@ -30,12 +30,12 @@ def _run_commit_open_verify_roundtrip(
     num_leaves: int,
     depth: int,
     start_index: int,
-    leaf_parts_length: int,
+    leaf_chain_ends_length: int,
 ) -> None:
     """Build a tree, then open and verify every active leaf against its root."""
     parameter = random_parameter(config)
     leaves: list[list[HashDigestVector]] = [
-        [random_domain(config) for _ in range(leaf_parts_length)] for _ in range(num_leaves)
+        [random_domain(config) for _ in range(leaf_chain_ends_length)] for _ in range(num_leaves)
     ]
 
     leaf_hashes: list[HashDigestVector] = [
@@ -43,9 +43,9 @@ def _run_commit_open_verify_roundtrip(
             config,
             parameter,
             TreeTweak(level=0, index=Uint64(start_index + i)),
-            leaf_parts,
+            leaf_chain_ends,
         )
-        for i, leaf_parts in enumerate(leaves)
+        for i, leaf_chain_ends in enumerate(leaves)
     ]
 
     tree = HashSubTree.new(
@@ -59,7 +59,7 @@ def _run_commit_open_verify_roundtrip(
     )
     root = tree.root()
 
-    for i, leaf_parts in enumerate(leaves):
+    for i, leaf_chain_ends in enumerate(leaves):
         position = Uint64(start_index + i)
         opening = tree.path(position)
         assert verify_path(
@@ -68,13 +68,13 @@ def _run_commit_open_verify_roundtrip(
             parameter=parameter,
             root=root,
             position=position,
-            leaf_parts=leaf_parts,
+            leaf_chain_ends=leaf_chain_ends,
             opening=opening,
         )
 
 
 @pytest.mark.parametrize(
-    "num_leaves, depth, start_index, leaf_parts_length",
+    "num_leaves, depth, start_index, leaf_chain_ends_length",
     [
         pytest.param(16, 4, 0, 3, id="Full tree (depth 4)", marks=pytest.mark.slow),
         pytest.param(12, 5, 0, 5, id="Half tree, left-aligned (depth 5)", marks=pytest.mark.slow),
@@ -90,7 +90,7 @@ def test_commit_open_verify_roundtrip(
     num_leaves: int,
     depth: int,
     start_index: int,
-    leaf_parts_length: int,
+    leaf_chain_ends_length: int,
 ) -> None:
     """A built tree opens and verifies every leaf for various shapes."""
     assert start_index + num_leaves <= (1 << depth)
@@ -98,7 +98,7 @@ def test_commit_open_verify_roundtrip(
     # Match the configured height to this tree's depth so every opening is well formed.
     config_for_depth = PROD_CONFIG.model_copy(update={"LOG_LIFETIME": depth})
     _run_commit_open_verify_roundtrip(
-        POSEIDON, config_for_depth, num_leaves, depth, start_index, leaf_parts_length
+        POSEIDON, config_for_depth, num_leaves, depth, start_index, leaf_chain_ends_length
     )
 
 
@@ -382,7 +382,7 @@ def test_verify_path_rejects_opening_length_mismatch(sibling_count: int) -> None
             parameter=random_parameter(config_with_lifetime_sixteen),
             root=random_domain(config_with_lifetime_sixteen),
             position=Uint64(0),
-            leaf_parts=[random_domain(config_with_lifetime_sixteen)],
+            leaf_chain_ends=[random_domain(config_with_lifetime_sixteen)],
             opening=opening,
         )
         is False
@@ -403,7 +403,7 @@ def test_verify_path_rejects_position_exceeding_capacity(position: int) -> None:
             parameter=random_parameter(config_with_lifetime_sixteen),
             root=random_domain(config_with_lifetime_sixteen),
             position=Uint64(position),
-            leaf_parts=[random_domain(config_with_lifetime_sixteen)],
+            leaf_chain_ends=[random_domain(config_with_lifetime_sixteen)],
             opening=opening,
         )
         is False
@@ -422,7 +422,7 @@ def test_verify_path_accepts_boundary_position_without_raising() -> None:
         parameter=random_parameter(config_with_lifetime_sixteen),
         root=random_domain(config_with_lifetime_sixteen),
         position=Uint64(15),
-        leaf_parts=[random_domain(config_with_lifetime_sixteen)],
+        leaf_chain_ends=[random_domain(config_with_lifetime_sixteen)],
         opening=opening,
     )
     assert isinstance(verification_result, bool)


### PR DESCRIPTION
## Summary

CLAUDE.md bans the vague word `part`/`parts` in identifiers, since a reference spec must name the thing, not its role. Two crypto locals in the XMSS modules violated this rule. This is a pure rename with no behavior, format, or algorithm change.

## Changes

- `message_parts` in the Poseidon tweakable hash holds message digest field-elements being hashed together, so it becomes `message_digests` (and the comprehension variable `message_part` becomes `message_digest`).
- `leaf_parts` in the Merkle path verifier and the XMSS interface holds the hash-chain end values that constitute a leaf, so it becomes `leaf_chain_ends`. The interface passes `chain_ends` literally, so the new name is precise.

Renamed at every occurrence, including docstrings and the mirrored tests under `tests/spec/crypto/xmss/`.

## Verification

- `rg "message_parts|leaf_parts"` returns nothing.
- `just check` passes fully (lint, format, type check, codespell, mdformat).
- `tests/spec/crypto/xmss/` for merkle, poseidon, and interface: 81 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)