### PR TITLE
feat(validator): source votes from the head chain's justified checkpoint

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -62,14 +62,22 @@ class AttestationCheck(CamelModel):
     source_slot: Slot | None = None
     """Expected source checkpoint slot."""
 
+    source_root_label: str | None = None
+    """Expected source checkpoint root, named by label and resolved to a root."""
+
     target_slot: Slot | None = None
     """Expected target checkpoint slot."""
 
-    location: Literal["new", "known"]
-    """Which pool the attestation should sit in, the pending or the accepted pool."""
+    location: Literal["new", "known", "signatures"]
+    """Which pool the attestation should sit in: the pending pool, the accepted pool, or the raw
+    per-validator signature pool."""
 
     def validate_attestation(
-        self, attestation: AttestationData, location: str, step_index: int
+        self,
+        attestation: AttestationData,
+        location: str,
+        step_index: int,
+        expected_source_root: Bytes32 | None = None,
     ) -> None:
         """Validate attestation properties."""
         for field_name in self.model_fields_set & _ATTESTATION_SLOT_ACCESSORS.keys():
@@ -80,6 +88,13 @@ class AttestationCheck(CamelModel):
                     f"Step {step_index}: validator {self.validator} {location} "
                     f"{field_name} = {actual_slot}, expected {expected_slot}"
                 )
+
+        if expected_source_root is not None and attestation.source.root != expected_source_root:
+            raise AssertionError(
+                f"Step {step_index}: validator {self.validator} {location} "
+                f"source root = 0x{attestation.source.root.hex()}, "
+                f"expected 0x{expected_source_root.hex()}"
+            )
 
 
 class StoreChecks(SelectiveCheck):
@@ -293,32 +308,53 @@ class StoreChecks(SelectiveCheck):
         if "attestation_checks" in fields:
             assert self.attestation_checks is not None
             for attestation_check in self.attestation_checks:
-                if attestation_check.location == "new":
-                    payloads = store.latest_new_aggregated_payloads
-                    label = "in latest_new"
-                else:
-                    payloads = store.latest_known_aggregated_payloads
-                    label = "in latest_known"
-
-                # Map each validator to its highest-slot vote across the raw pool.
+                # Map each validator to its highest-slot vote in the named pool.
                 #
                 # The checker inspects pool content before pruning, so no finality cutoff applies.
                 # On equal slots the first vote seen wins, matching the fork-choice rule.
                 extracted_attestations: dict[ValidatorIndex, AttestationData] = {}
-                for attestation_data, proofs in payloads.items():
-                    for proof in proofs:
-                        for participant_index in proof.participants.to_validator_indices():
-                            previous_vote = extracted_attestations.get(participant_index)
+                if attestation_check.location == "signatures":
+                    # The raw signature pool groups one entry per validator under each vote.
+                    label = "in attestation_signatures"
+                    for attestation_data, entries in store.attestation_signatures.items():
+                        for signature_entry in entries:
+                            voter_index = signature_entry.validator_index
+                            previous_vote = extracted_attestations.get(voter_index)
                             if previous_vote is None or previous_vote.slot < attestation_data.slot:
-                                extracted_attestations[participant_index] = attestation_data
+                                extracted_attestations[voter_index] = attestation_data
+                else:
+                    # The aggregated pools group proofs covering many validators under each vote.
+                    if attestation_check.location == "new":
+                        payloads = store.latest_new_aggregated_payloads
+                        label = "in latest_new"
+                    else:
+                        payloads = store.latest_known_aggregated_payloads
+                        label = "in latest_known"
+                    for attestation_data, proofs in payloads.items():
+                        for proof in proofs:
+                            for participant_index in proof.participants.to_validator_indices():
+                                previous_vote = extracted_attestations.get(participant_index)
+                                if (
+                                    previous_vote is None
+                                    or previous_vote.slot < attestation_data.slot
+                                ):
+                                    extracted_attestations[participant_index] = attestation_data
 
                 if attestation_check.validator not in extracted_attestations:
                     raise AssertionError(
                         f"Step {step_index}: validator {attestation_check.validator} not found "
-                        f"{label}_aggregated_payloads"
+                        f"{label}"
                     )
+                expected_source_root = (
+                    _resolve(attestation_check.source_root_label)
+                    if attestation_check.source_root_label is not None
+                    else None
+                )
                 attestation_check.validate_attestation(
-                    extracted_attestations[attestation_check.validator], label, step_index
+                    extracted_attestations[attestation_check.validator],
+                    label,
+                    step_index,
+                    expected_source_root,
                 )
 
         # Target slots keyed in each attestation pool

--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -326,10 +326,10 @@ class StoreChecks(SelectiveCheck):
                     # The aggregated pools group proofs covering many validators under each vote.
                     if attestation_check.location == "new":
                         payloads = store.latest_new_aggregated_payloads
-                        label = "in latest_new"
+                        label = "in latest_new_aggregated_payloads"
                     else:
                         payloads = store.latest_known_aggregated_payloads
-                        label = "in latest_known"
+                        label = "in latest_known_aggregated_payloads"
                     for attestation_data, proofs in payloads.items():
                         for proof in proofs:
                             for participant_index in proof.participants.to_validator_indices():

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -15,7 +15,7 @@ from lean_spec.spec.forks.lstar.containers import (
     ValidatorIndex,
 )
 from lean_spec.spec.forks.lstar.errors import RejectionReason, SpecRejectionError
-from lean_spec.spec.ssz import Uint64
+from lean_spec.spec.ssz import Bytes32, Uint64
 
 
 class ValidatorDutiesMixin(LstarSpecBase):
@@ -83,11 +83,20 @@ class ValidatorDutiesMixin(LstarSpecBase):
 
         target_checkpoint = self.get_attestation_target(store)
 
+        # Source the vote from the head chain's own justified checkpoint.
+        # The store can advance its justified from a minority fork the head never extended.
+        # Voting with the head's justified keeps the source on the chain the vote extends.
+        justified_source = store.states[store.head].latest_justified
+
+        # Replace the placeholder genesis root with the real one.
+        if justified_source.root == Bytes32.zero():
+            justified_source = Checkpoint(root=store.head, slot=justified_source.slot)
+
         return self.attestation_data_class(
             slot=slot,
             head=head_checkpoint,
             target=target_checkpoint,
-            source=store.latest_justified,
+            source=justified_source,
         )
 
     def produce_block_with_signatures(

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -92,7 +92,7 @@ class ValidatorDutiesMixin(LstarSpecBase):
         if justified_source.root == Bytes32.zero():
             justified_source = Checkpoint(root=store.head, slot=justified_source.slot)
 
-        # Sanity check: the source must be after target.
+        # Sanity check: the source must be before the target.
         assert justified_source.slot <= target_checkpoint.slot
 
         return self.attestation_data_class(

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -92,6 +92,9 @@ class ValidatorDutiesMixin(LstarSpecBase):
         if justified_source.root == Bytes32.zero():
             justified_source = Checkpoint(root=store.head, slot=justified_source.slot)
 
+        # Sanity check: the source must be after target.
+        assert justified_source.slot <= target_checkpoint.slot
+
         return self.attestation_data_class(
             slot=slot,
             head=head_checkpoint,

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -92,7 +92,7 @@ class ValidatorDutiesMixin(LstarSpecBase):
         if justified_source.root == Bytes32.zero():
             justified_source = Checkpoint(root=store.head, slot=justified_source.slot)
 
-        # Sanity check: the source must be before the target.
+        # Sanity check: the source must be older or equal to the target.
         assert justified_source.slot <= target_checkpoint.slot
 
         return self.attestation_data_class(

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -75,7 +75,7 @@ class ValidatorDutiesMixin(LstarSpecBase):
         return Checkpoint(root=target_block_root, slot=target_block.slot)
 
     def produce_attestation_data(self, store: LstarStore, slot: Slot) -> AttestationData:
-        """Attestation data for the given slot: head, target, and the latest justified source."""
+        """Attestation data for the given slot: head, target, and the head's justified source."""
         head_checkpoint = Checkpoint(
             root=store.head,
             slot=store.blocks[store.head].slot,

--- a/tests/consensus/lstar/fork_choice/test_attestation_source_divergence.py
+++ b/tests/consensus/lstar/fork_choice/test_attestation_source_divergence.py
@@ -5,9 +5,12 @@ import pytest
 from consensus_testing import (
     AggregatedAttestationCheck,
     AggregatedAttestationSpec,
+    AttestationCheck,
+    AttestationStep,
     BlockSpec,
     BlockStep,
     ForkChoiceTestFiller,
+    GossipAttestationSpec,
     StoreChecks,
 )
 from lean_spec.spec.forks import Slot, ValidatorIndex
@@ -112,6 +115,112 @@ def test_justified_divergence_self_heals_in_next_block(
                         AggregatedAttestationCheck(
                             participants={0},
                             target_slot=Slot(2),
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
+def test_honest_vote_sources_from_head_chain_not_store(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    An honest vote sources from the head chain's justified, not the store's.
+
+    Given
+    -----
+    - 4 validators; a slot needs 3 votes (2/3) to be justified.
+    - the chain:
+        genesis
+        - common(1)
+          - block_2(2) -> block_3(3)
+          - fork_4(4)
+    - block_3 includes V0's vote for block_2.
+    - fork_4 includes V1, V2, V3's votes for common.
+    - fork_4 reaches 3 votes, so it justifies slot 1.
+    - block_3 has only 1 vote, so it justifies nothing.
+    - the views diverge: store = common (slot 1), block_3 state = genesis (slot 0).
+    - head stays on block_3.
+
+    When
+    ----
+    - V0 gossips an honest vote at slot 4, produced from attestation duties on the block_3 head.
+
+    Then
+    ----
+    - the vote sits in the raw signature pool.
+    - its head is block_3 (slot 3), the current head.
+    - its source is genesis (slot 0), the head chain's own justified.
+    - its source is not common (slot 1), the store's justified.
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="common"),
+                checks=StoreChecks(head_slot=Slot(1)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), parent_label="common", label="block_2"),
+                checks=StoreChecks(head_slot=Slot(2)),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(3),
+                    parent_label="block_2",
+                    label="block_3",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[ValidatorIndex(0)],
+                            slot=Slot(2),
+                            target_slot=Slot(2),
+                            target_root_label="block_2",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(head_slot=Slot(3)),
+            ),
+            BlockStep(
+                block=BlockSpec(
+                    slot=Slot(4),
+                    parent_label="common",
+                    label="fork_4",
+                    attestations=[
+                        AggregatedAttestationSpec(
+                            validator_indices=[
+                                ValidatorIndex(1),
+                                ValidatorIndex(2),
+                                ValidatorIndex(3),
+                            ],
+                            slot=Slot(1),
+                            target_slot=Slot(1),
+                            target_root_label="common",
+                        ),
+                    ],
+                ),
+                checks=StoreChecks(
+                    head_slot=Slot(3),
+                    head_root_label="block_3",
+                    latest_justified_slot=Slot(1),
+                    latest_justified_root_label="common",
+                ),
+            ),
+            AttestationStep(
+                attestation=GossipAttestationSpec(
+                    validator_index=ValidatorIndex(0),
+                    slot=Slot(4),
+                    target_slot=Slot(3),
+                ),
+                is_aggregator=True,
+                checks=StoreChecks(
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(0),
+                            location="signatures",
+                            head_slot=Slot(3),
+                            source_slot=Slot(0),
+                            source_root_label="genesis",
                         ),
                     ],
                 ),

--- a/tests/node/validator/test_service.py
+++ b/tests/node/validator/test_service.py
@@ -937,7 +937,7 @@ class TestValidatorServiceIntegration:
         The attestation must reference:
         - head: the current chain head
         - target: the attestation target based on forkchoice
-        - source: the latest justified checkpoint
+        - source: the head chain's justified checkpoint
         """
         attestations_produced: list[SignedAttestation] = []
 
@@ -955,7 +955,9 @@ class TestValidatorServiceIntegration:
 
         store = real_sync_service.store
         expected_head_root = store.head
-        expected_source = store.latest_justified
+        # The head is the genesis anchor, whose state carries the zero-root justified placeholder.
+        # The produced source normalizes that placeholder to the real genesis root.
+        expected_source = Checkpoint(root=store.head, slot=Slot(0))
 
         for signed_attestation in attestations_produced:
             attestation_data = signed_attestation.data


### PR DESCRIPTION
## What

Change the attestation vote source in `produce_attestation_data` from the store's latest justified (`store.latest_justified`) to the latest justified on the **current head's state** (`store.states[store.head].latest_justified`).

## Why

A validator's vote source should name the justified checkpoint on the chain its vote extends, not the store's global view.

The store can advance its justified checkpoint from a minority fork that the head never extended (see `test_attestation_source_divergence.py`). When that happens the store's justified and the head chain's justified diverge, and sourcing from the store would place the vote's source off what the head chain actually justified.

```
            genesis
              |
            common(1)
            /        \
      block_2(2)     fork_4(4)   <- justifies common (slot 1): 3/4 votes
          |
      block_3(3)                 <- head; its state justifies nothing (slot 0)

store.latest_justified        = common (slot 1)   <- advanced by the fork_4 minority branch
head_state.latest_justified   = genesis (slot 0)  <- what the head chain actually justified
```

After this change a vote produced on `block_3` sources from slot 0 (the head chain), not slot 1 (the store).

## The liveness failure this prevents

`store.latest_justified` is always an ancestor of the head, but a minority fork can push it to a **higher slot** than the head chain's own state has justified. If the current canonical chain advances finalization while not justifying the `latest_justified` or beyond, the STF rules make it skip the repackaged attestations from the fork. While that happens, validators keep voting with the fork's `latest_justified` as source, making useless votes, and the justification divergence is never closed. Step by step:

```
genesis(0) - c1(1) - c2(2) - ... - c8(8) - c9(9) - c10(10) - c11(12)  canonical head chain (head = c11)
                                            |
                                           k10(11)          minority fork off c9
```

1. **The chain advances.** Blocks c1..c9 are built without justifying or finalizing anything.
2. **The chain forks.** Block k10 is proposed, with votes that justify slot 9 (c9), but keep the majority of head weight on the canonical chain.
3. **The canonical chain finalizes, but its justification stays behind the fork.** Earlier, correctly-sourced votes let the canonical chain finalize slot 1 (c1) and justify slot 2 (c2). Its justified slot (2) never climbs ahead of the slot the fork justified (9).
4. **Attestations from the fork can't be repackaged.** Since finalization advanced in the canonical chain, attestations from the fork are invalid and skipped in the STF. Slot 9 is unjustifiable when viewed from the canonical chain: [a delta of 8 is unjustifiable](https://github.com/lambdaclass/ethlambda/blob/main/docs/3sf_mini.md#the-justifiability-schedule).
5. **The chain is stuck.** Under the old rule every new vote sources from `store.latest_justified` = slot 9. To justify any checkpoint, the canonical chain needs votes whose source is slot 2, so those slot-9-sourced votes are skipped in the STF. Because of this, the chain stops including votes, which causes block production to stop due to the justification divergence being unclosable

Sourcing from the head state's justified breaks the stall: every vote anchors on a slot the canonical chain itself has justified (slot 2 here), so new votes to close the divergence are eventually included.

## Genesis handling

The raw genesis state holds a **zero-root placeholder** for its justified checkpoint; the state transition rebases that to the real genesis root on the first block. A vote cast directly on the genesis head normalizes the placeholder the same way, so the source always names a real block (otherwise `validate_attestation` would reject it with `UNKNOWN_SOURCE_BLOCK`).

## Testing

- All 84 affected node unit tests pass.
- All 542 consensus test vectors pass and are byte-identical across hash seeds.
- `just check` passes (lint, format, typecheck, spell, mdformat).
