### PR TITLE
refactor(fork-choice): make internal attestation-extraction helper private

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -631,7 +631,7 @@ class ForkChoiceMixin(LstarSpecBase):
 
             return store
 
-    def extract_attestations_from_aggregated_payloads(
+    def _extract_attestations_from_aggregated_payloads(
         self,
         aggregated_payloads: dict[AttestationData, set[SingleMessageAggregate]],
         latest_finalized_slot: Slot,
@@ -722,7 +722,7 @@ class ForkChoiceMixin(LstarSpecBase):
             Each block root mapped to its accumulated vote weight.
         """
         # Reduce the counted pool to each validator's latest still-relevant vote.
-        latest_votes = self.extract_attestations_from_aggregated_payloads(
+        latest_votes = self._extract_attestations_from_aggregated_payloads(
             store.latest_known_aggregated_payloads,
             store.latest_finalized.slot,
         )
@@ -809,7 +809,7 @@ class ForkChoiceMixin(LstarSpecBase):
             The store with its head set to the chosen block.
         """
         # Reduce the counted pool to each validator's latest still-relevant vote.
-        latest_votes = self.extract_attestations_from_aggregated_payloads(
+        latest_votes = self._extract_attestations_from_aggregated_payloads(
             store.latest_known_aggregated_payloads,
             store.latest_finalized.slot,
         )
@@ -896,7 +896,7 @@ class ForkChoiceMixin(LstarSpecBase):
         min_target_score = math.ceil(num_validators * 2 / 3)
 
         # Reduce the pending pool to each validator's latest still-relevant vote.
-        latest_votes = self.extract_attestations_from_aggregated_payloads(
+        latest_votes = self._extract_attestations_from_aggregated_payloads(
             store.latest_new_aggregated_payloads,
             store.latest_finalized.slot,
         )


### PR DESCRIPTION
## What

Rename the attestation-extraction helper in the lstar fork-choice mixin from a public method to a private (underscore-prefixed) one, and update its three internal call sites.

## Why

The helper lives in the same private LMD-GHOST weight-accumulation pipeline as its siblings (the ancestor-weight accumulator and the GHOST-head computer), both of which are underscore-prefixed. This one was public despite being called only from within its own module — a naming inconsistency that implied a public API surface that does not exist.

A repo-wide grep over `src/`, `tests/`, and `packages/` confirms there are no external or test callers; all four references are within the fork-choice module itself.

This is a pure rename. Behavior is identical, and `just check` passes (lint, format, type check, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)