### PR TITLE
fix(ssz): reject zero first offset in variable-size list decoder

### DIFF
--- a/src/lean_spec/spec/ssz/collections.py
+++ b/src/lean_spec/spec/ssz/collections.py
@@ -599,7 +599,13 @@ class SSZList[T: SSZType](_SSZSequence[T]):
                 f"{cls.__name__}: scope {scope} too small for variable-size list"
             )
         first_offset = int(Uint32.deserialize(stream, BYTES_PER_LENGTH_OFFSET))
-        if first_offset > scope or first_offset % BYTES_PER_LENGTH_OFFSET != 0:
+        # A non-empty variable-size list carries at least one offset word before any body.
+        # A zero first offset is contradictory: it means zero elements yet one full-scope element.
+        if (
+            first_offset < BYTES_PER_LENGTH_OFFSET
+            or first_offset > scope
+            or first_offset % BYTES_PER_LENGTH_OFFSET != 0
+        ):
             raise SSZSerializationError(f"{cls.__name__}: invalid offset {first_offset}")
         num_elements = first_offset // BYTES_PER_LENGTH_OFFSET
         if num_elements > cls.LIMIT:

--- a/tests/spec/ssz/test_collections.py
+++ b/tests/spec/ssz/test_collections.py
@@ -850,6 +850,12 @@ class TestSSZListSerialization:
             VariableContainerList2.decode_bytes(b"\x05\x00\x00\x00\x00\x00\x00\x00")
         assert str(exception_info.value) == "VariableContainerList2: invalid offset 5"
 
+    def test_variable_size_list_rejects_zero_first_offset(self) -> None:
+        """A zero first offset is contradictory and rejected before building the boundary list."""
+        with pytest.raises(SSZSerializationError) as exception_info:
+            VariableContainerList2.decode_bytes(bytes.fromhex("00000000aabbccdd"))
+        assert str(exception_info.value) == "VariableContainerList2: invalid offset 0"
+
     def test_variable_size_list_rejects_count_beyond_limit(self) -> None:
         """A first offset that implies more than LIMIT elements is rejected."""
         # Layout:


### PR DESCRIPTION
## What

The `SSZList` variable-size decoder now rejects a first offset below one offset word (four bytes), which closes the `first_offset == 0` gap reported in #1175.

## The bug

The decoder validated that the first offset was in range (`first_offset > scope`) and aligned (`first_offset % 4 != 0`), but never that it was at least one offset word wide. A first offset of zero slipped through both checks: zero is a multiple of four, and it is below any positive scope.

That value is contradictory:

```
num_elements   = first_offset // 4      = 0            "the list is empty"
boundary list  = [first_offset, scope]  = [0, scope]   one span (0, scope) -> one element
```

The count says zero while the boundary says one. The decoder then tries to parse an element spanning the whole scope while believing the count is zero. Today the input does fail — but only by accident, through a per-element short read deeper in the stack, not because the malformed offset was rejected.

For a wire format that must decode identically byte-for-byte across clients, this must fail closed by construction. consensus-specs lists a first offset with a mismatching minimum element size as something a decoder MUST harden against.

## The fix

Fold a lower-bound clause into the existing offset check so a first offset below one offset word — zero included — is rejected before the boundary list is built:

```python
if (
    first_offset < BYTES_PER_LENGTH_OFFSET
    or first_offset > scope
    or first_offset % BYTES_PER_LENGTH_OFFSET != 0
):
    raise SSZSerializationError(f"{cls.__name__}: invalid offset {first_offset}")
```

This mirrors the vector decoder in the same module, which already requires its first offset to equal the fixed-part width, and the container decoder, which requires its first offset to equal the fixed-part end.

## Test

Added a regression test that decodes the exact payload from the issue (`00000000aabbccdd`) and asserts the complete error message with string equality, so the message cannot drift unnoticed.

## Credit

Found via the Lean 4 formalization of this spec ([NyxFoundation/formal-leanSpec](https://github.com/NyxFoundation/formal-leanSpec)), examining the decode direction of SSZ round-tripping.

Closes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)