### PR TITLE
refactor(testing): use the shared hex codec in three fixtures

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/api_endpoint.py
@@ -4,6 +4,7 @@ from typing import Any, ClassVar
 
 from consensus_testing.genesis import build_anchor
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
+from consensus_testing.test_fixtures.hex_codec import to_hex
 from lean_spec.base import StrictBaseModel
 from lean_spec.node.metrics.registry import registry as metrics_registry
 from lean_spec.spec.forks import Slot
@@ -148,7 +149,7 @@ class ApiEndpointTest(BaseTestSpec):
                     content_type="application/json",
                     body={
                         "slot": int(store.latest_justified.slot),
-                        "root": "0x" + store.latest_justified.root.hex(),
+                        "root": to_hex(store.latest_justified.root),
                     },
                 )
 
@@ -158,7 +159,7 @@ class ApiEndpointTest(BaseTestSpec):
                 return EndpointResponseContract(
                     status_code=200,
                     content_type="application/octet-stream",
-                    body="0x" + finalized_state.encode_bytes().hex(),
+                    body=to_hex(finalized_state.encode_bytes()),
                 )
 
             case ("GET", "/lean/v0/fork_choice"):
@@ -168,9 +169,9 @@ class ApiEndpointTest(BaseTestSpec):
                 # Only post-finalization blocks are relevant to head selection.
                 nodes = [
                     {
-                        "root": "0x" + root.hex(),
+                        "root": to_hex(root),
                         "slot": int(block.slot),
-                        "parent_root": "0x" + block.parent_root.hex(),
+                        "parent_root": to_hex(block.parent_root),
                         "proposer_index": int(block.proposer_index),
                         "weight": weights.get(root, 0),
                     }
@@ -185,16 +186,16 @@ class ApiEndpointTest(BaseTestSpec):
                     content_type="application/json",
                     body={
                         "nodes": nodes,
-                        "head": "0x" + store.head.hex(),
+                        "head": to_hex(store.head),
                         "justified": {
                             "slot": int(store.latest_justified.slot),
-                            "root": "0x" + store.latest_justified.root.hex(),
+                            "root": to_hex(store.latest_justified.root),
                         },
                         "finalized": {
                             "slot": int(store.latest_finalized.slot),
-                            "root": "0x" + store.latest_finalized.root.hex(),
+                            "root": to_hex(store.latest_finalized.root),
                         },
-                        "safe_target": "0x" + store.safe_target.hex(),
+                        "safe_target": to_hex(store.safe_target),
                         "validator_count": len(head_state.validators),
                     },
                 )

--- a/packages/testing/src/consensus_testing/test_fixtures/reaggregation.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/reaggregation.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 
 from consensus_testing.keys import XmssKeyManager
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
+from consensus_testing.test_fixtures.hex_codec import to_hex
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import AggregationBits, Checkpoint, Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import (
@@ -198,17 +199,17 @@ class ReaggregationTest(BaseTestSpec):
         )
 
         return ReaggregationFixture(
-            block_proof="0x" + bytes(block_proof.proof.data).hex(),
+            block_proof=to_hex(bytes(block_proof.proof.data)),
             public_keys_per_message=[
-                ["0x" + public_key.encode_bytes().hex() for public_key in component_keys]
+                [to_hex(public_key.encode_bytes()) for public_key in component_keys]
                 for component_keys in public_keys_per_message
             ],
-            attestation_message="0x" + bytes(attestation_message).hex(),
+            attestation_message=to_hex(bytes(attestation_message)),
             attestation_slot=int(attestation_data.slot),
             block_attesters=[int(validator_index) for validator_index in self.block_attesters],
             local_attesters=[int(validator_index) for validator_index in self.local_attesters],
             combined_attesters=[
                 int(validator_index) for validator_index in combined_attester_indices
             ],
-            reaggregated_proof="0x" + bytes(reaggregated_proof.proof.data).hex(),
+            reaggregated_proof=to_hex(bytes(reaggregated_proof.proof.data)),
         )

--- a/packages/testing/src/consensus_testing/test_fixtures/sync.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/sync.py
@@ -4,6 +4,7 @@ from typing import ClassVar, Literal
 
 from consensus_testing.genesis import build_anchor
 from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
+from consensus_testing.test_fixtures.hex_codec import to_hex
 from lean_spec.base import StrictBaseModel
 from lean_spec.node.sync.checkpoint_sync import verify_checkpoint_state
 from lean_spec.spec.forks import Slot
@@ -55,7 +56,7 @@ class VerifyCheckpoint(StrictBaseModel):
         )
         return VerifyCheckpointOutput(
             valid=verify_checkpoint_state(state),
-            state_bytes="0x" + state.encode_bytes().hex(),
+            state_bytes=to_hex(state.encode_bytes()),
             validator_count=self.num_validators,
             anchor_slot=self.anchor_slot,
         )


### PR DESCRIPTION
## Summary

`reaggregation.py`, `sync.py`, and `api_endpoint.py` hand-rolled `"0x" + x.hex()` while sibling fixtures already import `to_hex` from the shared `hex_codec`. Replaced the 13 occurrences with `to_hex(...)`.

Pure structural refactor — `to_hex(data) == "0x" + data.hex()`, so emitted vectors are byte-identical. Found in the packages/testing audit (HEX-CODEC).

Lint: `ruff check` + `ruff format` clean.