### PR TITLE
refactor(fork-choice): make min_score an explicit optional threshold

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -741,7 +741,7 @@ class ForkChoiceMixin(LstarSpecBase):
         store: LstarStore,
         start_root: Bytes32,
         attestations: dict[ValidatorIndex, AttestationData],
-        min_score: int = 0,
+        min_score: int | None = None,
     ) -> Bytes32:
         """
         Walk the block tree according to the LMD GHOST rule.
@@ -778,7 +778,7 @@ class ForkChoiceMixin(LstarSpecBase):
 
         for root, block in store.blocks.items():
             # Prune low-weight branches early when a threshold is set.
-            if min_score > 0 and weights[root] < min_score:
+            if min_score is not None and weights[root] < min_score:
                 continue
 
             children_map[block.parent_root].append(root)


### PR DESCRIPTION
## What

The LMD-GHOST head/safe-target weight filter in the `lstar` fork choice used `min_score: int = 0`, where the value `0` was overloaded to mean "no threshold". This conflated a real score with the absence of a filter and forced the guard to read `min_score > 0`.

This PR changes the parameter to `min_score: int | None = None` and the guard to `if min_score is not None and weights[root] < min_score`. The no-filter caller (head computation) now passes nothing instead of relying on a magic zero; the supermajority safe-target caller continues to pass its real positive threshold unchanged.

## Why

`int | None = None` makes the "no filter" intent explicit instead of encoding it as a sentinel zero. A reader no longer has to know that `0` is special.

## Behavior

Behavior-preserving:
- A score below zero never excluded any branch (weights are non-negative vote counts).
- The previous `0`-as-no-filter case maps exactly to `None`.
- The only caller that relied on the old default passed no argument, so it transparently picks up `None`.

`just check` passes (lint, format, type check, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)