### PR TITLE
refactor(fork-choice): unify ancestor-at-slot walks into one helper

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -38,6 +38,54 @@ from lean_spec.spec.ssz import Bytes32, Uint64
 class ForkChoiceMixin(LstarSpecBase):
     """Fork choice and store maintenance for the lstar fork."""
 
+    def _ancestor_at_slot(
+        self,
+        store: LstarStore,
+        root: Bytes32,
+        slot: Slot,
+    ) -> Bytes32 | None:
+        """
+        Find the block on a root's parent chain whose slot equals a target.
+
+        Climb parent links from the starting root toward genesis.
+
+        Two failure modes both return None:
+
+        - No block sits at exactly the target slot on this chain.
+          The chain skipped over it, so the climb passes the slot without landing.
+        - The chain left the known tree before reaching the target slot.
+
+        Args:
+            store: Fork-choice store holding the known block tree.
+            root: Starting root whose parent chain is searched.
+            slot: Target slot to land on.
+
+        Returns:
+            The ancestor root sitting at exactly the target slot, or None.
+        """
+        # Climb parent links toward genesis.
+        #
+        # The walk stops the moment a root is absent from the local view.
+        current_root = root
+        while current_root in store.blocks:
+            current_block = store.blocks[current_root]
+
+            # Landed on the target slot: this block is the ancestor.
+            if current_block.slot == slot:
+                return current_root
+
+            # Climbed past the target slot without landing on it.
+            # That slot held no block on this chain.
+            if current_block.slot < slot:
+                return None
+
+            # Still above the target slot.
+            # Step to the parent and keep climbing.
+            current_root = current_block.parent_root
+
+        # The chain left the known tree before reaching the target slot.
+        return None
+
     def _checkpoint_is_ancestor(
         self,
         store: LstarStore,
@@ -59,30 +107,15 @@ class ForkChoiceMixin(LstarSpecBase):
         if ancestor.slot > descendant.slot:
             return False
 
-        # Climb parent links from the descendant toward genesis.
-        #
-        # The walk stops the moment a root is absent from the local view.
-        current_root = descendant.root
-        while current_root in store.blocks:
-            current_block = store.blocks[current_root]
+        # Resolve the block on the descendant's chain sitting at the ancestor's slot.
+        # A missing block there means the ancestor is off this chain entirely.
+        root_at_ancestor_slot = self._ancestor_at_slot(store, descendant.root, ancestor.slot)
+        if root_at_ancestor_slot is None:
+            return False
 
-            # Landed on the ancestor's slot.
-            # - It lies on the chain only when the roots also match.
-            # - A different root here means the checkpoints are on forked branches.
-            if current_block.slot == ancestor.slot:
-                return current_root == ancestor.root
-
-            # Climbed past the ancestor's slot without landing on it.
-            # That slot held no block on this chain, so the ancestor is off it.
-            if current_block.slot < ancestor.slot:
-                return False
-
-            # Still above the ancestor's slot.
-            # Step to the parent and keep climbing.
-            current_root = current_block.parent_root
-
-        # The chain left the known tree before reaching the ancestor's slot.
-        return False
+        # The ancestor lies on the chain only when that block is its exact root.
+        # A different root there means the checkpoints are on forked branches.
+        return root_at_ancestor_slot == ancestor.root
 
     def create_store(
         self,
@@ -825,16 +858,12 @@ class ForkChoiceMixin(LstarSpecBase):
         # Invariant: the finalized checkpoint stays on the head's chain.
         # Climb from the head to its ancestor at the finalized slot.
         finalized_slot = store.states[new_head].latest_finalized.slot
-        finalized_root = new_head
-        while finalized_root in store.blocks and store.blocks[finalized_root].slot > finalized_slot:
-            parent_root = store.blocks[finalized_root].parent_root
-            if parent_root not in store.blocks:
-                break
-            finalized_root = parent_root
+        finalized_root = self._ancestor_at_slot(store, new_head, finalized_slot)
 
-        # A fresh checkpoint-sync anchor stores no block at that slot.
+        # No block sits at that slot on the head's chain, or the chain left the known tree.
+        # A fresh checkpoint-sync anchor is one such case: it stores no block at that slot.
         # Keep the trusted anchor there rather than emit an unresolved root.
-        if store.blocks[finalized_root].slot == finalized_slot:
+        if finalized_root is not None:
             latest_finalized = Checkpoint(root=finalized_root, slot=finalized_slot)
         else:
             latest_finalized = store.latest_finalized


### PR DESCRIPTION
## What

The lstar fork choice hand-rolled the same "climb parent links up to the block at a target slot" walk in two places with slightly different stop conditions. This factors them into one private helper that returns the ancestor root at that slot, or `None` when no block sits there or the chain leaves the known tree.

- Attestation ancestry check: now resolves the block at the ancestor's slot and compares it to the ancestor's exact root.
- Head-update finalized walk: now resolves the finalized-slot root and rebuilds the checkpoint, falling back to the trusted anchor when the helper returns `None`.

The third parent-climbing loop (weight accumulation) is a different operation — it credits every block above a start slot rather than finding one ancestor — so it is intentionally left untouched.

## Why

The divergent stop conditions across duplicated walks were a correctness hazard. Consolidating to one helper with a single documented stop condition removes that drift risk.

## Equivalence argument (behavior-preserving)

The two consolidated walks are the same underlying lookup: "climb from a root until the block whose slot equals the target; return that root, else `None`." Edge cases verified to map identically:

- Ancestor slot above descendant slot: short-circuits to `False` (guard kept).
- Lands exactly on target slot: returns that root; matches the original root-equality test and checkpoint build.
- Slot skipped (no block at target on the chain): `None` -> ancestry `False` / head-update keeps the trusted anchor, same as the original's too-low landing.
- Chain leaves the known tree mid-climb: `None` -> same fallbacks; the original broke and took its `else` branch because the landed slot was still above the target.
- Head at or below the finalized slot: same anchor / checkpoint outcomes.

`None` is handled explicitly before any `Bytes32` comparison, since the strict `Bytes32` equality rejects comparison with `None`.

## Verification

- `just check`: All checks passed.
- `uv run fill --fork=lstar --clean -k fork_choice -n auto`: all 118 fork-choice vectors regenerate and pass; the broader lstar vector set is byte-identical across hash seeds (determinism check passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)