### PR TITLE
docs(lstar): drop code-restating comments in validator duties and timeline

### DIFF
--- a/src/lean_spec/spec/forks/lstar/timeline.py
+++ b/src/lean_spec/spec/forks/lstar/timeline.py
@@ -20,7 +20,6 @@ class TimelineMixin(LstarSpecBase):
         is_aggregator: bool = False,
     ) -> tuple[LstarStore, list[SignedAggregatedAttestation]]:
         """Advance store time by one interval and perform interval-specific actions."""
-        # Advance time by one interval
         store = store.model_copy(update={"time": store.time + Interval(1)})
         current_interval = Interval(int(store.time) % int(INTERVALS_PER_SLOT))
         new_aggregates: list[SignedAggregatedAttestation] = []
@@ -55,13 +54,10 @@ class TimelineMixin(LstarSpecBase):
         """
         all_new_aggregates: list[SignedAggregatedAttestation] = []
 
-        # Tick forward one interval at a time
         while store.time < target_interval:
-            # Check if proposal should be signaled for next interval
             next_interval = Interval(int(store.time) + 1)
             should_signal_proposal = has_proposal and next_interval == target_interval
 
-            # Advance by one interval with appropriate signaling
             store, new_aggregates = self.tick_interval(store, should_signal_proposal, is_aggregator)
             all_new_aggregates.extend(new_aggregates)
 

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -75,23 +75,14 @@ class ValidatorDutiesMixin(LstarSpecBase):
         return Checkpoint(root=target_block_root, slot=target_block.slot)
 
     def produce_attestation_data(self, store: LstarStore, slot: Slot) -> AttestationData:
-        """
-        Produce attestation data for the given slot.
-
-        This method constructs an AttestationData object according to the lean protocol
-        specification. The attestation data represents the chain state view including
-        head, target, and source checkpoints.
-        """
-        # Get the head block the validator sees for this slot
+        """Attestation data for the given slot: head, target, and the latest justified source."""
         head_checkpoint = Checkpoint(
             root=store.head,
             slot=store.blocks[store.head].slot,
         )
 
-        # Calculate the target checkpoint for this attestation
         target_checkpoint = self.get_attestation_target(store)
 
-        # Construct attestation data
         return self.attestation_data_class(
             slot=slot,
             head=head_checkpoint,


### PR DESCRIPTION
## What

Removes pure-narration inline comments and a filler docstring in two lstar fork modules:

- `validator_duties.py` — the attestation-data docstring repeated the field list ("This method constructs an AttestationData object ... including head, target, and source checkpoints"); it is reduced to a single accurate summary line. The "Get the head block ...", "Calculate the target checkpoint ...", and "Construct attestation data" comments restated the code beneath them and are deleted.
- `timeline.py` — "Advance time by one interval", "Tick forward one interval at a time", "Check if proposal should be signaled ...", and "Advance by one interval ..." restated their adjacent lines and are deleted.

## Why

Project documentation rules ban restating obvious code and filler docstrings ("This method ..."). A comment should exist only when the WHY is non-obvious.

Genuine-WHY comments are preserved untouched: the target lower-bound and justifiability rationale, the freshest-head / building-on-stale-state reasoning, and the slot-phase semantics in the interval match-case.

Docs-only change. No code paths changed. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)