### PR TITLE
fix(validator): enforce validator index matches registry position

### DIFF
--- a/src/lean_spec/spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/spec/forks/lstar/containers/validator.py
@@ -1,8 +1,13 @@
 """The validator registry tracked in the consensus state."""
 
+from typing import Self
+
+from pydantic import model_validator
+
 from lean_spec.spec.forks.lstar.config import VALIDATOR_REGISTRY_LIMIT
 from lean_spec.spec.forks.lstar.containers.identifiers import ValidatorIndex
 from lean_spec.spec.ssz import Bytes52, Container, SSZList
+from lean_spec.spec.ssz.exceptions import SSZValueError
 
 
 class Validator(Container):
@@ -22,3 +27,23 @@ class Validators(SSZList[Validator]):
     """Validator registry tracked in the state."""
 
     LIMIT = int(VALIDATOR_REGISTRY_LIMIT)
+
+    @model_validator(mode="after")
+    def _require_index_matches_position(self) -> Self:
+        """
+        Pin each stored index to its list position in the registry.
+
+        Every consensus lookup addresses a validator by its list position.
+        The stored index is serialized into the state root but never read for
+        consensus logic.
+        A position that disagrees with its index is therefore a silent footgun.
+        Rejecting the mismatch at construction keeps the two in lockstep.
+        """
+        for registry_position, validator in enumerate(self.data):
+            if int(validator.index) != registry_position:
+                raise SSZValueError(
+                    f"validator at position {registry_position} has "
+                    f"index {int(validator.index)}, "
+                    f"but the registry index must equal the list position"
+                )
+        return self

--- a/src/lean_spec/spec/forks/lstar/containers/validator.py
+++ b/src/lean_spec/spec/forks/lstar/containers/validator.py
@@ -30,15 +30,7 @@ class Validators(SSZList[Validator]):
 
     @model_validator(mode="after")
     def _require_index_matches_position(self) -> Self:
-        """
-        Pin each stored index to its list position in the registry.
-
-        Every consensus lookup addresses a validator by its list position.
-        The stored index is serialized into the state root but never read for
-        consensus logic.
-        A position that disagrees with its index is therefore a silent footgun.
-        Rejecting the mismatch at construction keeps the two in lockstep.
-        """
+        """Reject any registry whose stored validator indices disagree with their positions."""
         for registry_position, validator in enumerate(self.data):
             if int(validator.index) != registry_position:
                 raise SSZValueError(

--- a/tests/consensus/lstar/ssz/test_decode_rejections.py
+++ b/tests/consensus/lstar/ssz/test_decode_rejections.py
@@ -5,8 +5,9 @@ from typing import ClassVar
 import pytest
 
 from consensus_testing import ExpectedRejection, SSZTestFiller
-from lean_spec.spec.forks import RejectionReason
-from lean_spec.spec.ssz import BaseBitlist, BaseBitvector, Boolean, Bytes4, Uint32
+from lean_spec.spec.forks import RejectionReason, ValidatorIndex
+from lean_spec.spec.forks.lstar.containers import Validator, Validators
+from lean_spec.spec.ssz import BaseBitlist, BaseBitvector, Boolean, Bytes4, Bytes52, Uint32
 
 pytestmark = pytest.mark.valid_until("Lstar")
 
@@ -176,4 +177,45 @@ def test_uint32_decode_rejects_wrong_byte_length(ssz_test: SSZTestFiller) -> Non
         value=Uint32(0),
         raw_bytes="0x010203",
         expected_rejection=ExpectedRejection(reason=RejectionReason.DECODE_ERROR),
+    )
+
+
+def test_validators_decode_rejects_index_mismatched_with_position(ssz_test: SSZTestFiller) -> None:
+    """
+    Decoding a registry whose stored index disagrees with its position is rejected.
+
+    Given
+    -----
+    - a registry of two validators packed back to back.
+    - the validator at position 0 stores index 0.
+    - the validator at position 1 stores index 5.
+
+    When
+    ----
+    - the input is decoded into the registry type.
+
+    Then
+    ----
+    - decoding is rejected.
+    - the reason is that the stored index must equal the list position.
+    """
+    ssz_test(
+        type_name="Validators",
+        value=Validators(
+            data=[
+                Validator(
+                    attestation_public_key=Bytes52.zero(),
+                    proposal_public_key=Bytes52.zero(),
+                    index=ValidatorIndex(0),
+                )
+            ]
+        ),
+        raw_bytes=("0x" + "00" * 112 + "00" * 104 + "0500000000000000"),
+        expected_rejection=ExpectedRejection(
+            reason=RejectionReason.DECODE_ERROR,
+            exact_message=(
+                "validator at position 1 has index 5, "
+                "but the registry index must equal the list position"
+            ),
+        ),
     )


### PR DESCRIPTION
## What

Adds a construction-time invariant on the lstar validator registry container that rejects any list where `validators[i].index != i`, raising a clear `SSZValueError` instead of silently accepting the mismatch.

## Why

Within the fork, every validator lookup addresses the registry by list position (`validators[validator_index]`). The `Validator.index` field is never read for consensus logic, yet it is serialized into the SSZ `Validator` container and therefore contributes to the state root. Its default of `0` means any validator past position 0 silently disagrees with its position unless the caller sets it explicitly. A mismatched index would change the state root while carrying no consensus meaning: a latent footgun.

## Approach: invariant over removal

Removing the field is deliberately out of scope. It is part of the serialized container, so dropping it would shift the SSZ layout and every state root across the existing consensus vectors — a large, hard-to-review blast radius. The invariant approach instead pins the stored index to its position with zero serialization change.

## Blast-radius note

Both genesis construction paths (the node-side `to_validators` and the testing `_build_validators`) already assign sequential indices from the position via `enumerate`/`range`, so the invariant is satisfied by all existing fixtures and **no existing vector state root shifts**. Confirmed by a clean `fill` run with the byte-identical determinism check passing.

## Test

Adds a consensus decode-rejection vector under `tests/consensus/lstar/ssz/` that feeds a two-validator registry whose second entry stores index 5 at position 1, and asserts decoding is rejected with the full error message.

All `just check` quality gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)