### PR TITLE
ci: supersede in-progress runs on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

The concurrency group in `ci.yml` and `docker.yml` fell back to `github.run_id` when `github.head_ref` was empty — which is the case for **every push to main**:

```yaml
group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
```

`run_id` is unique per run, so no two main runs ever shared a group and `cancel-in-progress` never fired on main. A burst of merges (observed: four commits within ~47s) stacked CI and Docker runs that all ran to completion, saturating the shared runner pool — especially the small macOS pool — and pushing wall-clock into the hours through queue contention. In one run, jobs sat queued ~81 min before starting, even though the actual work was ~10 min.

## Fix

Fall back to `github.ref` instead, so every push to a branch shares one concurrency group and the newer run supersedes the older one:

```yaml
group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
```

Pull requests are unchanged: `head_ref` is still set there and keys the group by source branch, so per-PR superseding works exactly as before.

## Trade-off

An in-progress run on main is now cancelled by the next merge. That is intended — only the latest state of main needs full CI — but it means intermediate commits between rapid merges won't get a complete green run.