### PR TITLE
docs(state-transition): state the justifiable-distance rule inline

### DIFF
--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -275,7 +275,8 @@ class StateTransitionMixin(LstarSpecBase):
                 continue
 
             # The target slot must be justifiable after the finalized slot.
-            # 3SF-mini admits only a structured set of distances; see the justifiable-slot rule.
+            # 3SF-mini admits a target only when its distance from the finalized slot
+            # sits within the immediate window, is a perfect square, or is a pronic number.
             if not target.slot.is_justifiable_after(finalized_slot):
                 continue
 


### PR DESCRIPTION
## What

In the state-transition justification loop, the comment above the target-slot justifiability check pointed the reader at a named "justifiable-slot rule" that has no heading anywhere in the codebase. The actual logic lives in the slot justifiability check.

This replaces the dangling cross-reference with an inline statement of the rule itself: a target is admitted only when its distance from the finalized slot is within the immediate window, a perfect square, or a pronic number — matching exactly the three distance classes the slot justifiability logic enforces.

## Why

Project doc rule 1 forbids pointing at identifier/rule names that can rot. Stating the rule inline in plain English keeps the comment self-contained and accurate.

## Notes

Docs-only change. No code touched. `just check` passes (lint, format, type check, codespell, mdformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)