### PR TITLE
refactor(lstar): drop Any leakage from genesis/store creation

### DIFF
--- a/src/lean_spec/spec/forks/lstar/_base.py
+++ b/src/lean_spec/spec/forks/lstar/_base.py
@@ -22,7 +22,7 @@ from lean_spec.spec.forks.lstar.containers import (
     Validators,
 )
 from lean_spec.spec.forks.protocol import ForkProtocol
-from lean_spec.spec.ssz import Bytes32
+from lean_spec.spec.ssz import Bytes32, Uint64
 
 LstarStore = Store[State, Block]
 """Concrete Store specialization owned by the lstar fork."""
@@ -40,6 +40,11 @@ class LstarSpecBase(ForkProtocol):
     attestation_data_class: type[AttestationData]
     aggregated_attestation_class: type[AggregatedAttestation]
     genesis_config_class: type[GenesisConfig]
+
+    @abstractmethod
+    def generate_genesis(self, genesis_time: Uint64, validators: Validators) -> State:
+        """Genesis-construction contract."""
+        ...
 
     @abstractmethod
     def process_slots(self, state: State, target_slot: Slot) -> State:

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Iterable
 from itertools import batched
-from typing import Any
 
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks.lstar._base import LstarSpecBase
@@ -24,16 +23,14 @@ from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionErro
 from lean_spec.spec.observability import (
     observe_state_transition,
 )
-from lean_spec.spec.ssz import ZERO_HASH, Boolean, Bytes32, SSZList, Uint64
+from lean_spec.spec.ssz import ZERO_HASH, Boolean, Bytes32, Uint64
 
 
 class StateTransitionMixin(LstarSpecBase):
     """State transition function for the lstar fork."""
 
-    def generate_genesis(self, genesis_time: Uint64, validators: SSZList[Any]) -> State:
+    def generate_genesis(self, genesis_time: Uint64, validators: Validators) -> State:
         """Generate a genesis state with empty history and proper initial values."""
-        assert isinstance(validators, Validators)
-
         genesis_config = self.genesis_config_class(
             genesis_time=genesis_time,
         )

--- a/src/lean_spec/spec/forks/protocol.py
+++ b/src/lean_spec/spec/forks/protocol.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import Any, ClassVar, Protocol, Self
+from typing import ClassVar, Protocol, Self
 
 from lean_spec.spec.forks.lstar.containers import Checkpoint, Slot, ValidatorIndex
-from lean_spec.spec.ssz import Bytes32, SSZList, Uint64
+from lean_spec.spec.ssz import Bytes32
 
 
 class SpecSSZType(Protocol):
@@ -152,10 +152,6 @@ class ForkProtocol(ABC):
 
     genesis_config_class: type[SpecSSZType]
     """Concrete genesis configuration container class."""
-
-    @abstractmethod
-    def generate_genesis(self, genesis_time: Uint64, validators: SSZList[Any]) -> SpecStateType:
-        """Construct a genesis state for this fork."""
 
     @abstractmethod
     def create_store(


### PR DESCRIPTION
## What

The fork-protocol contract declared genesis construction with `SSZList[Any]` for its validator-set parameter, erasing the element type at the boundary. The concrete lstar override then recovered the type with `assert isinstance(validators, Validators)` — an assert that vanishes under `python -O` and existed solely to undo the `Any`.

This moves the genesis declaration out of the abstract, fork-agnostic `ForkProtocol` and into the lstar typed base (`LstarSpecBase`), declared with the concrete `Validators` and `State` types — exactly mirroring how the sibling signature-verification contract already names `Validators` there. The mixin override now matches that contract exactly, so the `Any` leak is gone and the recovering assert is deleted.

## Why this shape

`generate_genesis` is only ever invoked on the concrete lstar fork: the node composition root narrows to `LstarSpec` before calling it, and the testing package and consensus tests instantiate `LstarSpec` directly. It is never dispatched through the un-narrowed abstract protocol, so the abstract contract gained nothing from the `Any`-typed parameter.

`ty` enforces parameter contravariance, so narrowing only the override would break the Liskov substitution principle against the abstract protocol. Relocating the declaration to the concrete base is what keeps the type checker satisfied while removing the `Any`.

`create_store` is intentionally left untouched: its `assert isinstance` narrows genuine `SpecStateType`/`SpecBlockType` protocol parameters, and anchor construction still calls it through the abstract protocol — that boundary is real, not an `Any` leak.

## Safety

Behavior-preserving. No runtime validation guarding untrusted input is removed — only a type-recovery assert that the signature can now prove statically. `ty check` and `just check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)