### PR TITLE
refactor(testing): drop redundant pass in abstract fork name()

### DIFF
--- a/packages/testing/src/consensus_testing/forks/base.py
+++ b/packages/testing/src/consensus_testing/forks/base.py
@@ -22,4 +22,3 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     @abstractmethod
     def name(cls) -> str:
         """Fork name as it appears in the network field of generated fixtures."""
-        pass


### PR DESCRIPTION
## Summary

The abstract `BaseFork.name()` has a docstring followed by a redundant `pass`. The docstring is a complete method body, so the `pass` is dead filler. Removed it. Found in the packages/testing audit (INFRA-03).

Lint: `ruff check` + `ruff format` clean.