### PR TITLE
refactor(testing): share one workspace-root helper across the CLIs

### DIFF
--- a/packages/testing/src/consensus_testing/cli/__init__.py
+++ b/packages/testing/src/consensus_testing/cli/__init__.py
@@ -1,1 +1,14 @@
 """CLI tools for Ethereum test fixture generation."""
+
+from pathlib import Path
+
+
+def find_workspace_root() -> Path:
+    """Walk up from the current directory to the one whose pyproject declares the uv workspace."""
+    candidate = Path.cwd()
+    while candidate != candidate.parent:
+        pyproject = candidate / "pyproject.toml"
+        if pyproject.exists() and "[tool.uv.workspace]" in pyproject.read_text():
+            return candidate
+        candidate = candidate.parent
+    return Path.cwd()

--- a/packages/testing/src/consensus_testing/cli/apitest.py
+++ b/packages/testing/src/consensus_testing/cli/apitest.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import click
 import pytest
 
+from consensus_testing.cli import find_workspace_root
+
 
 @click.command(
     context_settings={
@@ -42,13 +44,7 @@ def apitest(
     config_path = Path(__file__).parent / "pytest_ini_files" / "pytest-apitest.ini"
 
     # The project root is the workspace pyproject.toml.
-    project_root = Path.cwd()
-    while project_root != project_root.parent:
-        if (project_root / "pyproject.toml").exists():
-            pyproject = project_root / "pyproject.toml"
-            if "[tool.uv.workspace]" in pyproject.read_text():
-                break
-        project_root = project_root.parent
+    project_root = find_workspace_root()
 
     args = [
         "-c",

--- a/packages/testing/src/consensus_testing/cli/fill.py
+++ b/packages/testing/src/consensus_testing/cli/fill.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import click
 
+from consensus_testing.cli import find_workspace_root
 from consensus_testing.keys import compute_key_set_digest, get_keys_directory
 from consensus_testing.keys_cli import PINNED_KEY_SET_DIGESTS, download_keys
 
@@ -95,13 +96,7 @@ def fill(
 
     config_path = Path(__file__).parent / "pytest_ini_files" / "pytest-fill.ini"
     # The project root is the workspace pyproject.toml.
-    project_root = Path.cwd()
-    while project_root != project_root.parent:
-        if (project_root / "pyproject.toml").exists():
-            pyproject = project_root / "pyproject.toml"
-            if "[tool.uv.workspace]" in pyproject.read_text():
-                break
-        project_root = project_root.parent
+    project_root = find_workspace_root()
 
     args = [
         "-c",


### PR DESCRIPTION
## Summary

The identical 7-line walk to locate the uv workspace root was copy-pasted byte-for-byte in `cli/fill.py` and `cli/apitest.py` and would drift. Extracted `find_workspace_root()` into `cli/__init__.py` (the natural shared home) and call it from both.

Behavior identical (returns the first ancestor whose pyproject declares the uv workspace, else cwd). CLI-only, no emitted vectors. Found in the packages/testing audit (INFRA-01).

Lint: `ruff check` + `ruff format` clean.