### PR TITLE
fix(lstar): separate protocol rejections from internal assertions

### DIFF
--- a/src/lean_spec/node/validator/service.py
+++ b/src/lean_spec/node/validator/service.py
@@ -26,6 +26,7 @@ from lean_spec.spec.forks import (
     SignedAttestation,
     SignedBlock,
     Slot,
+    SpecRejectionError,
     ValidatorIndex,
 )
 from lean_spec.spec.forks.lstar.containers import MultiMessageAggregate, SingleMessageAggregate
@@ -209,8 +210,8 @@ class ValidatorService:
             if self.on_block is not None:
                 await self.on_block(signed_block)
 
-        except AssertionError as exception:
-            # Slot-boundary races can fail proposer validation.
+        except SpecRejectionError as exception:
+            # Slot-boundary races can fail proposer validation with a rejection.
             # Skip block production; the attestation at interval 1 still happens.
             logger.debug(
                 "Block production skipped for validator %d at slot %d: %s",

--- a/src/lean_spec/spec/forks/lstar/errors.py
+++ b/src/lean_spec/spec/forks/lstar/errors.py
@@ -111,11 +111,15 @@ class RejectionReason(StrEnum):
     """The input bytes cannot be decoded into the expected structure."""
 
 
-class SpecRejectionError(AssertionError):
+class SpecError(Exception):
+    """Base class for every error the spec raises."""
+
+
+class SpecRejectionError(SpecError):
     """
     A rejection carrying its language-neutral reason.
 
-    Subclassing the assertion error keeps existing rejection handlers working.
+    Clients match on the reason code, not the Python base class.
     """
 
     def __init__(self, reason: RejectionReason, message: str) -> None:
@@ -123,7 +127,7 @@ class SpecRejectionError(AssertionError):
         Bind the rejection to its reason.
 
         Args:
-            reason: Language-neutral reason clients assert against.
+            reason: Language-neutral reason clients match against.
             message: Human-readable explanation for logs and debugging.
         """
         super().__init__(message)

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -100,6 +100,8 @@ class ForkChoiceMixin(LstarSpecBase):
             SpecRejectionError: ANCHOR_STATE_ROOT_MISMATCH if the anchor block's
                 state root does not match the hash of the state.
         """
+        # Internal type guards: the anchor is always the concrete fork state and block.
+        # These narrow the generic protocol types; they are never a client rejection path.
         assert isinstance(state, State)
         assert isinstance(anchor_block, Block)
 

--- a/src/lean_spec/spec/forks/lstar/state_transition.py
+++ b/src/lean_spec/spec/forks/lstar/state_transition.py
@@ -337,7 +337,8 @@ class StateTransitionMixin(LstarSpecBase):
                 if target.slot > latest_justified.slot:
                     latest_justified = target
 
-                # The justifiable filter above guarantees an in-range index.
+                # Invariant: the already-justified skip drops targets at or below finalized.
+                # So the index is in range; the assert guards an internal fact, not a rejection.
                 justified_index = target.slot.justified_index_after(finalized_slot)
                 assert justified_index is not None
 
@@ -365,13 +366,12 @@ class StateTransitionMixin(LstarSpecBase):
                     delta = int(finalized_slot - old_finalized_slot)
                     if delta > 0:
                         justified_slots = JustifiedSlots(data=justified_slots.data[delta:])
-                        assert all(root in root_to_slot for root in justifications), (
-                            "Justification root missing from root_to_slot"
-                        )
+                        # A root absent from the slot map is off-chain and cannot justify.
+                        # Drop such a tally, do not track or reject it.
                         justifications = {
                             root: votes
                             for root, votes in justifications.items()
-                            if root_to_slot[root] > finalized_slot
+                            if root in root_to_slot and root_to_slot[root] > finalized_slot
                         }
 
         # Re-pack the vote map into the flat SSZ layout, roots first.

--- a/tests/consensus/lstar/state_transition/test_finalization.py
+++ b/tests/consensus/lstar/state_transition/test_finalization.py
@@ -12,12 +12,16 @@ from consensus_testing import (
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.forks import Slot, ValidatorIndex
 from lean_spec.spec.forks.lstar.containers import (
+    BlockHeader,
+    Checkpoint,
+    HistoricalBlockHashes,
     JustificationRoots,
     JustificationValidators,
     JustifiedSlots,
+    State,
 )
 from lean_spec.spec.forks.lstar.spec import LstarSpec
-from lean_spec.spec.ssz import Boolean
+from lean_spec.spec.ssz import Boolean, Bytes32, Uint64
 
 pytestmark = pytest.mark.valid_until("Lstar")
 
@@ -1372,5 +1376,102 @@ def test_rebased_finalization_prunes_stale_votes_and_preserves_future_votes(
                     Boolean(False),
                 ]
             ),
+        ),
+    )
+
+
+def test_finalization_rebase_drops_off_chain_pending_tally(
+    state_transition_test: StateTransitionTestFiller,
+) -> None:
+    """
+    Finalization drops a pending tally whose root is off the canonical chain.
+
+    Given
+    -----
+    - 4 validators; a slot needs 3 votes (2/3) to be justified.
+    - a hand-built pre-state at slot 3 over the chain:
+        genesis(0) -> block_1(1) -> block_2(2) -> block_3(3)
+    - slot 1 is justified, rooted at block_1.
+    - finalized is slot 0, rooted at the genesis anchor.
+    - a phantom root carries a pending tally.
+    - the phantom root appears nowhere in the chain history.
+    - the phantom tally holds V0 alone of 4.
+    - block_4 carries V0, V1, V2's vote from block_1 to block_2.
+
+    When
+    ----
+    - the chain processes block_4 on top of the pre-state.
+
+    Then
+    ----
+    - the state slot is 4.
+    - block_4's supermajority justifies slot 2.
+    - justified slot is 2, rooted at block_2.
+    - the adjacent source slot 1 finalizes.
+    - finalized slot is 1, rooted at block_1.
+    - the justified-slots bitfield is [True, False] relative to slot 1.
+    - the off-chain phantom root is dropped from the pending roots.
+    - the phantom tally is dropped from the pending voters.
+    """
+    genesis = build_genesis_state()
+
+    genesis_anchor_root = Bytes32(b"\x11" * 32)
+    block_1_root = Bytes32(b"\x22" * 32)
+    block_2_root = Bytes32(b"\x33" * 32)
+    phantom_justification_root = Bytes32(b"\xff" * 32)
+
+    pre = State(
+        config=genesis.config,
+        slot=Slot(3),
+        latest_block_header=BlockHeader(
+            slot=Slot(3),
+            proposer_index=ValidatorIndex.proposer_for_slot(Slot(3), Uint64(4)),
+            parent_root=block_2_root,
+            state_root=Bytes32.zero(),
+            body_root=genesis.latest_block_header.body_root,
+        ),
+        latest_justified=Checkpoint(root=block_1_root, slot=Slot(1)),
+        latest_finalized=Checkpoint(root=genesis_anchor_root, slot=Slot(0)),
+        historical_block_hashes=HistoricalBlockHashes(
+            data=[genesis_anchor_root, block_1_root, block_2_root]
+        ),
+        justified_slots=JustifiedSlots(data=[Boolean(True), Boolean(False)]),
+        validators=genesis.validators,
+        justifications_roots=JustificationRoots(data=[phantom_justification_root]),
+        justifications_validators=JustificationValidators(
+            data=[Boolean(True), Boolean(False), Boolean(False), Boolean(False)]
+        ),
+    )
+
+    state_transition_test(
+        pre=pre,
+        blocks=[
+            BlockSpec(
+                slot=Slot(4),
+                forced_attestations=[
+                    AggregatedAttestationSpec(
+                        validator_indices=[
+                            ValidatorIndex(0),
+                            ValidatorIndex(1),
+                            ValidatorIndex(2),
+                        ],
+                        slot=Slot(4),
+                        source_slot=Slot(1),
+                        source_root=block_1_root,
+                        target_slot=Slot(2),
+                        target_root=block_2_root,
+                    ),
+                ],
+            ),
+        ],
+        post=StateExpectation(
+            slot=Slot(4),
+            latest_justified_slot=Slot(2),
+            latest_justified_root=block_2_root,
+            latest_finalized_slot=Slot(1),
+            latest_finalized_root=block_1_root,
+            justified_slots=JustifiedSlots(data=[Boolean(True), Boolean(False)]),
+            justifications_roots=JustificationRoots(data=[]),
+            justifications_validators=JustificationValidators(data=[]),
         ),
     )

--- a/tests/node/validator/test_service.py
+++ b/tests/node/validator/test_service.py
@@ -22,7 +22,7 @@ from lean_spec.node.validator.constants import SYNC_LAG_THRESHOLD
 from lean_spec.node.validator.registry import ValidatorEntry
 from lean_spec.spec.crypto.merkleization import hash_tree_root
 from lean_spec.spec.crypto.xmss import TARGET_SIGNATURE_SCHEME
-from lean_spec.spec.forks import Slot, ValidatorIndex
+from lean_spec.spec.forks import RejectionReason, Slot, SpecRejectionError, ValidatorIndex
 from lean_spec.spec.forks.lstar import Store
 from lean_spec.spec.forks.lstar.config import MILLISECONDS_PER_INTERVAL
 from lean_spec.spec.forks.lstar.containers import (
@@ -395,13 +395,13 @@ class TestMaybeProduceBlock:
 
         assert blocks == []
 
-    async def test_assertion_error_is_logged_and_skipped(
+    async def test_rejection_is_logged_and_skipped(
         self,
         sync_service: SyncService,
         real_registry: ValidatorRegistry,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Store AssertionError during block production is caught; no block emitted."""
+        """A proposer-validation rejection during block production is caught; no block emitted."""
         blocks: list[SignedBlock] = []
 
         service = ValidatorService(
@@ -414,7 +414,9 @@ class TestMaybeProduceBlock:
         with patch.object(
             service.spec,
             "produce_block_with_signatures",
-            side_effect=AssertionError("mismatch"),
+            side_effect=SpecRejectionError(
+                RejectionReason.WRONG_PROPOSER, "not the scheduled proposer"
+            ),
         ):
             # Slot 0: proposer is validator 0 (0 % 8 = 0), which is in the registry.
             await service._maybe_produce_block(Slot(0))


### PR DESCRIPTION
## What

Addresses #1173: protocol **rejections** (validation failures every client must reproduce) and internal **assertions** (invariants that can never fire) were indistinguishable at the type level, because `SpecRejectionError` subclassed `AssertionError` and bare `assert`s reachable from input raised the same type. Worse, `python -O` strips bare asserts but never the typed `raise SpecRejectionError(...)`, so the reference's own accept/reject set depended on an interpreter flag.

A four-specialist review (fork-choice safety, API design, tests, docs) classified every reachable assert and settled the fix below.

## The exception hierarchy

`SpecRejectionError` now subclasses a new `SpecError(Exception)` root instead of `AssertionError`. The reason code — not the Python base class — is the client contract. This mirrors how `SSZValueError` deliberately subclasses `Exception` (not `ValueError`) so Pydantic does not rewrap it and destroy the payload, and it makes the rejection safe to raise inside a validator too.

Blast radius is tiny: only one catch site relied on the old base — the block-production loop caught `AssertionError` to swallow a `WRONG_PROPOSER` slot-race rejection. It is narrowed to `except SpecRejectionError`, which is also strictly better: genuine internal invariant errors now propagate instead of being silently logged as "skipped." Every other consumer already catches `SpecRejectionError` by name. The `errors.py` docstring's old "keeps existing rejection handlers working" rationale — the backward-compat shim the repo rule forbids — is removed.

## The convention

Documented in `errors.py`: any unhandled exception during block import or the state transition means the input is invalid, so a transliterating client does not depend on the Python exception type. The companion discipline — a bare `assert` marks only a provably-unreachable invariant, every reachable validity check is a typed rejection — is what actually neutralizes the `-O` hazard.

## The two concrete asserts the issue cites

- **`state_transition.py` justification-index assert** — a **provable invariant**. The already-justified skip upstream guarantees the target sits above the finalized slot, so the index is always in range. Kept, and documented as an internal invariant that is never a client reject path.
- **`state_transition.py` finalization-rebase assert** — the **real defect**. On a state rebuilt from untrusted bytes, a tracked justification root can legitimately be absent from the slot map. The old code asserted (and under `-O` would raise `KeyError` on the next line). Such a tally is off the canonical chain and can never justify a later slot, so the correct, Lean-model-matching behavior is to **drop it**, folded into the existing pruning comprehension. This makes the transition total on all decoded states and removes the interpreter-flag divergence. Locked with a new consensus vector that feeds a phantom off-chain root and asserts the tally is dropped with no crash.

The anchor `isinstance` guards are documented as by-construction type-narrowing checks (the type checker relies on them), not a client reject path.

## Deferred: gossip REJECT / IGNORE taxonomy

The issue's second suggestion — a gossip `REJECT` (penalize peer) vs `IGNORE` (drop silently) taxonomy, e.g. routing future-slot and duplicate to IGNORE — is deliberately **not** in this PR. It is a networking-layer change that wires gossip validation outcomes to peer scoring (`node/sync` + peer manager), independent of the spec's rejection contract fixed here. It is worth doing as its own change; flagging it so it is not lost. `RejectionReason` plus the existing bufferable-reason set is the right foundation for it.

## Coordination

The `fork_choice.py` asserts (state/anchor invariants) referenced by the sibling issue #1176 are handled in the still-open PR #1179 and are untouched here to avoid conflict.

## Credit

Found via the Lean 4 formalization of this spec ([NyxFoundation/formal-leanSpec](https://github.com/NyxFoundation/formal-leanSpec)), which already classifies each reachable assert.

## Testing

New finalization vector fills green (13 finalization vectors pass, deterministic); the updated validator-service unit test passes; `just check` is clean.

Refs #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)