### PR TITLE
test(validator): add validator sync-lag duty gate test vectors

### DIFF
--- a/packages/testing/src/consensus_testing/__init__.py
+++ b/packages/testing/src/consensus_testing/__init__.py
@@ -27,6 +27,9 @@ from consensus_testing.test_fixtures import (
     ClearFirstAttestationBits,
     CorruptProof,
     DropMessageBinding,
+    DutyGateDecision,
+    DutyGateInitialState,
+    DutyGateStep,
     ExpectedRejection,
     FixtureInfo,
     ForkChoiceFixture,
@@ -56,6 +59,8 @@ from consensus_testing.test_fixtures import (
     SwapParticipantPublicKey,
     SyncFixture,
     SyncTest,
+    ValidatorDutyGateFixture,
+    ValidatorDutyGateTest,
     VerifyMultiMessageProofsFixture,
     VerifyMultiMessageProofsTest,
     VerifySignaturesFixture,
@@ -147,6 +152,7 @@ JustifiabilityTestFiller = Callable[..., JustifiabilityFixture]
 PoseidonPermutationTestFiller = Callable[..., PoseidonPermutationFixture]
 SyncTestFiller = Callable[..., SyncFixture]
 ReaggregationTestFiller = Callable[..., ReaggregationFixture]
+ValidatorDutyGateTestFiller = Callable[..., ValidatorDutyGateFixture]
 
 __all__ = [
     "CachedMessage",
@@ -257,6 +263,11 @@ __all__ = [
     "PoseidonPermutationTest",
     "SyncFixture",
     "SyncTest",
+    "DutyGateInitialState",
+    "DutyGateStep",
+    "DutyGateDecision",
+    "ValidatorDutyGateFixture",
+    "ValidatorDutyGateTest",
     # Test types
     "BaseForkChoiceStep",
     "TickStep",
@@ -284,4 +295,5 @@ __all__ = [
     "PoseidonPermutationTestFiller",
     "SyncTestFiller",
     "ReaggregationTestFiller",
+    "ValidatorDutyGateTestFiller",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/__init__.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/__init__.py
@@ -74,6 +74,13 @@ from consensus_testing.test_fixtures.state_transition import (
     StateTransitionTest,
 )
 from consensus_testing.test_fixtures.sync import SyncFixture, SyncTest, VerifyCheckpoint
+from consensus_testing.test_fixtures.validator_duty_gate import (
+    DutyGateDecision,
+    DutyGateInitialState,
+    DutyGateStep,
+    ValidatorDutyGateFixture,
+    ValidatorDutyGateTest,
+)
 from consensus_testing.test_fixtures.verify_proofs import (
     DropMessageBinding,
     IncrementEmittedSlot,
@@ -108,6 +115,7 @@ FIXTURE_FORMATS: tuple[type[BaseTestSpec], ...] = (
     SSZTest,
     StateTransitionTest,
     SyncTest,
+    ValidatorDutyGateTest,
     VerifyMultiMessageProofsTest,
     VerifySignaturesTest,
     VerifySingleMessageProofsTest,
@@ -199,4 +207,9 @@ __all__ = [
     "PoseidonPermutationTest",
     "SyncFixture",
     "SyncTest",
+    "DutyGateInitialState",
+    "DutyGateStep",
+    "DutyGateDecision",
+    "ValidatorDutyGateFixture",
+    "ValidatorDutyGateTest",
 ]

--- a/packages/testing/src/consensus_testing/test_fixtures/validator_duty_gate.py
+++ b/packages/testing/src/consensus_testing/test_fixtures/validator_duty_gate.py
@@ -1,0 +1,177 @@
+"""Validator sync-lag duty gate test fixture."""
+
+from typing import ClassVar, Literal, Self
+
+from pydantic import model_validator
+
+from consensus_testing.genesis import build_genesis_store
+from consensus_testing.mocks import MockNetworkRequester
+from consensus_testing.test_fixtures.base import BaseConsensusFixture, BaseTestSpec
+from lean_spec.base import StrictBaseModel
+from lean_spec.node.chain.clock import SlotClock
+from lean_spec.node.sync.block_cache import BlockCache
+from lean_spec.node.sync.peer_manager import PeerManager
+from lean_spec.node.sync.service import SyncService
+from lean_spec.node.validator import ValidatorRegistry, ValidatorService
+from lean_spec.spec.crypto.merkleization import hash_tree_root
+from lean_spec.spec.forks import Slot
+from lean_spec.spec.forks.lstar.containers import Block
+from lean_spec.spec.ssz import Uint64
+
+
+def _set_head_slot(sync_service: SyncService, head_slot: Slot) -> None:
+    """Rewrite the head block so it sits at the requested slot."""
+    blocks = dict(sync_service.store.blocks)
+    old_head_block = blocks.pop(sync_service.store.head)
+    new_head_block = Block(
+        slot=head_slot,
+        proposer_index=old_head_block.proposer_index,
+        parent_root=old_head_block.parent_root,
+        state_root=old_head_block.state_root,
+        body=old_head_block.body,
+    )
+    new_head_root = hash_tree_root(new_head_block)
+    blocks[new_head_root] = new_head_block
+    sync_service.store = sync_service.store.model_copy(
+        update={"blocks": blocks, "head": new_head_root}
+    )
+
+
+def _add_block_at_slot(sync_service: SyncService, slot: Slot) -> None:
+    """Add a non-head block at the given slot as freshness evidence."""
+    template_block = next(iter(sync_service.store.blocks.values()))
+    new_block = Block(
+        slot=slot,
+        proposer_index=template_block.proposer_index,
+        parent_root=template_block.parent_root,
+        state_root=template_block.state_root,
+        body=template_block.body,
+    )
+    new_block_root = hash_tree_root(new_block)
+    sync_service.store = sync_service.store.model_copy(
+        update={"blocks": {**sync_service.store.blocks, new_block_root: new_block}}
+    )
+
+
+class DutyGateInitialState(StrictBaseModel):
+    """The store view the gate starts from, before any step runs."""
+
+    head_slot: int
+    """Slot of the local head block."""
+
+    max_seen_slot: int
+    """Highest slot across all locally stored blocks. Must be at or above head_slot."""
+
+    @model_validator(mode="after")
+    def validate_max_seen_at_or_above_head(self) -> Self:
+        """The freshest seen slot cannot sit below the local head."""
+        if self.max_seen_slot < self.head_slot:
+            raise ValueError(
+                f"max_seen_slot {self.max_seen_slot} is below head_slot {self.head_slot}"
+            )
+        return self
+
+
+class DutyGateStep(StrictBaseModel):
+    """One evaluation of the gate at a wall-clock slot, after an optional head move."""
+
+    wall_clock_slot: int
+    """Wall-clock slot the gate compares the local head against."""
+
+    set_head_slot: int | None = None
+    """When set, move the head to this slot before evaluating."""
+
+    duty: Literal["block", "attestation"]
+    """Duty kind passed to the gate. The gate logic is the same for both."""
+
+
+class DutyGateDecision(StrictBaseModel):
+    """The gate's verdict for one step, with the inputs it was computed from."""
+
+    allow: bool
+    """Whether duties run. False means the gate silenced the duty."""
+
+    head_slot: int
+    """Local head slot the gate saw for this step."""
+
+    lag: int
+    """Slots the head trails the wall clock, saturating at zero."""
+
+    max_seen_slot: int
+    """Highest stored block slot the gate saw for this step."""
+
+
+class ValidatorDutyGateFixture(BaseConsensusFixture):
+    """Emitted vector for the validator sync-lag duty gate."""
+
+    initial_state: DutyGateInitialState
+    """Store view the gate starts from."""
+
+    steps: list[DutyGateStep]
+    """Ordered gate evaluations, each carrying an optional head move."""
+
+    decisions: list[DutyGateDecision]
+    """Gate verdict per step, in step order."""
+
+
+class ValidatorDutyGateTest(BaseTestSpec):
+    """Spec for the validator sync-lag duty gate."""
+
+    format_name: ClassVar[str] = "validator_duty_gate_test"
+    description: ClassVar[str] = "Tests the validator sync-lag duty gate decision and hysteresis"
+
+    initial_state: DutyGateInitialState
+    """Store view the gate starts from."""
+
+    steps: list[DutyGateStep]
+    """Ordered gate evaluations to run against one service instance."""
+
+    def generate(self) -> ValidatorDutyGateFixture:
+        """Replay the steps through the gate and record each verdict."""
+        # Keyless genesis is enough since the gate only reads block slots and the head.
+        store = build_genesis_store(keyed=False)
+        sync_service = SyncService(
+            store=store,
+            peer_manager=PeerManager(),
+            block_cache=BlockCache(),
+            clock=SlotClock(genesis_time=Uint64(0)),
+            network=MockNetworkRequester(),
+        )
+        service = ValidatorService(
+            sync_service=sync_service,
+            clock=SlotClock(genesis_time=Uint64(0)),
+            registry=ValidatorRegistry(),
+        )
+
+        _set_head_slot(sync_service, Slot(self.initial_state.head_slot))
+        if self.initial_state.max_seen_slot > self.initial_state.head_slot:
+            _add_block_at_slot(sync_service, Slot(self.initial_state.max_seen_slot))
+
+        decisions: list[DutyGateDecision] = []
+        for step in self.steps:
+            if step.set_head_slot is not None:
+                _set_head_slot(sync_service, Slot(step.set_head_slot))
+
+            # Re-derive the gate's view to emit beside its verdict. The gate exposes
+            # only the boolean, so these must mirror _is_synced_for_duties.
+            head_slot = sync_service.store.blocks[sync_service.store.head].slot
+            max_seen_slot = max(block.slot for block in sync_service.store.blocks.values())
+            wall_clock_slot = Slot(step.wall_clock_slot)
+            lag = 0 if head_slot >= wall_clock_slot else int(wall_clock_slot - head_slot)
+
+            allow = service._is_synced_for_duties(wall_clock_slot, step.duty)
+
+            decisions.append(
+                DutyGateDecision(
+                    allow=allow,
+                    head_slot=int(head_slot),
+                    lag=lag,
+                    max_seen_slot=int(max_seen_slot),
+                )
+            )
+
+        return ValidatorDutyGateFixture(
+            initial_state=self.initial_state,
+            steps=self.steps,
+            decisions=decisions,
+        )

--- a/tests/consensus/lstar/validator/test_duty_gate.py
+++ b/tests/consensus/lstar/validator/test_duty_gate.py
@@ -1,0 +1,75 @@
+"""Validator: sync-lag duty gate decision and hysteresis."""
+
+import pytest
+
+from consensus_testing import (
+    DutyGateInitialState,
+    DutyGateStep,
+    ValidatorDutyGateTestFiller,
+)
+
+pytestmark = pytest.mark.valid_until("Lstar")
+
+
+def test_threshold_and_hysteresis(
+    validator_duty_gate_test: ValidatorDutyGateTestFiller,
+) -> None:
+    """
+    The open-gate threshold, the hysteresis band, and clock-skew saturation.
+
+    Given
+    -----
+    - the head starts at slot 10 with a fresh block at slot 20, so the network never looks stalled.
+
+    When
+    ----
+    - lag 4 is allowed, the upper edge of the open threshold.
+    - lag 5 closes the gate.
+    - lag 3 stays closed, holding below the threshold and pinning the band to 2 rather than 1.
+    - lag 2 reopens the gate.
+    - the head moves ahead of the wall clock, saturating lag to 0.
+
+    Then
+    ----
+    - the decisions are allow, skip, skip, allow, allow in order.
+    """
+    validator_duty_gate_test(
+        initial_state=DutyGateInitialState(head_slot=10, max_seen_slot=20),
+        steps=[
+            DutyGateStep(wall_clock_slot=14, duty="block"),
+            DutyGateStep(wall_clock_slot=15, duty="block"),
+            DutyGateStep(wall_clock_slot=15, set_head_slot=12, duty="block"),
+            DutyGateStep(wall_clock_slot=15, set_head_slot=13, duty="block"),
+            DutyGateStep(wall_clock_slot=15, set_head_slot=20, duty="block"),
+        ],
+    )
+
+
+def test_network_stall_escape(
+    validator_duty_gate_test: ValidatorDutyGateTestFiller,
+) -> None:
+    """
+    The network-stall escape, its strict boundary, and that it covers an open and a closed gate.
+
+    Given
+    -----
+    - the head is at slot 10 and the freshest block at slot 12, so network lag tracks the clock.
+
+    When
+    ----
+    - network lag 8 is not yet a stall, so the local lag closes the gate.
+    - network lag 9 escapes the stall and reopens the closed gate.
+    - network lag 10 keeps an already-open gate signing, here for an attestation duty.
+
+    Then
+    ----
+    - the decisions are skip, allow, allow in order.
+    """
+    validator_duty_gate_test(
+        initial_state=DutyGateInitialState(head_slot=10, max_seen_slot=12),
+        steps=[
+            DutyGateStep(wall_clock_slot=20, duty="block"),
+            DutyGateStep(wall_clock_slot=21, duty="block"),
+            DutyGateStep(wall_clock_slot=22, duty="attestation"),
+        ],
+    )

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -59,6 +59,7 @@ _.validate_state_length
 _.validate_target
 _.validate_rejection_is_declared
 _.validate_signatures_are_out_of_scope
+_.validate_max_seen_at_or_above_head
 _._yaml_int_to_hex
 _._check_list_lengths
 _._reject_oversized_validator_set


### PR DESCRIPTION
## 🗒️ Description

Introduces a new consensus fixture format for the validator sync-lag duty gate and lands the first vectors.

### `validator_duty_gate` format

- Replays a sequence of steps against `ValidatorService._is_synced_for_duties` and records the allow or skip verdict per step. The gate stays the source of truth, the fixture only records what it decides.
- Each step gives a wall-clock slot and an optional head move. The hysteresis flag carries across steps, so one vector can drive the gate both open and closed.

### Initial vectors (2)

Under `tests/consensus/lstar/validator/`, two step sequences cover the decision surface:

- **Threshold and hysteresis**: lag 4 allowed and lag 5 gated (open threshold), lag 3 staying closed while lag 2 reopens (hysteresis band pinned to 2), and a head ahead of the wall clock saturating lag to 0.
- **Network-stall escape**: net-lag 8 still gates while net-lag 9 escapes (strict boundary), the escape reopening a closed gate and keeping an open one signing, for both block and attestation duties.

The missing-head fallback and run-loop wiring are left out as client-internal behavior, covered by each client's own unit tests.

## 🔗 Related Issues or PRs

Mirrors the validator sync-lag duty gate introduced in #708.

## ✅ Checklist

- [x] Ran local quality checks to avoid unnecessary CI fails:
    ```console
    just check
    ```
- [x] Considered adding appropriate tests for the changes.
- [x] N/A for docs, test-vector and fixture-format-only PR, the format is documented inline.
