### PR TITLE
simplify block building

### DIFF
--- a/src/lean_spec/spec/forks/lstar/block_production.py
+++ b/src/lean_spec/spec/forks/lstar/block_production.py
@@ -148,6 +148,10 @@ class BlockProductionMixin(LstarSpecBase):
                     if attestation_data.head.root not in known_block_roots:
                         continue
 
+                    # Skip votes whose source slot is not the current justified checkpoint.
+                    if attestation_data.source.slot != current_justified_checkpoint.slot:
+                        continue
+
                     # Reject votes that do not match this chain.
                     #
                     # This also rejects any checkpoint past the chain view.

--- a/src/lean_spec/spec/forks/lstar/validator_duties.py
+++ b/src/lean_spec/spec/forks/lstar/validator_duties.py
@@ -170,23 +170,6 @@ class ValidatorDutiesMixin(LstarSpecBase):
             aggregated_payloads=store.latest_known_aggregated_payloads,
         )
 
-        # Invariant: the produced block must close any justified divergence.
-        #
-        # The store may have advanced its justified checkpoint from attestations
-        # on a minority fork that the head state never processed. The fixed-point
-        # loop above must incorporate those attestations from the pool, advancing
-        # the block's justified checkpoint to at least match the store.
-        #
-        # Without this, other nodes processing the block would never see the
-        # justification advance, degrading consensus liveness: only nodes that
-        # happened to receive the minority fork would know justification moved.
-        block_justified = final_post_state.latest_justified.slot
-        store_justified = store.latest_justified.slot
-        assert block_justified >= store_justified, (
-            f"Produced block justified={block_justified} < store justified="
-            f"{store_justified}. Fixed-point attestation loop did not converge."
-        )
-
         # Compute block hash for storage.
         block_hash = hash_tree_root(final_block)
 


### PR DESCRIPTION
## 🗒️ Description
- Removes assertion in block building as #1166  with voting only happening on the state justified it should not lead to a situation where store justified has moved forward - https://github.com/leanEthereum/leanSpec/pull/1166#pullrequestreview-4562249808
- ~Prefers attestations that have higher target slot, we should prioritize latest votes over stale votes~ nvm it is a block optimization and will need vote counting as well which will complicate the spec
- Block building can be simplified to include attestations only with source as current justified, reverts #716   

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Closes #123). Default is N/A. -->

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] Ran local quality checks to avoid unnecessary CI fails:
    ```console
    just check
    ```
- [ ] Considered adding appropriate tests for the changes.
- [ ] Considered updating the online docs in the [./docs/](/leanEthereum/leanSpec/tree/main/docs/) directory.
