### PR TITLE
perf(fork-choice): prune votes on finalized-orphaned branches

### DIFF
--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -142,9 +142,16 @@ class ForkChoiceMixin(LstarSpecBase):
         Drop attestation data whose head can no longer influence fork choice.
 
         Fork choice only ever descends from the latest finalized block.
-        A vote whose head sits at or below the finalized slot cannot name a descendant of it.
-        Such a vote carries no fork-choice weight.
-        Dropping it never changes the chosen chain.
+        A vote carries no fork-choice weight, and is dropped, when either holds:
+
+        - Its head sits at or below the finalized slot.
+        - Its head is not a descendant of the finalized block.
+
+        The first head is no later than the finalized block.
+        The second head is on a sibling branch the finalized block orphaned.
+        Neither head lies under the finalized block.
+        So neither credits any block the forward walk from the justified root can reach.
+        Dropping such a vote never changes the chosen chain.
 
         The same cutoff prunes all three attestation-keyed pools:
 
@@ -152,25 +159,35 @@ class ForkChoiceMixin(LstarSpecBase):
         - Pending aggregated proofs not yet counted.
         - Aggregated proofs already counted toward fork choice.
         """
-        # Keep only entries whose attested head sits strictly above the finalized slot.
+
+        # An entry survives only when its head still lives under the finalized block.
         #
+        # The slot guard rejects heads at or below the finalized slot cheaply.
+        # The ancestry guard then rejects heads on a finalized-orphaned sibling branch.
+        # Such heads sit above the finalized slot yet never descend from the finalized block.
         # Every pool shares the same vote key, so one staleness test filters all three.
+        def head_lives_under_finalized(attestation_data: AttestationData) -> bool:
+            head = attestation_data.head
+            return head.slot > store.latest_finalized.slot and self._checkpoint_is_ancestor(
+                store, store.latest_finalized, head
+            )
+
         return store.model_copy(
             update={
                 "attestation_signatures": {
                     attestation_data: signatures
                     for attestation_data, signatures in store.attestation_signatures.items()
-                    if attestation_data.head.slot > store.latest_finalized.slot
+                    if head_lives_under_finalized(attestation_data)
                 },
                 "latest_new_aggregated_payloads": {
                     attestation_data: proofs
                     for attestation_data, proofs in store.latest_new_aggregated_payloads.items()
-                    if attestation_data.head.slot > store.latest_finalized.slot
+                    if head_lives_under_finalized(attestation_data)
                 },
                 "latest_known_aggregated_payloads": {
                     attestation_data: proofs
                     for attestation_data, proofs in store.latest_known_aggregated_payloads.items()
-                    if attestation_data.head.slot > store.latest_finalized.slot
+                    if head_lives_under_finalized(attestation_data)
                 },
             }
         )

--- a/tests/consensus/lstar/fork_choice/test_prune_finalized_orphaned_branch.py
+++ b/tests/consensus/lstar/fork_choice/test_prune_finalized_orphaned_branch.py
@@ -1,0 +1,166 @@
+"""Fork Choice: pruning drops votes on a finalized-orphaned branch."""
+
+import pytest
+
+from consensus_testing import (
+    AggregatedAttestationSpec,
+    BlockSpec,
+    BlockStep,
+    ForkChoiceTestFiller,
+    GossipAggregatedAttestationStep,
+    StoreChecks,
+    generate_pre_state,
+)
+from lean_spec.spec.forks import Slot, ValidatorIndex
+
+pytestmark = pytest.mark.valid_until("Lstar")
+
+
+def test_finalization_prunes_vote_on_orphaned_branch(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Finalization prunes a counted vote whose head sits above the finalized slot but
+    on a branch the finalized block orphaned, while head, justified, and finalized
+    stay exactly where the canonical chain puts them.
+
+    Given
+    -----
+    - 8 validators; a slot needs 6 votes (2/3) to be justified.
+    - the chain:
+        genesis(0) -> block_1(1)
+        - block_2(2) -> block_3(3) -> block_4(4)
+        - orph_2(2) -> orph_3(3) -> orph_4(4)
+    - block_2 carries V0..V5 targeting block_1, justifying slot 1.
+    - block_3 carries V0..V5 targeting block_2, justifying slot 2 and finalizing slot 1.
+    - the orphaned branch forks off block_1, below the eventual finalized slot 2.
+    - a counted aggregate from V6 targets orph_4 at slot 4, above the finalized slot.
+    - that vote's head orph_4 is not a descendant of block_2.
+
+    When
+    ----
+    - block_4 carries V0..V5 targeting block_3, justifying slot 3 and finalizing slot 2.
+
+    Then
+    ----
+    - head stays on block_4, on the canonical chain.
+    - justified advances to slot 3 on block_3.
+    - finalized advances to slot 2 on block_2.
+    - the only counted target slot is 3, the one canonical vote whose head outlives slot 2.
+    - the pending pool holds no target slots.
+    - the orphaned vote targeting slot 4 is pruned despite its head outliving the finalized slot.
+    """
+    fork_choice_test(
+        anchor_state=generate_pre_state(num_validators=8),
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), parent_label="genesis", label="block_1"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(2),
+                    parent_label="block_1",
+                    label="block_2",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(2),
+                            target_slot=Slot(1),
+                            target_root_label="block_1",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    head_root_label="block_2",
+                    latest_justified_slot=Slot(1),
+                    latest_finalized_slot=Slot(0),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(3),
+                    parent_label="block_2",
+                    label="block_3",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(3),
+                            target_slot=Slot(2),
+                            target_root_label="block_2",
+                            source_slot=Slot(1),
+                            source_root_label="block_1",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(3),
+                    head_root_label="block_3",
+                    latest_justified_slot=Slot(2),
+                    latest_finalized_slot=Slot(1),
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), parent_label="block_1", label="orph_2"),
+                checks=StoreChecks(head_slot=Slot(3), head_root_label="block_3"),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(3), parent_label="orph_2", label="orph_3"),
+                checks=StoreChecks(head_slot=Slot(3), head_root_label="block_3"),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(4), parent_label="orph_3", label="orph_4"),
+                checks=StoreChecks(
+                    head_slot=Slot(3),
+                    head_root_label="block_3",
+                    latest_justified_slot=Slot(2),
+                    latest_finalized_slot=Slot(1),
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=AggregatedAttestationSpec(
+                    validator_indices=[ValidatorIndex(6)],
+                    slot=Slot(4),
+                    target_slot=Slot(4),
+                    target_root_label="orph_4",
+                    head_root_label="orph_4",
+                    head_slot=Slot(4),
+                    source_slot=Slot(0),
+                    source_root_label="genesis",
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(3),
+                    head_root_label="block_3",
+                    latest_new_aggregated_target_slots=[Slot(4)],
+                ),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(4),
+                    parent_label="block_3",
+                    label="block_4",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[ValidatorIndex(i) for i in range(6)],
+                            slot=Slot(4),
+                            target_slot=Slot(3),
+                            target_root_label="block_3",
+                            source_slot=Slot(2),
+                            source_root_label="block_2",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(4),
+                    head_root_label="block_4",
+                    latest_justified_slot=Slot(3),
+                    latest_justified_root_label="block_3",
+                    latest_finalized_slot=Slot(2),
+                    latest_finalized_root_label="block_2",
+                    latest_known_aggregated_target_slots=[Slot(3)],
+                    latest_new_aggregated_target_slots=[],
+                ),
+            ),
+        ],
+    )


### PR DESCRIPTION
## What

`prune_stale_attestation_data` kept every vote whose head slot was strictly above the finalized slot. A vote whose head sits above the finalized slot but on a sibling branch that the finalized block orphaned (a branch forked from a block below the finalized block) was retained and iterated on every fork-choice pass, even though it can never contribute weight.

This adds a finalized-ancestry guard. A vote now survives the prune only when its head is **both**:

- strictly above the finalized slot (unchanged), **and**
- a descendant of the finalized block (new), checked via the existing `_checkpoint_is_ancestor` walk.

All three attestation-keyed pools share the one staleness test, as before.

## Why

The LMD-GHOST head walk is anchored at the justified root and descends only through children. A vote whose head is not a descendant of the finalized block credits no block on the canonical subtree, so it carries zero fork-choice weight — yet it was retained until finalization passed its head slot. On a high-slot dead branch that is unbounded retention pressure (e.g. equivocating votes on an orphaned fork), with no observable consensus effect.

## Safety argument (memory/retention optimization only — no observable behavior change)

The set of votes that can influence head, justified, or finalized is **identical** before and after this change:

- The finalized checkpoint is always an ancestor of the justified checkpoint, which is the root the GHOST walk starts from. Therefore **any** vote that can credit a block on the canonical (justified/finalized) subtree has a head that is a descendant of the finalized block, and is kept.
- The only votes additionally dropped are those whose head is provably not a descendant of the finalized block. Climbing parent links from such a head never passes through the finalized block, so none of its ancestors above the finalized slot lie on the canonical subtree. The forward walk from the justified root never reaches it; its weight is already zero.
- Blocks are only ever added to the store, never removed, so a retained vote's head root is always present and the ancestry walk resolves deterministically.

The change adds one ancestry walk per retained vote during the prune, which runs only when finalization advances. Head, justified, and finalized are unchanged for every input.

## Test vector

New `fork_choice` vector `test_finalization_prunes_vote_on_orphaned_branch`:

- Canonical chain `block_1..block_4` finalizes slot 2 on `block_2`.
- An orphaned branch `orph_2 -> orph_3 -> orph_4` forks off `block_1` (below the finalized slot), so its blocks never descend from `block_2`.
- A counted aggregate from V6 targets `orph_4` at slot 4 (head slot 4, above the finalized slot 2).
- On the finalizing block, head stays on `block_4`, justified advances to slot 3, finalized advances to slot 2, and the orphaned vote is pruned.

The vector fails on `main` (the orphaned vote at target slot 4 survives in the pending pool) and passes with this change (pending pool empty).

`just check` is green; the full lstar fixture set (541 vectors) and the fork_choice subset (119 vectors) pass, with the determinism check holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)