### PR TITLE
docs(testing): trim verbose docstrings in consensus_testing

### DIFF
--- a/packages/testing/src/consensus_testing/cli/apitest.py
+++ b/packages/testing/src/consensus_testing/cli/apitest.py
@@ -37,14 +37,11 @@ def apitest(
     """
     Run API conformance tests against an external server, i.e. a client implementation.
 
-    SERVER_URL is the base URL of the API server (e.g., http://localhost:5052).
-
-    For testing the local leanSpec implementation, use the local pytest suite under
-    tests/node/api/endpoints, which automatically starts a local server.
+    SERVER_URL is the base URL of the API server.
     """
     config_path = Path(__file__).parent / "pytest_ini_files" / "pytest-apitest.ini"
 
-    # Find project root
+    # The project root is the workspace pyproject.toml.
     project_root = Path.cwd()
     while project_root != project_root.parent:
         if (project_root / "pyproject.toml").exists():
@@ -53,7 +50,6 @@ def apitest(
                 break
         project_root = project_root.parent
 
-    # Build pytest arguments
     args = [
         "-c",
         str(config_path),

--- a/packages/testing/src/consensus_testing/cli/fill.py
+++ b/packages/testing/src/consensus_testing/cli/fill.py
@@ -75,19 +75,16 @@ def fill(
     check_determinism: bool,
 ) -> None:
     """Generate consensus test fixtures from test specifications."""
-    # The spec config reads this flag once, at import time.
-    # The current process froze the old value when the package imported.
+    # The spec config reads this flag once at import time.
     # Only the pytest subprocess below starts fresh and sees this export.
     os.environ["LEAN_ENV"] = scheme.lower()
 
-    # Crypto mode is independent of the scheme.
-    # Both schemes mock by default and run the prover only when asked.
+    # Crypto mode is independent of scheme: both schemes mock unless asked to run the prover.
     crypto_mode = crypto.lower()
 
-    # Check and download keys if needed
     keys_directory = get_keys_directory(scheme.lower())
 
-    # Check if keys already exist, if not, download them
+    # Download the keys if they are missing.
     if not (keys_directory.exists() and any(keys_directory.glob("*.json"))):
         click.echo(f"Test keys for '{scheme}' scheme not found. Downloading...")
         download_keys(scheme.lower())
@@ -97,17 +94,15 @@ def fill(
         download_keys(scheme.lower())
 
     config_path = Path(__file__).parent / "pytest_ini_files" / "pytest-fill.ini"
-    # Find project root by looking for pyproject.toml with [tool.uv.workspace]
+    # The project root is the workspace pyproject.toml.
     project_root = Path.cwd()
     while project_root != project_root.parent:
         if (project_root / "pyproject.toml").exists():
-            # Check if this is the workspace root
             pyproject = project_root / "pyproject.toml"
             if "[tool.uv.workspace]" in pyproject.read_text():
                 break
         project_root = project_root.parent
 
-    # Build pytest arguments
     args = [
         "-c",
         str(config_path),
@@ -120,13 +115,10 @@ def fill(
     if clean:
         args.append("--clean")
 
-    # Add all pytest args
     args.extend(pytest_args)
-
-    # Add extra click context args
     args.extend(ctx.args)
 
-    # Why a subprocess: a fresh interpreter imports the spec config anew.
+    # A subprocess gives a fresh interpreter that imports the spec config anew.
     # Only then does the scheme exported above take effect.
     exit_code = subprocess.run([sys.executable, "-m", "pytest", *args]).returncode
     if exit_code != 0:
@@ -142,25 +134,8 @@ def verify_fixture_determinism(config_path: Path, project_root: Path, fork: str)
     """
     Regenerate the full fixture tree under two hash seeds and diff them.
 
-    Set and dict iteration order is randomized per process by PYTHONHASHSEED.
-    A vector whose bytes depend on that order is not reproducible across clients.
-    Two seeds producing byte-identical output proves every vector is order-free.
-
-    Determinism is checked for all vectors by default, not an opt-in subset.
-    A new vector that emits set- or dict-derived fields is covered automatically.
-
-    The mocked prover is forced so proof bytes stay deterministic across both runs.
-    A single process pins each seed cleanly, so distribution is disabled.
-
-    This gate covers only hash-seed and iteration-order effects under the mocked prover.
-
-    The real prover emits randomized proof bytes by design.
-    Those proofs are intentionally outside this guarantee.
-    They never reproduce across two fills of identical inputs.
-
-    The non-proof fields of real-crypto vectors are not separately re-checked here.
-    Masking out exactly the randomized proof bytes would need a fragile per-container rule.
-    So no real-crypto diff is attempted.
+    Byte-identical output under two seeds proves every vector is order-free.
+    The mocked prover is forced, since the real prover emits randomized proofs by design.
     """
     consensus_tests = project_root / "tests" / "consensus"
     emitted_under_seed: list[Path] = []

--- a/packages/testing/src/consensus_testing/crypto_mode.py
+++ b/packages/testing/src/consensus_testing/crypto_mode.py
@@ -47,12 +47,7 @@ class AggregationProver:
     @classmethod
     @contextmanager
     def mocked(cls) -> Iterator[None]:
-        """
-        Swap the Rust prover bindings on the spec module for in-process stubs.
-
-        - Provers return a placeholder proof.
-        - Verifiers accept that placeholder.
-        """
+        """Swap the Rust prover bindings for stubs that emit and accept a placeholder."""
         originals = {
             name: getattr(aggregation, name) for name in (*cls._prover_names, *cls._verifier_names)
         }

--- a/packages/testing/src/consensus_testing/forks/base.py
+++ b/packages/testing/src/consensus_testing/forks/base.py
@@ -4,37 +4,22 @@ from abc import ABC, ABCMeta, abstractmethod
 
 
 class BaseForkMeta(ABCMeta):
-    """
-    Metaclass for BaseFork enabling fork ordering via inheritance.
-
-    Fork ordering works by checking subclass relationships.
-    For example, if ForkB inherits from ForkA, then ForkA precedes ForkB.
-    """
+    """Metaclass ordering forks by inheritance: an older fork is a base of a newer one."""
 
     def __repr__(cls: "type[BaseFork]") -> str:
-        """Print the name of the fork, instead of the class."""
+        """Print the fork name instead of the class."""
         return cls.name()
 
     def __le__(cls: "type[BaseFork]", other: "type[BaseFork]") -> bool:
-        """Check if this fork is older or equal to another (cls <= other)."""
+        """Older-or-equal: a fork precedes any fork that inherits from it."""
         return cls is other or issubclass(other, cls)
 
 
 class BaseFork(ABC, metaclass=BaseForkMeta):
-    """
-    Base class for spec test forks.
-
-    Each fork represents a specific version of the protocol.
-    Forks form an inheritance hierarchy where newer forks inherit from older ones.
-    """
+    """Protocol version in the fork inheritance hierarchy."""
 
     @classmethod
     @abstractmethod
     def name(cls) -> str:
-        """
-        Return the name of the fork as it appears in test fixtures.
-
-        By default, this is the class name (e.g., "Lstar" for consensus).
-        This is used in the 'network' field of generated fixtures.
-        """
+        """Fork name as it appears in the network field of generated fixtures."""
         pass

--- a/packages/testing/src/consensus_testing/genesis.py
+++ b/packages/testing/src/consensus_testing/genesis.py
@@ -26,15 +26,7 @@ def build_genesis_state(
     keyed: bool = True,
     fork: LstarSpec = LstarSpec(),
 ) -> State:
-    """
-    Build a genesis pre-state for consensus tests.
-
-    Keyed validators get real signing keys from the shared key manager.
-    Unkeyed validators get zeroed keys, for tests that never check signatures.
-
-    Raises:
-        ValueError: If keyed and the key manager holds fewer keys than requested.
-    """
+    """Build a genesis pre-state for consensus tests, with real or zeroed validator keys."""
     if keyed:
         key_manager = XmssKeyManager.shared()
         if num_validators > len(key_manager):
@@ -72,12 +64,7 @@ def build_genesis_state(
 
 
 def reconstruct_block_from_header(state: State) -> Block:
-    """
-    Rebuild the block matching a state's latest header.
-
-    The body is empty by the genesis and empty-block convention.
-    For a genesis state this is the genesis block.
-    """
+    """Rebuild the block matching a state's latest header, with an empty body by convention."""
     return Block(
         slot=state.latest_block_header.slot,
         proposer_index=state.latest_block_header.proposer_index,
@@ -96,11 +83,7 @@ def build_anchor(
     keyed: bool = True,
     synced: bool = False,
 ) -> tuple[State, Block]:
-    """
-    Build an anchor by advancing the genesis state through a slot.
-
-    At slot 0 the advance loop is empty, so this returns the genesis pair.
-    """
+    """Build an anchor by advancing the genesis state through a slot, genesis pair at slot 0."""
     state = build_genesis_state(num_validators, genesis_time=genesis_time, keyed=keyed, fork=fork)
 
     current_block = reconstruct_block_from_header(state)
@@ -109,7 +92,7 @@ def build_anchor(
     num_validators_u64 = Uint64(num_validators)
 
     # Advance one empty block per slot, up to and including the anchor.
-    # Using the spec's own builder gives the state real mid-chain history.
+    # The spec's own builder gives the state real mid-chain history.
     for next_slot in range(1, int(anchor_slot) + 1):
         slot = Slot(next_slot)
         proposer_index = ValidatorIndex.proposer_for_slot(slot, num_validators_u64)
@@ -162,11 +145,7 @@ def build_genesis_store(
     keyed: bool = True,
     time: Interval | None = None,
 ) -> Store:
-    """
-    Build a genesis fork-choice store.
-
-    Set observer for a store with no owning validator.
-    """
+    """Build a genesis fork-choice store, owned by a validator unless observer is set."""
     # Slot 0 makes the anchor builder produce the genesis state and block pair.
     state, genesis_block = build_anchor(
         num_validators, Slot(0), genesis_time=Uint64(genesis_time), keyed=keyed

--- a/packages/testing/src/consensus_testing/keys.py
+++ b/packages/testing/src/consensus_testing/keys.py
@@ -1,19 +1,7 @@
 """
-XMSS Key Management for Consensus Testing
+XMSS key management for test validators.
 
-Management of XMSS key pairs for test validators.
-
-Keys are pre-generated and cached on disk to avoid expensive generation
-during tests.
-The companion CLI module generates or downloads them.
-
-File format:
-
-- Each key pair is stored in a separate JSON file with hex-encoded SSZ.
-- Directory structure: `test_keys/{scheme}_scheme/{index}.json`
-- The top-level object has two roles, each containing a public and secret blob:
-  `{"attestation_keypair": {"public_key": ..., "secret_key": ...},
-    "proposal_keypair":    {"public_key": ..., "secret_key": ...}}`
+Keys are pre-generated and cached on disk to avoid expensive generation during tests.
 """
 
 from __future__ import annotations
@@ -60,40 +48,20 @@ LEAN_ENV_TO_SCHEMES: dict[str, GeneralizedXmssScheme] = {
     "test": TEST_SIGNATURE_SCHEME,
     "prod": PROD_SIGNATURE_SCHEME,
 }
-"""
-Maps short scheme names to their XMSS scheme instances.
-
-Used for:
-
-- CLI argument validation
-- Deriving on-disk directory names for cached keys
-- Keying the per-scheme manager cache in test fixtures
-"""
+"""Short scheme names mapped to their XMSS scheme instances."""
 
 
 def create_dummy_signature() -> Signature:
-    """
-    Create a structurally valid but cryptographically meaningless signature.
-
-    All fields are zero-filled.
-    The result has correct dimensions so it passes structural checks,
-    but it will fail any cryptographic verification.
-
-    Returns:
-        A zero-valued signature with correct field sizes.
-    """
-    # Build a single zero-filled hash digest with the scheme's hash length.
+    """Create a zero-filled signature that passes structural checks but fails verification."""
     zero_digest = HashDigestVector(data=[Fp(0)] * TARGET_CONFIG.HASH_LENGTH_FIELD_ELEMENTS)
 
     # The Merkle authentication path needs one sibling per tree level.
-    #
     # The tree height equals the log of the key lifetime.
     siblings = HashDigestList(data=[zero_digest] * TARGET_CONFIG.LOG_LIFETIME)
 
     # Winternitz one-time signatures use one hash chain per dimension.
     hashes = HashDigestList(data=[zero_digest] * TARGET_CONFIG.DIMENSION)
 
-    # Assemble a complete signature with all components zeroed out.
     return Signature(
         path=HashTreeOpening(siblings=siblings),
         rho=Randomness(data=[Fp(0)] * TARGET_CONFIG.RAND_LENGTH_FIELD_ELEMENTS),
@@ -102,23 +70,11 @@ def create_dummy_signature() -> Signature:
 
 
 DEFAULT_MAX_SLOT = Slot(10)
-"""
-Default max slot for the shared key manager.
-
-Slot 10 is high enough for most unit tests while keeping key generation fast.
-"""
+"""Default max slot, high enough for most unit tests while keeping key generation fast."""
 
 
 def get_keys_directory(scheme_name: str) -> Path:
-    """
-    Resolve the on-disk directory that holds key files for a scheme.
-
-    Args:
-        scheme_name: Short scheme identifier (e.g. "test" or "prod").
-
-    Returns:
-        Absolute path to the scheme's key directory.
-    """
+    """Resolve the on-disk directory that holds key files for a scheme."""
     return Path(__file__).parent / "test_keys" / f"{scheme_name}_scheme"
 
 
@@ -126,11 +82,7 @@ def compute_key_set_digest(keys_directory: Path) -> str:
     """
     Compute the SHA-256 digest identifying a directory's key set.
 
-    Hashes every validator's public keys in ascending index order.
     Two fills agree on vectors only if they agree on this digest.
-
-    Args:
-        keys_directory: Directory holding per-validator key files.
 
     Returns:
         Hex digest prefixed with 0x.
@@ -149,16 +101,8 @@ class XmssKeyManager:
     """
     Stateful manager for XMSS signing in tests.
 
-    XMSS is a stateful signature scheme.
-
-    Each signing operation consumes a one-time leaf and advances the key state forward.
-    This manager tracks that state across slots and validators.
-
-    Keys are lazily loaded from disk on first access, with a three-tier cache:
-
-    - Raw JSON (lightweight hex strings, ~2.7 KB per validator)
-    - Deserialized public keys only (avoids the heavy secret key objects)
-    - Advanced secret key state as live Python objects
+    Each signing operation consumes a one-time leaf and advances the key.
+    Keys load lazily into a three-tier cache: raw JSON, public keys, advanced secret state.
     """
 
     __slots__ = (
@@ -174,27 +118,11 @@ class XmssKeyManager:
     )
 
     _cache: ClassVar[dict[str, XmssKeyManager]] = {}
-    """
-    Per-scheme singleton cache for shared managers.
-
-    Replaced when a caller requests a larger max slot than what is cached.
-    """
+    """Per-scheme singleton cache, replaced when a wider max slot is requested."""
 
     @classmethod
     def shared(cls, max_slot: Slot = DEFAULT_MAX_SLOT) -> XmssKeyManager:
-        """
-        Return a shared manager, creating or replacing it as needed.
-
-        The cache holds one manager per scheme.
-        If the cached manager already covers the requested slot range, reuse it.
-        Otherwise, create a fresh one with the wider range.
-
-        Args:
-            max_slot: Highest slot the manager must support. Defaults to 10.
-
-        Returns:
-            A manager valid for at least the requested slot range.
-        """
+        """Return a shared manager, reusing the cache when its range covers the requested slot."""
         # A cached manager is usable if its range covers the requested max slot.
         cached = cls._cache.get(LEAN_ENV)
         if cached is not None and cached.max_slot >= max_slot:
@@ -210,12 +138,8 @@ class XmssKeyManager:
         """
         Clear advanced secret-key state from the cached manager.
 
-        XMSS keys are stateful — signing advances the key past used slots.
-        Without resetting, a test that signs at high slots poisons the cache
-        for later tests that need low-slot signatures.
-
-        Only the mutable signing state is cleared. The JSON and public-key
-        caches are immutable and preserved to avoid expensive re-loading.
+        Without a reset, signing at high slots poisons low-slot signing for later tests.
+        Only the mutable signing state is cleared; the immutable caches stay to avoid re-loading.
         """
         cached = cls._cache.get(LEAN_ENV)
         if cached is not None:
@@ -233,7 +157,7 @@ class XmssKeyManager:
         # Raw JSON cache: nested dict of hex-encoded SSZ strings, very lightweight.
         self._json_cache: dict[ValidatorIndex, dict[str, dict[str, str]]] = {}
 
-        # Deserialized public key pairs, still avoids secret key overhead.
+        # Deserialized public key pairs, avoiding secret key overhead.
         self._public_cache: dict[ValidatorIndex, tuple[PublicKey, PublicKey]] = {}
 
         # Populated lazily on first directory scan.
@@ -247,18 +171,12 @@ class XmssKeyManager:
 
     def _scan_indices(self) -> set[ValidatorIndex]:
         """
-        Discover which validator indices have key files on disk.
-
-        The result is cached after the first call.
-
-        Returns:
-            Set of validator indices with available key files.
+        Discover which validator indices have key files on disk, caching the result.
 
         Raises:
             FileNotFoundError: If the directory is missing or empty.
         """
         if self._available_indices is None:
-            # Verify the key directory exists before scanning.
             if not self._keys_directory.exists():
                 raise FileNotFoundError(
                     f"Keys directory not found: {self._keys_directory} - "
@@ -283,20 +201,12 @@ class XmssKeyManager:
         """
         Load raw JSON for a single validator, caching the result.
 
-        The JSON has two role keys, each holding hex-encoded SSZ blobs.
-        Keeping them as strings avoids the cost of deserializing secret keys.
-
-        Args:
-            index: Validator index to load.
-
-        Returns:
-            Nested dictionary of hex-encoded SSZ strings keyed by role then field.
+        Keeping the blobs as hex strings avoids the cost of deserializing secret keys.
 
         Raises:
             KeyError: If no key file exists for the index.
         """
         if index not in self._json_cache:
-            # Resolve the per-validator JSON file path.
             key_file = self._keys_directory / f"{index}.json"
             try:
                 with key_file.open() as key_file_handle:
@@ -309,17 +219,8 @@ class XmssKeyManager:
         """
         Deserialize a single secret key from disk.
 
-        Only the requested role's secret is decoded into a full Python object.
-        The other three fields remain as lightweight hex strings in the cache.
-
-        Args:
-            index: Validator index to look up.
-            role: Which signing role's secret to decode (attestation or proposal).
-
-        Returns:
-            The deserialized secret key.
+        Only the requested role's secret is decoded; the rest stay as lightweight hex strings.
         """
-        # Load the raw JSON (cached), then decode only the requested field.
         data = self._load_json(index)
         return SecretKey.decode_bytes(bytes.fromhex(data[f"{role}_keypair"]["secret_key"]))
 
@@ -327,8 +228,7 @@ class XmssKeyManager:
         """
         Fully deserialize a key pair including secrets.
 
-        Prefer using the public-key or signing accessors to avoid loading
-        heavy secret key objects unnecessarily.
+        Prefer the public-key or signing accessors to avoid loading heavy secret key objects.
         """
         try:
             return ValidatorKeyPair.model_validate(self._load_json(index))
@@ -350,30 +250,21 @@ class XmssKeyManager:
         return iter(sorted(self._scan_indices()))
 
     def key_set_digest(self) -> str:
-        """
-        Return the digest identifying this manager's on-disk key set.
-
-        Computed once and cached for the manager's lifetime.
-        """
+        """Return the digest identifying this manager's on-disk key set, computed once."""
         if self._key_set_digest is None:
             self._key_set_digest = compute_key_set_digest(self._keys_directory)
         return self._key_set_digest
 
     def get_public_keys(self, index: ValidatorIndex) -> tuple[PublicKey, PublicKey]:
         """
-        Return attestation and proposal public keys without touching secrets.
+        Return the attestation and proposal public keys without touching secrets.
 
-        Only the public key portions are deserialized from the hex JSON.
-        Secret keys (~2.7 KB raw, ~370 MB as Python objects) are not touched.
-
-        Args:
-            index: Validator index to look up.
+        Decoding the secret keys would cost ~370 MB of Python objects, so it is avoided.
 
         Returns:
             Tuple of (attestation public key, proposal public key).
         """
         if index not in self._public_cache:
-            # Decode only the two public key fields from the raw JSON.
             data = self._load_json(index)
             self._public_cache[index] = (
                 PublicKey.decode_bytes(bytes.fromhex(data["attestation_keypair"]["public_key"])),
@@ -391,51 +282,34 @@ class XmssKeyManager:
         """
         Core signing logic shared by attestation and proposal paths.
 
-        XMSS keys have a "prepared interval" -- the range of slots the key
-        can currently sign for. If the target slot falls outside that range,
-        the key state must be advanced forward until the slot is covered.
-
-        Memory strategy:
-
-        1. On cache miss, deserialize the key once from disk
-        2. Advance and sign
-        3. Keep the advanced object for the next sign
-
-        Args:
-            validator_index: Which validator's key to use.
-            slot: Target slot to sign for.
-            message: The 32-byte message digest to sign.
-            role: Which signing role's key (attestation or proposal) to advance.
+        An XMSS key has a prepared interval, the range of slots it can currently sign.
+        A target slot outside that range forces the key state forward until the slot is covered.
 
         Raises:
             ValueError: If the slot exceeds the key's total lifetime.
         """
         cache_key = (validator_index, role)
 
-        # Reuse the cached object directly when present, else decode from disk.
-        # Holding the object avoids the bytes-to-object round-trip on every sign.
-        # That round-trip dominated prod-scheme runtime under the compact-bytes cache.
+        # Reuse the cached object when present, else decode from disk.
+        # Holding the object avoids a bytes-to-object round-trip that dominated prod-scheme runtime.
         if cache_key in self._secret_state:
             secret_key = self._secret_state[cache_key]
         else:
             secret_key = self._get_secret_key(validator_index, role)
 
-        # Advance the key state until the target slot falls within the prepared interval.
-        #
-        # Each advancement step extends the interval by consuming the next one-time signing leaf.
+        # Advance the key until the target slot falls within the prepared interval.
+        # Each step extends the interval by consuming the next one-time signing leaf.
         prepared = self.scheme.get_prepared_interval(secret_key)
         while int(slot) not in prepared:
             activation = self.scheme.get_activation_interval(secret_key)
 
-            # If the prepared interval already reaches the activation boundary,
-            # no further advancement is possible, the key is exhausted.
+            # Reaching the activation boundary means the key is exhausted.
             if prepared.stop >= activation.stop:
                 raise ValueError(f"Slot {slot} exceeds key lifetime {activation.stop}")
 
             secret_key = self.scheme.advance_preparation(secret_key)
             prepared = self.scheme.get_prepared_interval(secret_key)
 
-        # Produce the signature for the target slot.
         signature = self.scheme.sign(secret_key, slot, message)
 
         # Park the advanced object back in the cache for the next sign.
@@ -451,12 +325,7 @@ class XmssKeyManager:
         """
         Sign attestation data using the validator's attestation key.
 
-        Advances only the attestation key state.
-        The proposal key remains untouched.
-
-        Args:
-            validator_index: Which validator signs.
-            attestation_data: The attestation to sign.
+        Advances only the attestation key state, leaving the proposal key untouched.
 
         Returns:
             XMSS signature over the attestation data root.
@@ -464,8 +333,6 @@ class XmssKeyManager:
         Raises:
             ValueError: If the attestation slot exceeds key lifetime.
         """
-        # Derive the message digest from the attestation data and delegate
-        # to the shared signing logic with the attestation secret.
         return self._sign_with_secret(
             validator_index,
             attestation_data.slot,
@@ -482,13 +349,7 @@ class XmssKeyManager:
         """
         Sign a block root using the validator's proposal key.
 
-        Advances only the proposal key state.
-        The attestation key remains untouched.
-
-        Args:
-            validator_index: Which validator signs.
-            slot: Slot of the block being proposed.
-            block_root: The hash tree root of the block.
+        Advances only the proposal key state, leaving the attestation key untouched.
 
         Returns:
             XMSS signature over the block root.
@@ -507,22 +368,16 @@ class XmssKeyManager:
         """
         Sign attestation data with each validator and aggregate the result.
 
-        Returns a single-message aggregate proof binding all participants
-        to the (data, slot) pair.
-
-        Each validator's XMSS attestation key signs the attestation data
-        root. The signatures are then handed to the multi-signature
-        binding to produce a single cryptographically valid single-message aggregate proof
-        binding all participants to (data, slot).
+        Each key signs the data root, then a binding folds them into one proof over data and slot.
 
         Args:
             validator_indices: Validators to sign with.
             attestation_data: The attestation data to sign.
-            precomputed_signatures: Optional pre-computed signatures keyed by
-                validator index. Missing entries are signed on the fly.
+            precomputed_signatures: Optional signatures keyed by validator index.
+                Missing entries are signed on the fly.
 
         Returns:
-            Cryptographically valid single-message aggregate proof covering validator_indices.
+            A single-message aggregate proof covering the given validators.
         """
         signatures = precomputed_signatures or {}
         raw_xmss = [
@@ -548,31 +403,19 @@ class XmssKeyManager:
         | None = None,
     ) -> list[SingleMessageAggregate]:
         """
-        Produce single-message aggregate proofs aligned with the given attestations.
+        Produce one single-message aggregate proof per attestation, parallel to the input.
 
-        For each aggregated attestation:
-
-        1. Identify participating validators from the aggregation bitfield.
-        2. Collect each participant's attestation public key and signature.
-        3. Combine them into a single single-message aggregate single-message proof via the
-           multi-signature binding.
-
-        Pre-computed signatures can be supplied via the lookup to avoid
-        redundant signing. Missing entries are signed on the fly.
+        Participants come from each attestation's bitfield.
+        The lookup supplies pre-computed signatures; missing entries are signed on the fly.
 
         Args:
             aggregated_attestations: Attestations with aggregation bitfields set.
-            signature_lookup: Optional pre-computed signatures keyed by
-                attestation data then validator index.
+            signature_lookup: Optional signatures keyed by attestation data then validator index.
 
         Returns:
-            One single-message aggregate proof per attestation, parallel to the input.
+            One proof per attestation, parallel to the input.
         """
         lookup = signature_lookup or {}
-
-        # Produce one aggregated proof per attestation that the leanVM can
-        # verify in one pass over all participants.
-        # Participants are decoded from each attestation's bitfield.
         return [
             self.sign_and_aggregate(
                 list(aggregate.aggregation_bits.to_validator_indices()),

--- a/packages/testing/src/consensus_testing/keys_cli.py
+++ b/packages/testing/src/consensus_testing/keys_cli.py
@@ -30,52 +30,25 @@ KEY_DOWNLOAD_URLS = {
     "test": "https://github.com/leanEthereum/leansig-test-keys/releases/download/latest/test_scheme.tar.gz",
     "prod": "https://github.com/leanEthereum/leansig-test-keys/releases/download/latest/prod_scheme.tar.gz",
 }
-"""
-GitHub release URLs for pre-generated key archives.
-
-Keyed by scheme name ("test" or "prod").
-Each URL points to a tar.gz containing per-validator JSON files.
-"""
+"""Release archive URL per scheme, each a tar.gz of per-validator key files."""
 
 PINNED_KEY_ARCHIVE_SHA256 = {
     "test": "2d616857f4936cde4e2720fa95a76f2644015390f4b8c188acbaa756f521dac8",
     "prod": "a40aa60fc0c0d1b4c761f19fb1678039400ae318da85f782dd57bc8cc0eb617d",
 }
-"""
-SHA-256 of each scheme's key archive.
-
-The release tag is mutable, so these checksums are the real pin.
-A re-cut release fails the download instead of silently changing vectors.
-Update together with the key-set digests when adopting a new release.
-"""
+"""SHA-256 of each scheme's key archive, the real pin since the release tag is mutable."""
 
 PINNED_KEY_SET_DIGESTS = {
     "test": "0x49306dfdb6dddd72afe265ec3b20a1901834dde9b3dfe4fee6b4f7ca58c7aa43",
     "prod": "0xc2b5fc4c1f1fbc181ddf07db3df985f79e1dcedcfb7df732ef20863d7cbcf491",
 }
-"""
-Expected key-set digest per scheme.
-
-Guards the on-disk keys, which the archive checksum cannot see.
-
-- test: the key set committed to this repository.
-- prod: the key set served by the current release.
-"""
+"""Expected key-set digest per scheme, guarding on-disk keys the archive checksum cannot see."""
 
 NUM_VALIDATORS: int = 8
-"""
-Default number of validator key pairs.
-
-Eight validators is enough to exercise committee logic and 2/3 supermajority
-thresholds while keeping key generation and test execution fast.
-"""
+"""Default validator count, enough to exercise committee logic and 2/3 thresholds while fast."""
 
 CLI_DEFAULT_MAX_SLOT = Slot(100)
-"""
-Maximum slot when generating keys via CLI (inclusive).
-
-One hundred slots provides ample signing headroom for typical test scenarios.
-"""
+"""Maximum slot when generating keys via CLI, inclusive."""
 
 
 def _generate_single_keypair(
@@ -85,19 +58,8 @@ def _generate_single_keypair(
     Generate attestation and proposal key pairs for one validator.
 
     Defined at module level so it can be pickled for multiprocessing.
-
-    Args:
-        scheme: XMSS scheme instance to use for key generation.
-        num_slots: Total number of slots the keys must cover.
-        index: Validator index (used only for progress logging).
-
-    Returns:
-        Complete key pair with both attestation and proposal keys.
     """
-    # Generate two independent key pairs: one for attestations, one for proposals.
-    #
-    # Separate keys allow signing both roles within the same slot
-    # without exhausting a one-time leaf.
+    # Separate keys let one validator sign both roles in a slot without exhausting a one-time leaf.
     start = time.monotonic()
     print(f"[key #{index}] generating attestation key...", flush=True)
     attestation_keypair = scheme.key_gen(Slot(0), Uint64(num_slots))
@@ -118,17 +80,7 @@ def _generate_single_keypair(
 
 
 def _generate_keys(lean_env: str, count: int, max_slot: int) -> None:
-    """
-    Generate XMSS key pairs in parallel and write each to a separate file.
-
-    Each validator gets its own JSON file to keep individual files small,
-    which matters especially for production-scheme keys.
-
-    Args:
-        lean_env: Scheme name (e.g. "test" or "prod").
-        count: Number of validator key pairs to generate.
-        max_slot: Maximum signable slot (key lifetime = max_slot + 1 slots).
-    """
+    """Generate XMSS key pairs in parallel, one small JSON file per validator."""
     scheme = LEAN_ENV_TO_SCHEMES[lean_env]
     keys_directory = get_keys_directory(lean_env)
     num_slots = max_slot + 1
@@ -139,16 +91,13 @@ def _generate_keys(lean_env: str, count: int, max_slot: int) -> None:
         f"({num_slots} slots) using {num_workers} cores..."
     )
 
-    # Ensure the output directory exists.
     keys_directory.mkdir(parents=True, exist_ok=True)
 
-    # Remove stale key files from previous runs that may have generated
-    # a different number of keys.
+    # Drop stale files from a prior run that may have made a different key count.
     for old_file in keys_directory.glob("*.json"):
         old_file.unlink()
 
-    # Generate key pairs in parallel across all CPU cores.
-    # Results arrive in index order thanks to executor.map.
+    # Results arrive in index order from the parallel map.
     gen_start = time.monotonic()
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
         worker_func = partial(_generate_single_keypair, scheme, num_slots)
@@ -167,35 +116,23 @@ def _generate_keys(lean_env: str, count: int, max_slot: int) -> None:
 
 
 def download_keys(scheme: str) -> None:
-    """
-    Download pre-generated key pairs from a GitHub release.
-
-    Downloads a tar.gz archive for the specified scheme, removes any
-    existing keys for that scheme, and extracts the archive in place.
-
-    Args:
-        scheme: Scheme name ("test" or "prod").
-    """
+    """Download a scheme's key archive from a GitHub release and extract it in place."""
     base_directory = get_keys_directory(scheme).parent
     url = KEY_DOWNLOAD_URLS[scheme]
 
     print(f"Downloading {scheme} keys from {url}...")
 
-    # Reserve a temp path; we open it explicitly below so the writer can close
-    # before the reader opens.
     temporary_fd, temporary_name = tempfile.mkstemp(suffix=".tar.gz")
     os.close(temporary_fd)
     tmp_path = Path(temporary_name)
 
     try:
         # Close the writer before opening the reader.
-        # Otherwise Python's userspace buffer can withhold the tail of the gzip stream.
-        # That produces a near-end decompression failure that looks like a truncated download.
+        # Otherwise a buffered tail can look like a truncated, undecompressable download.
         with urllib.request.urlopen(url) as response, tmp_path.open("wb") as out:
             shutil.copyfileobj(response, out)
 
-        # Verify the archive against the pinned checksum before extracting.
-        # The release tag is mutable, so the checksum is the real pin.
+        # The release tag is mutable, so verify the pinned checksum before extracting.
         with tmp_path.open("rb") as archive_handle:
             archive_sha256 = hashlib.file_digest(archive_handle, "sha256").hexdigest()
         if archive_sha256 != PINNED_KEY_ARCHIVE_SHA256[scheme]:
@@ -207,16 +144,14 @@ def download_keys(scheme: str) -> None:
                 "updating the pinned checksum and key-set digest on purpose."
             )
 
-        # Extract into a scratch directory and verify there first.
-        # A rejected archive must never destroy working keys.
+        # Extract and verify in scratch first, so a rejected archive never destroys working keys.
         # The archive root is the scheme directory itself.
         with tempfile.TemporaryDirectory() as scratch_name:
             scratch_directory = Path(scratch_name)
             with tarfile.open(tmp_path, "r:gz") as tar:
                 tar.extractall(path=scratch_directory, filter="data")
 
-            # Verify the extracted key set against the pinned digest.
-            # Catches content drift the checksum pin alone would miss.
+            # The digest catches content drift the checksum pin alone would miss.
             extracted_directory = scratch_directory / f"{scheme}_scheme"
             extracted_digest = compute_key_set_digest(extracted_directory)
             if extracted_digest != PINNED_KEY_SET_DIGESTS[scheme]:
@@ -228,7 +163,7 @@ def download_keys(scheme: str) -> None:
                     "For the test scheme, restore the committed keys from version control."
                 )
 
-            # Replace the live key set only after both verifications pass.
+            # Replace the live key set only after both checks pass.
             target_directory = base_directory / f"{scheme}_scheme"
             if target_directory.exists():
                 shutil.rmtree(target_directory)
@@ -237,7 +172,6 @@ def download_keys(scheme: str) -> None:
 
         print(f"Extracted {scheme} keys to {target_directory}/")
     finally:
-        # Always clean up the temporary download file.
         tmp_path.unlink(missing_ok=True)
 
     print("Download complete!")
@@ -284,12 +218,10 @@ Regenerating keys:
 )
 def keys(download: bool, scheme: str, count: int, max_slot: int) -> None:
     """Generate XMSS key pairs for consensus testing."""
-    # Download pre-generated keys instead of generating locally.
     if download:
         download_keys(scheme=scheme)
         return
 
-    # Generate fresh keys with the specified parameters.
     _generate_keys(lean_env=scheme, count=count, max_slot=max_slot)
 
 

--- a/packages/testing/src/consensus_testing/mocks.py
+++ b/packages/testing/src/consensus_testing/mocks.py
@@ -132,12 +132,7 @@ class MockForkchoiceStore:
     """
     In-memory forkchoice store double for sync-service tests.
 
-    One instance plays two roles at once.
-    It answers reads for the head, blocks, and checkpoints.
-    It also processes incoming blocks and attestations.
-
-    Processing reads its own fields, not a separate store.
-    So the leading store argument the protocol passes is accepted and ignored.
+    Processing reads its own fields, so the leading store argument is accepted and ignored.
     """
 
     head: Bytes32 = field(default_factory=Bytes32.zero)
@@ -175,9 +170,7 @@ class MockForkchoiceStore:
     """When it returns true for an aggregate, processing raises a spec rejection."""
 
     rejection_reason: RejectionReason = RejectionReason.UNKNOWN_TARGET_BLOCK
-    """Reason carried by a triggered rejection.
-    The default names a missing block, which the sync service buffers for replay.
-    Set a permanent reason to exercise the logged-and-dropped path."""
+    """Reason carried by a triggered rejection, defaulting to a missing block kept for replay."""
 
     on_block_post_state: State | None = None
     """Post-state recorded for each processed block, when set."""
@@ -205,7 +198,7 @@ class MockForkchoiceStore:
         root = hash_tree_root(signed_block.block)
         self.blocks[root] = signed_block.block
         self.head = root
-        # The double has no real safe-target rule, so the head doubles as it.
+        # No real safe-target rule here, so the head doubles as it.
         self.safe_target = root
         self.head_slot = signed_block.block.slot
         if self.on_block_post_state is not None:
@@ -333,9 +326,7 @@ def create_mock_sync_service(
     peer_manager = PeerManager()
     peer_manager.add_peer(PeerInfo(peer_id=peer_id, state=ConnectionState.CONNECTED))
 
-    # One double fills both roles the service expects.
-    # Its fields answer store reads.
-    # Its methods answer the processing the service drives.
+    # One double fills both roles: its fields answer reads, its methods drive processing.
     forkchoice_double = MockForkchoiceStore()
 
     return SyncService(

--- a/packages/testing/src/consensus_testing/pytest_plugins/filler.py
+++ b/packages/testing/src/consensus_testing/pytest_plugins/filler.py
@@ -27,13 +27,7 @@ class FixtureCollector:
     """Collects generated fixtures and writes them to disk."""
 
     def __init__(self, output_directory: Path, fork: str):
-        """
-        Initialize the fixture collector.
-
-        Args:
-            output_directory: Root directory for generated fixtures.
-            fork: The fork name (e.g., "Lstar").
-        """
+        """Initialize the fixture collector."""
         self.output_directory = output_directory
         self.fork = fork
         self.fixtures: list[tuple[str, Any, str]] = []
@@ -42,32 +36,14 @@ class FixtureCollector:
         """
         Compute the fixture file for one test function.
 
-        Layout: {output}/consensus/{format}/{test_path}/{function}.json
-        The format directory drops the redundant test suffix.
-
-        Args:
-            test_nodeid: Complete pytest node ID.
-            fixture_format: Format name (e.g., "state_transition_test").
-
-        Returns:
-            The path of the JSON file this test function's fixtures land in.
-
-        Raises:
-            ValueError: If the test file is not under the consensus spec
-                tests, where the output layout is defined.
-                Collection normally excludes such paths already;
-                this guards against misconfiguration.
+        Raises if the test file is not under the consensus spec tests.
         """
-        # Split the node ID into the test file path and bare function name.
-        # Parametrization suffixes (the bracketed part) are stripped so every
-        # parametrized case of one function shares one fixture file.
+        # Strip parametrization suffixes so every case of one function shares one file.
         nodeid_parts = test_nodeid.split("::")
         test_file_path = nodeid_parts[0]
         function_name_with_params = nodeid_parts[1] if len(nodeid_parts) > 1 else ""
         base_function_name = function_name_with_params.split("[")[0]
 
-        # Extract test path relative to the consensus spec tests
-        # e.g., tests/consensus/lstar/... -> lstar/...
         try:
             relative_path = Path(test_file_path).relative_to("tests/consensus")
         except ValueError as exception:
@@ -78,7 +54,6 @@ class FixtureCollector:
 
         test_path = relative_path.with_suffix("")
 
-        # Build output path: fixtures/consensus/{format}/{test_path}
         format_directory = fixture_format.removesuffix("_test")
         return (
             self.output_directory
@@ -95,15 +70,7 @@ class FixtureCollector:
         test_nodeid: str,
         config: pytest.Config | None = None,
     ) -> None:
-        """
-        Add a fixture to the collection.
-
-        Args:
-            fixture_format: Format name (e.g., "state_transition_test").
-            fixture: The fixture object.
-            test_nodeid: Complete pytest node ID.
-            config: Pytest config object to attach fixture path metadata.
-        """
+        """Add a fixture to the collection."""
         self.fixtures.append((fixture_format, fixture, test_nodeid))
 
         if config is not None:
@@ -182,23 +149,20 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 def pytest_ignore_collect(collection_path: Path) -> bool | None:
     """
-    Ignore test collection for paths outside the consensus spec tests.
+    Ignore paths outside the consensus spec tests.
 
-    This prevents pytest from collecting unit tests during fill,
-    reducing overhead significantly when there are many tests.
+    Skipping unit tests during fill cuts collection overhead sharply.
     """
-    # Check if path is under tests/ directory
     try:
         relative_path = collection_path.relative_to(Path.cwd() / "tests")
     except ValueError:
-        # Not under tests/, let pytest handle it normally
+        # Not under tests/, let pytest handle it normally.
         return None
 
-    # If it's directly under tests/consensus, don't ignore
     if str(relative_path).startswith("consensus"):
         return None
 
-    # Anything else under tests/ (unit, api, interop tests) is skipped during fill
+    # Anything else under tests/ is skipped during fill.
     if relative_path.parts:
         return True
 
@@ -207,7 +171,6 @@ def pytest_ignore_collect(collection_path: Path) -> bool | None:
 
 def pytest_configure(config: pytest.Config) -> None:
     """Setup the fixture generation session."""
-    # Register fork validity markers
     config.addinivalue_line(
         "markers",
         "valid_until(fork): specifies until which fork a test case is valid",
@@ -221,14 +184,12 @@ def pytest_configure(config: pytest.Config) -> None:
     # Crypto mode is chosen explicitly and applies to either scheme.
     AggregationProver.set_mode(CryptoMode(config.getoption("--crypto")))
 
-    # Get options
     output_directory = Path(config.getoption("--output"))
     fork_name = config.getoption("--fork")
     clean = config.getoption("--clean")
 
     available_fork_names = sorted(fork.name() for fork in FORKS_BY_NAME.values())
 
-    # Validate fork
     if not fork_name:
         print("Error: --fork is required", file=sys.stderr)
         print(
@@ -251,7 +212,6 @@ def pytest_configure(config: pytest.Config) -> None:
 
     fork_class = FORKS_BY_NAME[fork_name_normalized]
 
-    # Check output directory
     if output_directory.exists() and any(output_directory.iterdir()):
         if not clean:
             leftover_fixture_paths = list(output_directory.iterdir())
@@ -276,10 +236,9 @@ def pytest_configure(config: pytest.Config) -> None:
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """
-    Deselect tests not valid for the fork, and full real-crypto tests in the mocked lane.
+    Deselect tests invalid for the fork, and full real-crypto tests in the mocked lane.
 
-    Real-crypto vectors cannot be mocked, so the fast mocked lane keeps only the
-    smoke subset and leaves the rest to the real lane.
+    Real-crypto vectors cannot be mocked, so the fast lane keeps only their smoke subset.
     """
     if TEST_FORK_CLASS_KEY not in config.stash:
         return
@@ -312,11 +271,7 @@ def _check_markers_valid_for_fork(
     markers: list[Any],
     fork_class: type,
 ) -> bool:
-    """
-    Check if test markers indicate validity for the given fork.
-
-    Shared logic for both collection-time and parametrization-time fork filtering.
-    """
+    """Check whether test markers indicate validity for the given fork."""
     has_valid_until = False
     valid_until_forks = []
 
@@ -336,15 +291,9 @@ def _check_markers_valid_for_fork(
 
 def pytest_sessionstart(session: pytest.Session) -> None:
     """
-    Fail the session fast if re-signing the same message is not byte-identical.
+    Abort the fill if re-signing a message is not byte-identical.
 
-    A signature must depend only on the key, the slot, and the message.
-    Prior signing activity must never influence the bytes.
-
-    A scheme change breaking this invariant must abort the fill.
-    Emitting order-dependent vectors would be worse than failing.
-
-    Under sharded runs every worker process probes its own key state.
+    Order-dependent vectors are worse than failing.
     """
     probe_message = Bytes32(b"\x07" * 32)
     fresh_signature = XmssKeyManager.shared().sign_block_root(
@@ -424,26 +373,14 @@ def reset_xmss_signing_state() -> Iterator[None]:
     """
     Reset shared XMSS signing state before every test.
 
-    XMSS signing is stateful.
-    Each signature consumes a one-time leaf and advances the shared key state.
-
-    Every test must start from the same fresh key state.
-    Otherwise emitted vectors could depend on test order or worker sharding.
+    Signing consumes a one-time leaf, so a stale key would make vectors depend on test order.
     """
     XmssKeyManager.reset_signing_state()
     yield
 
 
 def base_spec_filler_parametrizer(spec_class: Any) -> Any:
-    """
-    Generate pytest.fixture for a given test spec class.
-
-    Args:
-        spec_class: The input spec class to create a filler for.
-
-    Returns:
-        A pytest fixture function whose value fills and collects a fixture.
-    """
+    """Build a pytest fixture whose value fills and collects a fixture for the spec class."""
 
     @pytest.fixture(
         scope="function",
@@ -469,8 +406,7 @@ def base_spec_filler_parametrizer(spec_class: Any) -> Any:
             else:
                 generated_fixture = test_spec.generate()
 
-            # A mocked proof is never verified.
-            # A real proof must fail only when the rejection is itself a proof failure.
+            # A real proof is invalid only when the rejection is itself a proof failure.
             # A non-crypto rejection (such as an unknown parent) still carries a valid proof.
             expected_rejection = test_spec.expected_rejection
             if mock_prover:
@@ -538,9 +474,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     )
 
 
-# Pytest fixtures for every consensus fixture format.
-# Each spec test requests one by its format name and calls it to build a test vector.
-# Registration iterates the canonical registry.
+# Register one filler fixture per consensus format from the canonical registry.
 # A new format needs no edit here.
 for fixture_format_class in FIXTURE_FORMATS:
     globals()[fixture_format_class.format_name] = base_spec_filler_parametrizer(

--- a/packages/testing/src/consensus_testing/rejection.py
+++ b/packages/testing/src/consensus_testing/rejection.py
@@ -5,18 +5,7 @@ from lean_spec.spec.forks.lstar.containers import AggregationError
 
 
 def classify_rejection(exception: Exception) -> RejectionReason:
-    """
-    Resolve the language-neutral reason behind a spec rejection.
-
-    Args:
-        exception: The exception the spec raised for the invalid input.
-
-    Returns:
-        The reason emitted into the test vector.
-
-    Raises:
-        ValueError: If the exception carries no reason.
-    """
+    """Resolve the language-neutral reason behind a spec rejection."""
     # Typed rejections carry their reason directly.
     if isinstance(exception, SpecRejectionError):
         return exception.reason

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -112,12 +112,7 @@ FIXTURE_FORMATS: tuple[type[BaseTestSpec], ...] = (
     VerifySignaturesTest,
     VerifySingleMessageProofsTest,
 )
-"""
-Canonical registry of every consensus fixture format.
-
-The pytest plugin registers one filler fixture per entry.
-A new format becomes fillable by adding its class here.
-"""
+"""Canonical registry of every consensus fixture format; add a class here to make it fillable."""
 
 __all__ = [
     "CachedMessage",

--- a/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
@@ -26,30 +26,17 @@ class EndpointResponseContract(StrictBaseModel):
 
 
 EndpointHandler = Callable[[Store, "ApiEndpointTest"], EndpointResponseContract]
-"""Uniform signature for all endpoint response builders.
-
-Every handler receives both arguments even if it only needs one.
-This keeps the dispatch table simple: one signature, one call site.
-"""
+"""Uniform signature for endpoint response builders, so the dispatch table has one call site."""
 
 
 def _build_store(num_validators: int, genesis_time: int, anchor_slot: int = 0) -> Store:
     """
-    Build a deterministic store rooted at genesis or at an advanced anchor.
+    Build a deterministic store, genesis-only or an empty chain advanced to the anchor slot.
 
-    At anchor_slot 0 the store is genesis-only. At higher slots the store
-    is seeded with a real (state, block) pair produced by advancing an
-    empty chain through anchor_slot; the store then carries non-empty
-    historical block hashes but leaves justification and finalization at
-    genesis (no attestations are injected). This is enough to exercise
-    endpoint responses whose shape depends on post-genesis slot numbers,
-    historical roots, and multi-node fork-choice trees.
+    No attestations are injected, so justification and finalization stay at genesis.
     """
     fork = LstarSpec()
-    # Walk the chain from genesis through anchor_slot using empty blocks.
-    # Slot 0 makes the builder return the genesis pair with no advance.
-    # The returned pair (state, block) is internally consistent with the
-    # historical chain the fixture wants to present to the endpoint.
+    # Walk the chain from genesis using empty blocks; slot 0 returns the genesis pair unchanged.
     state, block = build_anchor(
         fork=fork,
         num_validators=num_validators,
@@ -61,7 +48,7 @@ def _build_store(num_validators: int, genesis_time: int, anchor_slot: int = 0) -
 
 
 def _health_response(_store: Store, _fixture: "ApiEndpointTest") -> EndpointResponseContract:
-    """Static liveness check. Independent of consensus state."""
+    """Static liveness check, independent of consensus state."""
     return EndpointResponseContract(
         status_code=200,
         content_type="application/json",
@@ -70,7 +57,7 @@ def _health_response(_store: Store, _fixture: "ApiEndpointTest") -> EndpointResp
 
 
 def _justified_response(store: Store, _fixture: "ApiEndpointTest") -> EndpointResponseContract:
-    """Latest justified checkpoint: slot + root. Root varies with validator count."""
+    """Latest justified checkpoint as slot and root, with the root varying by validator count."""
     return EndpointResponseContract(
         status_code=200,
         content_type="application/json",
@@ -147,15 +134,11 @@ def _metrics_response(_store: Store, _fixture: "ApiEndpointTest") -> EndpointRes
     """
     Prometheus-format metrics scrape.
 
-    The body of /metrics is dynamic (counters accumulate, timestamps shift)
-    so the fixture pins only the stable contract: status, content-type,
-    and the full list of metric names clients must expose.
+    The body is dynamic, so the fixture pins only status, content type, and the metric names.
     """
     from lean_spec.node.metrics.registry import registry as metrics_registry
 
-    # Names enumerated from the leanMetrics spec. Any change to this list
-    # is a cross-client-visible metrics surface change and should be
-    # reflected in the spec first.
+    # Enumerated from the metrics spec; changing the list is a cross-client surface change.
     required_metric_names = [
         "lean_node_info",
         "lean_node_start_time_seconds",
@@ -177,8 +160,7 @@ def _metrics_response(_store: Store, _fixture: "ApiEndpointTest") -> EndpointRes
         "lean_validators_count",
         "lean_connected_peers",
     ]
-    # Touch the module import so spec refactors that remove the registry
-    # trip the fixture instead of failing silently.
+    # Touch the registry so its removal trips this fixture instead of failing silently.
     assert metrics_registry is not None
     return EndpointResponseContract(
         status_code=200,
@@ -190,13 +172,7 @@ def _metrics_response(_store: Store, _fixture: "ApiEndpointTest") -> EndpointRes
 def _aggregator_toggle_response(
     _store: Store, fixture: "ApiEndpointTest"
 ) -> EndpointResponseContract:
-    """
-    Expected response after toggling the aggregator role.
-
-    The fixture models a single POST against a node whose starting state is
-    initial_is_aggregator. The response reflects the new value and the
-    previous value as an is_aggregator / previous dict.
-    """
+    """Expected response after toggling the aggregator role, with the new and previous values."""
     body = fixture.request_body
     if not isinstance(body, dict) or not isinstance(body.get("enabled"), bool):
         raise ValueError(
@@ -227,13 +203,7 @@ _ENDPOINT_HANDLERS: dict[tuple[str, str], EndpointHandler] = {
 
 
 class ApiEndpointFixture(BaseConsensusFixture):
-    """
-    Emitted vector for API endpoint response conformance.
-
-    JSON output: endpoint, method, genesisParams, requestBody,
-    initialIsAggregator, expectedStatusCode, expectedContentType,
-    expectedBody.
-    """
+    """Emitted vector for API endpoint response conformance."""
 
     endpoint: str
     """API path under test."""
@@ -275,26 +245,17 @@ class ApiEndpointTest(BaseTestSpec):
     genesis_params: dict[str, int]
     """Genesis store inputs.
 
-    - numValidators: validator-set size (defaults to 4 when absent).
-    - genesisTime: unix genesis timestamp (defaults to 0 when absent).
-    - anchorSlot: optional post-genesis slot to advance the chain to
-      before building the store. Defaults to 0 (genesis-only).
+    - numValidators: validator-set size, default 4.
+    - genesisTime: unix genesis timestamp, default 0.
+    - anchorSlot: post-genesis slot to advance to, default 0 for genesis-only.
     """
 
     request_body: Any = None
-    """Optional request body for non-GET methods. JSON-serializable.
-
-    Consumed by admin endpoints (e.g. POST /lean/v0/admin/aggregator). Read-only
-    GET fixtures leave this as None.
-    """
+    """Optional JSON request body for non-GET methods."""
 
     initial_is_aggregator: bool = False
-    """Seeds the node's aggregator role before the request is sent.
-
-    Consumed by the admin aggregator endpoints. Clients must configure their
-    node with this value (e.g. via CLI or controller) before replaying the
-    fixture. Ignored by other endpoints.
-    """
+    """Aggregator role seeded before the request is sent.
+    Clients must configure their node with this value before replaying."""
 
     def generate(self) -> ApiEndpointFixture:
         """Build genesis store, compute expected response, emit the vector."""

--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -43,11 +43,7 @@ from lean_spec.spec.forks.lstar.spec import LstarSpec
 
 
 class ForkChoiceFixture(BaseConsensusFixture):
-    """
-    Emitted vector for event-driven fork choice scenarios.
-
-    JSON output: anchorState, anchorBlock, steps, maxSlot.
-    """
+    """Emitted vector for event-driven fork choice scenarios."""
 
     anchor_state: State
     """Initial trusted consensus state."""
@@ -63,21 +59,7 @@ class ForkChoiceFixture(BaseConsensusFixture):
 
 
 class ForkChoiceTest(BaseTestSpec):
-    """
-    Spec for event-driven fork choice scenarios.
-
-    Fork choice tests simulate a node processing events over time.
-    The Store maintains all chain state needed to compute the head.
-
-    Test structure:
-
-    1. Initialize Store from anchor state and block
-    2. Process steps in order (tick, block, attestation)
-    3. Validate Store state against expected values
-
-    Labels allow building forks.
-    Give a block a label, then reference it as a parent in later blocks.
-    """
+    """Spec for event-driven fork choice scenarios, with the store carrying all chain state."""
 
     format_name: ClassVar[str] = "fork_choice_test"
     """Identifier used in fixture output paths and metadata."""
@@ -86,73 +68,32 @@ class ForkChoiceTest(BaseTestSpec):
     """Human-readable summary for fixture documentation."""
 
     anchor_state: State = Field(default_factory=build_genesis_state)
-    """
-    Initial trusted consensus state.
-
-    Defaults to the standard genesis state.
-    Spell it out only when the test needs a non-default anchor.
-    """
+    """Initial trusted consensus state, defaulting to genesis."""
 
     anchor_block: Block | None = None
-    """
-    Initial trusted block (unsigned).
-
-    Derived from anchor state if not provided.
-    """
+    """Initial trusted block, derived from the anchor state when absent."""
 
     steps: list[ForkChoiceStep]
-    """
-    Sequence of fork choice events to process.
-
-    Events execute in order.
-    Store state carries forward between steps.
-    Each step can validate Store state via checks.
-    """
+    """Fork choice events to process in order, carrying store state forward."""
 
     anchor_valid: bool = True
-    """
-    Whether Store.from_anchor is expected to succeed.
-
-    Default True covers every normal test.
-    Set False to assert that store initialization itself must fail,
-    e.g. when the anchor block and state are inconsistent.
-    The base expected rejection field then refines the required failure.
-    """
+    """Whether store initialization is expected to succeed."""
 
     max_slot: Slot | None = None
-    """
-    Maximum slot for XMSS key validity.
-
-    Calculated from steps if not provided.
-    XMSS keys need precomputation up to this slot.
-    """
+    """Highest slot XMSS keys must cover, computed from the steps when absent."""
 
     def _resolved_anchor_block(self) -> Block:
-        """
-        Return the authored anchor block, or derive one from the anchor state.
-
-        Most tests start from genesis.
-        Deriving the anchor block from state reduces boilerplate.
-        """
+        """Return the authored anchor block, or rebuild one from the anchor state's header."""
         if self.anchor_block is not None:
             return self.anchor_block
-        # The state already carries the block header, so rebuild the matching block.
         return reconstruct_block_from_header(self.anchor_state)
 
     def _resolved_max_slot(self) -> Slot:
-        """
-        Return the authored max slot, or compute it from the steps.
-
-        XMSS keys require precomputation.
-        We scan steps to find the highest slot needed.
-        """
+        """Return the authored max slot, or the highest slot the steps need keys for."""
         if self.max_slot is not None:
             return self.max_slot
 
-        # Find the maximum slot across all block and attestation steps.
-        #
-        # XMSS signatures are slot-dependent.
-        # Keys must be generated up to this slot before signing.
+        # XMSS signatures are slot-dependent, so keys must exist up to the highest signed slot.
         slots_needing_keys = (
             step.block.slot if isinstance(step, BlockStep) else step.attestation.slot
             for step in self.steps
@@ -162,12 +103,7 @@ class ForkChoiceTest(BaseTestSpec):
 
     def generate(self) -> ForkChoiceFixture:
         """
-        Generate the fixture by running the spec's Store.
-
-        Executes each step against the actual specification and validates checks.
-
-        Returns:
-            The emitted vector with one filled step per authored step.
+        Run each step against the spec's store and emit one filled step per authored step.
 
         Raises:
             AssertionError: If any step fails unexpectedly or checks mismatch.
@@ -176,27 +112,16 @@ class ForkChoiceTest(BaseTestSpec):
         anchor_block = self._resolved_anchor_block()
         max_slot = self._resolved_max_slot()
 
-        # Expected anchor-init failure path.
-        #
-        # When anchor_valid is False, the test asserts that Store.from_anchor
-        # rejects the given (state, block) pair. The public_key sync that normally
-        # fixes up the anchor block's state root is skipped, since that would
-        # mask the very inconsistency under test.
+        # When the anchor is expected invalid, skip the public_key sync below.
+        # That sync would rewrite the state root and mask the inconsistency this path must reject.
         if not self.anchor_valid:
             return self._generate_invalid_anchor(spec, anchor_block, max_slot)
 
-        # Key manager setup
-        #
-        # XMSS keys are expensive to generate.
-        # The shared key manager caches keys across tests.
-        # Tests requiring higher max slot trigger key expansion.
+        # The shared key manager caches expensive XMSS keys across tests.
         key_manager = XmssKeyManager.shared(max_slot=max_slot)
 
-        # Validator public_key synchronization
-        #
-        # Test states use placeholder public_keys.
-        # We must replace them with the key manager's actual keys.
-        # Otherwise signature verification will fail.
+        # Test states carry placeholder public keys.
+        # Swap in the key manager's real keys or signature verification fails.
         updated_validators = []
         for validator_position, validator in enumerate(self.anchor_state.validators):
             validator_index = ValidatorIndex(validator_position)
@@ -212,34 +137,24 @@ class ForkChoiceTest(BaseTestSpec):
                 )
             )
 
-        # Updating validators changes the state root.
-        # We must also update the anchor block to match.
+        # Rewriting validators changes the state root, so the anchor block must follow.
         anchor_state = self.anchor_state.model_copy(
             update={"validators": Validators(data=updated_validators)}
         )
         anchor_block = anchor_block.model_copy(update={"state_root": hash_tree_root(anchor_state)})
 
-        # Store initialization
-        #
-        # The Store is the node's local view of the chain.
-        # It starts from a trusted anchor (usually genesis).
+        # The store is the node's local chain view, starting from a trusted anchor.
         store = spec.create_store(
             anchor_state,
             anchor_block,
             validator_index=ValidatorIndex(0),
         )
 
-        # Block registry for fork creation
-        #
-        # Labels let tests reference blocks by name.
-        # This enables building forks: "build block B with parent A".
-        # The "genesis" label is always available.
+        # Labels let tests reference blocks by name to build forks.
+        # The genesis label is always available.
         block_registry: dict[str, Block] = {"genesis": anchor_block}
 
-        # Step processing loop
-        #
-        # Process each step against the Store.
-        # Store follows immutable pattern: each method returns a new Store.
+        # The store is immutable: each spec call returns a new store.
         filled_steps: list[FilledForkChoiceStep] = []
         for step_index, step in enumerate(self.steps):
             old_head = store.head
@@ -251,17 +166,14 @@ class ForkChoiceTest(BaseTestSpec):
             try:
                 match step:
                     case TickStep():
-                        # Time advancement may trigger slot boundaries.
-                        # At slot boundaries, pending attestations may become active.
-                        # Always act as aggregator to ensure gossip signatures are aggregated
+                        # Crossing a slot boundary may activate pending attestations.
+                        # Always act as aggregator so gossip signatures get aggregated.
                         if step.interval is not None:
-                            # Tests that care about exact interval semantics can
-                            # target the store's internal interval clock directly.
+                            # An exact interval targets the store's interval clock directly.
                             target_interval = Interval(step.interval)
                         else:
                             assert step.time is not None
-                            # TickStep.time is a Unix timestamp in seconds.
-                            # The slot clock converts it to intervals since genesis.
+                            # A Unix timestamp converts to intervals since genesis.
                             target_interval = SlotClock(
                                 genesis_time=store.config.genesis_time,
                                 time_fn=lambda t=step.time: float(t),
@@ -274,18 +186,15 @@ class ForkChoiceTest(BaseTestSpec):
                         )
 
                     case BlockStep():
-                        # A step expecting the unknown-parent rejection may point
-                        # the block at a parent the store never imported.
-                        # The builder then skips the state transition and hands
-                        # the block straight to the spec, where that guard fires.
+                        # A step expecting the unknown-parent rejection names an unknown parent.
+                        # The builder skips the state transition and hands the block to the spec.
                         deliver_unknown_parent = (
                             step.expected_rejection is not None
                             and step.expected_rejection.reason
                             is RejectionReason.UNKNOWN_PARENT_BLOCK
                         )
 
-                        # Build a complete signed block from the lightweight spec.
-                        # The spec contains minimal fields; we fill the rest.
+                        # Fill the lightweight block spec into a complete signed block.
                         signed_block, store = step.block.build_signed_block_with_store(
                             store,
                             block_registry,
@@ -294,8 +203,7 @@ class ForkChoiceTest(BaseTestSpec):
                         )
                         filled_block = signed_block.block
 
-                        # Register labeled blocks for fork building.
-                        # Later blocks can reference this one as their parent.
+                        # Register the label so later blocks can name this one as parent.
                         if step.block.label is not None:
                             if step.block.label in block_registry:
                                 raise ValueError(
@@ -304,24 +212,19 @@ class ForkChoiceTest(BaseTestSpec):
                                 )
                             block_registry[step.block.label] = filled_block
 
-                        # Advance time to the block's slot unless the test
-                        # delivers the block ahead of the store clock.
-                        # This tick includes a block (has proposal).
-                        # Always act as aggregator to ensure gossip signatures are aggregated
+                        # Advance to the block's slot unless the test delivers it ahead of time.
+                        # The tick carries a proposal and acts as aggregator.
                         if step.tick_to_slot:
                             target_interval = Interval.from_slot(filled_block.slot)
                             store, _ = spec.on_tick(
                                 store, target_interval, has_proposal=True, is_aggregator=True
                             )
 
-                        # Process the block through Store.
-                        # This validates, applies state transition, and updates the store's head.
+                        # Validate, apply the state transition, and update the head.
                         store = spec.on_block(store, signed_block)
 
                     case AttestationStep():
-                        # Process a gossip attestation.
-                        # Gossip attestations arrive outside of blocks.
-                        # They influence the fork choice weight calculation.
+                        # Gossip attestations arrive outside blocks and feed the weight calculation.
                         filled_attestation = step.attestation.build_signed(
                             block_registry,
                             key_manager,
@@ -348,12 +251,10 @@ class ForkChoiceTest(BaseTestSpec):
                             f"Step {step_index}: unknown step type {type(step).__name__}"
                         )
 
-                # Record the canonical store observables for this step.
-                # Clients replay the step and must reproduce every field.
-                # Authored checks below remain a human-readable overlay.
+                # Snapshot the canonical store observables clients must reproduce.
+                # The authored checks below stay a human-readable overlay.
                 store_snapshot = StoreSnapshot.from_store(store)
 
-                # Validate Store state if checks are provided.
                 if step.checks is not None:
                     step.checks.validate_against_store(
                         store,
@@ -364,8 +265,7 @@ class ForkChoiceTest(BaseTestSpec):
                     )
 
             except (SpecRejectionError, AggregationError) as exception:
-                # Handle expected failures.
-                # Steps marked valid=False should raise spec rejections.
+                # Steps marked invalid should raise here.
                 # Harness bugs raise other types and propagate unswallowed.
                 if step.valid:
                     raise AssertionError(
@@ -379,20 +279,18 @@ class ForkChoiceTest(BaseTestSpec):
                     f"Step {step_index} ({type(step).__name__})",
                 )
 
-                # The rejected call returned nothing, so the store is unchanged.
-                # Snapshot it anyway: clients must verify the no-op.
+                # The rejected call left the store unchanged.
+                # Snapshot it anyway so clients verify the no-op.
                 store_snapshot = StoreSnapshot.from_store(store)
 
             else:
-                # Handle unexpected success.
-                # If we expected failure but the step succeeded, that's a test bug.
+                # A step that expected failure but succeeded is a test bug.
                 if not step.valid:
                     raise AssertionError(
                         f"Step {step_index} ({type(step).__name__}) succeeded but expected failure"
                     )
 
-            # Emit the filled counterpart of this step.
-            # Expected failures keep their built payload and the unchanged store.
+            # Emit the filled counterpart, keeping any built payload and the unchanged store.
             match step:
                 case TickStep():
                     filled_steps.append(
@@ -463,10 +361,7 @@ class ForkChoiceTest(BaseTestSpec):
         max_slot: Slot,
     ) -> ForkChoiceFixture:
         """
-        Assert that store initialization rejects the anchor pair.
-
-        Returns:
-            The emitted vector carrying the rejection reason and no steps.
+        Assert that store initialization rejects the anchor pair, emitting the reason.
 
         Raises:
             AssertionError: If initialization succeeds or fails for the wrong reason.
@@ -475,8 +370,7 @@ class ForkChoiceTest(BaseTestSpec):
             "steps must be empty when anchor_valid is False: "
             "Store.from_anchor is expected to fail before any step can run"
         )
-        # A vector saying only "reject this anchor" lets a client
-        # reject for the wrong reason and still pass.
+        # A bare "reject this anchor" vector lets a client reject for the wrong reason and pass.
         assert self.expected_rejection is not None, (
             "anchor_valid=False requires expected_rejection to be set"
         )

--- a/packages/testing/src/consensus_testing/test_fixtures/gossipsub_handler.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/gossipsub_handler.py
@@ -24,8 +24,7 @@ from lean_spec.node.networking.gossipsub.rpc import (
 )
 from lean_spec.node.networking.gossipsub.types import MessageId, Timestamp, TopicId
 
-# Sentinel that satisfies `outbound_stream is not None` checks.
-# The patched _send_rpc never touches the stream, so any non-None value works.
+# Sentinel for a non-None outbound stream; the patched sender never touches it.
 _FAKE_STREAM: Any = object()
 
 
@@ -311,11 +310,7 @@ class GossipsubExpectation(StrictBaseModel):
 
 
 class GossipsubHandlerFixture(BaseConsensusFixture):
-    """
-    Emitted vector for gossipsub handler behavior conformance.
-
-    JSON output: handlerName, params, initialState, event, now, expected.
-    """
+    """Emitted vector for gossipsub handler behavior conformance."""
 
     handler_name: str
     """Handler under test."""
@@ -337,27 +332,22 @@ class GossipsubHandlerFixture(BaseConsensusFixture):
 
 
 class GossipsubHandlerTest(BaseTestSpec):
-    """
-    Spec for gossipsub handler behavior conformance.
-
-    Tests protocol decisions: given initial state + incoming event,
-    what RPCs are sent and how does the mesh change?
-    """
+    """Spec for gossipsub handler behavior, pinning which RPCs are sent and how the mesh changes."""
 
     format_name: ClassVar[str] = "gossipsub_handler_test"
     description: ClassVar[str] = "Tests gossipsub handler protocol decisions"
 
     handler_name: str
-    """Handler being tested: graft, prune, ihave, iwant, message."""
+    """Handler being tested."""
 
     params: GossipsubMeshParameters = GossipsubMeshParameters()
     """Mesh degree parameters."""
 
     initial_state: GossipsubInitialState
-    """Behavior state to seed before the event: subscriptions, meshes, peers, caches."""
+    """Behavior state to seed before the event."""
 
     event: GossipsubEvent
-    """Incoming event: sending peer plus RPC content."""
+    """Incoming event to dispatch."""
 
     now: float = 1000.0
     """Current timestamp for backoff checks."""
@@ -374,12 +364,7 @@ class GossipsubHandlerTest(BaseTestSpec):
         )
 
     async def _execute(self) -> GossipsubExpectation:
-        """
-        Run the handler against a fully-configured behavior instance.
-
-        Builds the gossipsub behavior from fixture inputs, dispatches the
-        incoming RPC, and returns the outbound RPCs and final mesh state.
-        """
+        """Dispatch the incoming RPC and return the outbound RPCs and the final mesh state."""
         behavior = GossipsubBehavior(
             params=GossipsubParameters(
                 d=self.params.d,
@@ -393,19 +378,15 @@ class GossipsubHandlerTest(BaseTestSpec):
         capture = _SendCapture()
         behavior._send_rpc = capture  # type: ignore[assignment]
 
-        # Map between human-readable test names and opaque peer identifiers.
+        # Map opaque peer identifiers back to human-readable test names.
         peer_names: dict[PeerId, str] = {}
 
-        # Subscriptions define which topics the local node participates in.
-        #
-        # Handlers ignore messages for topics we are not subscribed to.
+        # Handlers ignore messages for topics the local node is not subscribed to.
         for topic in self.initial_state.subscriptions:
             behavior.mesh.subscribe(TopicId(topic))
 
         # Register each peer with its subscriptions and protocol state.
-        #
-        # Peer properties like backoff timers and IDONTWANT sets directly
-        # influence handler decisions (e.g., reject GRAFTs, skip forwarding).
+        # Backoff timers and IDONTWANT sets drive handler decisions like GRAFT rejection.
         for peer_name, peer_configuration in self.initial_state.peers.items():
             peer_id = PeerId.from_base58(peer_name)
             peer_names[peer_id] = peer_name
@@ -426,26 +407,17 @@ class GossipsubHandlerTest(BaseTestSpec):
                 peer_state.dont_want_ids.add(MessageId(from_hex(message_id_hex)))
             behavior._peers[peer_id] = peer_state
 
-        # Mesh topology determines who receives forwarded messages.
-        #
-        # Handlers check mesh membership for GRAFT acceptance, PRUNE removal,
-        # and message forwarding decisions.
+        # Mesh membership gates GRAFT acceptance, PRUNE removal, and forwarding.
         for topic_string, mesh_peer_names in self.initial_state.meshes.items():
             topic = TopicId(topic_string)
             for peer_name in mesh_peer_names:
                 behavior.mesh.add_to_mesh(topic, PeerId.from_base58(peer_name))
 
-        # Seen cache tracks previously-received message IDs.
-        #
-        # Duplicate messages are silently dropped; IHAVE for seen IDs
-        # does not trigger an IWANT response.
+        # Seen IDs are dropped as duplicates, and IHAVE for them triggers no IWANT.
         for message_id_hex in self.initial_state.seen_message_ids:
             behavior.seen_cache.add(MessageId(from_hex(message_id_hex)), Timestamp(self.now))
 
-        # Message cache holds full message payloads for IWANT responses.
-        #
-        # When a peer requests a message via IWANT, the handler looks it up
-        # here and sends the payload back.
+        # The message cache holds full payloads the handler returns on IWANT.
         for cached_message in self.initial_state.cached_messages:
             message = GossipsubMessage(
                 topic=cached_message.topic.encode("utf-8"),
@@ -454,7 +426,6 @@ class GossipsubHandlerTest(BaseTestSpec):
             message._cached_id = MessageId(from_hex(cached_message.message_id))
             behavior.message_cache.put(TopicId(cached_message.topic), message)
 
-        # Build the incoming RPC from the event.
         from_peer = PeerId.from_base58(self.event.from_peer)
         peer_names.setdefault(from_peer, self.event.from_peer)
 
@@ -463,8 +434,8 @@ class GossipsubHandlerTest(BaseTestSpec):
             await behavior._handle_rpc(from_peer, self.event.build_rpc())
 
         sent_rpcs = []
-        # The send order to mesh peers is set-driven, so it is not consensus-relevant.
-        # Sort by recipient name to keep the emitted vector reproducible across runs.
+        # Send order to mesh peers is set-driven.
+        # Sort by recipient name for a reproducible vector.
         for recipient_peer_id, rpc in sorted(
             capture.sent, key=lambda entry: peer_names.get(entry[0], str(entry[0]))
         ):
@@ -538,8 +509,7 @@ class GossipsubHandlerTest(BaseTestSpec):
                 )
             )
 
-        # Snapshot the mesh topology after handler execution.
-        # Sorting ensures deterministic output for fixture comparison.
+        # Snapshot the post-handler mesh topology, sorted for deterministic comparison.
         mesh_after = {
             str(topic): sorted(
                 peer_names.get(peer_id, str(peer_id))

--- a/packages/testing/src/consensus_testing/test_fixtures/justifiability.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/justifiability.py
@@ -18,11 +18,7 @@ class JustifiabilityOutput(StrictBaseModel):
 
 
 class JustifiabilityFixture(BaseConsensusFixture):
-    """
-    Emitted vector for 3SF-mini justifiability conformance.
-
-    JSON output: slot, finalizedSlot, output.
-    """
+    """Emitted vector for 3SF-mini justifiability conformance."""
 
     slot: int
     """Candidate slot under test."""
@@ -35,12 +31,7 @@ class JustifiabilityFixture(BaseConsensusFixture):
 
 
 class JustifiabilityTest(BaseTestSpec):
-    """
-    Spec for 3SF-mini justifiability conformance.
-
-    Tests Slot.is_justifiable_after(finalized_slot) which determines
-    whether a slot can be a justification target.
-    """
+    """Spec for 3SF-mini justifiability conformance."""
 
     format_name: ClassVar[str] = "justifiability_test"
     description: ClassVar[str] = "Tests 3SF-mini slot justifiability rules"

--- a/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/networking_codec.py
@@ -64,7 +64,7 @@ class VarintRoundtrip(StrictBaseModel):
         """Encode, decode back, and emit the reference bytes."""
         encoded = encode_varint(self.value)
 
-        # Decode must recover the original value and consume all bytes.
+        # Decoding must recover the value and consume every byte.
         decoded, byte_length = decode_varint(encoded)
         assert decoded == self.value, (
             f"Varint roundtrip: {self.value} -> {encoded.hex()} -> {decoded}"
@@ -86,12 +86,9 @@ class GossipTopicOutput(StrictBaseModel):
 
 class GossipTopicRoundtrip(StrictBaseModel):
     """
-    Build a topic string from components, parse it back, assert roundtrip.
+    Build a topic string, parse it back, and assert roundtrip.
 
-    When an expected network name is given, also run fork validation
-    against the parsed topic and report whether the network name matched.
-    This pins the accept / reject branches clients must agree on when
-    deciding which mesh to admit a topic into.
+    When an expected network name is given, fork validation pins the accept and reject branches.
     """
 
     kind: Literal["gossip_topic"] = "gossip_topic"
@@ -118,7 +115,7 @@ class GossipTopicRoundtrip(StrictBaseModel):
         )
         topic_string = topic.to_topic_id()
 
-        # Parse the string back to verify it reconstructs the same topic.
+        # Parsing back must reconstruct the same topic.
         parsed = GossipTopic.from_string(topic_string)
         assert parsed == topic, f"Topic roundtrip: {topic} -> {topic_string!r} -> {parsed}"
 
@@ -320,7 +317,7 @@ class GossipsubRpcRoundtrip(StrictBaseModel):
         )
         encoded = rpc.encode()
 
-        # Decode and re-encode must produce identical bytes.
+        # Decode then re-encode must reproduce the bytes exactly.
         re_encoded = RPC.decode(encoded).encode()
         assert encoded == re_encoded, "RPC roundtrip produced different bytes"
 
@@ -398,10 +395,7 @@ class ReqRespResponseStream(StrictBaseModel):
     """
     Encode a sequence of response chunks as a concatenated stream.
 
-    Multi-chunk responses (for example BlocksByRoot returning N blocks)
-    send their chunks back-to-back on a single libp2p stream: each
-    chunk is its own [code][varint][snappy_frame] triple, and the
-    receiver reads them in order until EOF.
+    Each chunk is its own code-varint-snappy_frame triple, read back-to-back in order until EOF.
     """
 
     kind: Literal["reqresp_response_stream"] = "reqresp_response_stream"
@@ -493,14 +487,14 @@ class EnrRoundtrip(StrictBaseModel):
         """Roundtrip the record through text and RLP, then emit its properties."""
         enr = ENR.from_string(self.enr_string)
 
-        # Text roundtrip: parse → serialize → must match original.
+        # Text roundtrip: re-serializing must match the original string.
         assert enr.to_string() == self.enr_string, "ENR text roundtrip failed"
 
-        # RLP roundtrip: serialize → parse → serialize → must match.
+        # RLP roundtrip: serialize, parse, serialize again must be stable.
         rlp_bytes = enr.to_rlp()
         assert ENR.from_rlp(rlp_bytes).to_rlp() == rlp_bytes, "ENR RLP roundtrip failed"
 
-        # Invariant: every record that survives the roundtrips names its scheme.
+        # Invariant: every record surviving the roundtrips names its scheme.
         assert enr.identity_scheme is not None, "ENR record carries no identity scheme"
 
         eth2_data = enr.eth2_data
@@ -530,11 +524,9 @@ class EnrRoundtrip(StrictBaseModel):
                 else None
             ),
             is_aggregator=enr.is_aggregator,
-            # The accept/reject verdict is the canonical contract a client must reproduce.
-            # Both verdicts are a deterministic function of the record bytes alone.
-            # Structural validity reads the record fields.
-            # Signature validity is secp256k1 ECDSA verification over keccak256 of the content.
-            # Verification takes no time, nonce, or RNG input, so the emitted value is stable.
+            # The accept/reject verdict is a deterministic function of the record bytes.
+            # Signature validity is secp256k1 ECDSA over keccak256 of the content.
+            # No nonce or RNG input, so the emitted verdict is stable.
             signature_valid=enr.verify_signature(),
             is_valid=enr.is_valid(),
         )
@@ -571,7 +563,7 @@ class PeerIdentifierDerivation(StrictBaseModel):
         peer_id = PeerId.from_public_key(protobuf)
         peer_id_string = str(peer_id)
 
-        # Roundtrip: Base58 decode → re-encode must match.
+        # Base58 roundtrip: decode then re-encode must match.
         roundtrip = PeerId.from_base58(peer_id_string)
         assert roundtrip == peer_id, "PeerId Base58 roundtrip failed"
 
@@ -736,11 +728,7 @@ NetworkingCodecOutput = (
 
 
 class NetworkingCodecFixture(BaseConsensusFixture):
-    """
-    Emitted vector for networking wire-format conformance.
-
-    JSON output: codec, output.
-    """
+    """Emitted vector for networking wire-format conformance."""
 
     codec: NetworkingCodec
     """Codec case under test, with its typed inputs."""
@@ -750,11 +738,7 @@ class NetworkingCodecFixture(BaseConsensusFixture):
 
 
 class NetworkingCodecTest(BaseTestSpec):
-    """
-    Spec for networking wire-format conformance.
-
-    Verifies encode/decode roundtrips for networking codecs.
-    """
+    """Spec for networking wire-format conformance."""
 
     format_name: ClassVar[str] = "networking_codec_test"
     description: ClassVar[str] = "Tests networking codec encode/decode roundtrip"

--- a/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/poseidon_permutation.py
@@ -30,13 +30,7 @@ class PoseidonPermutationFixture(BaseConsensusFixture):
 
 
 class PoseidonPermutationTest(BaseTestSpec):
-    """
-    Spec for Poseidon permutation conformance.
-
-    Each vector names the permutation width and supplies an input state
-    as decimal strings. Generation runs the spec's permutation engine
-    and emits the output state as decimal strings.
-    """
+    """Input spec for a Poseidon permutation conformance vector."""
 
     format_name: ClassVar[str] = "poseidon_permutation_test"
     description: ClassVar[str] = "Tests Poseidon permutation at widths 16 and 24"

--- a/packages/testing/src/consensus_testing/test_fixtures/reaggregation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/reaggregation.py
@@ -70,8 +70,8 @@ class ReaggregationTest(BaseTestSpec):
     """
     Split one attestation's proof out of a block, then merge it with the local partial.
 
-    The reference proof bytes are not deterministic.
-    Each vector is checked by verifying against the expected attesters' keys, not by byte match.
+    Proof bytes are not deterministic, so a vector is checked against the attesters' keys,
+    not by byte match.
     """
 
     format_name: ClassVar[str] = "reaggregation_test"

--- a/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/slot_clock.py
@@ -19,13 +19,9 @@ from lean_spec.spec.ssz import Uint64
 
 def _reject_non_integral_timestamp(timestamp: float) -> float:
     """
-    Reject a fractional timestamp that cannot round-trip across JSON parsers.
+    Reject a fractional timestamp.
 
-    Every timing input here is a whole second or whole millisecond.
-    A fractional float in a serialized vector is a portability hazard.
-    Its decimal text can parse back to a different binary value in another
-    language, breaking cross-client determinism.
-    The fractional part must therefore be zero.
+    A fractional float can parse back to a different binary value in another language.
     """
     if not math.isfinite(timestamp) or not float(timestamp).is_integer():
         raise ValueError(f"slot-clock timestamp must be a whole number, got {timestamp!r}")
@@ -80,7 +76,7 @@ class FromUnixTime(StrictBaseModel):
     """Unix genesis timestamp in seconds."""
 
     unix_seconds: IntegralTimestamp
-    """Wall-clock timestamp to convert. Must be a whole number of seconds."""
+    """Wall-clock timestamp to convert, in whole seconds."""
 
     def run(self) -> IntervalOutput:
         """Compute intervals since genesis at the given timestamp."""
@@ -112,7 +108,7 @@ class CurrentSlot(StrictBaseModel):
     """Unix genesis timestamp in seconds."""
 
     current_time_milliseconds: IntegralTimestamp
-    """Wall-clock timestamp in milliseconds. Must be a whole number of milliseconds."""
+    """Wall-clock timestamp in whole milliseconds."""
 
     def run(self) -> SlotOutput:
         """Compute the current slot at the given timestamp."""
@@ -133,7 +129,7 @@ class CurrentInterval(StrictBaseModel):
     """Unix genesis timestamp in seconds."""
 
     current_time_milliseconds: IntegralTimestamp
-    """Wall-clock timestamp in milliseconds. Must be a whole number of milliseconds."""
+    """Wall-clock timestamp in whole milliseconds."""
 
     def run(self) -> IntervalOutput:
         """Compute the in-slot interval at the given timestamp."""
@@ -154,7 +150,7 @@ class TotalIntervals(StrictBaseModel):
     """Unix genesis timestamp in seconds."""
 
     current_time_milliseconds: IntegralTimestamp
-    """Wall-clock timestamp in milliseconds. Must be a whole number of milliseconds."""
+    """Wall-clock timestamp in whole milliseconds."""
 
     def run(self) -> TotalIntervalsOutput:
         """Compute total intervals since genesis at the given timestamp."""
@@ -176,11 +172,7 @@ SlotClockOutput = IntervalOutput | SlotOutput | TotalIntervalsOutput
 
 
 class SlotClockFixture(BaseConsensusFixture):
-    """
-    Emitted vector for slot clock timing conformance.
-
-    JSON output: operation, config, output.
-    """
+    """Emitted vector for slot clock timing conformance."""
 
     operation: SlotClockOperation
     """Conversion under test, with its typed inputs."""
@@ -193,12 +185,7 @@ class SlotClockFixture(BaseConsensusFixture):
 
 
 class SlotClockTest(BaseTestSpec):
-    """
-    Spec for slot clock timing conformance.
-
-    Tests time-to-slot and time-to-interval conversions that every
-    consensus client must implement identically.
-    """
+    """Spec for slot clock timing conformance."""
 
     format_name: ClassVar[str] = "slot_clock_test"
     description: ClassVar[str] = "Tests slot clock time-to-slot/interval conversion"

--- a/packages/testing/src/consensus_testing/test_fixtures/ssz.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/ssz.py
@@ -14,12 +14,7 @@ from lean_spec.spec.ssz.ssz_base import SSZType
 
 
 class SSZFixture(BaseConsensusFixture):
-    """
-    Emitted vector for SSZ conformance.
-
-    JSON output: typeName, value, rawBytes (decode-failure mode only),
-    serialized, root.
-    """
+    """Emitted vector for SSZ conformance."""
 
     type_name: str
     """SSZ type class name."""
@@ -28,13 +23,13 @@ class SSZFixture(BaseConsensusFixture):
     """The SSZ value under test."""
 
     raw_bytes: str | None = None
-    """Hex-encoded malformed input, present in decode-failure mode only."""
+    """Hex malformed input, present in decode-failure mode only."""
 
     serialized: str
-    """Hex SSZ bytes; carries the malformed input verbatim on decode failure."""
+    """Hex SSZ bytes, or the malformed input verbatim on decode failure."""
 
     root: str
-    """Hex hash_tree_root. Empty in decode-failure mode."""
+    """Hex tree root, empty in decode-failure mode."""
 
     @field_serializer("value", when_used="json")
     def serialize_value(self, ssz_value: SSZType) -> Any:
@@ -54,18 +49,7 @@ class SSZFixture(BaseConsensusFixture):
 
 
 class SSZTest(BaseTestSpec):
-    """
-    Spec for SSZ conformance testing.
-
-    Supports two modes:
-
-    - Roundtrip mode (default): encode `value`, decode back, verify equality
-      and compute `hash_tree_root`. JSON output: typeName, value, serialized, root.
-    - Decode-failure mode: when `expected_rejection` is set, `raw_bytes` holds
-      the malformed input. Generation decodes the input as `type(value)` and
-      asserts the decoder rejects it. JSON output keeps the same shape;
-      `serialized` holds the malformed bytes and `root` is empty.
-    """
+    """Spec for SSZ conformance, running either a roundtrip or a decode-failure check."""
 
     format_name: ClassVar[str] = "ssz_test"
     description: ClassVar[str] = "Tests SSZ serialization roundtrip and hash_tree_root"
@@ -74,34 +58,15 @@ class SSZTest(BaseTestSpec):
     """SSZ type class name."""
 
     value: SSZType
-    """
-    The SSZ value under test.
+    """The SSZ value under test.
 
-    Roundtrip mode: the value to encode and round-trip.
-    Decode-failure mode: acts as a type tag; its class is used as the decoder.
-    Supply any instance of the target type (often a default-constructed one).
-    """
+    In decode-failure mode only its class matters, since the class supplies the decoder."""
 
     raw_bytes: str | None = None
-    """
-    Hex-encoded malformed input for decode-failure mode.
-
-    Only consulted when `expected_rejection` is set. Generation decodes these
-    bytes using `type(value).decode_bytes` and asserts the decoder raises.
-    """
+    """Hex malformed input, consulted only in decode-failure mode."""
 
     def generate(self) -> SSZFixture:
-        """
-        Verify SSZ roundtrip or decode-failure and produce the reference output.
-
-        Returns:
-            The emitted vector with serialized bytes and root populated.
-
-        Raises:
-            AssertionError:
-                - In roundtrip mode, if `decode(encode(value)) != value`.
-                - In decode-failure mode, if the decoder does not reject.
-        """
+        """Verify SSZ roundtrip or decode-failure and produce the reference output."""
         if self.expected_rejection is not None:
             return self._generate_decode_failure()
 
@@ -127,14 +92,9 @@ class SSZTest(BaseTestSpec):
 
     def _generate_decode_failure(self) -> SSZFixture:
         """
-        Run the decode-failure path: assert decoding `raw_bytes` raises.
+        Assert decoding the malformed bytes raises.
 
-        The class of `value` is used as the decoder. `serialized` carries
-        the malformed bytes verbatim so consumers can reproduce the input.
-
-        Raises:
-            AssertionError: If the decoder succeeds.
-            ValueError: If `raw_bytes` is missing.
+        The bytes are emitted verbatim so consumers can reproduce the rejected input.
         """
         if self.raw_bytes is None:
             raise ValueError("raw_bytes is required when expected_rejection is set")

--- a/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/state_transition.py
@@ -24,48 +24,26 @@ from lean_spec.spec.ssz import Bytes32
 
 
 class StateTransitionFixture(BaseConsensusFixture):
-    """
-    Emitted vector for block processing through state_transition().
-
-    JSON output: pre, blocks, post, postStateRoot.
-    """
+    """Emitted vector for block processing through the state transition."""
 
     pre: State
-    """The initial consensus state before processing."""
+    """Initial consensus state before processing."""
 
     blocks: list[Block]
-    """The filled Blocks, processed through the spec."""
+    """Filled blocks processed through the spec."""
 
     post: StateExpectation | None = None
     """Authored post-state expectations, echoed for readability."""
 
     post_state_root: Bytes32 | None = None
-    """
-    Hash tree root of the full post-state.
-
-    Populated whenever processing succeeds.
-    Clients must reproduce this root exactly, so two clients cannot
-    pass the same vector while holding divergent state.
-    Stays None for invalid tests, which produce no post-state.
-    """
+    """Hash tree root of the full post-state, so two clients cannot pass with divergent state."""
 
 
 class StateTransitionTest(BaseTestSpec):
     """
-    Spec for block processing through state_transition().
-
-    This is the primary test type that covers:
-    - Operations (attestations via blocks)
-    - Slot advancement (empty slots)
-    - Multi-block sequences
-    - Justification and finalization
-    - Invalid blocks
-
-    Tests everything through the main state_transition() public API.
+    Spec for block processing through the state transition.
 
     The state transition assumes signatures were verified upstream.
-    Invalid-signature scenarios belong to the fork choice and signature
-    verification formats, never to this one.
     """
 
     format_name: ClassVar[str] = "state_transition_test"
@@ -75,28 +53,13 @@ class StateTransitionTest(BaseTestSpec):
     )
 
     pre: State = Field(default_factory=build_genesis_state)
-    """
-    The initial consensus state before processing.
-
-    Defaults to the standard genesis state.
-    Spell it out only when the test needs a non-default pre-state.
-    """
+    """Initial consensus state before processing, defaulting to genesis."""
 
     blocks: list[BlockSpec]
-    """
-    Block specifications to process through the spec.
-
-    Tests provide a list of BlockSpec objects with required slots and optional
-    field overrides. Generation fills complete Block objects and emits them.
-    """
+    """Block specifications, each a required slot plus optional field overrides."""
 
     post: StateExpectation | None = None
-    """
-    Expected state after processing all blocks.
-
-    Only fields explicitly set in the StateExpectation will be validated.
-    If None, no post-state validation is performed (e.g., for invalid tests).
-    """
+    """Expected state after processing all blocks, validating only the fields explicitly set."""
 
     @model_validator(mode="after")
     def validate_signatures_are_out_of_scope(self) -> "StateTransitionTest":
@@ -118,9 +81,6 @@ class StateTransitionTest(BaseTestSpec):
         """
         Generate the fixture by running the spec.
 
-        Returns:
-            The emitted vector with filled blocks and post-state root.
-
         Raises:
             AssertionError: If processing fails unexpectedly or validation fails.
         """
@@ -128,15 +88,14 @@ class StateTransitionTest(BaseTestSpec):
         exception_raised: Exception | None = None
         spec = LstarSpec()
 
-        # Filled blocks accumulate as we process, even if a later block fails.
-        # This ensures the test fixture includes all blocks that were attempted.
+        # Accumulate filled blocks even if a later block fails, so the vector keeps every attempt.
         filled_blocks: list[Block] = []
         block_registry: dict[str, Block] = {}
         try:
             state = self.pre
 
             for block_index, block_spec in enumerate(self.blocks):
-                # Build block and optionally get cached post-state to avoid redundant transitions
+                # A cached post-state, when returned, avoids a redundant transition below.
                 block, cached_state = self._build_block_from_spec(
                     block_spec,
                     state,
@@ -144,10 +103,9 @@ class StateTransitionTest(BaseTestSpec):
                     is_final_block=block_index == len(self.blocks) - 1,
                 )
 
-                # Store the filled Block for serialization
                 filled_blocks.append(block)
 
-                # Register labeled blocks for parent and attestation target resolution
+                # Register labeled blocks for parent and attestation target resolution.
                 if block_spec.label is not None:
                     if block_spec.label in block_registry:
                         raise ValueError(
@@ -156,7 +114,6 @@ class StateTransitionTest(BaseTestSpec):
                         )
                     block_registry[block_spec.label] = block
 
-                # Use cached state if available, otherwise run state transition
                 if cached_state is not None:
                     state = cached_state
                 elif block_spec.skip_slot_processing:
@@ -168,21 +125,18 @@ class StateTransitionTest(BaseTestSpec):
         except SpecRejectionError as exception:
             exception_raised = exception
 
-        # Validate exception expectations
         self.assert_expected_outcome(exception_raised)
         rejection_reason = None
         if exception_raised is not None:
             # Emit the language-neutral reason clients assert against.
             rejection_reason = self.resolve_rejection_reason(exception_raised)
 
-        # Pin the full post-state for clients.
-        # Selective expectations below only cover authored fields.
-        # The root covers every field, closing the divergence gap.
+        # Authored expectations cover only some fields, so pin the full-state root too.
+        # The root closes the divergence gap across every other field.
         post_state_root = None
         if actual_post_state is not None:
             post_state_root = hash_tree_root(actual_post_state)
 
-        # Validate post-state expectations if provided
         if self.post is not None and actual_post_state is not None:
             self.post.validate_against_state(actual_post_state, block_registry=block_registry)
 
@@ -203,19 +157,7 @@ class StateTransitionTest(BaseTestSpec):
         is_final_block: bool,
     ) -> tuple[Block, State | None]:
         """
-        Build a Block from a BlockSpec, optionally caching the post-state.
-
-        Three construction paths:
-
-        1. Explicit state_root -- caller controls the root, no transition
-        2. Final block of an invalid test, or skip-slot -- placeholder zero
-           root, no transition. Earlier blocks of an invalid test build
-           normally so processing reaches the block expected to fail.
-        3. Normal -- full build_block with computed state root
-
-        After construction, any forced attestations are appended to the
-        body. These bypass the builder's filtering so they reach
-        process_attestations directly (e.g., unjustified source tests).
+        Build a block from its spec, optionally caching the post-state.
 
         Args:
             block_spec: Block specification with optional field overrides.
@@ -224,7 +166,7 @@ class StateTransitionTest(BaseTestSpec):
             is_final_block: Whether this is the last block of the test.
 
         Returns:
-            Block and cached post-state (None if not computed).
+            Block and cached post-state, None when not computed.
         """
         fork = LstarSpec()
         proposer_index = block_spec.resolve_proposer_index(len(state.validators))
@@ -234,8 +176,7 @@ class StateTransitionTest(BaseTestSpec):
         if not block_spec.skip_slot_processing:
             slot_advanced_state = fork.process_slots(state, block_spec.slot)
 
-        # Resolve the parent root.
-        # Default: latest block header from the slot-advanced state.
+        # Parent root defaults to the latest block header of the slot-advanced state.
         source_state = slot_advanced_state or state
         parent_root = block_spec.resolve_parent_root(
             block_registry,
@@ -245,7 +186,7 @@ class StateTransitionTest(BaseTestSpec):
         body = block_spec.body or BlockBody(attestations=AggregatedAttestations(data=[]))
         post_state: State | None = None
 
-        # Path 1: explicit state root override -- no state transition needed.
+        # Path 1: explicit state root override, no transition.
         if block_spec.state_root is not None:
             block = Block(
                 slot=block_spec.slot,
@@ -255,8 +196,7 @@ class StateTransitionTest(BaseTestSpec):
                 body=body,
             )
 
-        # Path 2: failing block of an invalid test, or skip-slot --
-        # placeholder root, no transition.
+        # Path 2: failing block of an invalid test, or skip-slot: placeholder root, no transition.
         elif (
             self.expected_rejection is not None and is_final_block
         ) or block_spec.skip_slot_processing:
@@ -289,9 +229,7 @@ class StateTransitionTest(BaseTestSpec):
                 aggregated_payloads=aggregated_payloads,
             )
 
-        # Append forced attestations if any.
-        # These bypass the builder's filtering so they reach the state
-        # transition even when the builder would exclude them.
+        # Forced attestations bypass the builder's filtering to reach the state transition.
         if block_spec.forced_attestations:
             forced = [
                 AggregatedAttestation(
@@ -314,8 +252,7 @@ class StateTransitionTest(BaseTestSpec):
                 }
             )
 
-            # The body changed, so re-run the transition to get the correct
-            # post-state and state root.
+            # The body changed, so re-run the transition for the correct post-state and root.
             if post_state is not None:
                 post_state = fork.process_slots(state, block_spec.slot)
                 post_state = fork.process_block(post_state, block)
@@ -340,8 +277,7 @@ class StateTransitionTest(BaseTestSpec):
         Returns:
             Aggregated payloads keyed by attestation data.
         """
-        # Compute max slot across all attestation specs for XMSS key lifetime.
-        # XMSS keys require precomputation up to the highest slot used.
+        # XMSS keys need precomputation up to the highest slot any attestation uses.
         max_slot = max(attestation_spec.slot for attestation_spec in attestation_specs)
         key_manager = XmssKeyManager.shared(max_slot=max_slot)
         payloads: dict[AttestationData, set[SingleMessageAggregate]] = {}

--- a/packages/testing/src/consensus_testing/test_fixtures/sync.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/sync.py
@@ -31,9 +31,7 @@ class VerifyCheckpoint(StrictBaseModel):
     """
     Build a state for a validator count and anchor slot, then report the verdict.
 
-    Zero (default) anchor slot yields a genesis state.
-    Positive values walk an empty-block chain through the slot so
-    historical block hashes reflect a real advanced anchor.
+    Anchor slot zero yields a genesis state, while a positive slot walks an empty-block chain.
     """
 
     kind: Literal["verify_checkpoint"] = "verify_checkpoint"
@@ -68,11 +66,7 @@ SyncOperation = VerifyCheckpoint
 
 
 class SyncFixture(BaseConsensusFixture):
-    """
-    Emitted vector for sync-layer conformance.
-
-    JSON output: operation, output.
-    """
+    """Emitted vector for sync-layer conformance."""
 
     operation: SyncOperation
     """Sync operation under test, with its typed inputs."""
@@ -85,8 +79,7 @@ class SyncTest(BaseTestSpec):
     """
     Spec for sync-layer conformance.
 
-    Each vector pins the expected verdict on a given input so clients
-    can align their sync-layer decisions bit-for-bit.
+    Each vector pins the expected verdict so clients align their sync decisions bit-for-bit.
     """
 
     format_name: ClassVar[str] = "sync_test"

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_proofs.py
@@ -28,68 +28,47 @@ ALTERNATE_HEAD_ROOT: Bytes32 = Bytes32(b"\xee" * 32)
 
 
 class RebindToAlternateHeadRoot(StrictBaseModel):
-    """
-    Rebind one component's proof to an alternate head root.
-
-    The honest attestation data is still emitted.
-    Only the targeted component's proof bytes carry the alternate binding.
-    """
+    """Rebind one component's proof to an alternate head root while emitting honest data."""
 
     component_index: int = 0
-    """Index of the component whose proof is rebound (0 for single-message vectors)."""
+    """Index of the component whose proof is rebound."""
 
 
 class IncrementEmittedSlot(StrictBaseModel):
     """Bump one component's emitted slot while its proof stays bound to the original slot."""
 
     component_index: int = 0
-    """Index of the component whose emitted slot is bumped (0 for single-message vectors)."""
+    """Index of the component whose emitted slot is bumped."""
 
 
 class SwapParticipantPublicKey(StrictBaseModel):
-    """
-    Replace one participant's public key with another validator's attestation key.
-
-    The honest proof is still emitted.
-    Only the targeted component's public key layout carries the swap.
-    """
+    """Replace one participant's public key while emitting the honest proof."""
 
     component_index: int = 0
-    """Index of the component whose participant list is edited (0 for single-message vectors)."""
+    """Index of the component whose participant list is edited."""
 
     participant_index: int
-    """Position in that component's participant list whose key is replaced."""
+    """Position in the participant list whose key is replaced."""
 
     with_validator_index: ValidatorIndex
     """Validator whose attestation key replaces the original."""
 
 
 class SwapMessageBindings(StrictBaseModel):
-    """
-    Swap the emitted message-slot bindings of two components.
-
-    The merged proof and the per-component key layout stay honest.
-    Each component's proof is then checked against the other component's binding.
-    A conforming verifier rejects this transposition.
-    """
+    """Swap the emitted message-slot bindings of two components against an honest proof."""
 
     first_component_index: int
-    """Index of one component whose emitted message-slot binding is swapped."""
+    """Index of one component whose binding is swapped."""
 
     second_component_index: int
-    """Index of the other component whose emitted message-slot binding is swapped."""
+    """Index of the other component whose binding is swapped."""
 
 
 class DropMessageBinding(StrictBaseModel):
-    """
-    Drop one component's emitted message-slot binding while keeping its keys.
-
-    The emitted binding list ends up shorter than the per-component key list.
-    A conforming verifier rejects the length mismatch.
-    """
+    """Drop one component's emitted message-slot binding while keeping its keys."""
 
     component_index: int
-    """Index of the component whose emitted message-slot binding is removed."""
+    """Index of the component whose binding is removed."""
 
 
 SingleMessageTamper = RebindToAlternateHeadRoot | IncrementEmittedSlot | SwapParticipantPublicKey
@@ -130,21 +109,15 @@ def _swap_participant_public_key(
     replacement_validator_index: ValidatorIndex,
     component_index: int,
 ) -> None:
-    """
-    Replace one participant's emitted public key in place.
-
-    Raises:
-        ValueError: If the position is out of range, or the replacement matches
-            the original key and would leave the bundle honest.
-    """
+    """Replace one participant's emitted public key in place."""
     if not 0 <= participant_index < len(public_keys):
         raise ValueError(
             f"participant_index {participant_index} out of range "
             f"for component {component_index} with {len(public_keys)} keys"
         )
     replacement = key_manager.get_public_keys(replacement_validator_index)[0]
-    # A replacement matching the original key would leave the bundle honest.
-    # The verifier would then accept and the rejection would be a false positive.
+    # A replacement matching the original key leaves the bundle honest.
+    # The verifier would accept and the rejection would be a false positive.
     if replacement == public_keys[participant_index]:
         raise ValueError(
             f"participant key replacement at component {component_index} "
@@ -158,18 +131,14 @@ class VerifySingleMessageProofsFixture(BaseConsensusFixture):
     """
     Emitted vector for single-message aggregate proof verification.
 
-    JSON output: attestationData, publicKeys, aggregationBits, message,
-    slot, proof.
+    JSON output: attestationData, publicKeys, aggregationBits, message, slot, proof.
     """
 
     attestation_data: AttestationData
     """The signed object."""
 
     public_keys: list[PublicKey]
-    """Attestation public keys for the participating validators.
-
-    Ordered consistently with the participation bitfield.
-    """
+    """Attestation public keys, ordered to match the participation bitfield."""
 
     aggregation_bits: AggregationBits
     """Participation bitfield naming the contributing validators."""
@@ -210,13 +179,12 @@ class VerifySingleMessageProofsTest(BaseTestSpec):
         Generate the proof, optionally tamper, self-verify, and emit the vector.
 
         Raises:
-            AssertionError: If the verifier outcome disagrees with the configured expectation.
+            AssertionError: If the outcome disagrees with the expectation.
             ValueError: If the tamper is misconfigured.
         """
         key_manager = XmssKeyManager.shared()
 
-        # A single-message vector carries exactly one component.
-        # The shared tampers must therefore target component 0.
+        # A single-message vector carries exactly one component, so tampers target component 0.
         if self.tamper is not None:
             _check_component_index(self.tamper.component_index, component_count=1)
 
@@ -230,9 +198,8 @@ class VerifySingleMessageProofsTest(BaseTestSpec):
         # Phase 2: optionally mutate exactly one binding of that bundle.
         match self.tamper:
             case RebindToAlternateHeadRoot():
-                # Regenerate the proof against an alternate head root.
-                # - The honest attestation data, message, slot, keys, and bits stay emitted.
-                # - Only the proof bytes carry the alternate binding.
+                # Regenerate only the proof bytes against an alternate head root.
+                # The emitted data, message, slot, keys, and bits stay honest.
                 proof = self._aggregate_proof(
                     key_manager, _alternate_head_data(self.attestation_data)
                 )
@@ -260,7 +227,6 @@ class VerifySingleMessageProofsTest(BaseTestSpec):
         self.assert_expected_outcome(exception_raised)
 
         # Phase 4: publish the client-visible outputs.
-        # Every tamper breaks the proof's cryptographic binding.
         return VerifySingleMessageProofsFixture(
             attestation_data=self.attestation_data,
             public_keys=public_keys,
@@ -291,15 +257,12 @@ class VerifySingleMessageProofsTest(BaseTestSpec):
         """
         Build a two-level proof so the verifier is exercised on the recursive path.
 
-        Children are leaf-only sub-proofs, so the folded tree is exactly two levels deep.
-
         Raises:
             ValueError: If a child group names an unknown validator or reuses one.
             AggregationError: If the prover rejects the inputs.
         """
         # Phase 1: reject a malformed partition before signing anything.
-        #
-        # Every grouped index must name a participant the bundle already carries.
+        # Every grouped index must name a carried participant.
         # No validator may appear in more than one child group.
         grouped_indices = [i for group in self.child_groups for i in group]
         grouped_index_set = set(grouped_indices)
@@ -392,8 +355,8 @@ class VerifyMultiMessageProofsTest(BaseTestSpec):
         Generate the merged proof, optionally tamper one binding, self-verify, emit the vector.
 
         Raises:
-            AssertionError: If the verifier outcome disagrees with the configured expectation.
-            ValueError: If the tamper is misconfigured or the input has no components.
+            AssertionError: If the outcome disagrees with the expectation.
+            ValueError: If the tamper is misconfigured or has no components.
         """
         key_manager = XmssKeyManager.shared()
         component_count = len(self.attestation_data_per_message)
@@ -435,9 +398,9 @@ class VerifyMultiMessageProofsTest(BaseTestSpec):
         match self.tamper:
             case RebindToAlternateHeadRoot(component_index=component_index):
                 _check_component_index(component_index, component_count)
-                # Regenerate the targeted component against an alternate head root and re-merge.
-                # The emitted attestation data, message, slot, keys, and bits stay honest.
-                # Only the merged proof bytes carry the alternate binding for this component.
+                # Regenerate the component against an alternate head root and re-merge.
+                # Only the merged proof bytes carry the alternate binding.
+                # The emitted data, message, slot, keys, and bits stay honest.
                 components[component_index] = key_manager.sign_and_aggregate(
                     self.validator_indices_per_message[component_index],
                     _alternate_head_data(self.attestation_data_per_message[component_index]),
@@ -450,8 +413,8 @@ class VerifyMultiMessageProofsTest(BaseTestSpec):
             case IncrementEmittedSlot(component_index=component_index):
                 _check_component_index(component_index, component_count)
                 bumped = slots[component_index] + Slot(1)
-                # A bumped slot landing on another component's slot would make the rejection
-                # ambiguous, since the verifier could then fail on the wrong binding.
+                # A bump landing on another component's slot makes the rejection ambiguous.
+                # The verifier could then fail on the wrong binding.
                 if any(
                     other_index != component_index and other_slot == bumped
                     for other_index, other_slot in enumerate(slots)
@@ -486,8 +449,8 @@ class VerifyMultiMessageProofsTest(BaseTestSpec):
                 _check_component_index(second_index, component_count)
                 if first_index == second_index:
                     raise ValueError("swap message bindings requires two distinct components")
-                # Swap each component's emitted message and slot so its proof faces the other's
-                # binding, while the merged proof and key layout stay honest.
+                # Swap the emitted message and slot of each component so its proof faces a mismatch.
+                # The merged proof and key layout stay honest.
                 messages[first_index], messages[second_index] = (
                     messages[second_index],
                     messages[first_index],
@@ -518,7 +481,6 @@ class VerifyMultiMessageProofsTest(BaseTestSpec):
         self.assert_expected_outcome(exception_raised)
 
         # Phase 5: publish the client-visible outputs.
-        # Every tamper breaks the proof's cryptographic binding.
         return VerifyMultiMessageProofsFixture(
             attestation_data_per_message=self.attestation_data_per_message,
             public_keys_per_message=public_keys_per_message,

--- a/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/verify_signatures.py
@@ -32,57 +32,30 @@ from lean_spec.spec.ssz import Boolean, ByteList512KiB, Bytes32
 
 
 class SetProposerIndex(StrictBaseModel):
-    """
-    Rewrite the block's proposer index.
-
-    Exercises the validator-bounds check that the builder skips
-    because its round-robin selection stays within range by
-    construction.
-    """
+    """Rewrite the proposer index to exercise the validator-bounds check the builder skips."""
 
     proposer_index: ValidatorIndex
     """Replacement proposer index written into the block."""
 
 
 class ClearFirstAttestationBits(StrictBaseModel):
-    """
-    Replace the first body attestation with one whose participation bits carry no set bit.
-
-    Exercises the empty-participants check inside signature verification.
-    """
+    """Clear the first attestation's bits to exercise the empty-participants check."""
 
 
 class CorruptProof(StrictBaseModel):
-    """
-    Replace the merged proof with a short non-decodable blob.
-
-    Exercises the multi-message aggregate decode check.
-    """
+    """Replace the merged proof with a non-decodable blob to exercise the decode check."""
 
 
 class AppendPhantomAttestation(StrictBaseModel):
-    """
-    Add a body attestation with no matching proof component.
-
-    Exercises the component count check between the body and the merged proof.
-    """
+    """Add an attestation with no proof component to exercise the component-count check."""
 
 
 class MutateStateRoot(StrictBaseModel):
-    """
-    Change a block field after signing so the block root differs.
-
-    Exercises the per-component message binding that prevents
-    reusing an honest proof under a different message.
-    """
+    """Change a block field after signing to break the proposer's per-component message binding."""
 
 
 class SwapFirstTwoAttestations(StrictBaseModel):
-    """
-    Swap the first two body attestations and re-sign only the proposer.
-
-    Exercises body/proof ordering without relying on a block-root mismatch.
-    """
+    """Swap the first two attestations and re-sign the proposer to exercise body/proof ordering."""
 
 
 SignedBlockTamper = (
@@ -111,46 +84,19 @@ class VerifySignaturesFixture(BaseConsensusFixture):
 
 
 class VerifySignaturesTest(BaseTestSpec):
-    """
-    Spec for verifying signatures on a signed block.
-
-    Generates a complete signed block from the block specification,
-    then verifies that signatures pass or fail as expected.
-
-    An optional `tamper` hook mutates the built signed block before
-    verification runs. This is the only supported way to exercise
-    signature-verification rejection paths that lie behind structural
-    invariants the block builder normally upholds.
-    """
+    """Input spec for verifying signatures on a generated signed block."""
 
     format_name: ClassVar[str] = "verify_signatures_test"
     description: ClassVar[str] = "Tests signature verification for signed blocks."
 
     anchor_state: State = Field(default_factory=build_genesis_state)
-    """
-    The initial consensus state before processing.
-
-    Defaults to the standard genesis state.
-    """
+    """The initial consensus state before processing."""
 
     block: BlockSpec
-    """
-    Block specifications to generate signatures for.
-
-    This defines the block parameters including attestations. Generation
-    builds a complete signed block with all necessary signatures.
-    """
+    """Block parameters from which the complete signed block is generated."""
 
     tamper: SignedBlockTamper | None = None
-    """
-    Optional post-build mutation applied before verification.
-
-    Each tamper type documents the rejection path it exercises.
-
-    Tampered blocks bypass the builder's structural invariants. The
-    resulting fixture pins the exact rejection a client must raise when
-    receiving such a block from a peer.
-    """
+    """Optional post-build mutation that reaches rejection paths the builder prevents."""
 
     def generate(self) -> VerifySignaturesFixture:
         """
@@ -160,29 +106,21 @@ class VerifySignaturesTest(BaseTestSpec):
             The emitted vector carrying the signed block.
 
         Raises:
-            AssertionError: If signature verification fails unexpectedly.
+            AssertionError: If verification fails unexpectedly.
         """
-        # Use shared key manager
         key_manager = XmssKeyManager.shared()
-
-        # Build the signed block
         signed_block = self.block.build_signed_block(self.anchor_state, key_manager)
 
-        # Apply optional post-build tamper before verification runs.
-        # This is the only way to exercise rejection paths the builder would
-        # otherwise prevent by construction.
+        # A tamper is the only way to reach rejection paths the builder prevents by construction.
         if self.tamper is not None:
             signed_block = self._apply_tamper(signed_block, self.tamper)
 
         exception_raised: Exception | None = None
-
-        # Verify signatures
         try:
             LstarSpec().verify_signatures(signed_block, self.anchor_state.validators)
         except SpecRejectionError as exception:
             exception_raised = exception
 
-        # Validate exception expectations
         self.assert_expected_outcome(exception_raised)
         rejection_reason = None
         if exception_raised is not None:
@@ -204,7 +142,7 @@ class VerifySignaturesTest(BaseTestSpec):
             tamper: The mutation to apply.
 
         Returns:
-            A new signed block with the requested mutation applied.
+            A new signed block with the mutation applied.
 
         Raises:
             ValueError: If the mutation cannot be applied to this block.
@@ -249,8 +187,7 @@ class VerifySignaturesTest(BaseTestSpec):
                 )
 
             case CorruptProof():
-                # Replace the merged proof with a short bogus payload.
-                # The verifier rejects the malformed proof bytes.
+                # Replace the merged proof with a short bogus payload the verifier cannot decode.
                 return signed_block.model_copy(
                     update={
                         "proof": MultiMessageAggregate(
@@ -260,10 +197,8 @@ class VerifySignaturesTest(BaseTestSpec):
                 )
 
             case AppendPhantomAttestation():
-                # Add a body attestation with no matching proof component.
-                # The proof binds one component per original attestation plus
-                # the proposer, so the body now claims more components than the
-                # proof carries.
+                # The proof binds one component per original attestation plus the proposer.
+                # An unbacked attestation makes the body claim more components than the proof.
                 phantom_data = AttestationData(
                     slot=Slot(0),
                     head=Checkpoint(root=Bytes32(b"\x00" * 32), slot=Slot(0)),
@@ -294,11 +229,9 @@ class VerifySignaturesTest(BaseTestSpec):
                 )
 
             case MutateStateRoot():
-                # Change a block field after signing so the block root differs.
-                # The proposer component's bound message no longer matches the
-                # recomputed block root, even though the signature is honest.
-                # This is the repackaging vector: an honest proof reused under
-                # a different message.
+                # Change a block field after signing so the recomputed block root differs.
+                # The proposer's honest signature now binds a message no client will recompute.
+                # This is the repackaging vector: an honest proof reused under a different message.
                 return signed_block.model_copy(
                     update={
                         "block": signed_block.block.model_copy(
@@ -333,8 +266,8 @@ class VerifySignaturesTest(BaseTestSpec):
                 )
                 swapped_block = signed_block.block.model_copy(update={"body": swapped_body})
 
-                # Keep the block root honestly signed; only the attestation
-                # proof order remains mismatched with the body order.
+                # Keep the block root honestly signed.
+                # Only the attestation proof order stays mismatched with the body order.
                 post_state = LstarSpec().process_slots(self.anchor_state, swapped_block.slot)
                 post_state = LstarSpec().process_block(post_state, swapped_block)
                 swapped_block = swapped_block.model_copy(

--- a/packages/testing/src/consensus_testing/test_types/attestation_specs.py
+++ b/packages/testing/src/consensus_testing/test_types/attestation_specs.py
@@ -32,11 +32,7 @@ class AttestationSpec(CamelModel):
     """The slot of the target block being attested to (required)."""
 
     target_root_label: str | None = None
-    """
-    Label referencing a previously created block as the target.
-
-    The block must exist in the block registry with this label.
-    """
+    """Label of a previously created block to use as the target."""
 
     target_root: Bytes32 | None = None
     """Optional explicit target root (bypasses label lookup)."""
@@ -68,7 +64,7 @@ class AttestationSpec(CamelModel):
         default_source: Checkpoint,
     ) -> AttestationData:
         """
-        Build attestation data by resolving the three checkpoints (target, head, source).
+        Build attestation data by resolving the target, head, and source checkpoints.
 
         Args:
             block_registry: Labeled blocks for checkpoint resolution.
@@ -81,10 +77,7 @@ class AttestationSpec(CamelModel):
         Raises:
             ValueError: If the target has neither an explicit root nor a label.
         """
-        # Resolve the target checkpoint.
-        #
-        # An explicit root takes highest priority.
-        # A label triggers lookup in the block registry.
+        # Resolve the target: explicit root, else label lookup.
         # Unlike the other two checkpoints, the target is mandatory.
         if self.target_root is not None:
             target = Checkpoint(root=self.target_root, slot=self.target_slot)
@@ -93,13 +86,9 @@ class AttestationSpec(CamelModel):
         else:
             raise ValueError("attestation spec requires a target root")
 
-        # Resolve the head checkpoint.
-        #
-        # Priority: explicit root > label > target checkpoint.
-        # - When using an explicit root without a slot, the target slot is used.
-        # - When no head information is provided at all, the head mirrors the target.
-        #
-        # This matches honest validator behavior.
+        # Resolve the head: explicit root, else label, else mirror the target.
+        # An explicit root without a slot borrows the target slot.
+        # Mirroring the target when unset matches honest validator behavior.
         if self.head_root is not None:
             head = Checkpoint(
                 root=self.head_root,
@@ -113,11 +102,8 @@ class AttestationSpec(CamelModel):
                 slot=self.head_slot if self.head_slot is not None else target.slot,
             )
 
-        # Resolve the source checkpoint.
-        #
-        # Priority: explicit root > label > the provided default.
-        # The source represents the most recent justified checkpoint the attester is aware of.
-        # When not overridden, the caller-provided default supplies the correct value.
+        # Resolve the source: explicit root, else label, else the caller default.
+        # The source is the most recent justified checkpoint the attester knows.
         if self.source_root is not None:
             source = Checkpoint(
                 root=self.source_root,
@@ -147,26 +133,13 @@ class AggregatedAttestationSpec(AttestationSpec):
 
     signer_indices: list[ValidatorIndex] | None = None
     """
-    Override which validators actually sign the attestation.
+    Validators that actually sign, when different from the claimed participants.
 
-    - When None (default), signatures are generated using the validators in validator_indices.
-    - When specified, signatures are generated using these validator indices instead.
-
-    This creates a mismatch between claimed participants and actual signers.
-    Useful for testing that verification rejects attestations where valid signatures
-    don't correspond to the claimed validators.
-
-    Must have same length as validator_indices when specified.
+    A set differing from the claimed participants forces a signer mismatch to test rejection.
     """
 
     aggregation_bits: AggregationBits | None = None
-    """
-    Raw aggregation bits for the block body, overriding index derivation.
-
-    - When unset, bits are derived from the validator indices.
-    - When set, the bits are used verbatim, even when zero-length or padded.
-    - Only the unsigned forced-attestation path honors the override.
-    """
+    """Raw aggregation bits used verbatim, honored only on the unsigned forced-attestation path."""
 
     def resolve_aggregation_bits(self) -> AggregationBits:
         """Return the bit override when present, else bits derived from the validator indices."""
@@ -181,10 +154,7 @@ class AggregatedAttestationSpec(AttestationSpec):
         key_manager: XmssKeyManager,
     ) -> SignedAggregatedAttestation:
         """
-        Build a complete signed aggregated attestation from this specification.
-
-        Supports valid, invalid, and participant-mismatch scenarios
-        depending on the spec's signature and signer configuration.
+        Build a signed aggregated attestation, valid or adversarial per this spec's config.
 
         Args:
             block_registry: Labeled blocks for checkpoint resolution.
@@ -196,19 +166,15 @@ class AggregatedAttestationSpec(AttestationSpec):
         """
         attestation_data = self.build_attestation_data(block_registry, state.latest_justified)
 
-        # Separate "claimed" from "actual" participants.
-        #
-        # - Claimed validators appear in the proof's participant bitfield.
-        # - Actual signers produce the cryptographic material.
-        # They default to the same set for honest attestations.
+        # Claimed validators fill the proof's participant bitfield.
+        # Actual signers produce the cryptographic material.
+        # They are the same set for honest attestations.
         validator_indices = self.validator_indices
         signer_indices = self.signer_indices or self.validator_indices
 
-        # Path 0: Raw bit override.
-        #
-        # Use the bits verbatim with placeholder proof bytes.
-        # An honest aggregate can never carry zero participants, so this is the
-        # only way to feed the gossip path an adversarial empty-bit aggregate.
+        # Path 0: raw bit override with placeholder proof bytes.
+        # An honest aggregate can never carry zero participants.
+        # This is the only way to feed the gossip path an adversarial empty-bit aggregate.
         if self.aggregation_bits is not None:
             placeholder = ByteList512KiB(data=b"\x00" * 32)
             proof = SingleMessageAggregate(
@@ -217,10 +183,8 @@ class AggregatedAttestationSpec(AttestationSpec):
             )
             return SignedAggregatedAttestation(data=attestation_data, proof=proof)
 
-        # Path 1: Invalid signature.
-        #
-        # Correct participant bitfield but zeroed-out proof bytes.
-        # Exercises signature verification rejection.
+        # Path 1: invalid signature.
+        # Correct participant bitfield, zeroed-out proof bytes to exercise rejection.
         if not self.valid_signature:
             placeholder = ByteList512KiB(data=b"\x00" * 32)
             proof = SingleMessageAggregate(
@@ -232,13 +196,9 @@ class AggregatedAttestationSpec(AttestationSpec):
         # Path 2: Valid signature.
         proof = key_manager.sign_and_aggregate(signer_indices, attestation_data)
 
-        # Path 3: Participant mismatch.
-        #
-        # Replace the participant bitfield with different validator indices
-        # while keeping the original proof bytes intact.
-        # The proof is cryptographically valid for the actual signers,
-        # but the claimed participants no longer match.
-        # The store must detect and reject this inconsistency.
+        # Path 3: participant mismatch.
+        # Swap in different claimed participants but keep the original proof bytes.
+        # The proof stays valid for the real signers, so the store must reject the inconsistency.
         if self.signer_indices and self.signer_indices != self.validator_indices:
             proof = SingleMessageAggregate(
                 participants=AggregationBits.from_indices(validator_indices),
@@ -257,11 +217,6 @@ class AggregatedAttestationSpec(AttestationSpec):
         """
         Build an invalid attestation proof and append it to the block body.
 
-        Handles two invalidity scenarios:
-
-        - Invalid signature: correct participant bitfield, zeroed-out proof bytes
-        - Signer mismatch: valid proof from wrong validators, claimed participants differ
-
         Args:
             block_registry: Labeled blocks for checkpoint resolution.
             state: State for attestation data building.
@@ -279,8 +234,8 @@ class AggregatedAttestationSpec(AttestationSpec):
             data=attestation_data,
         )
 
-        # Empty proof bytes flag "no real single-message aggregate here" — the caller treats
-        # any such entry as a placeholder and bypasses real binding merges.
+        # Empty proof bytes signal "no real aggregate here".
+        # The caller treats any such entry as a placeholder and bypasses real binding merges.
         placeholder = ByteList512KiB(data=b"")
 
         if not self.valid_signature:
@@ -294,7 +249,6 @@ class AggregatedAttestationSpec(AttestationSpec):
         else:
             invalid_proof = SingleMessageAggregate(participants=aggregation_bits, proof=placeholder)
 
-        # Append invalid attestation to the block body.
         block = block.model_copy(
             update={
                 "body": block.body.model_copy(
@@ -312,12 +266,9 @@ class AggregatedAttestationSpec(AttestationSpec):
 
 class GossipAttestationSpec(AttestationSpec):
     """
-    Gossip attestation specification for test definitions.
+    Single validator attesting via the gossip network.
 
-    Specifies a single validator attesting via the gossip network.
-    The source defaults to the anchor (genesis) block instead of the
-    latest justified checkpoint.
-    Honest attestations without overrides use data produced by the Store.
+    The source defaults to the anchor block, not the latest justified checkpoint.
     """
 
     validator_index: ValidatorIndex
@@ -345,11 +296,10 @@ class GossipAttestationSpec(AttestationSpec):
         expected_valid: bool,
     ) -> SignedAttestation:
         """
-        Build a complete signed attestation from this specification.
+        Build a signed attestation from this specification.
 
-        Valid attestations without overrides use honest data from the Store.
-        Invalid or overridden attestations use this spec's checkpoint fields,
-        with the anchor block as the default source.
+        Valid attestations without overrides use honest data from the store, otherwise this spec's
+        checkpoint fields with the anchor block as default source.
 
         Args:
             block_registry: Labeled blocks for target resolution.

--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -34,99 +34,42 @@ class BlockSpec(CamelModel):
     """
     Block specification for test definitions.
 
-    Contains the same fields as Block, but all optional except slot.
-    The framework fills in any missing fields automatically.
+    Mirrors a block's fields, but all are optional except the slot.
+    The framework fills in any missing field automatically.
     """
 
     slot: Slot
     """The slot for this block (required)."""
 
     proposer_index: ValidatorIndex | None = None
-    """
-    The proposer index for this block.
-
-    If None, framework selects using round-robin based on slot and num_validators.
-    """
+    """Proposer index, defaulting to the slot's round-robin proposer."""
 
     parent_root: Bytes32 | None = None
-    """
-    The root of the parent block.
-
-    If None, framework computes from state.latest_block_header.
-    """
+    """Parent block root, defaulting to the latest block header."""
 
     state_root: Bytes32 | None = None
-    """
-    The state root after applying this block.
-
-    If None, framework computes via state_transition dry-run.
-    """
+    """Post-state root, defaulting to a state-transition dry-run result."""
 
     body: BlockBody | None = None
-    """
-    The block body containing attestations.
-
-    If None, framework creates body from the attestations field.
-    If both body and attestations are None, framework creates body with empty attestations.
-    Note: If body is provided, attestations field is ignored.
-    """
+    """Block body, built from the attestations field when unset, winning over it when provided."""
 
     attestations: list[AggregatedAttestationSpec] | None = None
-    """
-    List of aggregated attestations to include in this block's body.
-
-    Each entry specifies multiple validators attesting to the same data.
-    The framework generates signatures and aggregates them.
-
-    If None, framework uses default behavior (empty body).
-    If body is provided, this field is ignored.
-    """
+    """Aggregated attestations for this block's body, ignored when a body is provided directly."""
 
     forced_attestations: list[AggregatedAttestationSpec] | None = None
-    """
-    Raw aggregated attestations appended directly to the final block body.
-
-    Unlike attestations, these entries bypass the block builder's filtering.
-    Use this only for STF coverage when the builder would pre-filter the
-    attestation before state processing (e.g., unjustified source).
-    """
+    """Aggregated attestations appended directly, bypassing the builder's pre-filtering."""
 
     label: str | None = None
-    """
-    Optional label to tag this block for later reference.
-
-    Enables fork creation by referencing labeled ancestors.
-    Labels must be unique within a test.
-    """
+    """Unique label tagging this block so a fork can reference it as an ancestor."""
 
     parent_label: str | None = None
-    """
-    Optional label referencing a previously created block as parent.
-
-    If None, parent is determined by the current canonical head.
-    If specified, parent_root is computed from the labeled block.
-    """
+    """Label of a block to use as parent, defaulting to the current canonical head."""
 
     valid_signature: bool = True
-    """
-    Flag whether the proposer's signature in generated block should be valid.
-
-    Used for testing that verification properly rejects invalid block signatures.
-    When False, a structurally valid but cryptographically invalid signature
-    (all zeros) will be generated for the proposer attestation instead of a
-    proper XMSS signature.
-
-    Defaults to True (valid signature).
-    If False, the proposer attestation will be given a dummy/invalid signature.
-    """
+    """Whether the proposer's signature should be valid, all-zero when false to test rejection."""
 
     skip_slot_processing: bool = False
-    """
-    If True, the state transition fixture skips automatic slot advancement
-    before processing this block.
-
-    Useful for tests that intentionally exercise slot mismatch failures.
-    """
+    """Skip automatic slot advancement before processing, to exercise slot-mismatch failures."""
 
     def resolve_proposer_index(self, num_validators: int) -> ValidatorIndex:
         """Return the proposer index, falling back to the spec's round-robin schedule."""
@@ -140,28 +83,21 @@ class BlockSpec(CamelModel):
         default_root: Bytes32,
     ) -> Bytes32:
         """
-        Resolve the parent block root with a three-level fallback:
-
-        1. Explicit parent_root on the spec (for direct override)
-        2. parent_label lookup in the block registry (for fork building)
-        3. default_root provided by the caller (typically the current head
-           or the state's latest block header root)
+        Resolve the parent block root: explicit root, else labeled block, else the default.
 
         Args:
             block_registry: Map of labels to previously built blocks.
-            default_root: Root to use when neither parent_root nor parent_label is set.
+            default_root: Root used when neither an explicit root nor a label is set.
 
         Returns:
             Root hash of the parent block.
 
         Raises:
-            ValueError: If parent_label is set but not found in registry.
+            ValueError: If the label is set but not found in the registry.
         """
-        # Explicit override takes highest priority.
         if self.parent_root is not None:
             return self.parent_root
 
-        # Label-based resolution for fork building.
         if self.parent_label is not None:
             if not (parent_block := block_registry.get(self.parent_label)):
                 raise ValueError(
@@ -170,7 +106,6 @@ class BlockSpec(CamelModel):
                 )
             return hash_tree_root(parent_block)
 
-        # No explicit parent: use the caller-provided default.
         return default_root
 
     def build_attestations(
@@ -193,9 +128,9 @@ class BlockSpec(CamelModel):
 
         Returns:
             Tuple of:
-                - All built attestations (one per validator per spec)
-                - Signature lookup keyed by (attestation_data, validator_index)
-                - Subset of attestations that have valid (non-dummy) signatures
+                - All built attestations, one per validator per spec.
+                - Signature lookup keyed by data and validator.
+                - Subset of attestations with valid signatures.
         """
         if self.attestations is None:
             return [], {}, []
@@ -208,13 +143,11 @@ class BlockSpec(CamelModel):
         valid_attestations: list[Attestation] = []
 
         for aggregated_spec in self.attestations:
-            # Build attestation data once.
             # All validators in this aggregation vote for the same target.
             attestation_data = aggregated_spec.build_attestation_data(
                 block_registry, state.latest_justified
             )
 
-            # Create one attestation per validator.
             # Each validator signs independently; signatures aggregate later.
             for validator_index in aggregated_spec.validator_indices:
                 attestation = Attestation(
@@ -223,7 +156,6 @@ class BlockSpec(CamelModel):
                 )
                 attestations.append(attestation)
 
-                # Generate signature or use invalid placeholder.
                 # Invalid signatures test rejection paths.
                 if aggregated_spec.valid_signature:
                     signature = key_manager.sign_attestation_data(
@@ -234,7 +166,6 @@ class BlockSpec(CamelModel):
                 else:
                     signature = create_dummy_signature()
 
-                # Index signature by attestation data and validator ID.
                 signature_lookup.setdefault(attestation_data, {}).setdefault(
                     validator_index,
                     signature,
@@ -251,30 +182,17 @@ class BlockSpec(CamelModel):
         state: State,
     ) -> SignedBlock:
         """
-        Sign a block and assemble the final SignedBlock with the merged proof.
+        Sign a block and assemble the signed block with the merged proof.
 
-        Builds a single-message aggregate wrapping the proposer's XMSS
-        signature, then merges that with the per-attestation single-message
-        aggregate proofs into a single multi-message aggregate proof and
-        stores it on the envelope. Consumers of this filler feed the block
-        through spec.on_block / verify_signatures, which decodes the proof
-        and verifies it, so an honest merged proof is required.
-
-        When valid_signature is False, the proposer signature is a dummy
-        XMSS one and the binding-driven aggregation would reject it before
-        verify_signatures ever runs. The multi-message aggregate envelope is then assembled
-        directly from the info entries with empty proof bytes — that
-        decodes structurally and lets verify_signatures reach (and reject
-        at) the multi-message proof verification, which is the contract the test exercises.
+        A dummy proposer signature is hand-assembled with empty proof bytes so it still decodes,
+        letting verification reach and reject at the proof check under test.
 
         Args:
             final_block: The unsigned block.
-            attestation_proofs: Per-attestation single-message aggregate proofs (parallel to
-                final_block.body.attestations).
+            attestation_proofs: Per-attestation proofs, parallel to the block's attestations.
             proposer_index: Which validator proposes this block.
             key_manager: XMSS key manager for signing.
-            state: State providing the validator registry used to resolve
-                participant public_keys for the merge.
+            state: State providing the validator registry for resolving participant keys.
 
         Returns:
             Complete signed block.
@@ -282,11 +200,9 @@ class BlockSpec(CamelModel):
         block_root = hash_tree_root(final_block)
         proposer_public_key = key_manager.get_public_keys(proposer_index)[1]
 
-        # The binding rejects placeholder bytes; if anything in the merged
-        # input is a dummy (invalid proposer sig or a build_invalid_proof
-        # attestation), bypass the multi-message aggregation entirely and assemble the
-        # multi-message aggregate envelope by hand. The result still SSZ-decodes so
-        # verify_signatures reaches the multi-message proof verification for the rejection.
+        # The binding rejects placeholder bytes.
+        # If any merged input is a dummy, skip the real merge and assemble the envelope by hand.
+        # It still decodes, so verification reaches the proof check that performs the rejection.
         any_placeholder_attestation = any(not proof.proof.data for proof in attestation_proofs)
         use_placeholder = not self.valid_signature or any_placeholder_attestation
 
@@ -332,9 +248,7 @@ class BlockSpec(CamelModel):
         key_manager: XmssKeyManager,
     ) -> SignedBlock:
         """
-        Build a complete SignedBlock from this specification without a Store.
-
-        Used by signature verification tests where no fork choice is involved.
+        Build a complete signed block without a store, for signature tests with no fork choice.
 
         Args:
             state: The anchor state to build against.
@@ -346,19 +260,17 @@ class BlockSpec(CamelModel):
         spec = LstarSpec()
         proposer_index = self.resolve_proposer_index(len(state.validators))
 
-        # Build a genesis block registry so attestation specs can resolve labels.
+        # Seed a genesis registry so attestation specs can resolve labels.
         anchor_block = reconstruct_block_from_header(state)
         block_registry: dict[str, Block] = {"genesis": anchor_block}
 
-        # Resolve the parent root.
-        # The default is the latest block header from the slot-advanced state.
+        # Default the parent to the latest block header of the slot-advanced state.
         parent_state = spec.process_slots(state, self.slot)
         parent_root = self.resolve_parent_root(
             block_registry,
             default_root=hash_tree_root(parent_state.latest_block_header),
         )
 
-        # Separate valid and invalid attestation specs.
         # Valid specs go through normal aggregation; invalid specs get special proofs.
         invalid_specs = [
             attestation_spec
@@ -370,8 +282,7 @@ class BlockSpec(CamelModel):
             )
         ]
 
-        # Build a valid-only copy for normal attestation construction.
-        # A copy keeps this spec unchanged, so building twice gives the same result.
+        # Copy with only the valid specs so building twice leaves this spec unchanged.
         valid_specs = [
             attestation_spec
             for attestation_spec in (self.attestations or [])
@@ -379,20 +290,17 @@ class BlockSpec(CamelModel):
         ]
         valid_only = self.model_copy(update={"attestations": valid_specs})
 
-        # Build valid attestations and their signatures.
         valid_attestations, signature_lookup, _ = valid_only.build_attestations(
             state, block_registry, key_manager
         )
 
-        # Group attestations that share the same AttestationData.
-        # Validators seeing the same head/source/target produce identical data,
-        # so they can be merged into a single aggregated attestation.
+        # Validators seeing the same head, source, and target produce identical data.
+        # Group them so each unique data merges into one aggregated attestation.
         data_to_validator_indices: dict[AttestationData, list[ValidatorIndex]] = defaultdict(list)
         for attestation in valid_attestations:
             data_to_validator_indices[attestation.data].append(attestation.validator_index)
 
-        # Build one AggregatedAttestation per unique data.
-        # Each carries a bitfield marking which validators participated.
+        # One aggregate per unique data, with a bitfield of its participants.
         aggregated_attestations = [
             AggregatedAttestation(
                 aggregation_bits=AggregationBits.from_indices(validator_indices),
@@ -420,8 +328,7 @@ class BlockSpec(CamelModel):
             aggregated_payloads=aggregated_payloads,
         )
 
-        # Append proofs for invalid attestation specs.
-        # These exercise signature verification rejection paths.
+        # Append proofs for invalid specs to exercise verification rejection paths.
         for invalid_spec in invalid_specs:
             final_block, invalid_proof = invalid_spec.build_invalid_proof(
                 block_registry, state, key_manager, final_block
@@ -440,14 +347,13 @@ class BlockSpec(CamelModel):
         """
         Build a block whose parent the store never imported.
 
-        The unknown-parent guard rejects it before the state transition or
-        signature checks, so an empty body and placeholder proof suffice.
+        The unknown-parent guard rejects it before any other check, so an empty body and
+        placeholder proof suffice.
         """
         anchor_state = store.states[store.head]
         proposer_index = self.resolve_proposer_index(len(anchor_state.validators))
 
-        # An empty body keeps the block trivially well formed.
-        # The state root is left at zero: the guard rejects before checking it.
+        # Empty body, zero state root: the guard rejects before either is checked.
         block = Block(
             slot=self.slot,
             proposer_index=proposer_index,
@@ -456,9 +362,8 @@ class BlockSpec(CamelModel):
             body=BlockBody(attestations=AggregatedAttestations(data=[])),
         )
 
-        # An empty proof decodes structurally.
-        # The unknown-parent guard fires before proof verification, so a
-        # placeholder proof never reaches a verifier.
+        # An empty proof decodes structurally and never reaches a verifier:
+        # the unknown-parent guard fires before proof verification.
         return SignedBlock(block=block, proof=MultiMessageAggregate(proof=ByteList512KiB(data=b"")))
 
     def build_signed_block_with_store(
@@ -469,51 +374,32 @@ class BlockSpec(CamelModel):
         deliver_unknown_parent: bool = False,
     ) -> tuple[SignedBlock, Store]:
         """
-        Build a complete signed block through the Store's attestation pipeline.
+        Build a signed block by replaying gossip, aggregation, and proposal through the store.
 
-        Simulates what a real node does when proposing a block.
-        Replays the gossip, aggregation, and proposal pipeline through the Store.
-
-        Returns a Store enriched with the aggregated single-message aggregate payloads built
-        during the simulated pipeline. The caller can persist these so future
-        block builds can re-aggregate the same attestations rather than
-        reconstructing them from on-chain block bodies (which would require
-        splitting the block-level multi-message aggregate proof — a heavy and, in the test
-        recursive-aggregation mode, unreliable operation). Other fields of
-        the original Store (gossip signatures, time, head, etc.) are
-        preserved so the simulated build does not consume state the caller
-        is tracking separately.
+        The returned store keeps the freshly aggregated payloads so future builds re-aggregate the
+        same attestations, avoiding a heavy and unreliable split of the block-level proof.
 
         Args:
             store: Fork choice store for head state lookup and gossip processing.
             block_registry: Labeled blocks for fork creation.
             key_manager: Key manager for signing.
-            deliver_unknown_parent: When True and the parent state is absent,
-                build a structurally valid block against the anchor state with
-                its parent root overridden, instead of raising.
-                This hands the block to the spec so its own unknown-parent
-                guard runs and rejects it.
+            deliver_unknown_parent: When the parent state is absent, build against the anchor
+                state with the parent root overridden so the unknown-parent guard rejects it.
 
         Returns:
-            The signed block and the Store with new known payloads merged in.
+            The signed block and the store with new known payloads merged in.
         """
         spec = LstarSpec()
         proposer_index = self.resolve_proposer_index(len(store.states[store.head].validators))
 
-        # Resolve parent block.
-        # Parent can be specified by label (for forks) or defaults to head.
+        # Parent is set by label for forks, else defaults to the head.
         parent_root = self.resolve_parent_root(block_registry, default_root=store.head)
 
-        # The parent's state is missing from the store.
-        #
-        # The normal path treats this as a hard harness error: no state means
+        # A missing parent state is normally a hard harness error:
         # the builder cannot run the state transition for this fork.
-        #
-        # The unknown-parent path is the one exception.
-        # A test may deliberately fabricate a parent root the store never saw,
-        # to exercise the spec's own unknown-parent rejection.
-        # That guard runs before the state transition, so the block needs no
-        # valid post-state — it only needs to be structurally well formed.
+        # The one exception is a deliberately fabricated unknown parent.
+        # Its guard runs before the state transition, so the block needs no valid post-state,
+        # only a structurally well-formed shape.
         if parent_root not in store.states:
             if deliver_unknown_parent:
                 return self._build_unknown_parent_block(store, parent_root), store
@@ -522,29 +408,26 @@ class BlockSpec(CamelModel):
                 "has no state in store - cannot build on this fork"
             )
 
-        # Preserve the caller's Store so unrelated fields (gossip signatures,
-        # head, finalization checkpoints, time) survive the simulated pipeline.
-        # Only the freshly aggregated single-message aggregate payloads merge back at the end.
+        # Preserve the caller's store so its unrelated fields survive the simulated pipeline.
+        # Only the freshly aggregated payloads merge back at the end.
         caller_store = store
         store = copy.deepcopy(store)
 
-        # Build attestations from this spec's attestation fields.
         parent_state = store.states[parent_root]
         _, attestation_signatures, valid_attestations = self.build_attestations(
             parent_state, block_registry, key_manager
         )
 
-        # Advance the local store clock to the block's slot before gossiping.
-        # In-body attestations carry data.slot = self.slot; the Store's time
-        # check rejects votes whose slot has not yet started locally.
+        # In-body attestations carry the block's slot.
+        # The store's time check rejects votes whose slot has not yet started locally,
+        # so advance the local clock first.
         block_slot_interval = Interval.from_slot(self.slot)
         if store.time < block_slot_interval:
             store, _ = spec.on_tick(
                 store, block_slot_interval, has_proposal=True, is_aggregator=True
             )
 
-        # Gossip valid attestation signatures into the Store.
-        # This runs signature verification through the spec's validation path.
+        # Gossip valid signatures so they run through the spec's verification path.
         for attestation in valid_attestations:
             signatures_for_data = attestation_signatures.get(attestation.data)
             if (
@@ -562,14 +445,12 @@ class BlockSpec(CamelModel):
                 is_aggregator=True,
             )
 
-        # Trigger Store aggregation to merge gossip signatures into known payloads.
-        # Aggregation runs on a local clone: gossip pools mutate here, but the
-        # caller's gossip-signature view must not be consumed by this simulated
-        # build. Only the freshly aggregated single-message aggregate payloads propagate back.
+        # Aggregate gossip signatures into known payloads on the local clone.
+        # Gossip pools mutate here, but the caller's gossip view must not be consumed.
+        # Only the freshly aggregated payloads propagate back.
         aggregation_store, _ = spec.aggregate(store)
         merged_store = spec.accept_new_attestations(aggregation_store)
 
-        # Build the block through the spec's State.build_block().
         final_block, _, _, block_proofs = spec.build_block(
             parent_state,
             slot=self.slot,
@@ -579,8 +460,7 @@ class BlockSpec(CamelModel):
             aggregated_payloads=merged_store.latest_known_aggregated_payloads,
         )
 
-        # Merge new known payloads (built locally) back into the caller's
-        # store while leaving every other field untouched.
+        # Merge the locally built known payloads back, leaving every other field untouched.
         merged_known = {
             attestation_data: set(proofs)
             for attestation_data, proofs in caller_store.latest_known_aggregated_payloads.items()
@@ -589,8 +469,8 @@ class BlockSpec(CamelModel):
             merged_known.setdefault(attestation_data, set()).update(proofs)
         store = caller_store.model_copy(update={"latest_known_aggregated_payloads": merged_known})
 
-        # Append forced attestations that bypass the builder's MAX cap.
-        # Each entry is signed and aggregated so the block carries valid proofs.
+        # Append forced attestations that bypass the builder's cap.
+        # Each is signed and aggregated so the block carries valid proofs.
         if self.forced_attestations:
             for attestation_spec in self.forced_attestations:
                 attestation_data = attestation_spec.build_attestation_data(
@@ -620,7 +500,7 @@ class BlockSpec(CamelModel):
                     }
                 )
 
-            # Recompute state root with the modified body.
+            # Recompute the state root for the modified body.
             post_state = spec.process_slots(parent_state, self.slot)
             post_state = spec.process_block(post_state, final_block)
             final_block = final_block.model_copy(update={"state_root": hash_tree_root(post_state)})

--- a/packages/testing/src/consensus_testing/test_types/state_expectation.py
+++ b/packages/testing/src/consensus_testing/test_types/state_expectation.py
@@ -19,15 +19,7 @@ from lean_spec.spec.ssz import Bytes32
 
 
 class StateExpectation(SelectiveCheck):
-    """
-    Expected State fields after state transition (selective validation).
-
-    All fields are optional - only specified fields are validated.
-    Uses Pydantic's model_fields_set to track which fields were explicitly set.
-
-    This allows test writers to specify only the fields they care about,
-    making tests more focused and maintainable.
-    """
+    """Expected state fields after a transition, validating only those a test set."""
 
     _SCALAR_ACCESSORS: ClassVar[dict[str, Callable[[State], Any]]] = {
         "slot": lambda s: s.slot,
@@ -63,12 +55,7 @@ class StateExpectation(SelectiveCheck):
     """Expected latest justified checkpoint root."""
 
     latest_justified_root_label: str | None = None
-    """
-    Expected latest justified checkpoint root by label reference.
-
-    Alternative to latest_justified_root that uses the block label system.
-    The framework resolves this label to the actual block root.
-    """
+    """Expected latest justified checkpoint root, by block label."""
 
     latest_finalized_slot: Slot | None = None
     """Expected latest finalized checkpoint slot."""
@@ -77,12 +64,7 @@ class StateExpectation(SelectiveCheck):
     """Expected latest finalized checkpoint root."""
 
     latest_finalized_root_label: str | None = None
-    """
-    Expected latest finalized checkpoint root by label reference.
-
-    Alternative to latest_finalized_root that uses the block label system.
-    The framework resolves this label to the actual block root.
-    """
+    """Expected latest finalized checkpoint root, by block label."""
 
     validator_count: int | None = None
     """Expected number of validators."""
@@ -121,12 +103,7 @@ class StateExpectation(SelectiveCheck):
     """Expected justifications roots collection."""
 
     justifications_roots_labels: list[str] | None = None
-    """
-    Expected pending justification roots by label reference.
-
-    Alternative to justifications_roots that uses the block label system.
-    The framework resolves each label to the actual block root.
-    """
+    """Expected pending justification roots, by block label."""
 
     justifications_roots_count: int | None = None
     """Expected number of pending justification target roots."""
@@ -143,10 +120,7 @@ class StateExpectation(SelectiveCheck):
         block_registry: dict[str, Block] | None = None,
     ) -> None:
         """
-        Validate this expectation against actual State.
-
-        Only validates fields that were explicitly set by the test writer.
-        Uses Pydantic's model_fields_set to determine which fields to check.
+        Validate this expectation against an actual state, checking only the fields a test set.
 
         Args:
             state: The actual state to validate against.

--- a/packages/testing/src/consensus_testing/test_types/step_types.py
+++ b/packages/testing/src/consensus_testing/test_types/step_types.py
@@ -22,13 +22,7 @@ from lean_spec.spec.forks.lstar.containers import (
 
 
 class BaseForkChoiceStep(CamelModel):
-    """
-    Base class for fork choice event steps.
-
-    All step types inherit from this base and include:
-    - valid flag for expected success/failure
-    - optional Store state checks to validate after processing
-    """
+    """Base class for fork choice event steps."""
 
     model_config = CamelModel.model_config | {"frozen": True}
 
@@ -36,30 +30,17 @@ class BaseForkChoiceStep(CamelModel):
     """Whether this step is expected to succeed."""
 
     expected_rejection: ExpectedRejection | None = None
-    """
-    Expected rejection when valid=False.
-
-    The classified reason must match.
-    The exception message must contain the optional substring.
-    Never serialized: the emitted contract is the filled step's reason field.
-    """
+    """Expected rejection when invalid, never serialized into the emitted contract."""
 
     checks: StoreChecks | None = None
-    """
-    Store state checks to validate after processing this step.
-
-    If provided, the fixture will validate the Store state matches
-    these checks after executing the step.
-    Only fields that are explicitly set will be validated.
-    """
+    """Store state checks to validate after this step, limited to fields explicitly set."""
 
     @model_validator(mode="after")
     def validate_rejection_is_declared(self) -> "BaseForkChoiceStep":
         """
         Require a declared rejection on every step expected to fail.
 
-        A vector saying only "reject this" lets a client reject
-        for the wrong reason and still pass.
+        A vector saying only "reject this" lets a client reject for the wrong reason and pass.
         """
         if not self.valid and self.expected_rejection is None:
             raise ValueError("steps with valid=False must declare their expected_rejection")
@@ -67,13 +48,7 @@ class BaseForkChoiceStep(CamelModel):
 
 
 class TickStep(BaseForkChoiceStep):
-    """
-    Time advancement step.
-
-    Advances the fork choice store time to a specific unix timestamp or
-    exact interval count. This triggers interval-based actions like
-    attestation processing.
-    """
+    """Advance store time to a unix timestamp or interval count, triggering interval actions."""
 
     step_type: Literal["tick"] = "tick"
     """Discriminator field for serialization."""
@@ -96,66 +71,38 @@ class TickStep(BaseForkChoiceStep):
 
 
 class BlockStep(BaseForkChoiceStep):
-    """
-    Block processing step.
-
-    Processes a block through the fork choice store.
-    This updates the store's block tree and may trigger head updates.
-
-    Input: BlockSpec (can be partial or fully specified).
-    Output: Block object built and processed through the spec.
-    """
+    """Process a block through the store, updating the block tree and possibly the head."""
 
     step_type: Literal["block"] = "block"
     """Discriminator field for serialization."""
 
     block: BlockSpec
-    """
-    Block specification for this step.
-
-    Tests provide a BlockSpec with required slot and optional field overrides.
-    Generation fills a complete Block and emits it in the filled step.
-    """
+    """Block specification with required slot and optional overrides, filled during generation."""
 
     tick_to_slot: bool = True
-    """
-    Whether to advance the store clock to the block's slot before import.
+    """Whether to advance the store clock to the block's slot before import.
 
-    Default True matches a node whose clock reached the slot already.
-    Set False to deliver the block while the store clock lags behind,
-    pinning how clients treat a block ahead of their local time.
+    Set False to pin how clients treat a block ahead of their local time.
     """
 
 
 class AttestationStep(BaseForkChoiceStep):
     """
-    Attestation processing step.
+    Process a gossip attestation, updating validator attestation tracking.
 
-    Processes an attestation received from gossip.
-    This updates validator attestation tracking in the store.
-
-    Note: Attestations included in blocks are processed automatically
-    when the block is processed. This step is for gossip attestations.
+    Attestations inside blocks are processed with the block, not here.
     """
 
     step_type: Literal["attestation"] = "attestation"
     """Discriminator field for serialization."""
 
     attestation: GossipAttestationSpec
-    """
-    Gossip attestation specification for this step.
-
-    Tests provide a GossipAttestationSpec with required fields.
-    Generation fills in the attestation data and signature.
-    """
+    """Gossip attestation specification, with data and signature filled during generation."""
 
     is_aggregator: bool = False
-    """
-    Whether the node holds the aggregator role for this attestation.
+    """Whether the node holds the aggregator role for this attestation.
 
     Only aggregator nodes store gossip signatures in the raw signature pool.
-    Defaults to False so existing fillers preserve the behavior where gossip
-    attestations are validated but not stored.
     """
 
 
@@ -166,12 +113,9 @@ class GossipAggregatedAttestationStep(BaseForkChoiceStep):
     """Discriminator field for serialization."""
 
     attestation: AggregatedAttestationSpec
-    """
-    Specification for the aggregated gossip attestation.
-    """
+    """Specification for the aggregated gossip attestation."""
 
 
-# Discriminated union type for all fork choice steps
 ForkChoiceStep = Annotated[
     TickStep | BlockStep | AttestationStep | GossipAggregatedAttestationStep,
     Field(discriminator="step_type"),
@@ -179,11 +123,7 @@ ForkChoiceStep = Annotated[
 
 
 class BaseFilledStep(CamelModel):
-    """
-    Base class for emitted fork choice steps.
-
-    Carries the authored flags plus the generation outputs every step shares.
-    """
+    """Base class for emitted fork choice steps, carrying the shared generation outputs."""
 
     model_config = CamelModel.model_config | {"frozen": True}
 
@@ -191,23 +131,15 @@ class BaseFilledStep(CamelModel):
     """Whether this step succeeded."""
 
     rejection_reason: RejectionReason | None = None
-    """
-    Language-neutral reason this step's input must be rejected.
-
-    Filled during generation for invalid steps.
-    This is the field clients assert against.
-    """
+    """Language-neutral reason the input was rejected, the field clients assert against."""
 
     checks: StoreChecks | None = None
     """Store state checks the step was validated against."""
 
     store_snapshot: StoreSnapshot
-    """
-    Canonical store observables after this step.
+    """Canonical store observables after this step, populated even for rejected steps.
 
-    Populated for every step, including rejected ones.
-    A rejected input leaves the store unchanged, and the snapshot
-    pins that no-op so a client cannot corrupt state on rejection.
+    Pins the no-op on rejection so a client cannot corrupt state on a rejected input.
     """
 
 
@@ -247,8 +179,7 @@ class FilledBlockStep(BaseFilledStep):
         """
         Serialize the block, merging the authored label into its payload.
 
-        The label rides inside the block object so consumers can resolve
-        fork references without a side table.
+        The label rides inside the block object so consumers resolve forks without a side table.
         """
         serialized_block = filled_block.to_json()
         if self.block_root_label:
@@ -279,7 +210,6 @@ class FilledGossipAggregatedAttestationStep(BaseFilledStep):
     """The filled SignedAggregatedAttestation, processed through the spec."""
 
 
-# Discriminated union type for all emitted fork choice steps
 FilledForkChoiceStep = Annotated[
     FilledTickStep
     | FilledBlockStep

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -35,30 +35,20 @@ def _ancestor_set(blocks: dict[Bytes32, Block], head: Bytes32) -> set[Bytes32]:
 
 
 class AggregatedAttestationCheck(CamelModel):
-    """
-    Validation checks for an aggregated attestation in the block body.
-
-    Used to verify signature aggregation results by checking which validators
-    are covered by each aggregated attestation.
-    """
+    """Validation checks for one aggregated attestation in the block body."""
 
     participants: set[int]
     """Expected validator indices covered by this aggregated attestation."""
 
     attestation_slot: Slot | None = None
-    """Expected attestation data slot (optional - only check if set)."""
+    """Expected attestation data slot, checked only when set."""
 
     target_slot: Slot | None = None
-    """Expected target checkpoint slot (optional - only check if set)."""
+    """Expected target checkpoint slot, checked only when set."""
 
 
 class AttestationCheck(CamelModel):
-    """
-    Validation checks for a specific validator's attestation.
-
-    All fields optional - only check fields explicitly set.
-    Used to validate attestation content beyond just counting.
-    """
+    """Validation checks for one validator's attestation, limited to fields explicitly set."""
 
     validator: ValidatorIndex
     """Which validator's attestation to check."""
@@ -76,11 +66,7 @@ class AttestationCheck(CamelModel):
     """Expected target checkpoint slot."""
 
     location: Literal["new", "known"]
-    """
-    Expected attestation location:
-        - "new" for `latest_new_aggregated_payloads`
-        - "known" for `latest_known_aggregated_payloads`
-    """
+    """Which pool the attestation should sit in, the pending or the accepted pool."""
 
     def validate_attestation(
         self, attestation: AttestationData, location: str, step_index: int
@@ -97,12 +83,7 @@ class AttestationCheck(CamelModel):
 
 
 class StoreChecks(SelectiveCheck):
-    """
-    Store state checks for fork choice tests.
-
-    All fields are optional. Only specified fields are validated.
-    This allows tests to focus on the properties they care about.
-    """
+    """Store state checks for fork choice tests, validating only the fields a test sets."""
 
     _SCALAR_ACCESSORS: ClassVar[dict[str, Callable[[Store], Any]]] = {
         "time": lambda store: store.time,
@@ -144,20 +125,12 @@ class StoreChecks(SelectiveCheck):
     """Expected head block root."""
 
     head_root_label: str | None = None
-    """
-    Expected head block root by label reference.
-
-    Alternative to head_root that uses the block label system.
-    The framework resolves this label to the actual block root.
-    """
+    """Expected head block root, named by label and resolved to a root."""
 
     filled_block_root_label: str | None = None
-    """
-    Expected root of the block built for this step, resolved by label.
+    """Expected root of the block built for this step, named by label.
 
-    This is useful when a test needs to prove that the fixture rebuilt or
-    resubmitted an exact previously known block rather than merely producing a
-    different block that leaves the head unchanged.
+    Proves the fixture rebuilt the exact known block, not a different one with an unchanged head.
     """
 
     latest_justified_slot: Slot | None = None
@@ -167,12 +140,7 @@ class StoreChecks(SelectiveCheck):
     """Expected latest justified checkpoint root."""
 
     latest_justified_root_label: str | None = None
-    """
-    Expected latest justified checkpoint root by label reference.
-
-    Alternative to latest_justified_root that uses the block label system.
-    The framework resolves this label to the actual block root.
-    """
+    """Expected latest justified checkpoint root, named by label and resolved to a root."""
 
     latest_finalized_slot: Slot | None = None
     """Expected latest finalized checkpoint slot."""
@@ -181,12 +149,7 @@ class StoreChecks(SelectiveCheck):
     """Expected latest finalized checkpoint root."""
 
     latest_finalized_root_label: str | None = None
-    """
-    Expected latest finalized checkpoint root by label reference.
-
-    Alternative to latest_finalized_root that uses the block label system.
-    The framework resolves this label to the actual block root.
-    """
+    """Expected latest finalized checkpoint root, named by label and resolved to a root."""
 
     safe_target: Bytes32 | None = None
     """Expected safe target root."""
@@ -195,120 +158,52 @@ class StoreChecks(SelectiveCheck):
     """Expected safe target block slot."""
 
     safe_target_root_label: str | None = None
-    """
-    Expected safe target root by label reference.
-
-    Alternative to safe_target that uses the block label system.
-    The framework resolves this label to the actual block root.
-    """
+    """Expected safe target root, named by label and resolved to a root."""
 
     attestation_target_slot: Slot | None = None
-    """
-    Expected attestation target checkpoint slot.
+    """Expected attestation target checkpoint slot.
 
-    Validates the complete checkpoint (both slot and root):
-    - The checkpoint slot matches the expected value
-    - The checkpoint root references an actual block at that slot
+    The checkpoint root must also reference an actual block at that slot.
     """
 
     attestation_target_root_label: str | None = None
-    """
-    Expected attestation target checkpoint root by label reference.
-
-    The framework resolves this label to a block root and compares it to the
-    root that the spec would attest to from the current store.
-    """
+    """Expected attestation target root, named by label and resolved to a root."""
 
     attestation_checks: list[AttestationCheck] | None = None
-    """Optional list of attestation content checks for specific validators."""
+    """Attestation content checks for specific validators."""
 
     attestation_signature_target_slots: list[Slot] | None = None
-    """
-    Expected target slots present in attestation_signatures.
-
-    Compares the exact set of target checkpoint slots keyed in the raw gossip
-    signature map, independent of how many validators signed each target.
-    """
+    """Expected set of target slots keyed in the raw gossip signature map."""
 
     latest_new_aggregated_target_slots: list[Slot] | None = None
-    """
-    Expected target slots present in latest_new_aggregated_payloads.
-
-    Compares the exact set of target checkpoint slots keyed in the pending
-    aggregated proof map.
-    """
+    """Expected set of target slots keyed in the pending aggregated proof map."""
 
     latest_known_aggregated_target_slots: list[Slot] | None = None
-    """
-    Expected target slots present in latest_known_aggregated_payloads.
-
-    Compares the exact set of target checkpoint slots keyed in the accepted
-    aggregated proof map.
-    """
+    """Expected set of target slots keyed in the accepted aggregated proof map."""
 
     new_pool_proof_participants: dict[Slot, set[int]] | None = None
-    """
-    Expected union of participants across pending-pool proofs, keyed by target slot.
-
-    Compares the set of validator indices covered by every proof in the
-    pending aggregated proof map for each target slot.
-    Pins the coverage a fresh aggregation round produced in the pending pool.
-    """
+    """Expected union of validator indices across pending-pool proofs, per target slot."""
 
     block_attestation_count: int | None = None
-    """
-    Expected number of aggregated attestations in the block body.
+    """Expected number of aggregated attestations in the block body.
 
-    Use this to verify signature aggregation behavior:
-    - 1 = all attestations aggregated into a single proof
-    - >1 = attestations split due to incompatible sources
+    More than one means attestations split over incompatible sources rather than merging.
     """
 
     block_attestations: list[AggregatedAttestationCheck] | None = None
-    """
-    Detailed checks for each aggregated attestation in the block body.
-
-    Each check validates:
-    - participants: which validators are covered by this aggregation
-    - attestation_slot: the attestation data slot (optional)
-    - target_slot: the target checkpoint slot (optional)
-    """
+    """Detailed per-attestation checks for the block body."""
 
     lexicographic_head_among: list[str] | None = None
-    """
-    Verify that the head is chosen via lexicographic tiebreaker.
+    """Fork labels expected to tie, with the head chosen by the lexicographic tiebreaker.
 
-    When specified, validates that:
-    1. All listed fork labels have equal attestation weight
-    2. The current head is one of these forks
-    3. The head has the lexicographically highest block root among them
-
-    This is used to test the fork choice tiebreaker rule: when multiple forks
-    have equal weight, the fork with the highest block root (lexicographically)
-    should be selected as the head.
+    All listed forks must have equal attestation weight, and the head carries the highest root.
     """
 
     reorg_depth: int | None = None
-    """
-    Expected reorg depth after this step.
-
-    Reorg depth is the number of blocks reverted when the head switches
-    from the old chain to the new chain. Computed by finding the common
-    ancestor of the old and new heads, then counting blocks from the old
-    head back to that ancestor.
-
-    Only meaningful when the head actually changes. If the head didn't
-    change, the actual reorg depth is 0.
-    """
+    """Expected count of blocks from the old head back to its common ancestor with the new head."""
 
     labels_in_store: list[str] | None = None
-    """
-    Block labels that must be present in the store's block tree.
-
-    Each label is resolved to a block root via the block registry,
-    then checked for presence in `store.blocks`. This verifies
-    that blocks from abandoned forks are retained (not pruned).
-    """
+    """Block labels still present in the block tree, verifying abandoned forks are retained."""
 
     def validate_against_store(
         self,
@@ -319,17 +214,15 @@ class StoreChecks(SelectiveCheck):
         old_head: Bytes32 | None = None,
     ) -> None:
         """
-        Validate these checks against actual Store state.
-
-        Only validates fields that were explicitly set by the test writer.
+        Validate these checks against actual store state, limited to fields the test set.
 
         Args:
             store: The fork choice store to validate against.
             step_index: Index of the step being validated (for error messages).
             block_registry: Optional labeled blocks for resolving label-based checks.
             filled_block: Optional block for validating block body attestations.
-            old_head: Previous head root before this step executed. Required
-                for reorg_depth checks.
+            old_head: Previous head root before this step executed.
+                Required for reorg_depth checks.
         """
         fields = self.model_fields_set
 
@@ -347,7 +240,7 @@ class StoreChecks(SelectiveCheck):
         # Scalar store fields
         self.validate_scalar_fields(store, f"Step {step_index}")
 
-        # Label-based root checks (resolve label -> root, then compare)
+        # Resolve each label to a root, then compare.
         for field_name in fields & self._LABEL_ROOT_ACCESSORS.keys():
             expected_root = _resolve(getattr(self, field_name))
             _check(field_name, self._LABEL_ROOT_ACCESSORS[field_name](store), expected_root)

--- a/packages/testing/src/consensus_testing/test_types/store_snapshot.py
+++ b/packages/testing/src/consensus_testing/test_types/store_snapshot.py
@@ -27,8 +27,7 @@ class AttestationPoolEntry(StrictBaseModel):
     """
     Validator coverage of one attestation data in the raw signature pool.
 
-    Signature bytes are excluded: coverage is the consensus-relevant
-    observable, and it keeps vectors lean.
+    Signature bytes are excluded since coverage is the consensus-relevant observable.
     """
 
     data_root: Bytes32
@@ -42,8 +41,7 @@ class AggregatedPoolEntry(StrictBaseModel):
     """
     Participant coverage of one attestation data in an aggregated payload pool.
 
-    Proof bytes are excluded: the aggregation prover is randomized,
-    so they differ between two fills of identical inputs.
+    Proof bytes are excluded since the randomized prover differs between identical fills.
     """
 
     data_root: Bytes32
@@ -57,11 +55,7 @@ class StoreSnapshot(StrictBaseModel):
     """
     Canonical store observables captured after a fork choice step.
 
-    Recorded by the framework after every step, including rejected ones.
-    Clients must reproduce every field, not just authored checks.
-
-    Explicit fields avoid needing a spec-defined canonical store encoding.
-    They are self-describing and language-neutral.
+    Recorded after every step, including rejected ones, so clients reproduce every field.
     """
 
     time: Interval
@@ -80,32 +74,24 @@ class StoreSnapshot(StrictBaseModel):
     """Highest slot finalized checkpoint known to the store."""
 
     block_roots: list[Bytes32]
-    """
-    Every block root the store retains, ascending.
+    """Every block root the store retains, ascending.
 
-    Pruning behavior stays invisible without the full membership.
-    An over- or under-pruning client must fail here.
+    Full membership makes pruning observable, so an over- or under-pruning client fails here.
     """
 
     block_weights: list[BlockWeightEntry]
-    """
-    Fork-choice weight per block above the finalized slot, ascending by root.
+    """Fork-choice weight per block above the finalized slot, ascending by root.
 
-    Zero-weight blocks are included.
-    Two clients can agree on the head while holding divergent weights.
-    They then split on the next attestation.
-    The weights drive head selection and must match exactly.
+    Weights drive head selection and must match exactly, even where two clients agree on the head.
     """
 
     attestation_signatures: list[AttestationPoolEntry]
     """Raw signature pool coverage, ascending by data root."""
 
     new_aggregated_payloads: list[AggregatedPoolEntry]
-    """
-    Pending aggregated payload pool, ascending by data root.
+    """Pending aggregated payload pool, ascending by data root.
 
-    These payloads do not contribute to fork choice yet.
-    The new-to-known migration timing is consensus-relevant.
+    These payloads do not contribute to fork choice yet, but their migration timing is observable.
     """
 
     known_aggregated_payloads: list[AggregatedPoolEntry]

--- a/packages/testing/src/consensus_testing/test_types/utils.py
+++ b/packages/testing/src/consensus_testing/test_types/utils.py
@@ -12,19 +12,7 @@ def resolve_block_root(
     label: str,
     block_registry: dict[str, Block],
 ) -> Bytes32:
-    """
-    Resolve a block label to its hash tree root.
-
-    Args:
-        label: Block label in the registry.
-        block_registry: Labeled blocks for lookup.
-
-    Returns:
-        The block's hash tree root.
-
-    Raises:
-        ValueError: If label not found in registry.
-    """
+    """Resolve a block label to its hash tree root, raising if the label is unknown."""
     if (block := block_registry.get(label)) is None:
         raise ValueError(f"label '{label}' not found - available: {list(block_registry.keys())}")
     return hash_tree_root(block)
@@ -35,22 +23,8 @@ def resolve_checkpoint(
     slot_override: Slot | None,
     block_registry: dict[str, Block],
 ) -> Checkpoint:
-    """
-    Resolve a block label and optional slot override into a Checkpoint.
-
-    Args:
-        label: Block label in the registry.
-        slot_override: When set, overrides the block's actual slot.
-        block_registry: Labeled blocks for lookup.
-
-    Returns:
-        Checkpoint with the block's root and resolved slot.
-
-    Raises:
-        ValueError: If label not found in registry.
-    """
+    """Resolve a block label into a checkpoint, preferring the slot override over the block slot."""
     root = resolve_block_root(label, block_registry)
-    # An explicit override wins; otherwise fall back to the labeled block's own slot.
     if slot_override is not None:
         return Checkpoint(root=root, slot=slot_override)
     return Checkpoint(root=root, slot=block_registry[label].slot)

--- a/packages/testing/src/consensus_testing/values.py
+++ b/packages/testing/src/consensus_testing/values.py
@@ -24,12 +24,7 @@ TEST_VALIDATOR_INDEX = ValidatorIndex(0)
 
 
 def signed_block_with_empty_proof(block: Block) -> SignedBlock:
-    """
-    Wrap an unsigned block in an empty proof.
-
-    The fork-choice store retains only unsigned blocks.
-    A genesis or anchor block that no proposer ever signed carries an empty proof.
-    """
+    """Wrap an unsigned block in an empty proof, as a genesis or anchor block carries."""
     return SignedBlock(
         block=block,
         proof=MultiMessageAggregate(proof=ByteList512KiB(data=b"")),
@@ -39,11 +34,7 @@ def signed_block_with_empty_proof(block: Block) -> SignedBlock:
 def store_backed_signed_block_getter(
     store: Store,
 ) -> Callable[[Bytes32], SignedBlock | None]:
-    """
-    Build a signed-block lookup over a store's unsigned blocks.
-
-    Returns None for an unknown root, mirroring a node that lacks the block.
-    """
+    """Build a signed-block lookup over a store's unsigned blocks."""
 
     def signed_block_for(root: Bytes32) -> SignedBlock | None:
         block = store.blocks.get(root)
@@ -87,16 +78,7 @@ def make_signed_attestation(
     target: Checkpoint,
     source: Checkpoint | None = None,
 ) -> SignedAttestation:
-    """
-    Build a single-validator signed attestation with a dummy signature.
-
-    Head and target share the target checkpoint.
-    Source defaults to a zero checkpoint.
-
-    The output is structurally valid only, not guaranteed consistent with any chain.
-    The source, target, and head triple is never checked for realizability.
-    Keep this out of the real spec's attestation processing.
-    """
+    """Build a single-validator signed attestation that is structurally valid but chain-agnostic."""
     return SignedAttestation(
         validator_index=validator,
         data=AttestationData(


### PR DESCRIPTION
## Summary

Makes the documentation across `packages/testing/src/consensus_testing` substantially leaner, without losing any protocol meaning. The docstrings and comments in the test-vector framework had drifted toward multi-paragraph prose where the project's documentation rules call for one-line summaries.

Net effect: **449 insertions, 1701 deletions** — purely documentation text. No code, names, signatures, imports, or string literals changed.

## What changed

- **One-line by default** — class/function/field docstrings of ordinary complexity reduced to a single summary line (documentation rule 6).
- **Un-wrapped single sentences** — sentences that had been split across two physical lines are joined onto one line (≤100 chars), rephrased tighter where needed. "One sentence per line" forbids two sentences on one line; it does not mandate wrapping one sentence across two.
- **Cut padded bodies** — multi-sentence docstring bodies trimmed to the single load-bearing "why", dropping restatement and obvious-mechanics narration.
- **Terse fields** — field/attribute docstrings collapsed to one noun phrase.

## What was preserved

The single most important consensus/crypto invariant in each docstring was kept, e.g.: state transition assumes signatures verified upstream, the no-op store snapshot pins a rejection, equal-slot LMD ties resolve to first-seen, XMSS one-time-leaf statefulness, deterministic (no-RNG) ENR signatures, and the full-post-state-root divergence closure. A consensus-domain review pass confirmed no invariant was dropped or distorted.

## Verification

`just check` passes (ruff lint + format, ty type check, codespell, mdformat).