### PR TITLE
refactor(testing): dispatch max-slot derivation with a match

### DIFF
--- a/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/fork_choice.py
@@ -94,12 +94,19 @@ class ForkChoiceTest(BaseTestSpec):
             return self.max_slot
 
         # XMSS signatures are slot-dependent, so keys must exist up to the highest signed slot.
-        slots_needing_keys = (
-            step.block.slot if isinstance(step, BlockStep) else step.attestation.slot
-            for step in self.steps
-            if isinstance(step, (BlockStep, AttestationStep, GossipAggregatedAttestationStep))
+        def slot_needing_keys(step: ForkChoiceStep) -> Slot | None:
+            match step:
+                case BlockStep():
+                    return step.block.slot
+                case AttestationStep() | GossipAggregatedAttestationStep():
+                    return step.attestation.slot
+                case _:
+                    return None
+
+        return max(
+            (slot for step in self.steps if (slot := slot_needing_keys(step)) is not None),
+            default=Slot(0),
         )
-        return max(slots_needing_keys, default=Slot(0))
 
     def generate(self) -> ForkChoiceFixture:
         """


### PR DESCRIPTION
## Summary

`_resolved_max_slot` filtered steps by `isinstance` and then re-tested the type in a ternary (a `BlockStep` was filtered in and re-checked; the two attestation types shared a branch hidden in the ternary's else). Replaced with a local `match` that tests each step type once and names the two attestation cases explicitly.

Pure structural refactor — `max` over the same multiset of slots. Found in the packages/testing audit (FIXTURES-04).

Lint: `ruff check` + `ruff format` clean.