### PR TITLE
fix(fork-choice): bound a block's slot before the empty-slot loop runs

### DIFF
--- a/src/lean_spec/spec/forks/lstar/errors.py
+++ b/src/lean_spec/spec/forks/lstar/errors.py
@@ -10,6 +10,12 @@ class RejectionReason(StrEnum):
     BLOCK_SLOT_NOT_IN_FUTURE = "BLOCK_SLOT_NOT_IN_FUTURE"
     """The block slot is not strictly greater than the current state slot."""
 
+    BLOCK_SLOT_GAP_TOO_LARGE = "BLOCK_SLOT_GAP_TOO_LARGE"
+    """The block slot runs so far beyond its parent it would force an unbounded empty-slot walk."""
+
+    BLOCK_TOO_FAR_IN_FUTURE = "BLOCK_TOO_FAR_IN_FUTURE"
+    """The block slot is beyond the store's accepted future horizon."""
+
     BLOCK_OLDER_THAN_LATEST_HEADER = "BLOCK_OLDER_THAN_LATEST_HEADER"
     """The block slot is not newer than the latest block header."""
 

--- a/src/lean_spec/spec/forks/lstar/fork_choice.py
+++ b/src/lean_spec/spec/forks/lstar/fork_choice.py
@@ -9,6 +9,7 @@ from lean_spec.spec.crypto.xmss.interface import TARGET_SIGNATURE_SCHEME
 from lean_spec.spec.forks.lstar._base import LstarSpecBase, LstarStore
 from lean_spec.spec.forks.lstar.config import (
     GOSSIP_DISPARITY_INTERVALS,
+    HISTORICAL_ROOTS_LIMIT,
     INTERVALS_PER_SLOT,
 )
 from lean_spec.spec.forks.lstar.containers import (
@@ -542,6 +543,8 @@ class ForkChoiceMixin(LstarSpecBase):
 
         Raises:
             SpecRejectionError: UNKNOWN_PARENT_BLOCK if the parent state is not in the store.
+            SpecRejectionError: BLOCK_SLOT_GAP_TOO_LARGE if the slot runs too far beyond the parent.
+            SpecRejectionError: BLOCK_TOO_FAR_IN_FUTURE if the slot is past the future horizon.
             SpecRejectionError: DUPLICATE_ATTESTATION_DATA if the block repeats an AttestationData.
             SpecRejectionError: TOO_MANY_ATTESTATION_DATA if the block exceeds the data cap.
         """
@@ -567,6 +570,21 @@ class ForkChoiceMixin(LstarSpecBase):
                     RejectionReason.UNKNOWN_PARENT_BLOCK,
                     f"Parent state not found (root={block.parent_root.hex()}). "
                     f"Sync parent chain before processing block at slot {block.slot}.",
+                )
+
+            # The empty-slot loop in the transition runs once per slot from the parent to the block.
+            #
+            # A block far beyond its parent, or far in the future, would spin that loop unboundedly.
+            if int(block.slot) - int(parent_state.slot) > int(HISTORICAL_ROOTS_LIMIT):
+                raise SpecRejectionError(
+                    RejectionReason.BLOCK_SLOT_GAP_TOO_LARGE,
+                    "Block slot is too far beyond its parent",
+                )
+            current_slot = int(store.time) // int(INTERVALS_PER_SLOT)
+            if int(block.slot) > current_slot + 1:
+                raise SpecRejectionError(
+                    RejectionReason.BLOCK_TOO_FAR_IN_FUTURE,
+                    "Block too far in future",
                 )
 
             # Reject a block body that repeats the same vote data.

--- a/tests/consensus/lstar/fork_choice/test_block_future_horizon.py
+++ b/tests/consensus/lstar/fork_choice/test_block_future_horizon.py
@@ -1,0 +1,136 @@
+"""Fork Choice: blocks past the clock's future horizon are rejected."""
+
+import pytest
+
+from consensus_testing import (
+    BlockSpec,
+    BlockStep,
+    ExpectedRejection,
+    ForkChoiceTestFiller,
+    StoreChecks,
+    TickStep,
+)
+from lean_spec.spec.forks import Interval, RejectionReason, Slot
+
+pytestmark = pytest.mark.valid_until("Lstar")
+
+
+def test_block_beyond_future_horizon_rejected(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    A block two slots past the store clock is rejected as too far in future.
+
+    Given
+    -----
+    - 4 validators.
+    - the chain:
+        genesis
+    - the store clock sits at genesis and never ticks.
+
+    When
+    ----
+    - a block at slot 2 arrives while the clock reports current slot 0.
+
+    Then
+    ----
+    - the store rejects the block with reason block too far in future.
+    - store time stays at interval 0.
+    - the head stays at genesis (slot 0).
+    """
+    fork_choice_test(
+        steps=[
+            BlockStep(
+                block=BlockSpec(slot=Slot(2)),
+                tick_to_slot=False,
+                valid=False,
+                expected_rejection=ExpectedRejection(
+                    reason=RejectionReason.BLOCK_TOO_FAR_IN_FUTURE,
+                    exact_message="Block too far in future",
+                ),
+                checks=StoreChecks(time=Interval(0), head_slot=Slot(0)),
+            ),
+        ],
+    )
+
+
+def test_block_at_clock_horizon_edge_imported(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    A block exactly one slot past the clock imports at the future horizon edge.
+
+    Given
+    -----
+    - 4 validators.
+    - the chain:
+        genesis -> block(2)
+    - the clock ticks to the start of slot 1 (interval 5), so current slot is 1.
+
+    When
+    ----
+    - a block at slot 2 arrives without advancing the clock.
+
+    Then
+    ----
+    - the horizon is current slot plus one, so slot 2 is admissible.
+    - store time stays at interval 5.
+    - the head advances to the slot 2 block.
+    """
+    fork_choice_test(
+        steps=[
+            TickStep(
+                interval=5,
+                checks=StoreChecks(time=Interval(5), head_slot=Slot(0)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(2)),
+                tick_to_slot=False,
+                checks=StoreChecks(time=Interval(5), head_slot=Slot(2)),
+            ),
+        ],
+    )
+
+
+def test_block_one_past_horizon_rejected(
+    fork_choice_test: ForkChoiceTestFiller,
+) -> None:
+    """
+    A block two slots past the clock is rejected even at a non-genesis clock.
+
+    Given
+    -----
+    - 4 validators.
+    - the chain:
+        genesis
+    - the clock ticks to the start of slot 1 (interval 5), so current slot is 1.
+
+    When
+    ----
+    - a block at slot 3 arrives without advancing the clock.
+
+    Then
+    ----
+    - the horizon is current slot plus one, so slot 3 exceeds it.
+    - the store rejects the block with reason block too far in future.
+    - store time stays at interval 5.
+    - the head stays at genesis (slot 0).
+    """
+    fork_choice_test(
+        steps=[
+            TickStep(
+                interval=5,
+                checks=StoreChecks(time=Interval(5), head_slot=Slot(0)),
+            ),
+            BlockStep(
+                block=BlockSpec(slot=Slot(3)),
+                tick_to_slot=False,
+                valid=False,
+                expected_rejection=ExpectedRejection(
+                    reason=RejectionReason.BLOCK_TOO_FAR_IN_FUTURE,
+                    exact_message="Block too far in future",
+                ),
+                checks=StoreChecks(time=Interval(5), head_slot=Slot(0)),
+            ),
+        ],
+    )


### PR DESCRIPTION
## What

Closes #1171: block acceptance had a lower slot bound but no upper bound, so a single validly-signed block could force the state-transition's empty-slot loop to run unboundedly — a denial of service every transliterating client inherits.

## The bug

The empty-slot loop advances `state.slot` one slot at a time up to `block.slot`, so its length is exactly `block.slot − parent.slot`. `on_block` ran no upper-bound check on `block.slot` before the transition. The proposer of a slot is `slot % num_validators`, so one key is the valid proposer for infinitely many slots and can sign a block at slot `2**63`; the always-present genesis state is a reachable parent; and the post-state root is only checked *after* the loop. So one small message forces ~`2**63` iterations.

## The fix — two guards in `on_block`, before the transition

The consensus decision here matters: the loop length is `block.slot − parent.slot`, **not** `block.slot − current_slot`. A clock horizon alone bounds `block.slot` but not the loop — a block on the genesis parent at slot ≈ `current_slot` passes a clock check yet still runs ~`current_slot` iterations, a residual that grows with node uptime. So the fix uses both:

- **Parent-gap cap (primary):** reject `block.slot − parent.slot > HISTORICAL_ROOTS_LIMIT` (2^18). This bounds the actual loop variable directly and is clock-independent. It is **lossless**: `process_block_header` grows the `historical_block_hashes` list (capped at 2^18) by the gap, so any block with a larger gap is already doomed to overflow that list — but only *after* the loop runs. Capping the gap up front rejects exactly those already-doomed blocks, with no false rejections and no liveness cost, reusing the existing constant.
- **Clock horizon (secondary):** reject `block.slot > current_slot + 1`. Mirrors the attestation future-slot guard and keeps far-future blocks out of the store. The margin is a **whole slot**, not the attestation path's one interval, so an intended early block still imports.

Both work in Python integers (the near-2^64 wire slot never overflows), both run before signature verification so a far-future block is rejected cheaply, and both live only in `on_block` — the untrusted-input boundary. Block production advances slots through `build_block`/`process_slots` directly, so it is unaffected; the guard deliberately does not go in `process_slots`.

This matches consensus-specs, which also places the future-slot bound in `on_block` before the transition — but with a whole-slot margin rather than an exact `current_slot >= block.slot` assert, because this spec deliberately imports self-authenticating early blocks (see `test_early_block_arrival.py`).

## Tests

Consensus vectors (fork behavior is vector-tested):

- `test_block_future_horizon.py` — a slot-2 block with the clock pinned at interval 0 is rejected with `BLOCK_TOO_FAR_IN_FUTURE` (full-message equality), the store untouched; plus a non-genesis-clock boundary (clock at slot 1: a slot-2 block imports, a slot-3 block is rejected).
- The existing early-arrival vectors still import unchanged (a slot-1 block at interval 0 is within the one-slot margin).

The parent-gap cap is verified by construction rather than by a vector: a block with a >2^18 slot gap cannot be built through the fixture (the builder runs the real transition, and the signing keys are slot-bounded) and would overflow the historical-roots list regardless. This is documented, not vectored.

`just check` is clean; the new and affected vectors fill deterministically.

## Credit

Found via the Lean 4 formalization of this spec ([NyxFoundation/formal-leanSpec](https://github.com/NyxFoundation/formal-leanSpec)): the empty-slot loop was proved to terminate for a *given* target, but nothing bounded the target itself — exactly the missing precondition.

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)