### PR TITLE
refactor(testing): build keyed genesis validators by comprehension

### DIFF
--- a/packages/testing/src/consensus_testing/genesis.py
+++ b/packages/testing/src/consensus_testing/genesis.py
@@ -34,19 +34,18 @@ def build_genesis_state(
                 f"Not enough keys: need {num_validators} validators "
                 f"but the key manager has only {len(key_manager)} keys"
             )
-        validators = []
-        for validator_position in range(num_validators):
-            validator_index = ValidatorIndex(validator_position)
-            attestation_public_key, proposal_public_key = key_manager.get_public_keys(
-                validator_index
+        validators = [
+            Validator(
+                attestation_public_key=Bytes52(
+                    key_manager.get_public_keys(ValidatorIndex(validator_index))[0].encode_bytes()
+                ),
+                proposal_public_key=Bytes52(
+                    key_manager.get_public_keys(ValidatorIndex(validator_index))[1].encode_bytes()
+                ),
+                index=ValidatorIndex(validator_index),
             )
-            validators.append(
-                Validator(
-                    attestation_public_key=Bytes52(attestation_public_key.encode_bytes()),
-                    proposal_public_key=Bytes52(proposal_public_key.encode_bytes()),
-                    index=validator_index,
-                )
-            )
+            for validator_index in range(num_validators)
+        ]
     else:
         validators = [
             Validator(


### PR DESCRIPTION
## Summary

In `build_genesis_state`, the keyed branch built the validator list with an imperative append loop while the unkeyed branch used a comprehension. Converted the keyed branch to a comprehension that mirrors the unkeyed one, so a reader sees one shape. The key-count guard is preserved.

Pure structural refactor — same validators, same order, same keys; genesis state byte-identical. Found in the packages/testing audit (INFRA-02).

Lint: `ruff check` + `ruff format` clean.