### PR TITLE
refactor(fork-choice): single weight-computation entry point

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -729,12 +729,10 @@ class ForkChoiceMixin(LstarSpecBase):
 
         # Credit every block on those votes' ancestor chains above finalization.
         #
-        # Return a plain dict so callers read missing blocks as absent, not zero.
-        weights = self._accumulate_ancestor_weights(
-            store, latest_votes, store.latest_finalized.slot
-        )
-
-        return dict(weights)
+        # Every caller reads this map with a default of zero for absent blocks.
+        # The shared accumulator already returns a default-zero mapping.
+        # So returning it directly is observably identical to copying it first.
+        return self._accumulate_ancestor_weights(store, latest_votes, store.latest_finalized.slot)
 
     def _compute_lmd_ghost_head(
         self,


### PR DESCRIPTION
## What

The API weight map and the LMD-GHOST head walk both derive their weights
through the same two shared methods: latest-vote extraction, then
ancestor-weight accumulation. The accumulator already returns a default-zero
mapping (a `defaultdict(int)`), and every weight caller reads the resulting
map with an explicit default of zero for absent blocks (`weights.get(root, 0)`
in the API handler, the store snapshot, the store checks, and the API-endpoint
fixture).

So the extra `defaultdict -> dict` copy in the API entry point was needless:
returning the accumulator's mapping directly is observably identical for every
caller. This drops the copy and records the contract inline.

## Why

Removes a pointless allocation and a misleading comment (the copy did not
actually change observable behavior), leaving one shared accumulation as the
single source of block weights for both head selection and the API.

## Safety

Behavior-preserving. The two weight consumers anchor accumulation at different
slots by design (head walk anchors at the justified root's slot, the API
anchors at the finalized slot), so they are intentionally NOT merged into one
call — only the redundant copy is removed. Head selection results and the API
weights are byte-for-byte unchanged. No consensus behavior changes, so no new
test vector is required.

`just check` passes (lint, format, ty, codespell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)