### PR TITLE
docs(lstar): tidy docstring summaries in slot, checkpoint, state

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
+++ b/src/lean_spec/spec/forks/lstar/containers/checkpoint.py
@@ -22,11 +22,10 @@ class Checkpoint(Container):
 
     def advance_to(self, candidate: "Checkpoint") -> "Checkpoint":
         """
-        Return the later of two checkpoints, keeping this one on a slot tie.
-
-        Forward-only progression for justified and finalized checkpoints.
+        The later of two checkpoints, keeping this one on a slot tie.
 
         The candidate replaces this checkpoint only when its slot is strictly higher.
+        This enforces forward-only progression for justified and finalized checkpoints.
         """
         return candidate if candidate.slot > self.slot else self
 

--- a/src/lean_spec/spec/forks/lstar/containers/state.py
+++ b/src/lean_spec/spec/forks/lstar/containers/state.py
@@ -58,7 +58,7 @@ class JustifiedSlots(BaseBitlist):
 
         # Check the tracked bitfield for the slot's status.
         #
-        # We assume the slot is within the tracked range.
+        # The slot is expected within the tracked range.
         #
         # If the caller asks for a slot too far in the future, it indicates a logic error.
         # Surface it as a domain rejection so the uniform rejection funnel catches it,

--- a/src/lean_spec/spec/forks/lstar/slot.py
+++ b/src/lean_spec/spec/forks/lstar/slot.py
@@ -27,7 +27,7 @@ class Slot(Uint64):
 
     def is_justifiable_after(self, finalized_slot: "Slot") -> bool:
         """
-        Checks if this slot is a valid candidate for justification after a given finalized slot.
+        Whether this slot is a valid justification candidate after a given finalized slot.
 
         According to the 3SF-mini specification, a slot is justifiable if its
         distance (delta) from the last finalized slot is:


### PR DESCRIPTION
## What

Three small docstring-summary nits in the lstar fork, flagged by the documentation rules:

- Reword the justification-candidate summary in the slot module from a question-style "Checks if ..." opener to a noun phrase (rule 7: summaries are noun phrases).
- Collapse the checkpoint advance docstring from three restatements of the same idea to a single accurate summary line, while preserving the genuine forward-only progression invariant (rule 6: one-line default).
- Drop the self-contradicting first-person "We assume the slot is within the tracked range" phrasing in the justified-slot range check, which conflicted with the out-of-range handling immediately below.

## Why

Keeps the reference spec docstrings precise and consistent with the project documentation rules.

Docs-only. No code or behavior change. `just check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)