### PR TITLE
fix(testing): stop dropping an explicit proposer index of 0

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/block_spec.py
+++ b/packages/testing/src/consensus_testing/test_types/block_spec.py
@@ -73,9 +73,9 @@ class BlockSpec(CamelModel):
 
     def resolve_proposer_index(self, num_validators: int) -> ValidatorIndex:
         """Return the proposer index, falling back to the spec's round-robin schedule."""
-        return self.proposer_index or ValidatorIndex.proposer_for_slot(
-            self.slot, Uint64(num_validators)
-        )
+        if self.proposer_index is not None:
+            return self.proposer_index
+        return ValidatorIndex.proposer_for_slot(self.slot, Uint64(num_validators))
 
     def resolve_parent_root(
         self,


### PR DESCRIPTION
## Summary

`BlockSpec.resolve_proposer_index` used `self.proposer_index or ValidatorIndex.proposer_for_slot(...)`. Because `ValidatorIndex` subclasses `int` with no `__bool__`, `ValidatorIndex(0)` is falsy (verified: `ValidatorIndex(0) or 99 == 99`), so a `BlockSpec` that explicitly pins proposer **0** was silently discarded and replaced by the round-robin default — a silently-wrong block.

Replaced the truthiness fallback with an explicit `is not None` check. The field is typed `ValidatorIndex | None`, so this is exact.

Latent today (no current vector pins proposer 0 via `BlockSpec`); behavior fix. Vectors that never pin proposer 0 are byte-identical. Found in the packages/testing audit (TYPES-01).

Lint: `ruff check` + `ruff format` clean.