### PR TITLE
refactor(fork-choice): enumerate payload key union without copying values

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -863,7 +863,7 @@ class ForkChoiceMixin(LstarSpecBase):
         merged_aggregated_payloads = {
             attestation_data: known_payloads.get(attestation_data, set())
             | new_payloads.get(attestation_data, set())
-            for attestation_data in {**known_payloads, **new_payloads}
+            for attestation_data in dict.fromkeys((*known_payloads, *new_payloads))
         }
 
         # Promote into the counted pool and clear the pending one.


### PR DESCRIPTION
## What

When promoting pending aggregate proofs into the counted pool, the dict comprehension iterated `{**known_payloads, **new_payloads}` purely to enumerate the union of attestation-data keys. Building that merged dict copies every set value only to discard it (the comprehension re-fetches via `.get()`). This replaces it with `dict.fromkeys((*known_payloads, *new_payloads))`, which enumerates the same keys without copying any values.

## Why this is behavior- and order-preserving

`dict.fromkeys((*known_payloads, *new_payloads))` yields keys in exactly the same order the merged-dict spread did: all counted-pool keys in insertion order, then pending-pool keys not already present, in their insertion order. The resulting `merged_aggregated_payloads` therefore has identical key insertion order.

This matters because of the LMD determinism invariant: equal-slot fork-choice ties resolve by first-seen insertion order. A set-union (`known_payloads.keys() | new_payloads.keys()`) was deliberately avoided here because set iteration order is hash-seeded and would not preserve that order.

`just check` passes (lint, format, type check, codespell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)