### PR TITLE
docs(timeline): explain the per-interval tick schedule

### DIFF
--- a/src/lean_spec/spec/forks/lstar/timeline.py
+++ b/src/lean_spec/spec/forks/lstar/timeline.py
@@ -19,7 +19,24 @@ class TimelineMixin(LstarSpecBase):
         has_proposal: bool,
         is_aggregator: bool = False,
     ) -> tuple[LstarStore, list[SignedAggregatedAttestation]]:
-        """Advance store time by one interval and perform interval-specific actions."""
+        """
+        Advance store time by one interval and perform interval-specific actions.
+
+        Each slot is split into five intervals so consensus work runs at fixed points
+        relative to when a block arrives and votes spread across the network.
+
+        Timing of the action points within a slot:
+
+        - Interval 0: ingest the slot's pending votes once the proposal has landed.
+        - Interval 2: aggregators bundle the slot's votes into proofs and broadcast them.
+        - Interval 3: advance the safe target from the latest votes for fast confirmation.
+        - Interval 4: ingest the votes that accumulated through the rest of the slot.
+
+        Aggregation waits until interval 2 so a block proposed at the slot start has
+        time to propagate and gather votes before they are bundled.
+        Fast confirmation sits at interval 3, after aggregates exist, so the safe
+        target reflects the freshest votes the node has seen.
+        """
         # Advance time by one interval
         store = store.model_copy(update={"time": store.time + Interval(1)})
         current_interval = Interval(int(store.time) % int(INTERVALS_PER_SLOT))


### PR DESCRIPTION
## What

Expands the docstring of the interval-tick method in the lstar timeline so it explains the five-interval slot schedule, not just that it "advances time and performs interval-specific actions".

The body now names each action point within a slot:

- Interval 0: ingest the slot's pending votes once the proposal lands.
- Interval 2: aggregators bundle the slot's votes into proofs and broadcast them.
- Interval 3: advance the safe target from the latest votes for fast confirmation.
- Interval 4: ingest the votes that accumulated through the rest of the slot.

## Why

The match arms encode a consensus-critical schedule, but the one-line docstring gave no hint why there are five intervals, why aggregation sits at interval 2, or why fast confirmation sits at interval 3. The new prose states the rationale: aggregation waits until interval 2 so a block proposed at slot start has time to propagate and gather votes before bundling, and fast confirmation follows at interval 3 so the safe target reflects the freshest votes.

Docs-only change. No behavior change. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)