### PR TITLE
docs(store): document that latest_finalized is reorg-mutable

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/store.py
+++ b/src/lean_spec/spec/forks/lstar/containers/store.py
@@ -43,7 +43,12 @@ class Store[StateT: Container, BlockT: Container](StrictBaseModel):
     """Highest-slot justified checkpoint observed so far."""
 
     latest_finalized: Checkpoint
-    """Highest-slot finalized checkpoint observed so far."""
+    """
+    Finalization as seen from the canonical head, not irreversible economic finality.
+
+    This tracks the head chain's view and is reorg-mutable.
+    A reorg onto a fork that finalized a lower slot lowers this value.
+    """
 
     blocks: dict[Bytes32, BlockT] = Field(default_factory=dict)
     """


### PR DESCRIPTION
## What

Clarifies the field docstring for the fork-choice store's latest finalized checkpoint.

The previous docstring read "Highest-slot finalized checkpoint observed so far," which invites readers to treat the value as irreversible economic finality.

## Why

The value is derived from the canonical head's state in update_head: it climbs from the chosen head to its ancestor at that head state's finalized slot. On a reorg onto a fork that locally finalized a lower slot, the store's value moves backward. This is the correct 3SF behavior (see test_losing_fork_higher_finalized_does_not_latch), but a consumer that assumes the value never decreases would be wrong.

The new docstring states the head-view, reorg-mutable semantics in two short lines.

Docs-only; no code or behavior change. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)