### PR TITLE
fix(fork-choice): make the equal-slot equivocation tie deterministic

### DIFF
--- a/packages/testing/src/consensus_testing/test_types/store_checks.py
+++ b/packages/testing/src/consensus_testing/test_types/store_checks.py
@@ -307,11 +307,19 @@ class StoreChecks(SelectiveCheck):
         # Per-validator attestation content checks
         if "attestation_checks" in fields:
             assert self.attestation_checks is not None
+
+            # Vote ordering key mirroring the fork-choice rule.
+            #
+            # A higher slot wins.
+            # An equal-slot tie breaks toward the larger canonical attestation-data root.
+            # This makes the extracted winner independent of arrival or insertion order.
+            def _canonical_precedence(vote: AttestationData) -> tuple[Slot, Bytes32]:
+                return (vote.slot, hash_tree_root(vote))
+
             for attestation_check in self.attestation_checks:
-                # Map each validator to its highest-slot vote in the named pool.
+                # Map each validator to its winning vote in the named pool.
                 #
                 # The checker inspects pool content before pruning, so no finality cutoff applies.
-                # On equal slots the first vote seen wins, matching the fork-choice rule.
                 extracted_attestations: dict[ValidatorIndex, AttestationData] = {}
                 if attestation_check.location == "signatures":
                     # The raw signature pool groups one entry per validator under each vote.
@@ -320,7 +328,9 @@ class StoreChecks(SelectiveCheck):
                         for signature_entry in entries:
                             voter_index = signature_entry.validator_index
                             previous_vote = extracted_attestations.get(voter_index)
-                            if previous_vote is None or previous_vote.slot < attestation_data.slot:
+                            if previous_vote is None or _canonical_precedence(
+                                previous_vote
+                            ) < _canonical_precedence(attestation_data):
                                 extracted_attestations[voter_index] = attestation_data
                 else:
                     # The aggregated pools group proofs covering many validators under each vote.
@@ -334,10 +344,9 @@ class StoreChecks(SelectiveCheck):
                         for proof in proofs:
                             for participant_index in proof.participants.to_validator_indices():
                                 previous_vote = extracted_attestations.get(participant_index)
-                                if (
-                                    previous_vote is None
-                                    or previous_vote.slot < attestation_data.slot
-                                ):
+                                if previous_vote is None or _canonical_precedence(
+                                    previous_vote
+                                ) < _canonical_precedence(attestation_data):
                                     extracted_attestations[participant_index] = attestation_data
 
                 if attestation_check.validator not in extracted_attestations:

--- a/src/lean_spec/spec/forks/lstar/block_production.py
+++ b/src/lean_spec/spec/forks/lstar/block_production.py
@@ -123,8 +123,11 @@ class BlockProductionMixin(LstarSpecBase):
             processed_attestation_data: set[AttestationData] = set()
 
             # Order candidates by target slot, once.
+            # The canonical root breaks target-slot ties so every node builds the same block.
+            # It also makes the truncation cutoff content-derived, never arrival-order derived.
             candidates_in_target_slot_order = sorted(
-                aggregated_payloads.items(), key=lambda item: item[0].target.slot
+                aggregated_payloads.items(),
+                key=lambda item: (item[0].target.slot, hash_tree_root(item[0])),
             )
 
             # Fixed-point selection.

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -645,8 +645,9 @@ class ForkChoiceMixin(LstarSpecBase):
         Map each participating validator to the latest vote it cast.
 
         This is the LMD view fork choice runs on.
-        Two votes share a slot only across distinct attestation data, never within one data.
-        On such an equal-slot tie the strict comparison keeps the first distinct data inserted.
+        An equivocator can cast two distinct votes at one slot.
+        An equal-slot tie breaks toward the larger canonical attestation-data root.
+        The result is therefore independent of arrival or insertion order.
 
         A vote whose head sits at or below the finalized slot carries no fork-choice weight.
         Such stale votes are skipped here, so callers pass their pool without pre-filtering.
@@ -660,20 +661,29 @@ class ForkChoiceMixin(LstarSpecBase):
         """
         latest_vote_by_validator: dict[ValidatorIndex, AttestationData] = {}
 
-        # Walk every vote, every proof for it, and every validator the proof covers.
-        for attestation_data, proofs in aggregated_payloads.items():
-            # Skip votes whose head no longer outlives the finalized slot.
+        # Process votes newest-first, breaking an equal-slot tie toward the larger canonical root.
+        # This is the same rule the block tiebreak applies to block roots.
+        # The sort key runs hash_tree_root once per distinct vote, never per validator.
+        votes_by_canonical_precedence = sorted(
+            aggregated_payloads.items(),
+            key=lambda vote_and_proofs: (
+                vote_and_proofs[0].slot,
+                hash_tree_root(vote_and_proofs[0]),
+            ),
+            reverse=True,
+        )
+
+        for attestation_data, proofs in votes_by_canonical_precedence:
+            # A vote whose head sits at or below the finalized slot carries no weight.
             if attestation_data.head.slot <= latest_finalized_slot:
                 continue
-
-            # Every proof here shares one attestation data, so they share one slot.
-            # The strict slot comparison below never overwrites between them.
+            # Every proof here carries the identical attestation data.
+            # Whichever proof the loop visits, the stored vote is the same.
             # Set iteration order is therefore non-consensus and safe to leave native.
             for proof in proofs:
                 for validator_index in proof.participants.to_validator_indices():
-                    # Keep this vote only when it is newer than the one already stored.
-                    previous_vote = latest_vote_by_validator.get(validator_index)
-                    if previous_vote is None or previous_vote.slot < attestation_data.slot:
+                    # Descending order means the first vote seen for a validator is its winner.
+                    if validator_index not in latest_vote_by_validator:
                         latest_vote_by_validator[validator_index] = attestation_data
 
         return latest_vote_by_validator

--- a/tests/consensus/lstar/fork_choice/test_equivocation.py
+++ b/tests/consensus/lstar/fork_choice/test_equivocation.py
@@ -246,7 +246,7 @@ def test_same_slot_equivocating_attesters_count_once(
     fork_choice_test: ForkChoiceTestFiller,
 ) -> None:
     """
-    An equivocating validator is counted once, on the fork it first voted.
+    An equivocating validator is counted once, on the canonical-root fork.
 
     Given
     -----
@@ -258,7 +258,8 @@ def test_same_slot_equivocating_attesters_count_once(
     - one vote at slot 3 targets fork_a from V0, V1, V2.
     - one vote at slot 3 targets fork_b from V0, V1, V3, V4.
     - V0 and V1 equivocate by voting on both forks at the same slot.
-    - fork_a is gossiped first, so V0 and V1's first votes stick to it.
+    - the two votes tie on slot, so the larger attestation-data root wins.
+    - the fork_b vote carries the larger root.
 
     When
     ----
@@ -266,10 +267,10 @@ def test_same_slot_equivocating_attesters_count_once(
 
     Then
     ----
-    - V0 and V1 count once, toward fork_a.
-    - fork_a has effective weight 3 from V0, V1, V2.
-    - fork_b has effective weight 2 from V3, V4.
-    - head stays on fork_a.
+    - V0 and V1 count once, toward fork_b.
+    - fork_b has effective weight 4 from V0, V1, V3, V4.
+    - fork_a has effective weight 1 from V2.
+    - head is fork_b.
     - no slot is justified by the below-threshold votes.
     """
     fork_choice_test(
@@ -316,8 +317,8 @@ def test_same_slot_equivocating_attesters_count_once(
             TickStep(
                 time=16,
                 checks=StoreChecks(
-                    head_slot=Slot(2),
-                    head_root_label="fork_a",
+                    head_slot=Slot(3),
+                    head_root_label="fork_b",
                     latest_justified_slot=Slot(0),
                     latest_finalized_slot=Slot(0),
                     latest_known_aggregated_target_slots=[Slot(2), Slot(3)],
@@ -326,13 +327,13 @@ def test_same_slot_equivocating_attesters_count_once(
                             validator=ValidatorIndex(0),
                             location="known",
                             attestation_slot=Slot(3),
-                            target_slot=Slot(2),
+                            target_slot=Slot(3),
                         ),
                         AttestationCheck(
                             validator=ValidatorIndex(1),
                             location="known",
                             attestation_slot=Slot(3),
-                            target_slot=Slot(2),
+                            target_slot=Slot(3),
                         ),
                         AttestationCheck(
                             validator=ValidatorIndex(2),
@@ -351,6 +352,178 @@ def test_same_slot_equivocating_attesters_count_once(
                             location="known",
                             attestation_slot=Slot(3),
                             target_slot=Slot(3),
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
+def test_equivocation_head_independent_of_arrival_order_a_then_b(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Head ignores arrival order: fork_a arriving first still picks the canonical-root fork.
+
+    Given
+    -----
+    - 6 validators; a slot needs 4 votes (2/3) to be justified.
+    - the chain:
+        genesis -> common(1)
+        - fork_a(2)
+        - fork_b(3)
+    - one vote at slot 3 targets fork_a from V0, V1.
+    - one vote at slot 3 targets fork_b from V0, V2.
+    - V0 equivocates by voting on both forks at the same slot.
+    - V1 backs fork_a alone; V2 backs fork_b alone.
+    - without V0 the two forks tie one-to-one, so V0's vote decides the head.
+    - the two votes tie on slot, so the larger attestation-data root wins.
+    - the fork_a vote carries the larger root.
+
+    When
+    ----
+    - the fork_a vote arrives first, then the fork_b vote.
+
+    Then
+    ----
+    - V0 counts once, toward the larger-root fork.
+    - the larger-root fork has effective weight 2.
+    - the smaller-root fork has effective weight 1.
+    - head is fork_a.
+    - no slot is justified by the below-threshold votes.
+    """
+    fork_choice_test(
+        anchor_state=build_genesis_state(num_validators=6),
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="common"),
+                checks=StoreChecks(head_slot=Slot(1), head_root_label="common"),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), parent_label="common", label="fork_a"),
+                checks=StoreChecks(head_slot=Slot(2), head_root_label="fork_a"),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(3), parent_label="common", label="fork_b"),
+                checks=StoreChecks(lexicographic_head_among=["fork_a", "fork_b"]),
+            ),
+            TickStep(interval=18),
+            GossipAggregatedAttestationStep(
+                attestation=AggregatedAttestationSpec(
+                    validator_indices=[ValidatorIndex(0), ValidatorIndex(1)],
+                    slot=Slot(3),
+                    target_slot=Slot(2),
+                    target_root_label="fork_a",
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=AggregatedAttestationSpec(
+                    validator_indices=[ValidatorIndex(0), ValidatorIndex(2)],
+                    slot=Slot(3),
+                    target_slot=Slot(3),
+                    target_root_label="fork_b",
+                ),
+            ),
+            TickStep(
+                time=16,
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    head_root_label="fork_a",
+                    latest_justified_slot=Slot(0),
+                    latest_finalized_slot=Slot(0),
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(0),
+                            location="known",
+                            attestation_slot=Slot(3),
+                            target_slot=Slot(2),
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
+def test_equivocation_head_independent_of_arrival_order_b_then_a(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    Head ignores arrival order: fork_b arriving first still picks the canonical-root fork.
+
+    Given
+    -----
+    - 6 validators; a slot needs 4 votes (2/3) to be justified.
+    - the chain:
+        genesis -> common(1)
+        - fork_a(2)
+        - fork_b(3)
+    - one vote at slot 3 targets fork_a from V0, V1.
+    - one vote at slot 3 targets fork_b from V0, V2.
+    - V0 equivocates by voting on both forks at the same slot.
+    - V1 backs fork_a alone; V2 backs fork_b alone.
+    - without V0 the two forks tie one-to-one, so V0's vote decides the head.
+    - the two votes tie on slot, so the larger attestation-data root wins.
+    - the fork_a vote carries the larger root.
+
+    When
+    ----
+    - the fork_b vote arrives first, then the fork_a vote.
+
+    Then
+    ----
+    - V0 counts once, toward the larger-root fork.
+    - the larger-root fork has effective weight 2.
+    - the smaller-root fork has effective weight 1.
+    - head is fork_a, matching the opposite arrival order.
+    - no slot is justified by the below-threshold votes.
+    """
+    fork_choice_test(
+        anchor_state=build_genesis_state(num_validators=6),
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(1), label="common"),
+                checks=StoreChecks(head_slot=Slot(1), head_root_label="common"),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2), parent_label="common", label="fork_a"),
+                checks=StoreChecks(head_slot=Slot(2), head_root_label="fork_a"),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(3), parent_label="common", label="fork_b"),
+                checks=StoreChecks(lexicographic_head_among=["fork_a", "fork_b"]),
+            ),
+            TickStep(interval=18),
+            GossipAggregatedAttestationStep(
+                attestation=AggregatedAttestationSpec(
+                    validator_indices=[ValidatorIndex(0), ValidatorIndex(2)],
+                    slot=Slot(3),
+                    target_slot=Slot(3),
+                    target_root_label="fork_b",
+                ),
+            ),
+            GossipAggregatedAttestationStep(
+                attestation=AggregatedAttestationSpec(
+                    validator_indices=[ValidatorIndex(0), ValidatorIndex(1)],
+                    slot=Slot(3),
+                    target_slot=Slot(2),
+                    target_root_label="fork_a",
+                ),
+            ),
+            TickStep(
+                time=16,
+                checks=StoreChecks(
+                    head_slot=Slot(2),
+                    head_root_label="fork_a",
+                    latest_justified_slot=Slot(0),
+                    latest_finalized_slot=Slot(0),
+                    attestation_checks=[
+                        AttestationCheck(
+                            validator=ValidatorIndex(0),
+                            location="known",
+                            attestation_slot=Slot(3),
+                            target_slot=Slot(2),
                         ),
                     ],
                 ),


### PR DESCRIPTION
## What

Fixes #1172: an equivocation tie-break in fork choice was insertion-order dependent, so two honest nodes with the same blocks and votes but different arrival order could pick **different heads permanently**. This is a genuine consensus-safety / determinism bug — all unit tests passed; the split only appeared between nodes on a live network.

## The bug

An equivocating validator can sign two distinct votes `A` and `B` for the same slot. Nothing rejects the second (the pool is keyed by attestation data, and the two data differ), so both are admitted and aggregated. The latest-vote extraction then resolved the equal-slot tie with a strict `<` on slot:

```python
if previous_vote is None or previous_vote.slot < attestation_data.slot:  # s < s is False on a tie
    latest_vote_by_validator[validator_index] = attestation_data
```

On the tie the second vote never overwrites the first, so the winner is simply whichever was iterated first — i.e. dict insertion = arrival order. The block-level tiebreak `max(children, key=(weights[r], r))` is one layer too late: the equivocator's weight has already landed on different branches on the two nodes, so the branch weights are unequal and the tiebreak never fires. The heads diverge and stay diverged.

## The fix

Resolve the equal-slot tie **deterministically by the largest canonical attestation-data root**, the same rule the block-level tiebreak applies to block roots. The extraction now sorts the pool by `(slot, hash_tree_root(data))` descending and keeps the first vote per validator:

- The head becomes a pure function of store contents — independent of arrival or insertion order.
- An equivocator is counted **once**, on one branch every node agrees on. That is strictly safer than the status quo, where first-seen let one Byzantine validator land its weight on branch A at one node and branch B at another (an effective cross-network double-count). Fork-choice head weight is not the finality mechanism, so counting one deterministic vote changes no finalization.
- `hash_tree_root(attestation_data)` is computed once per distinct vote (in the sort key), never per validator.

This is chosen over the consensus-specs approach of dropping equivocators via an `equivocating_indices` set: that requires slashing / equivocation-detection infrastructure this fork does not have, whereas a canonical tiebreak needs none.

Block production gains the same `(target.slot, hash_tree_root)` secondary sort key, so a proposer builds the same block regardless of arrival order (a related determinism gap where distinct data at one target slot previously fell back to arrival order under truncation).

## Determinism note (supersedes an earlier choice)

An earlier change (PR #892) made the tie keep the **first-seen** vote via an insertion-order-preserving pool merge. That only guaranteed *intra-run* reproducibility (identical output across `PYTHONHASHSEED` for a single scripted fill); it did **not** give *inter-node* agreement, which is what this issue is about. The canonical-root tiebreak is a strict superset: it keeps the hash-seed reproducibility PR #892 wanted **and** adds inter-node determinism. Verified by filling the equivocation vectors under `PYTHONHASHSEED=0` and `7` — byte-identical.

## Tests

Consensus vectors only (fork tests are vector-driven):

- The testing fixture's own vote checker mirrored the old first-seen rule; it is brought into lockstep with the spec so `attestation_checks` match the fixed store.
- An existing vector asserted the arrival-order winner (`fork_a`, first-gossiped); it is corrected to the deterministic winner (`fork_b`, larger data root), with its Given/When/Then docstring rewritten to describe the canonical rule.
- Two new vectors deliver the same equivocating votes in **opposite arrival orders** and assert an **identical head** — directly encoding order-independence (pre-fix they diverged, post-fix they agree).

Full `tests/consensus/lstar/fork_choice/` re-fill passes (119 vectors), no other vector relied on arrival order; `just check` is clean.

## Credit

Found via the Lean 4 formalization of this spec ([NyxFoundation/formal-leanSpec](https://github.com/NyxFoundation/formal-leanSpec)): modeling the store as an unordered map made "the head is a function of store contents" unprovable, because the result depended on an insertion order a map does not carry.

Refs #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)