### PR TITLE
refactor(aggregation): add failure context to bare AggregationError raises

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/aggregation.py
+++ b/src/lean_spec/spec/forks/lstar/containers/aggregation.py
@@ -117,7 +117,9 @@ class SingleMessageAggregate(Container):
                 mode=LEAN_ENV,
             )
         except Exception as exception:
-            raise AggregationError(str(exception)) from exception
+            raise AggregationError(
+                f"single-message aggregate build failed: {exception}"
+            ) from exception
 
         return cls(
             participants=participants,
@@ -246,7 +248,7 @@ class MultiMessageAggregate(Container):
                 mode=LEAN_ENV,
             )
         except Exception as exception:
-            raise AggregationError(str(exception)) from exception
+            raise AggregationError(f"multi-message merge failed: {exception}") from exception
 
         return cls(proof=ByteList512KiB(data=multi_message_aggregate_wire))
 


### PR DESCRIPTION
## What

Two of the five `except ... raise AggregationError(...)` sites in the lstar aggregation containers wrapped Rust prover failures in a bare `AggregationError(str(exception))`, with no calling-context prefix:

- the single-message aggregate build (the `aggregate_single_message` prover call)
- the multi-message merge (the `merge_many_single_message_proof` prover call)

The other three sites (single-message verify, multi-message split, multi-message verify) already prefix their messages with the operation that failed. This PR brings the two bare sites in line:

- single-message build -> "single-message aggregate build failed: ..."
- multi-message merge   -> "multi-message merge failed: ..."

## Why

Consistency. The same failure mode (prover rejects the inputs) now reports its calling context everywhere, instead of losing it in two places. A caught error message names the operation that failed without the reader having to inspect the traceback.

This is message-only: the exception type raised is unchanged, the `from exception` chaining is preserved, and behavior is otherwise identical. No external `lean_multisig_py` symbols renamed.

`just check` passes (lint, format, typecheck, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)