### PR TITLE
chore(vulture): exclude build artifacts and prune stale whitelist entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,9 @@ fail_under = 90
 # The whitelist names the indirectly-used symbols vulture cannot see; listing
 # them explicitly keeps the ignores tight instead of relying on wide globs.
 paths = ["src", "packages", "tests", "vulture_whitelist.py"]
+# Skip build artifacts under packages, which duplicate the real source and would
+# otherwise report every package symbol twice.
+exclude = ["*/build/*"]
 # Show the largest unused blocks first; they are the highest-value removals.
 sort_by_size = true
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -54,6 +54,7 @@ _._coerce_and_validate
 _._accept_hex_string
 _._validate_byte_list_data
 _._validate_decomposition
+_._require_index_matches_position
 _.validate_state_length
 _.validate_target
 _.validate_rejection_is_declared
@@ -67,10 +68,6 @@ _.serialize_value
 _.serialize_block
 _._serialize_data
 _._serialize_as_hex
-
-# Fork-upgrade protocol method, invoked polymorphically on a fork transition.
-# A single-fork tree has no transition yet, so there is no call site.
-_.upgrade_state
 
 # Signature parameters mandated by external protocols we cannot rename.
 # The pydantic core-schema hook, the pytest session-finish hook, and the
@@ -169,10 +166,6 @@ y
 first_name
 slot_number
 _.slot_number
-
-# Access tier recorded on every route entry to document the route, not yet
-# read back by the registration path.
-is_admin
 
 # Attribute assignment in slotted-class tests that proves new attributes are
 # rejected; the assignment is the action under test, never read back.


### PR DESCRIPTION
## Summary

Vulture (the dead-code gate) was failing on `main`. Two distinct causes, fixed at the root rather than by silencing.

### 1. Build artifacts scanned twice
`[tool.vulture].paths` includes `packages`, so vulture recursed into the **gitignored** `packages/testing/build/` tree, which duplicates the real source under `packages/testing/src/`. Every package symbol was reported a second time (5 of the 6 findings). Added `exclude = ["*/build/*"]` so build output is never scanned — this is scoping, not a symbol whitelist, and survives any rebuild.

### 2. One real, invisible-but-used validator
`Validators._require_index_matches_position` (added in #1147) is a Pydantic `@model_validator(mode="after")` that enforces validator index == registry position. It runs on every construction but is invisible to static analysis, so it joins the existing "Pydantic validators" section of the whitelist.

### Whitelist cleanup (no dead code left behind)
Audited all 106 whitelist symbols against the real code. Exactly two referenced symbols that **no longer exist anywhere** — pure cruft left when their code was deleted:
- `_.upgrade_state` — fork-upgrade protocol method, since removed.
- `is_admin` — route access-tier flag, since removed.

Both whitelist lines (and their comments) are dropped. Net: the whitelist is **tighter** (−2 stale, +1 genuine).

## Verification
- `just deadcode` (vulture) passes with zero findings.
- Changes limited to `pyproject.toml` and `vulture_whitelist.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)