### PR TITLE
style(slot): use future annotations and unquote self-references

### DIFF
--- a/src/lean_spec/spec/forks/lstar/slot.py
+++ b/src/lean_spec/spec/forks/lstar/slot.py
@@ -1,5 +1,7 @@
 """Slot primitive shared by the consensus and crypto layers."""
 
+from __future__ import annotations
+
 import math
 from typing import Final
 
@@ -12,7 +14,7 @@ IMMEDIATE_JUSTIFICATION_WINDOW: Final = 5
 class Slot(Uint64):
     """A slot number, as a 64-bit unsigned integer."""
 
-    def justified_index_after(self, finalized_slot: "Slot") -> int | None:
+    def justified_index_after(self, finalized_slot: Slot) -> int | None:
         """
         Return the relative bitfield index for justification tracking.
 
@@ -25,7 +27,7 @@ class Slot(Uint64):
         # Slot (finalized_slot + 1) maps to index 0.
         return int(self - finalized_slot) - 1
 
-    def is_justifiable_after(self, finalized_slot: "Slot") -> bool:
+    def is_justifiable_after(self, finalized_slot: Slot) -> bool:
         """
         Checks if this slot is a valid candidate for justification after a given finalized slot.
 


### PR DESCRIPTION
## What

Add `from __future__ import annotations` to the slot module and unquote the two self-referential `Slot` annotations on the slot methods.

## Why

The code-style rule prefers `from __future__ import annotations` over quoted forward references. That import is prohibited only in files defining Pydantic models, because lazy annotations break Pydantic's forward-ref resolution.

This module defines no Pydantic model. `Slot` is a plain `Uint64` (`int`) subclass with no `BaseModel` involvement, so the prohibition does not apply. The base `Uint64` already uses future annotations itself.

Behavior is identical. `just check` passes in full, including `ty check`, confirming the annotations still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)