### PR TITLE
refactor(testing): open the fixture output file via Path.open

### DIFF
--- a/packages/testing/src/consensus_testing/pytest_plugins/filler.py
+++ b/packages/testing/src/consensus_testing/pytest_plugins/filler.py
@@ -97,7 +97,7 @@ class FixtureCollector:
                 test_id = f"{test_nodeid}[fork_{self.fork}-{fixture_format}]"
                 all_tests[test_id] = fixture.json_dict_with_info()
 
-            with open(output_file, "w") as output_handle:
+            with output_file.open("w") as output_handle:
                 json.dump(all_tests, output_handle, indent=4)
 
 


### PR DESCRIPTION
## Summary

`write_fixtures` used `open(output_file, "w")` where `output_file` is a `Path`; the rest of the plugin uses pathlib idioms. Switched to `output_file.open("w")`. Pure structural refactor. Found in the packages/testing audit (INFRA-09).

Lint: `ruff check` + `ruff format` clean.