### PR TITLE
refactor(timeline): name the within-slot interval and drop redundant wrap

### DIFF
--- a/src/lean_spec/spec/forks/lstar/timeline.py
+++ b/src/lean_spec/spec/forks/lstar/timeline.py
@@ -22,10 +22,10 @@ class TimelineMixin(LstarSpecBase):
         """Advance store time by one interval and perform interval-specific actions."""
         # Advance time by one interval
         store = store.model_copy(update={"time": store.time + Interval(1)})
-        current_interval = Interval(int(store.time) % int(INTERVALS_PER_SLOT))
+        interval_within_slot = int(store.time) % int(INTERVALS_PER_SLOT)
         new_aggregates: list[SignedAggregatedAttestation] = []
 
-        match int(current_interval):
+        match interval_within_slot:
             # Slot start: ingest pending attestations once the slot's proposal lands.
             case 0 if has_proposal:
                 store = self.accept_new_attestations(store)


### PR DESCRIPTION
## What

In the interval-ticking logic for the lstar fork, the within-slot interval position was built as an `Interval(...)` and then immediately unwrapped back to a plain int in the `match` via `int(...)`. This computes the plain int once and matches on it directly, dropping the redundant wrap.

It also renames the variable from `current_interval` (a vague name suggesting an absolute interval) to `interval_within_slot`, which accurately states that it is the position within the slot, not an absolute interval count.

## Why

- The `Interval(...)` construction served no purpose: its only use was the very next `match int(...)`, so it was wrapped and unwrapped on adjacent lines.
- `current_interval` was misleading; the value is `time % INTERVALS_PER_SLOT`, i.e. where we are inside the current slot.

Behavior is identical. `just check` passes (lint, format, type check, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)