### PR TITLE
docs(fork-choice): clarify equal-slot tie resolution wording

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -640,7 +640,8 @@ class ForkChoiceMixin(LstarSpecBase):
         Map each participating validator to the latest vote it cast.
 
         This is the LMD view fork choice runs on.
-        On equal slots the first vote seen wins, since the slot comparison is strict.
+        Two votes share a slot only across distinct attestation data, never within one data.
+        On such an equal-slot tie the strict comparison keeps the first distinct data inserted.
 
         A vote whose head sits at or below the finalized slot carries no fork-choice weight.
         Such stale votes are skipped here, so callers pass their pool without pre-filtering.


### PR DESCRIPTION
## What

Reword the docstring of the latest-vote extraction in the lstar fork-choice module so it no longer reads as contradicting the loop comment just below it.

The docstring said the first vote seen wins on equal slots. The adjacent loop comment said all proofs under one attestation data share a slot and so never overwrite each other. Read together, these could seem to disagree about whether equal-slot determinism matters.

The new wording makes the level explicit: equal-slot collisions arise only across distinct attestation data, never between proofs under one data. The strict slot comparison then keeps the first distinct data inserted. This is consistent with both the strict `<` comparison in the code and the loop comment.

## Why

A reader could otherwise stall trying to reconcile the two statements. No behavior changes.

## Validation

Docs-only change. No code touched. `just check` passes (lint, format, type, spell, mdformat, lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)