### PR TITLE
fix(vulture): track the hash_tree_root handler rename

### DIFF
--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -15,14 +15,14 @@
 
 # Single-dispatch handlers for the hash_tree_root generic function.
 # Dispatched by argument type, so they have no direct call site.
-_htr_packed_leaf
-_htr_bytes
-_htr_bytelist
-_htr_bitvector_base
-_htr_bitlist_base
-_htr_vector
-_htr_list
-_htr_container
+_hash_tree_root_packed_leaf
+_hash_tree_root_bytes
+_hash_tree_root_bytelist
+_hash_tree_root_bitvector_base
+_hash_tree_root_bitlist_base
+_hash_tree_root_vector
+_hash_tree_root_list
+_hash_tree_root_container
 
 # Magic methods invoked by the interpreter.
 # Flagged only because they are defined as overloaded functions or as an


### PR DESCRIPTION
## Problem

The dead-code CI job (`just deadcode`) fails on `main`:

```
src/lean_spec/spec/crypto/merkleization.py:211: unused function '_hash_tree_root_packed_leaf' (60% confidence)
src/lean_spec/spec/crypto/merkleization.py:221: unused function '_hash_tree_root_bytes' (60% confidence)
... (8 handlers total)
error: recipe `deadcode` failed on line 43 with exit code 3
```

(see https://github.com/leanEthereum/leanSpec/actions/runs/27710866929/job/81971271367)

## Cause

The single-dispatch `hash_tree_root` handlers are registered via `@hash_tree_root.register`, so their names have no direct call site and vulture cannot see the use. They were whitelisted under the `_htr_` prefix.

A later refactor (#1124) renamed them to the spelled-out `_hash_tree_root_` prefix but did not update `vulture_whitelist.py`. The old names no longer exist, so the whitelist entries match nothing and the renamed handlers are reported as unused.

## Fix

Rename the eight whitelist entries to match the current handler names. No source code changes.

## Verification

- Before: `just deadcode` fails with the 8 reports above.
- After: `just deadcode` passes.