### PR TITLE
docs(fork-choice): trim drifted numbered overviews in docstrings

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -179,14 +179,7 @@ class ForkChoiceMixin(LstarSpecBase):
         """
         Validate incoming attestation before processing.
 
-        Ensures the vote respects the basic laws of time and topology:
-            1. The blocks voted for must exist in our store.
-            2. A vote cannot span backwards in time (source > target).
-            3. The head must be at least as recent as source and target.
-            4. Checkpoint slots must match the actual block slots.
-            5. Source, target, and head must lie on one parent chain.
-            6. The vote's slot cannot precede the slot of the head it claims to have seen.
-            7. The vote's slot must have started locally (a small disparity margin is allowed).
+        Ensures the vote respects the basic laws of time and topology.
 
         Raises:
             SpecRejectionError: If the attestation fails any of the validation checks above.
@@ -528,12 +521,7 @@ class ForkChoiceMixin(LstarSpecBase):
         """
         Process a new block and update the forkchoice state.
 
-        This method integrates a block into the forkchoice store by:
-
-        1. Validating the block's parent exists
-        2. Computing the post-state via the state transition function
-        3. Processing attestations included in the block body (on-chain)
-        4. Updating the forkchoice head
+        Integrates a block into the forkchoice store and recomputes the head.
 
         Raises:
             SpecRejectionError: UNKNOWN_PARENT_BLOCK if the parent state is not in the store.


### PR DESCRIPTION
## What

Two docstrings in the lstar fork-choice module carried numbered overview lists that duplicated the method bodies' own labeled section comments, and both had drifted out of sync with the code.

- The attestation-validation docstring listed seven checks, while the body has six labeled sections (the topology check was split across two list items).
- The block-processing docstring listed four steps but omitted the duplicate-data rejection and signature verification that the body actually performs.

Each numbered list is trimmed to a single accurate summary line. The labeled in-body comments remain the source of truth, per the doc rule that bans an algorithm recap in the docstring when the body already has labeled phase comments.

## Why

Numbered overviews that mirror the body decay independently of it. Both lists had already drifted in count and content, so they now misinform rather than guide.

Docs-only change. No behavior change. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)